### PR TITLE
chore: fix local dev Dockerfiles and docker-compose

### DIFF
--- a/atlas/Dockerfile
+++ b/atlas/Dockerfile
@@ -12,10 +12,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-# Copy workspace Cargo files
-COPY Cargo.toml Cargo.lock ./
-
-# Copy all required crates for atlas
+# Copy only required crates (no workspace Cargo.toml - build standalone)
 COPY atlas ./atlas
 COPY hermes-relay ./hermes-relay
 COPY hermes-schema ./hermes-schema
@@ -23,7 +20,7 @@ COPY hermes-substream ./hermes-substream
 COPY stream ./stream
 COPY wire ./wire
 
-# Build from the atlas directory
+# Build from the crate directory (standalone, not as workspace member)
 WORKDIR /app/atlas
 RUN cargo build --release
 

--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -204,7 +204,7 @@ Computes the canonical graph from space topology events.
 
 Pre-populates resolved IPFS contents ahead of time so the edits transformer doesn't block on network I/O.
 
-**Location:** `cache/`
+**Location:** `hermes-ipfs-cache/`
 
 **How it works:**
 1. Connects to hermes-substream `map_edits_published` (parallelized, runs ahead)
@@ -298,9 +298,10 @@ NON-CANONICAL (isolated islands):
 
 | Topic | Producer | Message Type | Description |
 |-------|----------|--------------|-------------|
-| `spaces` | spaces | HermesCreateSpace | Space creation and relationship changes |
-| `edits` | edits | HermesEdit | Resolved knowledge graph edits |
-| `topology` | topology | CanonicalGraphUpdated | Canonical graph updates |
+| `space.creations` | hermes-processor | HermesCreateSpace | Space creation events |
+| `space.trust.extensions` | hermes-processor | HermesSpaceTrustExtension | Trust extension events (verified, related, subtopic) |
+| `knowledge.edits` | hermes-processor | HermesEdit | Resolved knowledge graph edits |
+| `topology.canonical` | atlas | CanonicalGraphUpdated | Canonical graph updates |
 | `governance` | (future) | (TBD) | Proposals, voting, membership |
 | `curation` | (future) | (TBD) | Ranking, voting on entities |
 
@@ -311,10 +312,11 @@ gaia/
 ├── hermes-substream/    # Substream: decodes Space Registry events (excluded from workspace)
 ├── hermes-relay/        # Library: connects to substream, provides typed event stream
 ├── hermes-schema/       # Library: Kafka output protobuf definitions
-├── hermes-processor/    # Binary: main processor (TBD)
-├── cache/               # Service: IPFS content pre-fetcher
+├── hermes-processor/    # Binary: processes mock events, publishes to Kafka (spaces, edits)
+├── hermes-spaces/       # Binary: spaces transformer (uses hermes-relay)
+├── hermes-ipfs-cache/   # Service: IPFS content pre-fetcher
 ├── mock-substream/      # Library: test event generation
-└── atlas/               # Library: canonical graph computation
+└── atlas/               # Binary: canonical graph computation, publishes to Kafka
 ```
 
 Each binary depends on `hermes-relay` for data source access and `hermes-schema` for output types.
@@ -371,17 +373,20 @@ Each binary depends on `hermes-relay` for data source access and `hermes-schema`
 Each transformer runs as an independent service:
 
 ```bash
-# Local development
+# Local development (from hermes/ directory)
+cd hermes
 docker-compose up
 
 # Starts:
 # - Kafka broker (localhost:9092)
 # - Kafka UI (http://localhost:8080)
