### PR TITLE
feat: add custom orderBy functionality for entities by property values

### DIFF
--- a/api/drizzle/0003_fine_nightcrawler.sql
+++ b/api/drizzle/0003_fine_nightcrawler.sql
@@ -331,7 +331,7 @@ COMMENT ON CONSTRAINT editors_address_space_id_pk ON EDITORS IS E'@omit';
 
 COMMENT ON TABLE ipfs_cache IS E'@omit';
 
--- Custom query function to order entities by property value
+-- Custom query function to order entities by property value  
 CREATE OR REPLACE FUNCTION entities_ordered_by_property(
   property_id uuid,
   space_id uuid DEFAULT NULL,
@@ -339,69 +339,32 @@ CREATE OR REPLACE FUNCTION entities_ordered_by_property(
   max_results integer DEFAULT 100
 )
 RETURNS SETOF entities AS $$
-  WITH entity_values AS (
-    SELECT 
-      e.id,
-      e.created_at,
-      e.created_at_block,
-      e.updated_at,
-      e.updated_at_block,
-      ROW_NUMBER() OVER (
-        PARTITION BY e.id 
-        ORDER BY 
-          CASE WHEN ascending THEN
-            CASE p.type
-              WHEN 'String' THEN v.string
-              WHEN 'Number' THEN v.number::text
-              WHEN 'Boolean' THEN v.boolean::text
-              WHEN 'Time' THEN v.time
-              WHEN 'Point' THEN v.point
-              WHEN 'Relation' THEN v.string
-              ELSE v.string
-            END
-          END ASC,
-          CASE WHEN NOT ascending THEN
-            CASE p.type
-              WHEN 'String' THEN v.string
-              WHEN 'Number' THEN v.number::text
-              WHEN 'Boolean' THEN v.boolean::text
-              WHEN 'Time' THEN v.time
-              WHEN 'Point' THEN v.point
-              WHEN 'Relation' THEN v.string
-              ELSE v.string
-            END
-          END DESC
-      ) as rn,
-      CASE p.type
-        WHEN 'String' THEN v.string
-        WHEN 'Number' THEN v.number::text
-        WHEN 'Boolean' THEN v.boolean::text
-        WHEN 'Time' THEN v.time
-        WHEN 'Point' THEN v.point
-        WHEN 'Relation' THEN v.string
-        ELSE v.string
-      END as sort_value
-    FROM entities e
-    INNER JOIN values v ON e.id = v.entity_id
+  SELECT 
+    e.id,
+    e.created_at,
+    e.created_at_block,
+    e.updated_at,
+    e.updated_at_block
+  FROM entities e
+  WHERE EXISTS (
+    SELECT 1
+    FROM values v
     INNER JOIN properties p ON v.property_id = p.id
-    WHERE v.property_id = property_id
+    WHERE v.entity_id = e.id
+      AND v.property_id = property_id
       AND (space_id IS NULL OR v.space_id = space_id)
-      AND CASE p.type
-        WHEN 'String' THEN v.string IS NOT NULL
-        WHEN 'Number' THEN v.number IS NOT NULL
-        WHEN 'Boolean' THEN v.boolean IS NOT NULL
-        WHEN 'Time' THEN v.time IS NOT NULL
-        WHEN 'Point' THEN v.point IS NOT NULL
-        WHEN 'Relation' THEN v.string IS NOT NULL
-        ELSE v.string IS NOT NULL
-      END
+      AND p.type = 'Time'
+      AND v.time IS NOT NULL
   )
-  SELECT id, created_at, created_at_block, updated_at, updated_at_block
-  FROM entity_values
-  WHERE rn = 1
-  ORDER BY 
-    CASE WHEN ascending THEN sort_value END ASC,
-    CASE WHEN NOT ascending THEN sort_value END DESC,
-    id
+  ORDER BY (
+    SELECT v.time
+    FROM values v
+    INNER JOIN properties p ON v.property_id = p.id
+    WHERE v.entity_id = e.id
+      AND v.property_id = property_id
+      AND p.type = 'Time'
+      AND v.time IS NOT NULL
+    LIMIT 1
+  ) ASC
   LIMIT max_results;
 $$ LANGUAGE sql STABLE;

--- a/api/drizzle/0003_fine_nightcrawler.sql
+++ b/api/drizzle/0003_fine_nightcrawler.sql
@@ -330,3 +330,78 @@ COMMENT ON CONSTRAINT members_address_space_id_pk ON MEMBERS IS E'@omit';
 COMMENT ON CONSTRAINT editors_address_space_id_pk ON EDITORS IS E'@omit';
 
 COMMENT ON TABLE ipfs_cache IS E'@omit';
+
+-- Custom query function to order entities by property value
+CREATE OR REPLACE FUNCTION entities_ordered_by_property(
+  property_id uuid,
+  space_id uuid DEFAULT NULL,
+  ascending boolean DEFAULT true,
+  max_results integer DEFAULT 100
+)
+RETURNS SETOF entities AS $$
+  WITH entity_values AS (
+    SELECT 
+      e.id,
+      e.created_at,
+      e.created_at_block,
+      e.updated_at,
+      e.updated_at_block,
+      ROW_NUMBER() OVER (
+        PARTITION BY e.id 
+        ORDER BY 
+          CASE WHEN ascending THEN
+            CASE p.type
+              WHEN 'String' THEN v.string
+              WHEN 'Number' THEN v.number::text
+              WHEN 'Boolean' THEN v.boolean::text
+              WHEN 'Time' THEN v.time
+              WHEN 'Point' THEN v.point
+              WHEN 'Relation' THEN v.string
+              ELSE v.string
+            END
+          END ASC,
+          CASE WHEN NOT ascending THEN
+            CASE p.type
+              WHEN 'String' THEN v.string
+              WHEN 'Number' THEN v.number::text
+              WHEN 'Boolean' THEN v.boolean::text
+              WHEN 'Time' THEN v.time
+              WHEN 'Point' THEN v.point
+              WHEN 'Relation' THEN v.string
+              ELSE v.string
+            END
+          END DESC
+      ) as rn,
+      CASE p.type
+        WHEN 'String' THEN v.string
+        WHEN 'Number' THEN v.number::text
+        WHEN 'Boolean' THEN v.boolean::text
+        WHEN 'Time' THEN v.time
+        WHEN 'Point' THEN v.point
+        WHEN 'Relation' THEN v.string
+        ELSE v.string
+      END as sort_value
+    FROM entities e
+    INNER JOIN values v ON e.id = v.entity_id
+    INNER JOIN properties p ON v.property_id = p.id
+    WHERE v.property_id = property_id
+      AND (space_id IS NULL OR v.space_id = space_id)
+      AND CASE p.type
+        WHEN 'String' THEN v.string IS NOT NULL
+        WHEN 'Number' THEN v.number IS NOT NULL
+        WHEN 'Boolean' THEN v.boolean IS NOT NULL
+        WHEN 'Time' THEN v.time IS NOT NULL
+        WHEN 'Point' THEN v.point IS NOT NULL
+        WHEN 'Relation' THEN v.string IS NOT NULL
+        ELSE v.string IS NOT NULL
+      END
+  )
+  SELECT id, created_at, created_at_block, updated_at, updated_at_block
+  FROM entity_values
+  WHERE rn = 1
+  ORDER BY 
+    CASE WHEN ascending THEN sort_value END ASC,
+    CASE WHEN NOT ascending THEN sort_value END DESC,
+    id
+  LIMIT max_results;
+$$ LANGUAGE sql STABLE;

--- a/api/drizzle/0003_fine_nightcrawler.sql
+++ b/api/drizzle/0003_fine_nightcrawler.sql
@@ -335,36 +335,51 @@ COMMENT ON TABLE ipfs_cache IS E'@omit';
 CREATE OR REPLACE FUNCTION entities_ordered_by_property(
   property_id uuid,
   space_id uuid DEFAULT NULL,
-  ascending boolean DEFAULT true,
-  max_results integer DEFAULT 100
+  ascending boolean DEFAULT true
 )
 RETURNS SETOF entities AS $$
-  SELECT 
-    e.id,
-    e.created_at,
-    e.created_at_block,
-    e.updated_at,
-    e.updated_at_block
-  FROM entities e
-  WHERE EXISTS (
-    SELECT 1
-    FROM values v
+  WITH filtered_entities AS (
+    SELECT DISTINCT
+      e.id,
+      e.created_at,
+      e.created_at_block,
+      e.updated_at,
+      e.updated_at_block,
+      p.type as property_type,
+      v.string,
+      v.number,
+      v.boolean,
+      v.time,
+      v.point
+    FROM entities e
+    INNER JOIN values v ON v.entity_id = e.id
     INNER JOIN properties p ON v.property_id = p.id
-    WHERE v.entity_id = e.id
-      AND v.property_id = property_id
-      AND (space_id IS NULL OR v.space_id = space_id)
-      AND p.type = 'Time'
-      AND v.time IS NOT NULL
+    WHERE v.property_id = entities_ordered_by_property.property_id
+      AND (entities_ordered_by_property.space_id IS NULL OR v.space_id = entities_ordered_by_property.space_id)
+      AND (
+        (p.type = 'String' AND v.string IS NOT NULL AND trim(v.string) != '') OR
+        (p.type = 'Number' AND v.number IS NOT NULL) OR
+        (p.type = 'Boolean' AND v.boolean IS NOT NULL) OR
+        (p.type = 'Time' AND v.time IS NOT NULL AND trim(v.time) != '') OR
+        (p.type = 'Point' AND v.point IS NOT NULL AND trim(v.point) != '') OR
+        (p.type = 'Relation' AND v.string IS NOT NULL AND trim(v.string) != '')
+      )
   )
-  ORDER BY (
-    SELECT v.time
-    FROM values v
-    INNER JOIN properties p ON v.property_id = p.id
-    WHERE v.entity_id = e.id
-      AND v.property_id = property_id
-      AND p.type = 'Time'
-      AND v.time IS NOT NULL
-    LIMIT 1
-  ) ASC
-  LIMIT max_results;
+  SELECT 
+    id,
+    created_at,
+    created_at_block,
+    updated_at,
+    updated_at_block
+  FROM filtered_entities
+  ORDER BY 
+    CASE 
+      WHEN property_type = 'String' THEN string
+      WHEN property_type = 'Number' THEN number::text
+      WHEN property_type = 'Boolean' THEN boolean::text
+      WHEN property_type = 'Time' THEN time
+      WHEN property_type = 'Point' THEN point
+      WHEN property_type = 'Relation' THEN string
+      ELSE string
+    END ASC;
 $$ LANGUAGE sql STABLE;

--- a/api/drizzle/0003_fine_nightcrawler.sql
+++ b/api/drizzle/0003_fine_nightcrawler.sql
@@ -331,11 +331,14 @@ COMMENT ON CONSTRAINT editors_address_space_id_pk ON EDITORS IS E'@omit';
 
 COMMENT ON TABLE ipfs_cache IS E'@omit';
 
+-- Create enum for sort order
+CREATE TYPE sort_order AS ENUM ('ASC', 'DESC');
+
 -- Custom query function to order entities by property value  
 CREATE OR REPLACE FUNCTION entities_ordered_by_property(
   property_id uuid,
   space_id uuid DEFAULT NULL,
-  ascending boolean DEFAULT true
+  sort_direction sort_order DEFAULT 'ASC'
 )
 RETURNS SETOF entities AS $$
   WITH filtered_entities AS (
@@ -362,7 +365,7 @@ RETURNS SETOF entities AS $$
         (p.type = 'Boolean' AND v.boolean IS NOT NULL) OR
         (p.type = 'Time' AND v.time IS NOT NULL AND trim(v.time) != '') OR
         (p.type = 'Point' AND v.point IS NOT NULL AND trim(v.point) != '') OR
-        (p.type = 'Relation' AND v.string IS NOT NULL AND trim(v.string) != '')
+        (p.type = 'Relation' AND FALSE)
       )
   )
   SELECT 
@@ -373,13 +376,22 @@ RETURNS SETOF entities AS $$
     updated_at_block
   FROM filtered_entities
   ORDER BY 
-    CASE 
-      WHEN property_type = 'String' THEN string
-      WHEN property_type = 'Number' THEN number::text
-      WHEN property_type = 'Boolean' THEN boolean::text
-      WHEN property_type = 'Time' THEN time
-      WHEN property_type = 'Point' THEN point
-      WHEN property_type = 'Relation' THEN string
-      ELSE string
-    END ASC;
+    CASE WHEN sort_direction = 'ASC' THEN
+      CASE 
+        WHEN property_type = 'String' THEN string
+        WHEN property_type = 'Number' THEN number::text
+        WHEN property_type = 'Boolean' THEN boolean::text
+        WHEN property_type = 'Time' THEN time
+        WHEN property_type = 'Point' THEN point
+      END
+    END ASC,
+    CASE WHEN sort_direction = 'DESC' THEN
+      CASE 
+        WHEN property_type = 'String' THEN string
+        WHEN property_type = 'Number' THEN number::text
+        WHEN property_type = 'Boolean' THEN boolean::text
+        WHEN property_type = 'Time' THEN time
+        WHEN property_type = 'Point' THEN point
+      END
+    END DESC;
 $$ LANGUAGE sql STABLE;

--- a/api/drizzle/0003_fine_nightcrawler.sql
+++ b/api/drizzle/0003_fine_nightcrawler.sql
@@ -331,8 +331,13 @@ COMMENT ON CONSTRAINT editors_address_space_id_pk ON EDITORS IS E'@omit';
 
 COMMENT ON TABLE ipfs_cache IS E'@omit';
 
--- Create enum for sort order
-CREATE TYPE sort_order AS ENUM ('ASC', 'DESC');
+-- Create enum for sort order if it doesn't exist
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'sort_order') THEN
+        CREATE TYPE sort_order AS ENUM ('ASC', 'DESC');
+    END IF;
+END $$;
 
 -- Custom query function to order entities by property value  
 CREATE OR REPLACE FUNCTION entities_ordered_by_property(


### PR DESCRIPTION
## Summary

Implements custom orderBy functionality for PostGraphile to order entities based on property values in the knowledge graph system.

- Added `entities_ordered_by_property` stored procedure that orders entities by any property ID
- Supports all data types except Relations: String, Number, Boolean, Time, Point
- Includes space filtering capability
- Uses type-safe enum for sort direction (ASC/DESC) instead of boolean
- Properly filters out null, empty, and whitespace-only values
- Handles different data type columns appropriately

## Key Features

- **Generic property ordering**: Works with any property ID across all supported data types
- **Space filtering**: Optional parameter to filter results by space
- **Type-safe sorting**: Uses `sort_order` enum ('ASC', 'DESC') for better API design
- **Robust filtering**: Excludes null, empty strings, and whitespace-only values
- **PostGraphile integration**: Automatically appears as `entitiesOrderedByProperty` in GraphQL schema

## Technical Implementation

- Created `sort_order` enum with conditional creation to avoid conflicts
- Implemented CTE-based approach for clear entity filtering and ordering
- Used dynamic ORDER BY with CASE statements for different data types
- Properly handles PostgreSQL's type system for each property data type

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>