### PR TITLE
fix: dataloader state resets

### DIFF
--- a/api/src/services/storage/dataloaders.ts
+++ b/api/src/services/storage/dataloaders.ts
@@ -2,7 +2,7 @@ import {SystemIds} from "@graphprotocol/grc-20"
 import DataLoader from "dataloader"
 import {Context, Data, Effect} from "effect"
 import type {RelationFilter, ValueFilter} from "~/src/generated/graphql"
-import {Storage} from "./storage"
+import {db, Storage} from "./storage"
 
 export class BatchingError extends Data.TaggedError("BatchingError")<{
 	cause?: unknown
@@ -100,254 +100,6 @@ export class Batching extends Context.Tag("Batching")<Batching, BatchingShape>()
 export const make = Effect.gen(function* () {
 	const storage = yield* Storage
 
-	const entitiesLoader = new DataLoader((ids: readonly string[]) => {
-		return Effect.runPromise(
-			storage
-				.use(async (client) => {
-					const entities = await client.query.entities.findMany({
-						where: (entities, {inArray}) => inArray(entities.id, ids),
-					})
-
-					const entityMap = new Map(entities.map((e) => [e.id, e]))
-					return ids.map((id) => entityMap.get(id) ?? null)
-				})
-				.pipe(Effect.withSpan("entitiesLoader"), Effect.annotateSpans({ids})),
-		)
-	})
-
-	const entityNamesLoader = new DataLoader((ids: readonly string[]) => {
-		return Effect.runPromise(
-			storage.use(async (client) => {
-				const values = await client.query.values.findMany({
-					where: (values, {inArray, and, eq}) =>
-						and(inArray(values.entityId, ids), eq(values.propertyId, SystemIds.NAME_PROPERTY)),
-					columns: {
-						entityId: true,
-						value: true,
-					},
-				})
-
-				const valueMap = new Map(values.map((v) => [v.entityId, v.value]))
-				return ids.map((id) => valueMap.get(id) || null)
-			}),
-		)
-	})
-
-	const entityDescriptionsLoader = new DataLoader((ids: readonly string[]) => {
-		return Effect.runPromise(
-			storage
-				.use(async (client) => {
-					const values = await client.query.values.findMany({
-						where: (values, {inArray, and, eq}) =>
-							and(inArray(values.entityId, ids), eq(values.propertyId, SystemIds.DESCRIPTION_PROPERTY)),
-						columns: {
-							entityId: true,
-							value: true,
-						},
-					})
-
-					const valueMap = new Map(values.map((v) => [v.entityId, v.value]))
-					return ids.map((id) => valueMap.get(id) || null)
-				})
-				.pipe(Effect.withSpan("entityDescriptionsLoader"), Effect.annotateSpans({ids})),
-		)
-	})
-
-	const entityValuesLoader = new DataLoader(
-		(
-			keys: readonly {
-				entityId: string
-				spaceId?: string | null
-				filter?: ValueFilter | null
-			}[],
-		) => {
-			return Effect.runPromise(
-				storage
-					.use(async (client) => {
-						const entityIds = keys.map((k) => k.entityId)
-						const allValues = await client.query.values.findMany({
-							where: (values, {inArray}) => inArray(values.entityId, entityIds),
-						})
-
-						const valuesByEntity = new Map<string, (typeof allValues)[number][]>()
-						for (const value of allValues) {
-							if (!valuesByEntity.has(value.entityId)) {
-								valuesByEntity.set(value.entityId, [])
-							}
-							valuesByEntity.get(value.entityId)?.push(value)
-						}
-
-						return keys.map((key) => {
-							let entityValues = valuesByEntity.get(key.entityId) || []
-
-							// Apply spaceId filter
-							if (key.spaceId) {
-								entityValues = entityValues.filter((v) => v.spaceId === key.spaceId)
-							}
-
-							// Apply value filter
-							if (key.filter?.property) {
-								entityValues = entityValues.filter((v) => v.propertyId === key.filter?.property)
-							}
-
-							return entityValues
-						})
-					})
-					.pipe(Effect.withSpan("entityValuesLoader"), Effect.annotateSpans({keys})),
-			)
-		},
-		{
-			cacheKeyFn: (key) => `${key.entityId}:${key.spaceId || "null"}:${JSON.stringify(key.filter) || "null"}`,
-		},
-	)
-
-	const entityRelationsLoader = new DataLoader(
-		(
-			keys: readonly {
-				entityId: string
-				spaceId?: string | null
-				filter?: RelationFilter | null
-			}[],
-		) => {
-			return Effect.runPromise(
-				storage
-					.use(async (client) => {
-						const entityIds = keys.map((k) => k.entityId)
-						const allRelations = await client.query.relations.findMany({
-							where: (relations, {inArray}) => inArray(relations.fromEntityId, entityIds),
-						})
-
-						const relationsByEntity = new Map<string, (typeof allRelations)[number][]>()
-						for (const relation of allRelations) {
-							if (!relationsByEntity.has(relation.fromEntityId)) {
-								relationsByEntity.set(relation.fromEntityId, [])
-							}
-							relationsByEntity.get(relation.fromEntityId)?.push(relation)
-						}
-
-						return keys.map((key) => {
-							let entityRelations = relationsByEntity.get(key.entityId) || []
-
-							// Apply spaceId filter
-							if (key.spaceId) {
-								entityRelations = entityRelations.filter((r) => r.spaceId === key.spaceId)
-							}
-
-							// Apply relation filters
-							if (key.filter) {
-								if (key.filter.typeId && key.filter.typeId !== "") {
-									entityRelations = entityRelations.filter((r) => r.typeId === key.filter?.typeId)
-								}
-								if (key.filter.fromEntityId && key.filter.fromEntityId !== "") {
-									entityRelations = entityRelations.filter(
-										(r) => r.fromEntityId === key.filter?.fromEntityId,
-									)
-								}
-								if (key.filter.toEntityId && key.filter.toEntityId !== "") {
-									entityRelations = entityRelations.filter(
-										(r) => r.toEntityId === key.filter?.toEntityId,
-									)
-								}
-								if (key.filter.relationEntityId && key.filter.relationEntityId !== "") {
-									entityRelations = entityRelations.filter(
-										(r) => r.entityId === key.filter?.relationEntityId,
-									)
-								}
-							}
-
-							return entityRelations
-						})
-					})
-					.pipe(Effect.withSpan("entityRelationsLoader"), Effect.annotateSpans({keys})),
-			)
-		},
-		{
-			cacheKeyFn: (key) =>
-				`relations:${key.entityId}:${key.spaceId || "null"}:${JSON.stringify(key.filter) || "null"}`,
-		},
-	)
-
-	const entityBacklinksLoader = new DataLoader(
-		(
-			keys: readonly {
-				entityId: string
-				spaceId?: string | null
-				filter?: RelationFilter | null
-			}[],
-		) => {
-			return Effect.runPromise(
-				storage
-					.use(async (client) => {
-						const entityIds = keys.map((k) => k.entityId)
-						const allBacklinks = await client.query.relations.findMany({
-							where: (relations, {inArray}) => inArray(relations.toEntityId, entityIds),
-						})
-
-						const backlinksByEntity = new Map<string, (typeof allBacklinks)[number][]>()
-						for (const backlink of allBacklinks) {
-							if (!backlinksByEntity.has(backlink.toEntityId)) {
-								backlinksByEntity.set(backlink.toEntityId, [])
-							}
-							backlinksByEntity.get(backlink.toEntityId)?.push(backlink)
-						}
-
-						return keys.map((key) => {
-							let entityBacklinks = backlinksByEntity.get(key.entityId) || []
-
-							// Apply spaceId filter
-							if (key.spaceId) {
-								entityBacklinks = entityBacklinks.filter((r) => r.spaceId === key.spaceId)
-							}
-
-							// Apply relation filters
-							if (key.filter) {
-								if (key.filter.typeId && key.filter.typeId !== "") {
-									entityBacklinks = entityBacklinks.filter((r) => r.typeId === key.filter?.typeId)
-								}
-								if (key.filter.fromEntityId && key.filter.fromEntityId !== "") {
-									entityBacklinks = entityBacklinks.filter(
-										(r) => r.fromEntityId === key.filter?.fromEntityId,
-									)
-								}
-								if (key.filter.toEntityId && key.filter.toEntityId !== "") {
-									entityBacklinks = entityBacklinks.filter(
-										(r) => r.toEntityId === key.filter?.toEntityId,
-									)
-								}
-								if (key.filter.relationEntityId && key.filter.relationEntityId !== "") {
-									entityBacklinks = entityBacklinks.filter(
-										(r) => r.entityId === key.filter?.relationEntityId,
-									)
-								}
-							}
-
-							return entityBacklinks
-						})
-					})
-					.pipe(Effect.withSpan("entityBacklinksLoader"), Effect.annotateSpans({keys})),
-			)
-		},
-		{
-			cacheKeyFn: (key) =>
-				`backlinks:${key.entityId}:${key.spaceId || "null"}:${JSON.stringify(key.filter) || "null"}`,
-		},
-	)
-
-	const propertiesLoader = new DataLoader((ids: readonly string[]) => {
-		return Effect.runPromise(
-			storage
-				.use(async (client) => {
-					const properties = await client.query.properties.findMany({
-						where: (properties, {inArray}) => inArray(properties.id, ids),
-					})
-
-					const propertyMap = new Map(properties.map((p) => [p.id, p]))
-					return ids.map((id) => propertyMap.get(id) || null)
-				})
-				.pipe(Effect.withSpan("propertiesLoader"), Effect.annotateSpans({ids})),
-		)
-	})
-
 	return Batching.of({
 		loadEntity: (id: string) =>
 			Effect.tryPromise({
@@ -420,3 +172,262 @@ export const make = Effect.gen(function* () {
 			}).pipe(Effect.annotateSpans({propertyId}), Effect.withSpan("loadProperty")),
 	})
 })
+
+const entitiesLoader = new DataLoader((ids: readonly string[]) => {
+	const batch = async () => {
+		const entities = await db.query.entities.findMany({
+			where: (entities, {inArray}) => inArray(entities.id, ids),
+		})
+
+		const entityMap = new Map(entities.map((e) => [e.id, e]))
+		return ids.map((id) => entityMap.get(id) ?? null)
+	}
+
+	return Effect.runPromise(
+		Effect.promise(batch).pipe(
+			Effect.withSpan("entitiesLoader"),
+			Effect.annotateSpans({ids, batchLength: ids.length}),
+		),
+	)
+})
+
+const entityNamesLoader = new DataLoader((ids: readonly string[]) => {
+	const batch = async () => {
+		const values = await db.query.values.findMany({
+			where: (values, {inArray, and, eq}) =>
+				and(inArray(values.entityId, ids), eq(values.propertyId, SystemIds.NAME_PROPERTY)),
+			columns: {
+				entityId: true,
+				value: true,
+			},
+		})
+
+		const valueMap = new Map(values.map((v) => [v.entityId, v.value]))
+		return ids.map((id) => valueMap.get(id) || null)
+	}
+
+	return Effect.runPromise(
+		Effect.promise(batch).pipe(
+			Effect.withSpan("entityNamesLoader"),
+			Effect.annotateSpans({ids, batchLength: ids.length}),
+		),
+	)
+})
+
+const entityDescriptionsLoader = new DataLoader((ids: readonly string[]) => {
+	const batch = async () => {
+		const values = await db.query.values.findMany({
+			where: (values, {inArray, and, eq}) =>
+				and(inArray(values.entityId, ids), eq(values.propertyId, SystemIds.DESCRIPTION_PROPERTY)),
+			columns: {
+				entityId: true,
+				value: true,
+			},
+		})
+
+		const valueMap = new Map(values.map((v) => [v.entityId, v.value]))
+		return ids.map((id) => valueMap.get(id) || null)
+	}
+
+	return Effect.runPromise(
+		Effect.promise(batch).pipe(
+			Effect.withSpan("entityDescriptionsLoader"),
+			Effect.annotateSpans({ids, batchLength: ids.length}),
+		),
+	)
+})
+
+const entityValuesLoader = new DataLoader(
+	(
+		keys: readonly {
+			entityId: string
+			spaceId?: string | null
+			filter?: ValueFilter | null
+		}[],
+	) => {
+		const batch = async () => {
+			const entityIds = keys.map((k) => k.entityId)
+			const allValues = await db.query.values.findMany({
+				where: (values, {inArray}) => inArray(values.entityId, entityIds),
+			})
+
+			const valuesByEntity = new Map<string, (typeof allValues)[number][]>()
+			for (const value of allValues) {
+				if (!valuesByEntity.has(value.entityId)) {
+					valuesByEntity.set(value.entityId, [])
+				}
+				valuesByEntity.get(value.entityId)?.push(value)
+			}
+
+			return keys.map((key) => {
+				let entityValues = valuesByEntity.get(key.entityId) || []
+
+				// Apply spaceId filter
+				if (key.spaceId) {
+					entityValues = entityValues.filter((v) => v.spaceId === key.spaceId)
+				}
+
+				// Apply value filter
+				if (key.filter?.property) {
+					entityValues = entityValues.filter((v) => v.propertyId === key.filter?.property)
+				}
+
+				return entityValues
+			})
+		}
+
+		return Effect.runPromise(
+			Effect.promise(batch).pipe(
+				Effect.withSpan("entityValuesLoader"),
+				Effect.annotateSpans({keys, batchLength: keys.length}),
+			),
+		)
+	},
+	{
+		cacheKeyFn: (key) => `${key.entityId}:${key.spaceId || "null"}:${JSON.stringify(key.filter) || "null"}`,
+	},
+)
+
+const entityRelationsLoader = new DataLoader(
+	(
+		keys: readonly {
+			entityId: string
+			spaceId?: string | null
+			filter?: RelationFilter | null
+		}[],
+	) => {
+		const batch = async () => {
+			const entityIds = keys.map((k) => k.entityId)
+			const allRelations = await db.query.relations.findMany({
+				where: (relations, {inArray}) => inArray(relations.fromEntityId, entityIds),
+			})
+
+			const relationsByEntity = new Map<string, (typeof allRelations)[number][]>()
+			for (const relation of allRelations) {
+				if (!relationsByEntity.has(relation.fromEntityId)) {
+					relationsByEntity.set(relation.fromEntityId, [])
+				}
+				relationsByEntity.get(relation.fromEntityId)?.push(relation)
+			}
+
+			return keys.map((key) => {
+				let entityRelations = relationsByEntity.get(key.entityId) || []
+
+				// Apply spaceId filter
+				if (key.spaceId) {
+					entityRelations = entityRelations.filter((r) => r.spaceId === key.spaceId)
+				}
+
+				// Apply relation filters
+				if (key.filter) {
+					if (key.filter.typeId && key.filter.typeId !== "") {
+						entityRelations = entityRelations.filter((r) => r.typeId === key.filter?.typeId)
+					}
+					if (key.filter.fromEntityId && key.filter.fromEntityId !== "") {
+						entityRelations = entityRelations.filter((r) => r.fromEntityId === key.filter?.fromEntityId)
+					}
+					if (key.filter.toEntityId && key.filter.toEntityId !== "") {
+						entityRelations = entityRelations.filter((r) => r.toEntityId === key.filter?.toEntityId)
+					}
+					if (key.filter.relationEntityId && key.filter.relationEntityId !== "") {
+						entityRelations = entityRelations.filter((r) => r.entityId === key.filter?.relationEntityId)
+					}
+				}
+
+				return entityRelations
+			})
+		}
+
+		return Effect.runPromise(
+			Effect.promise(batch).pipe(
+				Effect.withSpan("entityRelationsLoader"),
+				Effect.annotateSpans({keys, batchLength: keys.length}),
+			),
+		)
+	},
+	{
+		cacheKeyFn: (key) =>
+			`relations:${key.entityId}:${key.spaceId || "null"}:${JSON.stringify(key.filter) || "null"}`,
+	},
+)
+
+const propertiesLoader = new DataLoader((ids: readonly string[]) => {
+	const batch = async () => {
+		const properties = await db.query.properties.findMany({
+			where: (properties, {inArray}) => inArray(properties.id, ids),
+		})
+
+		const propertyMap = new Map(properties.map((p) => [p.id, p]))
+		return ids.map((id) => propertyMap.get(id) || null)
+	}
+
+	return Effect.runPromise(
+		Effect.promise(batch).pipe(
+			Effect.withSpan("propertiesLoader"),
+			Effect.annotateSpans({ids, batchLength: ids.length}),
+		),
+	)
+})
+
+const entityBacklinksLoader = new DataLoader(
+	(
+		keys: readonly {
+			entityId: string
+			spaceId?: string | null
+			filter?: RelationFilter | null
+		}[],
+	) => {
+		const batch = async () => {
+			const entityIds = keys.map((k) => k.entityId)
+			const allBacklinks = await db.query.relations.findMany({
+				where: (relations, {inArray}) => inArray(relations.toEntityId, entityIds),
+			})
+
+			const backlinksByEntity = new Map<string, (typeof allBacklinks)[number][]>()
+			for (const backlink of allBacklinks) {
+				if (!backlinksByEntity.has(backlink.toEntityId)) {
+					backlinksByEntity.set(backlink.toEntityId, [])
+				}
+				backlinksByEntity.get(backlink.toEntityId)?.push(backlink)
+			}
+
+			return keys.map((key) => {
+				let entityBacklinks = backlinksByEntity.get(key.entityId) || []
+
+				// Apply spaceId filter
+				if (key.spaceId) {
+					entityBacklinks = entityBacklinks.filter((r) => r.spaceId === key.spaceId)
+				}
+
+				// Apply relation filters
+				if (key.filter) {
+					if (key.filter.typeId && key.filter.typeId !== "") {
+						entityBacklinks = entityBacklinks.filter((r) => r.typeId === key.filter?.typeId)
+					}
+					if (key.filter.fromEntityId && key.filter.fromEntityId !== "") {
+						entityBacklinks = entityBacklinks.filter((r) => r.fromEntityId === key.filter?.fromEntityId)
+					}
+					if (key.filter.toEntityId && key.filter.toEntityId !== "") {
+						entityBacklinks = entityBacklinks.filter((r) => r.toEntityId === key.filter?.toEntityId)
+					}
+					if (key.filter.relationEntityId && key.filter.relationEntityId !== "") {
+						entityBacklinks = entityBacklinks.filter((r) => r.entityId === key.filter?.relationEntityId)
+					}
+				}
+
+				return entityBacklinks
+			})
+		}
+
+		return Effect.runPromise(
+			Effect.promise(batch).pipe(
+				Effect.withSpan("entityBacklinksLoader"),
+				Effect.annotateSpans({keys, batchLength: keys.length}),
+			),
+		)
+	},
+	{
+		cacheKeyFn: (key) =>
+			`backlinks:${key.entityId}:${key.spaceId || "null"}:${JSON.stringify(key.filter) || "null"}`,
+	},
+)

--- a/api/src/services/telemetry.ts
+++ b/api/src/services/telemetry.ts
@@ -1,6 +1,6 @@
 import {NodeSdk} from "@effect/opentelemetry"
 import {OTLPTraceExporter} from "@opentelemetry/exporter-trace-otlp-proto"
-import {BatchSpanProcessor, ConsoleSpanExporter} from "@opentelemetry/sdk-trace-base"
+import {BatchSpanProcessor} from "@opentelemetry/sdk-trace-base"
 import {Redacted} from "effect"
 import {EnvironmentLive} from "./environment"
 


### PR DESCRIPTION
Our dataloaders were redefined between resolvers, so we weren't getting batching across different revolvers. We now define the dataloaders are singletons so they are able to batch across resolvers correctly.