-# - spaces transformer
-# - edits transformer
-# - topology transformer
-# - IPFS cache service
+# - hermes-spaces transformer
+# - atlas (topology transformer)
+# - hermes-ipfs-cache service
+# - PostgreSQL (for IPFS cache)
 ```
+
+All services run with mock data by default, processing a deterministic test topology and publishing to Kafka topics.
 
 ### Independent Operations
 

--- a/hermes-ipfs-cache/Dockerfile
+++ b/hermes-ipfs-cache/Dockerfile
@@ -11,10 +11,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-# Copy workspace files
-COPY Cargo.toml Cargo.lock ./
-
-# Copy workspace dependencies
+# Copy only required crates (no workspace Cargo.toml - build standalone)
 COPY hermes-ipfs-cache ./hermes-ipfs-cache
 COPY hermes-relay ./hermes-relay
 COPY hermes-substream ./hermes-substream
@@ -22,8 +19,9 @@ COPY stream ./stream
 COPY wire ./wire
 COPY ipfs ./ipfs
 
-# Build
-RUN cargo build --release -p hermes-ipfs-cache
+# Build from the crate directory (standalone, not as workspace member)
+WORKDIR /app/hermes-ipfs-cache
+RUN cargo build --release
 
 FROM debian:bookworm-slim
 
@@ -31,6 +29,6 @@ RUN apt-get update && \
     apt-get install -y ca-certificates libssl3 && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/target/release/hermes-ipfs-cache /usr/local/bin/hermes-ipfs-cache
+COPY --from=builder /app/hermes-ipfs-cache/target/release/hermes-ipfs-cache /usr/local/bin/hermes-ipfs-cache
 
 CMD ["hermes-ipfs-cache"]

--- a/hermes-spaces/Dockerfile
+++ b/hermes-spaces/Dockerfile
@@ -12,21 +12,18 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-# Copy workspace configuration
-COPY Cargo.toml Cargo.lock ./
-
-# Copy all required crates
+# Copy only required crates (no workspace Cargo.toml - build standalone)
 COPY hermes-spaces ./hermes-spaces
 COPY hermes-relay ./hermes-relay
+COPY hermes-kafka ./hermes-kafka
 COPY hermes-schema ./hermes-schema
+COPY hermes-substream ./hermes-substream
 COPY stream ./stream
 COPY wire ./wire
 
-# Copy the substream package file
-COPY hermes-substream/hermes-substream.spkg ./hermes-substream.spkg
-
-# Build from the workspace root
-RUN cargo build --release --package hermes-spaces
+# Build from the crate directory (standalone, not as workspace member)
+WORKDIR /app/hermes-spaces
+RUN cargo build --release
 
 FROM debian:bookworm-slim
 
@@ -34,10 +31,7 @@ RUN apt-get update && \
     apt-get install -y ca-certificates libssl3 && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/target/release/hermes-spaces /usr/local/bin/hermes-spaces
-COPY --from=builder /app/hermes-substream.spkg /app/hermes-substream.spkg
-
-WORKDIR /app
+COPY --from=builder /app/hermes-spaces/target/release/hermes-spaces /usr/local/bin/hermes-spaces
 
 # Default environment variables
 ENV KAFKA_BROKER=kafka-broker-0.broker.kafka.svc.cluster.local:29092

--- a/hermes/docker-compose.yaml
+++ b/hermes/docker-compose.yaml
@@ -68,10 +68,10 @@ services:
       kafka:
         condition: service_healthy
 
-  hermes-processor:
+  hermes-spaces:
     build:
       context: ..
-      dockerfile: hermes-processor/Dockerfile
+      dockerfile: hermes-spaces/Dockerfile
     environment:
       KAFKA_BROKER: kafka:29092
     depends_on:


### PR DESCRIPTION
## Summary

- Fix Dockerfiles to build standalone without workspace `Cargo.toml` (prevents build failures when workspace members change)
- Replace `hermes-processor` with `hermes-spaces` in docker-compose
- Update `docs/hermes-architecture.md` to reflect actual crate structure, topic names, and deployment

## Local Development

```bash
cd hermes
docker-compose up
```

Starts:
- Kafka broker (localhost:9092)
- Kafka UI (http://localhost:8080)
- `hermes-spaces` transformer
- `atlas` (topology transformer)
- `hermes-ipfs-cache` service
- PostgreSQL (for IPFS cache)

All services run with mock data by default.