### PR TITLE
chore: remove wire/src/main.rs

### DIFF
--- a/wire/src/main.rs
+++ b/wire/src/main.rs
@@ -1,5 +1,0 @@
-mod compression;
-
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
## Summary
- Removing unused main.rs file from wire module