### PR TITLE
feat: initialize properties cache from database on startup

### DIFF
--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -243,7 +243,7 @@ async fn main() -> Result<(), IndexingError> {
     match storage {
         Ok(result) => {
             let cache = PostgresCache::new().await?;
-            let properties_cache = PropertiesCache::new();
+            let properties_cache = PropertiesCache::from_storage(&result).await?;
             
             let indexer = KgIndexer::new(result, cache, properties_cache);
 


### PR DESCRIPTION
## Summary
Previously we would not hydrate the properties cache with properties from the database on service startup. This meant that any service restarts (for errors or for new deployments) would initialize with an empty cache. Any new values would then fail validation because the property did not exist in the cache.

- Add `PropertiesCache::from_storage()` method to initialize cache from existing database properties
- Add `PostgresStorage::get_all_properties()` method to fetch all properties from database  
- Update main.rs to use database initialization instead of starting with empty cache
- Add comprehensive integration test covering all data types and edge cases

## Test Coverage
- New integration test `test_properties_cache_initialization_from_database` validates:
  - All 6 data types (String, Number, Boolean, Time, Point, Relation) are loaded correctly
  - Cache behaves properly for both existing and non-existent properties  
  - Empty database scenario works correctly
  - Database-to-cache consistency is maintained