### PR TITLE
fix: return userVote in proposal list endpoint

### DIFF
--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -1,5 +1,5 @@
 import SimplifyInflectionPlugin from "@graphile-contrib/pg-simplify-inflector"
-import {useResponseCache} from "@graphql-yoga/plugin-response-cache"
+import {createInMemoryCache, useResponseCache} from "@graphql-yoga/plugin-response-cache"
 import {createYoga, useExecutionCancellation} from "graphql-yoga"
 import {Pool} from "pg"
 import {createPostGraphileSchema, withPostGraphileContext} from "postgraphile"
@@ -37,7 +37,7 @@ const pgPool = new Pool({
 
 // Base PostGraphile options (without uuidScalarPlugin)
 const postgraphileOptions = {
-	watchPg: true,
+	watchPg: false,
 	graphiql: true,
 	enhanceGraphiql: true,
 	dynamicJson: true,
@@ -108,6 +108,7 @@ const sharedPlugins = [
 	useResponseCache({
 		session: () => null,
 		ttl: 10_000, // 10 seconds
+		cache: createInMemoryCache({max: 1024}),
 	}),
 	useGraphQLInstrumentation(),
 ]

--- a/api/src/proposals/queries.ts
+++ b/api/src/proposals/queries.ts
@@ -4,22 +4,22 @@
  * Uses Effect for error handling and tracing.
  */
 
-import {sql} from "drizzle-orm"
-import type {NodePgDatabase} from "drizzle-orm/node-postgres"
-import {Data, Effect} from "effect"
+import { sql } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Data, Effect } from "effect";
 import {
-	type ProposalAction,
-	type ProposalActionType,
-	type ProposalStatus,
-	type ProposalWithVotes,
-	RATIO_BASE,
-	VOTE_OPTIONS,
-	type Vote,
-	type VoteOption,
-	type VotingMode,
-} from "./types"
+  type ProposalAction,
+  type ProposalActionType,
+  type ProposalStatus,
+  type ProposalWithVotes,
+  RATIO_BASE,
+  VOTE_OPTIONS,
+  type Vote,
+  type VoteOption,
+  type VotingMode,
+} from "./types";
 
-type Database = NodePgDatabase<Record<string, unknown>>
+type Database = NodePgDatabase<Record<string, unknown>>;
 
 // =============================================================================
 // Shared Types and Mappers
@@ -27,97 +27,102 @@ type Database = NodePgDatabase<Record<string, unknown>>
 
 /** Raw action row from JSON aggregation */
 interface ActionJsonRow {
-	action_type: string
-	target_id: string | null
-	content_uri: string | null
-	content_id: string | null
-	quorum: number | null
-	fast_threshold: number | null
-	slow_threshold: number | null
-	duration: number | null
+  action_type: string;
+  target_id: string | null;
+  content_uri: string | null;
+  content_id: string | null;
+  quorum: number | null;
+  fast_threshold: number | null;
+  slow_threshold: number | null;
+  duration: number | null;
 }
 
 /** Raw vote row from JSON aggregation */
 interface VoteJsonRow {
-	voter_id: string
-	vote: string
+  voter_id: string;
+  vote: string;
 }
 
 /** Base proposal row fields shared between queries */
 interface BaseProposalRow extends Record<string, unknown> {
-	id: string
-	space_id: string
-	name: string | null
-	proposed_by: string
-	voting_mode: "Fast" | "Slow"
-	start_time: string
-	end_time: string
-	quorum: string
-	threshold: string
-	executed_at: string | null
-	yes_count: string
-	no_count: string
-	abstain_count: string
-	actions_json: ActionJsonRow[] | null
+  id: string;
+  space_id: string;
+  name: string | null;
+  proposed_by: string;
+  voting_mode: "Fast" | "Slow";
+  start_time: string;
+  end_time: string;
+  quorum: string;
+  threshold: string;
+  executed_at: string | null;
+  yes_count: string;
+  no_count: string;
+  abstain_count: string;
+  actions_json: ActionJsonRow[] | null;
 }
 
 /**
  * Maps raw action JSON to domain ProposalAction.
  */
-function mapActionsFromJson(actionsJson: ActionJsonRow[] | null): ProposalAction[] {
-	return (actionsJson ?? []).map((a) => ({
-		actionType: a.action_type as ProposalActionType,
-		targetId: a.target_id,
-		contentUri: a.content_uri,
-		contentId: a.content_id,
-		quorum: a.quorum,
-		fastThreshold: a.fast_threshold,
-		slowThreshold: a.slow_threshold,
-		duration: a.duration,
-	}))
+function mapActionsFromJson(
+  actionsJson: ActionJsonRow[] | null,
+): ProposalAction[] {
+  return (actionsJson ?? []).map((a) => ({
+    actionType: a.action_type as ProposalActionType,
+    targetId: a.target_id,
+    contentUri: a.content_uri,
+    contentId: a.content_id,
+    quorum: a.quorum,
+    fastThreshold: a.fast_threshold,
+    slowThreshold: a.slow_threshold,
+    duration: a.duration,
+  }));
 }
 
 /**
  * Maps raw vote JSON to domain Vote, filtering invalid values.
  */
 function mapVotesFromJson(votesJson: VoteJsonRow[] | null): Vote[] {
-	return (votesJson ?? [])
-		.map((v) => {
-			const voteUpper = v.vote.toUpperCase()
-			if (!VOTE_OPTIONS.includes(voteUpper as VoteOption)) {
-				// Skip invalid votes rather than crash or pass bad data
-				return null
-			}
-			return {
-				voterId: v.voter_id,
-				vote: voteUpper as VoteOption,
-			}
-		})
-		.filter((v): v is Vote => v !== null)
+  return (votesJson ?? [])
+    .map((v) => {
+      const voteUpper = v.vote.toUpperCase();
+      if (!VOTE_OPTIONS.includes(voteUpper as VoteOption)) {
+        // Skip invalid votes rather than crash or pass bad data
+        return null;
+      }
+      return {
+        voterId: v.voter_id,
+        vote: voteUpper as VoteOption,
+      };
+    })
+    .filter((v): v is Vote => v !== null);
 }
 
 /**
  * Maps base proposal row fields to domain ProposalWithVotes.
  * Votes array must be provided separately (empty for list, populated for single).
  */
-function mapRowToProposal(row: BaseProposalRow, votes: Vote[]): ProposalWithVotes {
-	return {
-		id: row.id,
-		spaceId: row.space_id,
-		name: row.name,
-		proposedBy: row.proposed_by,
-		votingMode: row.voting_mode as VotingMode,
-		startTime: BigInt(row.start_time),
-		endTime: BigInt(row.end_time),
-		quorum: BigInt(row.quorum),
-		threshold: BigInt(row.threshold),
-		executedAt: row.executed_at ? BigInt(row.executed_at) : null,
-		yesCount: BigInt(row.yes_count),
-		noCount: BigInt(row.no_count),
-		abstainCount: BigInt(row.abstain_count),
-		votes,
-		actions: mapActionsFromJson(row.actions_json),
-	}
+function mapRowToProposal(
+  row: BaseProposalRow,
+  votes: Vote[],
+): ProposalWithVotes {
+  return {
+    id: row.id,
+    spaceId: row.space_id,
+    name: row.name,
+    proposedBy: row.proposed_by,
+    votingMode: row.voting_mode as VotingMode,
+    startTime: BigInt(row.start_time),
+    endTime: BigInt(row.end_time),
+    quorum: BigInt(row.quorum),
+    threshold: BigInt(row.threshold),
+    executedAt: row.executed_at ? BigInt(row.executed_at) : null,
+    yesCount: BigInt(row.yes_count),
+    noCount: BigInt(row.no_count),
+    abstainCount: BigInt(row.abstain_count),
+    votes,
+    actions: mapActionsFromJson(row.actions_json),
+  };
 }
 
 // =============================================================================
@@ -129,12 +134,12 @@ function mapRowToProposal(row: BaseProposalRow, votes: Vote[]): ProposalWithVote
  * Using Data.TaggedError for exhaustive pattern matching with Effect.
  */
 export class QueryError extends Data.TaggedError("QueryError")<{
-	readonly operation: string
-	readonly cause: Error
+  readonly operation: string;
+  readonly cause: Error;
 }> {
-	get message(): string {
-		return this.cause.message
-	}
+  get message(): string {
+    return this.cause.message;
+  }
 }
 
 /**
@@ -146,15 +151,17 @@ export class QueryError extends Data.TaggedError("QueryError")<{
  * @returns The proposal with vote counts, votes, and actions, or null if not found
  */
 export function getProposalWithVotes(
-	db: Database,
-	proposalId: string,
+  db: Database,
+  proposalId: string,
 ): Effect.Effect<ProposalWithVotes | null, QueryError> {
-	return Effect.tryPromise({
-		try: async () => {
-			// PostgreSQL returns bigint columns as strings to preserve precision
-			// Use JSON aggregation to get votes and actions in a single query
-			// Vote counts use denormalized columns; individual votes fetched via LATERAL
-			const result = await db.execute<BaseProposalRow & {votes_json: VoteJsonRow[] | null}>(sql`
+  return Effect.tryPromise({
+    try: async () => {
+      // PostgreSQL returns bigint columns as strings to preserve precision
+      // Use JSON aggregation to get votes and actions in a single query
+      // Vote counts use denormalized columns; individual votes fetched via LATERAL
+      const result = await db.execute<
+        BaseProposalRow & { votes_json: VoteJsonRow[] | null }
+      >(sql`
         SELECT 
           p.id,
           p.space_id,
@@ -195,60 +202,66 @@ export function getProposalWithVotes(
           WHERE proposal_id = p.id
         ) a ON true
         WHERE p.id = ${proposalId}::uuid
-      `)
+      `);
 
-			const row = result.rows[0]
-			if (!row) return null
+      const row = result.rows[0];
+      if (!row) return null;
 
-			const votes = mapVotesFromJson(row.votes_json)
-			return mapRowToProposal(row, votes)
-		},
-		catch: (error) =>
-			new QueryError({
-				operation: "getProposalWithVotes",
-				cause: error as Error,
-			}),
-	}).pipe(
-		Effect.withSpan("queries.getProposalWithVotes", {
-			attributes: {"query.proposal_id": proposalId},
-		}),
-	)
+      const votes = mapVotesFromJson(row.votes_json);
+      return mapRowToProposal(row, votes);
+    },
+    catch: (error) =>
+      new QueryError({
+        operation: "getProposalWithVotes",
+        cause: error as Error,
+      }),
+  }).pipe(
+    Effect.withSpan("queries.getProposalWithVotes", {
+      attributes: { "query.proposal_id": proposalId },
+    }),
+  );
 }
 
 /**
  * Sort order options for listing proposals.
  */
-export const PROPOSAL_ORDER_BY = ["created_at", "end_time", "start_time"] as const
-export type ProposalOrderBy = (typeof PROPOSAL_ORDER_BY)[number]
+export const PROPOSAL_ORDER_BY = [
+  "created_at",
+  "end_time",
+  "start_time",
+] as const;
+export type ProposalOrderBy = (typeof PROPOSAL_ORDER_BY)[number];
 
-export const PROPOSAL_ORDER_DIRECTION = ["asc", "desc"] as const
-export type ProposalOrderDirection = (typeof PROPOSAL_ORDER_DIRECTION)[number]
+export const PROPOSAL_ORDER_DIRECTION = ["asc", "desc"] as const;
+export type ProposalOrderDirection = (typeof PROPOSAL_ORDER_DIRECTION)[number];
 
 /**
  * Options for listing proposals in a space.
  */
 export interface ListProposalsOptions {
-	spaceId: string
-	limit: number
-	cursor?: string
-	/** Include only proposals with these action types */
-	actionTypes?: ProposalActionType[]
-	/** Exclude proposals with these action types */
-	excludeActionTypes?: ProposalActionType[]
-	/** Filter by computed proposal status */
-	status?: ProposalStatus[]
-	/** Field to order by (default: created_at) */
-	orderBy?: ProposalOrderBy
-	/** Sort direction (default: desc) */
-	orderDirection?: ProposalOrderDirection
+  spaceId: string;
+  limit: number;
+  cursor?: string;
+  /** Include only proposals with these action types */
+  actionTypes?: ProposalActionType[];
+  /** Exclude proposals with these action types */
+  excludeActionTypes?: ProposalActionType[];
+  /** Filter by computed proposal status */
+  status?: ProposalStatus[];
+  /** Field to order by (default: created_at) */
+  orderBy?: ProposalOrderBy;
+  /** Sort direction (default: desc) */
+  orderDirection?: ProposalOrderDirection;
+  /** Voter ID to look up the user's vote on each proposal */
+  voterId?: string;
 }
 
 /**
  * Result of listing proposals with cursor for pagination.
  */
 export interface ListProposalsResult {
-	proposals: ProposalWithVotes[]
-	nextCursor: string | null
+  proposals: ProposalWithVotes[];
+  nextCursor: string | null;
 }
 
 /**
@@ -262,64 +275,68 @@ export interface ListProposalsResult {
  * Returns the appropriate SQL fragment for ordering.
  */
 function buildOrderClause(
-	orderBy: ProposalOrderBy = "created_at",
-	orderDirection: ProposalOrderDirection = "desc",
+  orderBy: ProposalOrderBy = "created_at",
+  orderDirection: ProposalOrderDirection = "desc",
 ): ReturnType<typeof sql> {
-	// Map orderBy to actual column and build ORDER BY
-	// Using explicit branches to avoid SQL injection - we control the column names
-	if (orderDirection === "asc") {
-		switch (orderBy) {
-			case "end_time":
-				return sql`ORDER BY p.end_time ASC, p.id ASC`
-			case "start_time":
-				return sql`ORDER BY p.start_time ASC, p.id ASC`
-			case "created_at":
-			default:
-				return sql`ORDER BY p.created_at ASC, p.id ASC`
-		}
-	} else {
-		switch (orderBy) {
-			case "end_time":
-				return sql`ORDER BY p.end_time DESC, p.id DESC`
-			case "start_time":
-				return sql`ORDER BY p.start_time DESC, p.id DESC`
-			case "created_at":
-			default:
-				return sql`ORDER BY p.created_at DESC, p.id DESC`
-		}
-	}
+  // Map orderBy to actual column and build ORDER BY
+  // Using explicit branches to avoid SQL injection - we control the column names
+  if (orderDirection === "asc") {
+    switch (orderBy) {
+      case "end_time":
+        return sql`ORDER BY p.end_time ASC, p.id ASC`;
+      case "start_time":
+        return sql`ORDER BY p.start_time ASC, p.id ASC`;
+      case "created_at":
+      default:
+        return sql`ORDER BY p.created_at ASC, p.id ASC`;
+    }
+  } else {
+    switch (orderBy) {
+      case "end_time":
+        return sql`ORDER BY p.end_time DESC, p.id DESC`;
+      case "start_time":
+        return sql`ORDER BY p.start_time DESC, p.id DESC`;
+      case "created_at":
+      default:
+        return sql`ORDER BY p.created_at DESC, p.id DESC`;
+    }
+  }
 }
 
 /** UUID pattern for cursor validation */
-const UUID_PATTERN = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
 
 /** Numeric pattern for bigint cursor values */
-const BIGINT_PATTERN = /^-?\d+$/
+const BIGINT_PATTERN = /^-?\d+$/;
 
 /**
  * Validates the cursor format and returns parsed components.
  * Returns null if cursor is invalid.
  */
-function parseCursor(cursor: string, orderBy: ProposalOrderBy): {orderValue: string; cursorId: string} | null {
-	const parts = cursor.split("|")
-	if (parts.length !== 2) return null
+function parseCursor(
+  cursor: string,
+  orderBy: ProposalOrderBy,
+): { orderValue: string; cursorId: string } | null {
+  const parts = cursor.split("|");
+  if (parts.length !== 2) return null;
 
-	const [orderValue, cursorId] = parts
-	if (!orderValue || !cursorId) return null
+  const [orderValue, cursorId] = parts;
+  if (!orderValue || !cursorId) return null;
 
-	// Validate cursorId is a valid UUID
-	if (!UUID_PATTERN.test(cursorId)) return null
+  // Validate cursorId is a valid UUID
+  if (!UUID_PATTERN.test(cursorId)) return null;
 
-	// Validate orderValue format based on orderBy type
-	if (orderBy === "created_at") {
-		// Should be ISO timestamp - basic format check
-		if (!/^\d{4}-\d{2}-\d{2}/.test(orderValue)) return null
-	} else {
-		// Should be bigint for end_time/start_time
-		if (!BIGINT_PATTERN.test(orderValue)) return null
-	}
+  // Validate orderValue format based on orderBy type
+  if (orderBy === "created_at") {
+    // Should be ISO timestamp - basic format check
+    if (!/^\d{4}-\d{2}-\d{2}/.test(orderValue)) return null;
+  } else {
+    // Should be bigint for end_time/start_time
+    if (!BIGINT_PATTERN.test(orderValue)) return null;
+  }
 
-	return {orderValue, cursorId}
+  return { orderValue, cursorId };
 }
 
 /**
@@ -328,46 +345,46 @@ function parseCursor(cursor: string, orderBy: ProposalOrderBy): {orderValue: str
  * Returns empty SQL fragment if cursor is missing or invalid.
  */
 function buildCursorCondition(
-	cursor: string | undefined,
-	orderBy: ProposalOrderBy = "created_at",
-	orderDirection: ProposalOrderDirection = "desc",
+  cursor: string | undefined,
+  orderBy: ProposalOrderBy = "created_at",
+  orderDirection: ProposalOrderDirection = "desc",
 ): ReturnType<typeof sql> {
-	if (!cursor) return sql``
+  if (!cursor) return sql``;
 
-	const parsed = parseCursor(cursor, orderBy)
-	if (!parsed) {
-		// Log warning for debugging - invalid cursor format causes pagination to restart from beginning
-		console.warn(
-			`[queries] Invalid cursor format ignored, restarting pagination: cursor=${cursor}, orderBy=${orderBy}`,
-		)
-		return sql``
-	}
+  const parsed = parseCursor(cursor, orderBy);
+  if (!parsed) {
+    // Log warning for debugging - invalid cursor format causes pagination to restart from beginning
+    console.warn(
+      `[queries] Invalid cursor format ignored, restarting pagination: cursor=${cursor}, orderBy=${orderBy}`,
+    );
+    return sql``;
+  }
 
-	const {orderValue, cursorId} = parsed
+  const { orderValue, cursorId } = parsed;
 
-	// Build comparison based on direction (< for DESC, > for ASC)
-	// Using tuple comparison for stable pagination with ties
-	if (orderDirection === "asc") {
-		switch (orderBy) {
-			case "end_time":
-				return sql`AND (p.end_time, p.id) > (${orderValue}::bigint, ${cursorId}::uuid)`
-			case "start_time":
-				return sql`AND (p.start_time, p.id) > (${orderValue}::bigint, ${cursorId}::uuid)`
-			case "created_at":
-			default:
-				return sql`AND (p.created_at, p.id) > (${orderValue}::timestamptz, ${cursorId}::uuid)`
-		}
-	} else {
-		switch (orderBy) {
-			case "end_time":
-				return sql`AND (p.end_time, p.id) < (${orderValue}::bigint, ${cursorId}::uuid)`
-			case "start_time":
-				return sql`AND (p.start_time, p.id) < (${orderValue}::bigint, ${cursorId}::uuid)`
-			case "created_at":
-			default:
-				return sql`AND (p.created_at, p.id) < (${orderValue}::timestamptz, ${cursorId}::uuid)`
-		}
-	}
+  // Build comparison based on direction (< for DESC, > for ASC)
+  // Using tuple comparison for stable pagination with ties
+  if (orderDirection === "asc") {
+    switch (orderBy) {
+      case "end_time":
+        return sql`AND (p.end_time, p.id) > (${orderValue}::bigint, ${cursorId}::uuid)`;
+      case "start_time":
+        return sql`AND (p.start_time, p.id) > (${orderValue}::bigint, ${cursorId}::uuid)`;
+      case "created_at":
+      default:
+        return sql`AND (p.created_at, p.id) > (${orderValue}::timestamptz, ${cursorId}::uuid)`;
+    }
+  } else {
+    switch (orderBy) {
+      case "end_time":
+        return sql`AND (p.end_time, p.id) < (${orderValue}::bigint, ${cursorId}::uuid)`;
+      case "start_time":
+        return sql`AND (p.start_time, p.id) < (${orderValue}::bigint, ${cursorId}::uuid)`;
+      case "created_at":
+      default:
+        return sql`AND (p.created_at, p.id) < (${orderValue}::timestamptz, ${cursorId}::uuid)`;
+    }
+  }
 }
 
 /**
@@ -375,18 +392,18 @@ function buildCursorCondition(
  * Returns format "order_value|id" for stable pagination.
  */
 function extractCursorValue(
-	row: BaseProposalRow & {created_at: string},
-	orderBy: ProposalOrderBy = "created_at",
+  row: BaseProposalRow & { created_at: string },
+  orderBy: ProposalOrderBy = "created_at",
 ): string {
-	switch (orderBy) {
-		case "end_time":
-			return `${row.end_time}|${row.id}`
-		case "start_time":
-			return `${row.start_time}|${row.id}`
-		case "created_at":
-		default:
-			return `${row.created_at}|${row.id}`
-	}
+  switch (orderBy) {
+    case "end_time":
+      return `${row.end_time}|${row.id}`;
+    case "start_time":
+      return `${row.start_time}|${row.id}`;
+    case "created_at":
+    default:
+      return `${row.created_at}|${row.id}`;
+  }
 }
 
 /**
@@ -407,62 +424,82 @@ function extractCursorValue(
  * @returns Paginated list of proposals with vote counts and actions
  */
 export function listProposalsInSpace(
-	db: Database,
-	options: ListProposalsOptions,
+  db: Database,
+  options: ListProposalsOptions,
 ): Effect.Effect<ListProposalsResult, QueryError> {
-	const {spaceId, limit, cursor, actionTypes, excludeActionTypes, status, orderBy, orderDirection} = options
+  const {
+    spaceId,
+    limit,
+    cursor,
+    actionTypes,
+    excludeActionTypes,
+    status,
+    orderBy,
+    orderDirection,
+    voterId,
+  } = options;
 
-	return Effect.tryPromise({
-		try: async () => {
-			// Build dynamic query conditions
-			const cursorCondition = buildCursorCondition(cursor, orderBy, orderDirection)
-			const orderClause = buildOrderClause(orderBy, orderDirection)
+  return Effect.tryPromise({
+    try: async () => {
+      // Build dynamic query conditions
+      const cursorCondition = buildCursorCondition(
+        cursor,
+        orderBy,
+        orderDirection,
+      );
+      const orderClause = buildOrderClause(orderBy, orderDirection);
 
-			// Build action type filter conditions
-			// Use EXISTS subquery instead of JOIN to avoid SQL injection and cartesian products
-			let actionTypeCondition = sql``
-			if (actionTypes && actionTypes.length > 0) {
-				// Include filter: proposal must have at least one of these action types
-				// Build safe parameterized OR conditions
-				const actionTypeChecks = actionTypes.map((t) => sql`pa_filter.action_type = ${t}::"proposalActionType"`)
-				const actionTypeOr = actionTypeChecks.reduce((acc, check) => sql`${acc} OR ${check}`)
-				actionTypeCondition = sql`AND EXISTS (
+      // Build action type filter conditions
+      // Use EXISTS subquery instead of JOIN to avoid SQL injection and cartesian products
+      let actionTypeCondition = sql``;
+      if (actionTypes && actionTypes.length > 0) {
+        // Include filter: proposal must have at least one of these action types
+        // Build safe parameterized OR conditions
+        const actionTypeChecks = actionTypes.map(
+          (t) => sql`pa_filter.action_type = ${t}::"proposalActionType"`,
+        );
+        const actionTypeOr = actionTypeChecks.reduce(
+          (acc, check) => sql`${acc} OR ${check}`,
+        );
+        actionTypeCondition = sql`AND EXISTS (
           SELECT 1 FROM proposal_actions pa_filter 
           WHERE pa_filter.proposal_id = p.id AND (${actionTypeOr})
-        )`
-			} else if (excludeActionTypes && excludeActionTypes.length > 0) {
-				// Exclude filter: proposal must NOT have any of these action types
-				const excludeTypeChecks = excludeActionTypes.map(
-					(t) => sql`pa_exclude.action_type = ${t}::"proposalActionType"`,
-				)
-				const excludeTypeOr = excludeTypeChecks.reduce((acc, check) => sql`${acc} OR ${check}`)
-				actionTypeCondition = sql`AND NOT EXISTS (
+        )`;
+      } else if (excludeActionTypes && excludeActionTypes.length > 0) {
+        // Exclude filter: proposal must NOT have any of these action types
+        const excludeTypeChecks = excludeActionTypes.map(
+          (t) => sql`pa_exclude.action_type = ${t}::"proposalActionType"`,
+        );
+        const excludeTypeOr = excludeTypeChecks.reduce(
+          (acc, check) => sql`${acc} OR ${check}`,
+        );
+        actionTypeCondition = sql`AND NOT EXISTS (
           SELECT 1 FROM proposal_actions pa_exclude 
           WHERE pa_exclude.proposal_id = p.id AND (${excludeTypeOr})
-        )`
-			}
+        )`;
+      }
 
-			// Build status filter condition
-			// Status is computed in SQL using denormalized vote counts on the proposals table
-			// This matches the logic in status.ts computeProposalStatus
-			let statusCondition = sql``
-			if (status && status.length > 0) {
-				const nowSeconds = BigInt(Math.floor(Date.now() / 1000))
+      // Build status filter condition
+      // Status is computed in SQL using denormalized vote counts on the proposals table
+      // This matches the logic in status.ts computeProposalStatus
+      let statusCondition = sql``;
+      if (status && status.length > 0) {
+        const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
 
-				// Build OR conditions for each requested status
-				// Uses denormalized p.yes_count, p.no_count, p.abstain_count for efficient filtering
-				const statusChecks = status.map((s) => {
-					switch (s) {
-						case "ACCEPTED":
-							// Already executed
-							return sql`(p.executed_at IS NOT NULL)`
+        // Build OR conditions for each requested status
+        // Uses denormalized p.yes_count, p.no_count, p.abstain_count for efficient filtering
+        const statusChecks = status.map((s) => {
+          switch (s) {
+            case "ACCEPTED":
+              // Already executed
+              return sql`(p.executed_at IS NOT NULL)`;
 
-						case "EXECUTABLE":
-							// Not executed AND meets threshold conditions
-							// Fast path: yes > (threshold - 1), equivalent to yes >= threshold for threshold > 0
-							//            For threshold = 0, this means yes > 0 (needs at least 1 yes vote)
-							// Slow path: voting ended AND quorum met AND (RATIO_BASE - threshold) * yes > threshold * no
-							return sql`(
+            case "EXECUTABLE":
+              // Not executed AND meets threshold conditions
+              // Fast path: yes > (threshold - 1), equivalent to yes >= threshold for threshold > 0
+              //            For threshold = 0, this means yes > 0 (needs at least 1 yes vote)
+              // Slow path: voting ended AND quorum met AND (RATIO_BASE - threshold) * yes > threshold * no
+              return sql`(
                 p.executed_at IS NULL
                 AND (
                   (p.voting_mode = 'Fast' AND p.yes_count > GREATEST(p.threshold - 1, 0))
@@ -473,12 +510,12 @@ export function listProposalsInSpace(
                     AND (${RATIO_BASE}::numeric - p.threshold::numeric) * p.yes_count::numeric > p.threshold::numeric * p.no_count::numeric
                   )
                 )
-              )`
+              )`;
 
-						case "REJECTED":
-							// Not executed AND voting ended AND threshold/quorum not met
-							// Fast path: yes <= (threshold - 1), i.e., NOT (yes > threshold - 1)
-							return sql`(
+            case "REJECTED":
+              // Not executed AND voting ended AND threshold/quorum not met
+              // Fast path: yes <= (threshold - 1), i.e., NOT (yes > threshold - 1)
+              return sql`(
                 p.executed_at IS NULL
                 AND ${nowSeconds}::bigint > p.end_time
                 AND (
@@ -491,36 +528,52 @@ export function listProposalsInSpace(
                     )
                   )
                 )
-              )`
+              )`;
 
-						case "PROPOSED":
-							// Not executed AND voting not ended AND (fast path: threshold not yet met)
-							// Fast path: yes <= (threshold - 1), i.e., NOT yet executable
-							return sql`(
+            case "PROPOSED":
+              // Not executed AND voting not ended AND (fast path: threshold not yet met)
+              // Fast path: yes <= (threshold - 1), i.e., NOT yet executable
+              return sql`(
                 p.executed_at IS NULL
                 AND ${nowSeconds}::bigint <= p.end_time
                 AND (
                   p.voting_mode = 'Slow'
                   OR (p.voting_mode = 'Fast' AND p.yes_count <= GREATEST(p.threshold - 1, 0))
                 )
-              )`
+              )`;
 
-						default: {
-							// Exhaustiveness check - TypeScript will error if a new status is added
-							const _exhaustive: never = s
-							return sql`FALSE`
-						}
-					}
-				})
+            default: {
+              // Exhaustiveness check - TypeScript will error if a new status is added
+              const _exhaustive: never = s;
+              return sql`FALSE`;
+            }
+          }
+        });
 
-				const statusOr = statusChecks.reduce((acc, check) => sql`${acc} OR ${check}`)
-				statusCondition = sql`AND (${statusOr})`
-			}
+        const statusOr = statusChecks.reduce(
+          (acc, check) => sql`${acc} OR ${check}`,
+        );
+        statusCondition = sql`AND (${statusOr})`;
+      }
 
-			// Note: votes_json omitted for performance - use single proposal endpoint for voters
-			// Vote counts are now denormalized on the proposals table, eliminating the LATERAL join
-			const result = await db.execute<BaseProposalRow & {created_at: string}>(
-				sql`
+      // Vote counts are denormalized on the proposals table.
+      // Individual voters are omitted for performance (use single proposal endpoint for full voter list).
+      // When voterId is provided, we fetch just the user's vote via a LATERAL join.
+      const userVoteJoin = voterId
+        ? sql`LEFT JOIN LATERAL (
+            SELECT vote FROM proposal_votes
+            WHERE proposal_id = p.id AND voter_id = ${voterId}::uuid
+            LIMIT 1
+          ) user_vote ON true`
+        : sql``;
+      const userVoteSelect = voterId
+        ? sql`, user_vote.vote as user_vote`
+        : sql``;
+
+      const result = await db.execute<
+        BaseProposalRow & { created_at: string; user_vote?: string | null }
+      >(
+        sql`
         SELECT 
           p.id,
           p.space_id,
@@ -537,6 +590,7 @@ export function listProposalsInSpace(
           p.no_count,
           p.abstain_count,
           actions_agg.actions_json
+          ${userVoteSelect}
         FROM proposals p
         LEFT JOIN LATERAL (
           SELECT COALESCE(json_agg(json_build_object(
@@ -552,6 +606,7 @@ export function listProposalsInSpace(
           FROM proposal_actions
           WHERE proposal_id = p.id
         ) actions_agg ON true
+        ${userVoteJoin}
         WHERE p.space_id = ${spaceId}::uuid
         ${cursorCondition}
         ${actionTypeCondition}
@@ -559,38 +614,50 @@ export function listProposalsInSpace(
         ${orderClause}
         LIMIT ${limit + 1}
       `,
-			)
+      );
 
-			const rows = result.rows
-			const hasMore = rows.length > limit
-			const proposalRows = hasMore ? rows.slice(0, limit) : rows
+      const rows = result.rows;
+      const hasMore = rows.length > limit;
+      const proposalRows = hasMore ? rows.slice(0, limit) : rows;
 
-			// Map rows to domain objects with empty votes (use single endpoint for voters)
-			const proposals = proposalRows.map((row) => mapRowToProposal(row, []))
+      // Map rows to domain objects.
+      // Include the user's vote as a single entry in the votes array when present,
+      // so buildProposalResponse can resolve userVote from it.
+      const proposals = proposalRows.map((row) => {
+        const userVoteValue = row.user_vote?.toUpperCase();
+        const votes: Vote[] =
+          voterId &&
+          userVoteValue &&
+          VOTE_OPTIONS.includes(userVoteValue as VoteOption)
+            ? [{ voterId, vote: userVoteValue as VoteOption }]
+            : [];
+        return mapRowToProposal(row, votes);
+      });
 
-			// Next cursor is the order value + id of the last item
-			const lastRow = proposalRows[proposalRows.length - 1]
-			const nextCursor = hasMore && lastRow ? extractCursorValue(lastRow, orderBy) : null
+      // Next cursor is the order value + id of the last item
+      const lastRow = proposalRows[proposalRows.length - 1];
+      const nextCursor =
+        hasMore && lastRow ? extractCursorValue(lastRow, orderBy) : null;
 
-			return {proposals, nextCursor}
-		},
-		catch: (error) =>
-			new QueryError({
-				operation: "listProposalsInSpace",
-				cause: error as Error,
-			}),
-	}).pipe(
-		Effect.withSpan("queries.listProposalsInSpace", {
-			attributes: {
-				"query.space_id": spaceId,
-				"query.limit": limit,
-				"query.cursor": cursor ?? "none",
-				"query.action_types": actionTypes?.join(",") ?? "all",
-				"query.exclude_action_types": excludeActionTypes?.join(",") ?? "none",
-				"query.status": status?.join(",") ?? "all",
-				"query.order_by": orderBy ?? "created_at",
-				"query.order_direction": orderDirection ?? "desc",
-			},
-		}),
-	)
+      return { proposals, nextCursor };
+    },
+    catch: (error) =>
+      new QueryError({
+        operation: "listProposalsInSpace",
+        cause: error as Error,
+      }),
+  }).pipe(
+    Effect.withSpan("queries.listProposalsInSpace", {
+      attributes: {
+        "query.space_id": spaceId,
+        "query.limit": limit,
+        "query.cursor": cursor ?? "none",
+        "query.action_types": actionTypes?.join(",") ?? "all",
+        "query.exclude_action_types": excludeActionTypes?.join(",") ?? "none",
+        "query.status": status?.join(",") ?? "all",
+        "query.order_by": orderBy ?? "created_at",
+        "query.order_direction": orderDirection ?? "desc",
+      },
+    }),
+  );
 }

--- a/api/src/proposals/router.ts
+++ b/api/src/proposals/router.ts
@@ -4,129 +4,131 @@
  * Provides REST endpoints for querying proposal status.
  */
 
-import type {NodePgDatabase} from "drizzle-orm/node-postgres"
-import {Data, Effect, Either} from "effect"
-import {Hono} from "hono"
-import {describeRoute} from "hono-openapi"
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Data, Effect, Either } from "effect";
+import { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
 
-import type {AppRuntime} from "../services/runtime"
-import {isValidUuid, normalizeUuid} from "../utils/uuid"
+import type { AppRuntime } from "../services/runtime";
+import { isValidUuid, normalizeUuid } from "../utils/uuid";
 import {
-	getProposalWithVotes,
-	listProposalsInSpace,
-	PROPOSAL_ORDER_BY,
-	PROPOSAL_ORDER_DIRECTION,
-	type ProposalOrderBy,
-	type ProposalOrderDirection,
-	type QueryError,
-} from "./queries"
-import {computeProposalStatus, getCurrentTimeSeconds} from "./status"
+  getProposalWithVotes,
+  listProposalsInSpace,
+  PROPOSAL_ORDER_BY,
+  PROPOSAL_ORDER_DIRECTION,
+  type ProposalOrderBy,
+  type ProposalOrderDirection,
+  type QueryError,
+} from "./queries";
+import { computeProposalStatus, getCurrentTimeSeconds } from "./status";
 import {
-	type ActionResponse,
-	PROPOSAL_ACTION_TYPES,
-	PROPOSAL_STATUSES,
-	type ProposalActionType,
-	type ProposalStatus,
-	type ProposalStatusResponse,
-	type ProposalWithVotes,
-	RATIO_BASE,
-	type Vote,
-	type VoteOption,
-} from "./types"
+  type ActionResponse,
+  PROPOSAL_ACTION_TYPES,
+  PROPOSAL_STATUSES,
+  type ProposalActionType,
+  type ProposalStatus,
+  type ProposalStatusResponse,
+  type ProposalWithVotes,
+  RATIO_BASE,
+  type Vote,
+  type VoteOption,
+} from "./types";
 
-type Database = NodePgDatabase<Record<string, unknown>>
+type Database = NodePgDatabase<Record<string, unknown>>;
 
 type AppEnv = {
-	Variables: {
-		requestId: string
-	}
-}
+  Variables: {
+    requestId: string;
+  };
+};
 
 class ValidationError extends Data.TaggedError("ValidationError")<{
-	message: string
+  message: string;
 }> {}
 
 class NotFoundError extends Data.TaggedError("NotFoundError")<{
-	message: string
+  message: string;
 }> {}
 
-type ProposalStatusError = ValidationError | NotFoundError | QueryError
-type ProposalListError = ValidationError | QueryError
+type ProposalStatusError = ValidationError | NotFoundError | QueryError;
+type ProposalListError = ValidationError | QueryError;
 
 /**
  * Maps an internal ProposalAction to the discriminated union ActionResponse.
  * Each action type has its own shape with only the relevant fields.
  * Returns UNKNOWN if required fields are missing (defensive against bad DB data).
  */
-function mapToActionResponse(action: ProposalWithVotes["actions"][number]): ActionResponse {
-	switch (action.actionType) {
-		case "AddMember":
-			if (!action.targetId) return {actionType: "UNKNOWN"}
-			return {
-				actionType: "ADD_MEMBER",
-				targetId: normalizeUuid(action.targetId),
-			}
-		case "RemoveMember":
-			if (!action.targetId) return {actionType: "UNKNOWN"}
-			return {
-				actionType: "REMOVE_MEMBER",
-				targetId: normalizeUuid(action.targetId),
-			}
-		case "AddEditor":
-			if (!action.targetId) return {actionType: "UNKNOWN"}
-			return {
-				actionType: "ADD_EDITOR",
-				targetId: normalizeUuid(action.targetId),
-			}
-		case "RemoveEditor":
-			if (!action.targetId) return {actionType: "UNKNOWN"}
-			return {
-				actionType: "REMOVE_EDITOR",
-				targetId: normalizeUuid(action.targetId),
-			}
-		case "UnflagEditor":
-			if (!action.targetId) return {actionType: "UNKNOWN"}
-			return {
-				actionType: "UNFLAG_EDITOR",
-				targetId: normalizeUuid(action.targetId),
-			}
-		case "Publish":
-			if (!action.contentUri) return {actionType: "UNKNOWN"}
-			return {
-				actionType: "PUBLISH",
-				contentUri: action.contentUri,
-			}
-		case "Flag":
-			if (!action.contentId) return {actionType: "UNKNOWN"}
-			return {
-				actionType: "FLAG",
-				contentId: action.contentId,
-			}
-		case "Unflag":
-			if (!action.contentId) return {actionType: "UNKNOWN"}
-			return {
-				actionType: "UNFLAG",
-				contentId: action.contentId,
-			}
-		case "UpdateVotingSettings":
-			if (
-				action.quorum == null ||
-				action.fastThreshold == null ||
-				action.slowThreshold == null ||
-				action.duration == null
-			) {
-				return {actionType: "UNKNOWN"}
-			}
-			return {
-				actionType: "UPDATE_VOTING_SETTINGS",
-				quorum: action.quorum,
-				fastThreshold: action.fastThreshold,
-				slowThreshold: action.slowThreshold,
-				duration: action.duration,
-			}
-		default:
-			return {actionType: "UNKNOWN"}
-	}
+function mapToActionResponse(
+  action: ProposalWithVotes["actions"][number],
+): ActionResponse {
+  switch (action.actionType) {
+    case "AddMember":
+      if (!action.targetId) return { actionType: "UNKNOWN" };
+      return {
+        actionType: "ADD_MEMBER",
+        targetId: normalizeUuid(action.targetId),
+      };
+    case "RemoveMember":
+      if (!action.targetId) return { actionType: "UNKNOWN" };
+      return {
+        actionType: "REMOVE_MEMBER",
+        targetId: normalizeUuid(action.targetId),
+      };
+    case "AddEditor":
+      if (!action.targetId) return { actionType: "UNKNOWN" };
+      return {
+        actionType: "ADD_EDITOR",
+        targetId: normalizeUuid(action.targetId),
+      };
+    case "RemoveEditor":
+      if (!action.targetId) return { actionType: "UNKNOWN" };
+      return {
+        actionType: "REMOVE_EDITOR",
+        targetId: normalizeUuid(action.targetId),
+      };
+    case "UnflagEditor":
+      if (!action.targetId) return { actionType: "UNKNOWN" };
+      return {
+        actionType: "UNFLAG_EDITOR",
+        targetId: normalizeUuid(action.targetId),
+      };
+    case "Publish":
+      if (!action.contentUri) return { actionType: "UNKNOWN" };
+      return {
+        actionType: "PUBLISH",
+        contentUri: action.contentUri,
+      };
+    case "Flag":
+      if (!action.contentId) return { actionType: "UNKNOWN" };
+      return {
+        actionType: "FLAG",
+        contentId: action.contentId,
+      };
+    case "Unflag":
+      if (!action.contentId) return { actionType: "UNKNOWN" };
+      return {
+        actionType: "UNFLAG",
+        contentId: action.contentId,
+      };
+    case "UpdateVotingSettings":
+      if (
+        action.quorum == null ||
+        action.fastThreshold == null ||
+        action.slowThreshold == null ||
+        action.duration == null
+      ) {
+        return { actionType: "UNKNOWN" };
+      }
+      return {
+        actionType: "UPDATE_VOTING_SETTINGS",
+        quorum: action.quorum,
+        fastThreshold: action.fastThreshold,
+        slowThreshold: action.slowThreshold,
+        duration: action.duration,
+      };
+    default:
+      return { actionType: "UNKNOWN" };
+  }
 }
 
 /**
@@ -137,151 +139,175 @@ function mapToActionResponse(action: ProposalWithVotes["actions"][number]): Acti
  * @param voterId - Optional voter ID to find user's vote
  */
 function buildProposalResponse(
-	proposal: ProposalWithVotes,
-	nowSeconds: bigint,
-	voterId?: string,
+  proposal: ProposalWithVotes,
+  nowSeconds: bigint,
+  voterId?: string,
 ): ProposalStatusResponse {
-	const {status, isQuorumReached, isThresholdReached} = computeProposalStatus(proposal, nowSeconds)
+  const { status, isQuorumReached, isThresholdReached } = computeProposalStatus(
+    proposal,
+    nowSeconds,
+  );
 
-	const now = Number(nowSeconds)
-	const endTime = Number(proposal.endTime)
-	const isVotingEnded = now > endTime
-	const timeRemaining = isVotingEnded ? null : endTime - now
+  const now = Number(nowSeconds);
+  const endTime = Number(proposal.endTime);
+  const isVotingEnded = now > endTime;
+  const timeRemaining = isVotingEnded ? null : endTime - now;
 
-	const totalVotes = proposal.yesCount + proposal.noCount + proposal.abstainCount
-	const quorumRequired = Number(proposal.quorum)
-	const quorumCurrent = Number(totalVotes)
-	const quorumProgress = quorumRequired > 0 ? Math.min(quorumCurrent / quorumRequired, 1) : 1
+  const totalVotes =
+    proposal.yesCount + proposal.noCount + proposal.abstainCount;
+  const quorumRequired = Number(proposal.quorum);
+  const quorumCurrent = Number(totalVotes);
+  const quorumProgress =
+    quorumRequired > 0 ? Math.min(quorumCurrent / quorumRequired, 1) : 1;
 
-	const thresholdRequired = proposal.threshold
-	let thresholdCurrent: number
-	let thresholdProgress: number
+  const thresholdRequired = proposal.threshold;
+  let thresholdCurrent: number;
+  let thresholdProgress: number;
 
-	if (proposal.votingMode === "Fast") {
-		// Fast path: absolute yes votes needed
-		// Progress is measured against the full threshold for UI display
-		thresholdCurrent = Number(proposal.yesCount)
-		thresholdProgress = thresholdRequired > 0n ? Math.min(thresholdCurrent / Number(thresholdRequired), 1) : 1
-	} else {
-		const yesVotes = Number(proposal.yesCount)
-		const noVotes = Number(proposal.noCount)
-		thresholdCurrent = yesVotes
+  if (proposal.votingMode === "Fast") {
+    // Fast path: absolute yes votes needed
+    // Progress is measured against the full threshold for UI display
+    thresholdCurrent = Number(proposal.yesCount);
+    thresholdProgress =
+      thresholdRequired > 0n
+        ? Math.min(thresholdCurrent / Number(thresholdRequired), 1)
+        : 1;
+  } else {
+    const yesVotes = Number(proposal.yesCount);
+    const noVotes = Number(proposal.noCount);
+    thresholdCurrent = yesVotes;
 
-		if (yesVotes + noVotes === 0) {
-			thresholdProgress = 0
-		} else {
-			const requiredYesRatio = 1 - Number(thresholdRequired) / Number(RATIO_BASE)
-			const actualYesRatio = yesVotes / (yesVotes + noVotes)
-			thresholdProgress = requiredYesRatio > 0 ? Math.min(actualYesRatio / requiredYesRatio, 1) : 1
-		}
-	}
+    if (yesVotes + noVotes === 0) {
+      thresholdProgress = 0;
+    } else {
+      const requiredYesRatio =
+        1 - Number(thresholdRequired) / Number(RATIO_BASE);
+      const actualYesRatio = yesVotes / (yesVotes + noVotes);
+      thresholdProgress =
+        requiredYesRatio > 0
+          ? Math.min(actualYesRatio / requiredYesRatio, 1)
+          : 1;
+    }
+  }
 
-	// Build voters list for response
-	const voters: Vote[] = proposal.votes.map((v) => ({
-		voterId: normalizeUuid(v.voterId),
-		vote: v.vote,
-	}))
+  // Build voters list for response
+  const voters: Vote[] = proposal.votes.map((v) => ({
+    voterId: normalizeUuid(v.voterId),
+    vote: v.vote,
+  }));
 
-	// Find user's vote if voterId provided
-	let userVote: VoteOption | null = null
-	if (voterId) {
-		const normalizedVoterId = normalizeUuid(voterId)
-		const userVoteRecord = proposal.votes.find((v) => normalizeUuid(v.voterId) === normalizedVoterId)
-		userVote = userVoteRecord?.vote ?? null
-	}
+  // Find user's vote if voterId provided
+  let userVote: VoteOption | null = null;
+  if (voterId) {
+    const normalizedVoterId = normalizeUuid(voterId);
+    const userVoteRecord = proposal.votes.find(
+      (v) => normalizeUuid(v.voterId) === normalizedVoterId,
+    );
+    userVote = userVoteRecord?.vote ?? null;
+  }
 
-	// Build actions list for response (discriminated union)
-	const actions: ActionResponse[] = proposal.actions.map(mapToActionResponse)
+  // Build actions list for response (discriminated union)
+  const actions: ActionResponse[] = proposal.actions.map(mapToActionResponse);
 
-	return {
-		proposalId: normalizeUuid(proposal.id),
-		spaceId: normalizeUuid(proposal.spaceId),
-		name: proposal.name,
-		proposedBy: normalizeUuid(proposal.proposedBy),
-		status,
-		votingMode: proposal.votingMode.toUpperCase() as "FAST" | "SLOW",
-		actions,
-		votes: {
-			yes: Number(proposal.yesCount),
-			no: Number(proposal.noCount),
-			abstain: Number(proposal.abstainCount),
-			total: Number(totalVotes),
-			voters,
-		},
-		userVote,
-		quorum: {
-			required: quorumRequired,
-			current: quorumCurrent,
-			progress: quorumProgress,
-			reached: isQuorumReached,
-		},
-		threshold: {
-			required: thresholdRequired.toString(),
-			current: thresholdCurrent,
-			progress: thresholdProgress,
-			reached: isThresholdReached,
-		},
-		timing: {
-			startTime: Number(proposal.startTime),
-			endTime,
-			timeRemaining,
-			isVotingEnded,
-		},
-		canExecute: status === "EXECUTABLE",
-	}
+  return {
+    proposalId: normalizeUuid(proposal.id),
+    spaceId: normalizeUuid(proposal.spaceId),
+    name: proposal.name,
+    proposedBy: normalizeUuid(proposal.proposedBy),
+    status,
+    votingMode: proposal.votingMode.toUpperCase() as "FAST" | "SLOW",
+    actions,
+    votes: {
+      yes: Number(proposal.yesCount),
+      no: Number(proposal.noCount),
+      abstain: Number(proposal.abstainCount),
+      total: Number(totalVotes),
+      voters,
+    },
+    userVote,
+    quorum: {
+      required: quorumRequired,
+      current: quorumCurrent,
+      progress: quorumProgress,
+      reached: isQuorumReached,
+    },
+    threshold: {
+      required: thresholdRequired.toString(),
+      current: thresholdCurrent,
+      progress: thresholdProgress,
+      reached: isThresholdReached,
+    },
+    timing: {
+      startTime: Number(proposal.startTime),
+      endTime,
+      timeRemaining,
+      isVotingEnded,
+    },
+    canExecute: status === "EXECUTABLE",
+  };
 }
 
 /**
  * Parse and validate a comma-separated list of action types.
  * Returns an Effect that fails with ValidationError on invalid input.
  */
-function parseActionTypes(param: string | undefined): Effect.Effect<ProposalActionType[] | undefined, ValidationError> {
-	if (!param) return Effect.succeed(undefined)
-	const types = param.split(",").map((t) => t.trim())
-	const invalid = types.filter((t) => !PROPOSAL_ACTION_TYPES.includes(t as ProposalActionType))
-	if (invalid.length > 0) {
-		return Effect.fail(
-			new ValidationError({
-				message: `Invalid action types: ${invalid.join(", ")}. Valid: ${PROPOSAL_ACTION_TYPES.join(", ")}`,
-			}),
-		)
-	}
-	return Effect.succeed(types as ProposalActionType[])
+function parseActionTypes(
+  param: string | undefined,
+): Effect.Effect<ProposalActionType[] | undefined, ValidationError> {
+  if (!param) return Effect.succeed(undefined);
+  const types = param.split(",").map((t) => t.trim());
+  const invalid = types.filter(
+    (t) => !PROPOSAL_ACTION_TYPES.includes(t as ProposalActionType),
+  );
+  if (invalid.length > 0) {
+    return Effect.fail(
+      new ValidationError({
+        message: `Invalid action types: ${invalid.join(", ")}. Valid: ${PROPOSAL_ACTION_TYPES.join(", ")}`,
+      }),
+    );
+  }
+  return Effect.succeed(types as ProposalActionType[]);
 }
 
 /**
  * Parse and validate a comma-separated list of proposal statuses.
  * Returns an Effect that fails with ValidationError on invalid input.
  */
-function parseStatuses(param: string | undefined): Effect.Effect<ProposalStatus[] | undefined, ValidationError> {
-	if (!param) return Effect.succeed(undefined)
-	const statuses = param.split(",").map((s) => s.trim().toUpperCase())
-	const invalid = statuses.filter((s) => !PROPOSAL_STATUSES.includes(s as ProposalStatus))
-	if (invalid.length > 0) {
-		return Effect.fail(
-			new ValidationError({
-				message: `Invalid statuses: ${invalid.join(", ")}. Valid: ${PROPOSAL_STATUSES.join(", ")}`,
-			}),
-		)
-	}
-	return Effect.succeed(statuses as ProposalStatus[])
+function parseStatuses(
+  param: string | undefined,
+): Effect.Effect<ProposalStatus[] | undefined, ValidationError> {
+  if (!param) return Effect.succeed(undefined);
+  const statuses = param.split(",").map((s) => s.trim().toUpperCase());
+  const invalid = statuses.filter(
+    (s) => !PROPOSAL_STATUSES.includes(s as ProposalStatus),
+  );
+  if (invalid.length > 0) {
+    return Effect.fail(
+      new ValidationError({
+        message: `Invalid statuses: ${invalid.join(", ")}. Valid: ${PROPOSAL_STATUSES.join(", ")}`,
+      }),
+    );
+  }
+  return Effect.succeed(statuses as ProposalStatus[]);
 }
 
 /**
  * Parse and validate orderBy parameter.
  * Returns an Effect that fails with ValidationError on invalid input.
  */
-function parseOrderBy(param: string | undefined): Effect.Effect<ProposalOrderBy | undefined, ValidationError> {
-	if (!param) return Effect.succeed(undefined)
-	const orderBy = param.trim().toLowerCase()
-	if (!PROPOSAL_ORDER_BY.includes(orderBy as ProposalOrderBy)) {
-		return Effect.fail(
-			new ValidationError({
-				message: `Invalid orderBy: ${param}. Valid: ${PROPOSAL_ORDER_BY.join(", ")}`,
-			}),
-		)
-	}
-	return Effect.succeed(orderBy as ProposalOrderBy)
+function parseOrderBy(
+  param: string | undefined,
+): Effect.Effect<ProposalOrderBy | undefined, ValidationError> {
+  if (!param) return Effect.succeed(undefined);
+  const orderBy = param.trim().toLowerCase();
+  if (!PROPOSAL_ORDER_BY.includes(orderBy as ProposalOrderBy)) {
+    return Effect.fail(
+      new ValidationError({
+        message: `Invalid orderBy: ${param}. Valid: ${PROPOSAL_ORDER_BY.join(", ")}`,
+      }),
+    );
+  }
+  return Effect.succeed(orderBy as ProposalOrderBy);
 }
 
 /**
@@ -289,336 +315,364 @@ function parseOrderBy(param: string | undefined): Effect.Effect<ProposalOrderBy 
  * Returns an Effect that fails with ValidationError on invalid input.
  */
 function parseOrderDirection(
-	param: string | undefined,
+  param: string | undefined,
 ): Effect.Effect<ProposalOrderDirection | undefined, ValidationError> {
-	if (!param) return Effect.succeed(undefined)
-	const direction = param.trim().toLowerCase()
-	if (!PROPOSAL_ORDER_DIRECTION.includes(direction as ProposalOrderDirection)) {
-		return Effect.fail(
-			new ValidationError({
-				message: `Invalid orderDirection: ${param}. Valid: ${PROPOSAL_ORDER_DIRECTION.join(", ")}`,
-			}),
-		)
-	}
-	return Effect.succeed(direction as ProposalOrderDirection)
+  if (!param) return Effect.succeed(undefined);
+  const direction = param.trim().toLowerCase();
+  if (!PROPOSAL_ORDER_DIRECTION.includes(direction as ProposalOrderDirection)) {
+    return Effect.fail(
+      new ValidationError({
+        message: `Invalid orderDirection: ${param}. Valid: ${PROPOSAL_ORDER_DIRECTION.join(", ")}`,
+      }),
+    );
+  }
+  return Effect.succeed(direction as ProposalOrderDirection);
 }
 
 /**
  * Create the proposals router.
  */
 export function createProposalsRouter(db: Database, runtime: AppRuntime) {
-	const router = new Hono<AppEnv>()
+  const router = new Hono<AppEnv>();
 
-	// GET /proposals/:id/status - Single proposal status
-	router.get(
-		"/:id/status",
-		describeRoute({
-			tags: ["Proposals"],
-			summary: "Get proposal status",
-			description: "Computes proposal status matching the smart contract's isSupportThresholdReached() logic.",
-			parameters: [
-				{
-					name: "id",
-					in: "path",
-					required: true,
-					schema: {type: "string", format: "uuid"},
-				},
-				{
-					name: "voterId",
-					in: "query",
-					description: "UUID of the voter to check for their vote",
-					schema: {type: "string", format: "uuid"},
-				},
-			],
-			responses: {
-				200: {
-					description: "Proposal status",
-					content: {
-						"application/json": {
-							schema: {$ref: "#/components/schemas/ProposalStatusResponse"},
-						},
-					},
-				},
-				400: {description: "Invalid parameter"},
-				404: {description: "Proposal not found"},
-				500: {description: "Internal server error"},
-			},
-		}),
-		async (c) => {
-			const proposalId = c.req.param("id")
-			const voterId = c.req.query("voterId")
-			const requestId = c.get("requestId") ?? "unknown"
+  // GET /proposals/:id/status - Single proposal status
+  router.get(
+    "/:id/status",
+    describeRoute({
+      tags: ["Proposals"],
+      summary: "Get proposal status",
+      description:
+        "Computes proposal status matching the smart contract's isSupportThresholdReached() logic.",
+      parameters: [
+        {
+          name: "id",
+          in: "path",
+          required: true,
+          schema: { type: "string", format: "uuid" },
+        },
+        {
+          name: "voterId",
+          in: "query",
+          description: "UUID of the voter to check for their vote",
+          schema: { type: "string", format: "uuid" },
+        },
+      ],
+      responses: {
+        200: {
+          description: "Proposal status",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ProposalStatusResponse" },
+            },
+          },
+        },
+        400: { description: "Invalid parameter" },
+        404: { description: "Proposal not found" },
+        500: { description: "Internal server error" },
+      },
+    }),
+    async (c) => {
+      const proposalId = c.req.param("id");
+      const voterId = c.req.query("voterId");
+      const requestId = c.get("requestId") ?? "unknown";
 
-			const program = Effect.gen(function* () {
-				yield* Effect.logInfo("GetProposalStatus started", {
-					proposalId,
-					voterId,
-				})
+      const program = Effect.gen(function* () {
+        yield* Effect.logInfo("GetProposalStatus started", {
+          proposalId,
+          voterId,
+        });
 
-				if (!isValidUuid(proposalId)) {
-					return yield* Effect.fail(
-						new ValidationError({
-							message: "Proposal ID must be a valid UUID",
-						}),
-					)
-				}
+        if (!isValidUuid(proposalId)) {
+          return yield* Effect.fail(
+            new ValidationError({
+              message: "Proposal ID must be a valid UUID",
+            }),
+          );
+        }
 
-				if (voterId && !isValidUuid(voterId)) {
-					return yield* Effect.fail(
-						new ValidationError({
-							message: "Voter ID must be a valid UUID",
-						}),
-					)
-				}
+        if (voterId && !isValidUuid(voterId)) {
+          return yield* Effect.fail(
+            new ValidationError({
+              message: "Voter ID must be a valid UUID",
+            }),
+          );
+        }
 
-				const proposal = yield* getProposalWithVotes(db, proposalId)
+        const proposal = yield* getProposalWithVotes(db, proposalId);
 
-				if (!proposal) {
-					return yield* Effect.fail(
-						new NotFoundError({
-							message: `Proposal '${proposalId}' not found`,
-						}),
-					)
-				}
+        if (!proposal) {
+          return yield* Effect.fail(
+            new NotFoundError({
+              message: `Proposal '${proposalId}' not found`,
+            }),
+          );
+        }
 
-				const nowSeconds = getCurrentTimeSeconds()
-				return buildProposalResponse(proposal, nowSeconds, voterId)
-			}).pipe(
-				Effect.tapError((error) => {
-					switch (error._tag) {
-						case "QueryError":
-							return Effect.logError("GetProposalStatus failed", {
-								errorType: "database_error",
-								operation: error.operation,
-								message: error.cause.message,
-							})
-						case "ValidationError":
-							return Effect.logWarning("GetProposalStatus failed", {
-								errorType: "validation_error",
-								message: error.message,
-							})
-						case "NotFoundError":
-							return Effect.logInfo("GetProposalStatus failed", {
-								errorType: "not_found",
-								message: error.message,
-							})
-					}
-				}),
-				Effect.withSpan("GET /proposals/:id/status"),
-				Effect.annotateLogs({requestId, proposalId}),
-				Effect.annotateSpans({requestId, proposalId}),
-			)
+        const nowSeconds = getCurrentTimeSeconds();
+        return buildProposalResponse(proposal, nowSeconds, voterId);
+      }).pipe(
+        Effect.tapError((error) => {
+          switch (error._tag) {
+            case "QueryError":
+              return Effect.logError("GetProposalStatus failed", {
+                errorType: "database_error",
+                operation: error.operation,
+                message: error.cause.message,
+              });
+            case "ValidationError":
+              return Effect.logWarning("GetProposalStatus failed", {
+                errorType: "validation_error",
+                message: error.message,
+              });
+            case "NotFoundError":
+              return Effect.logInfo("GetProposalStatus failed", {
+                errorType: "not_found",
+                message: error.message,
+              });
+          }
+        }),
+        Effect.withSpan("GET /proposals/:id/status"),
+        Effect.annotateLogs({ requestId, proposalId }),
+        Effect.annotateSpans({ requestId, proposalId }),
+      );
 
-			const result = await runtime.runPromise(Effect.either(program))
+      const result = await runtime.runPromise(Effect.either(program));
 
-			return Either.match(result, {
-				onLeft: (error: ProposalStatusError) => {
-					switch (error._tag) {
-						case "ValidationError":
-							return c.json({error: "Invalid parameter", message: error.message}, 400)
-						case "NotFoundError":
-							return c.json({error: "Not found", message: error.message}, 404)
-						case "QueryError":
-							return c.json(
-								{
-									error: "Internal server error",
-									message: "An unexpected error occurred",
-								},
-								500,
-							)
-					}
-				},
-				onRight: (response) => c.json(response),
-			})
-		},
-	)
+      return Either.match(result, {
+        onLeft: (error: ProposalStatusError) => {
+          switch (error._tag) {
+            case "ValidationError":
+              return c.json(
+                { error: "Invalid parameter", message: error.message },
+                400,
+              );
+            case "NotFoundError":
+              return c.json(
+                { error: "Not found", message: error.message },
+                404,
+              );
+            case "QueryError":
+              return c.json(
+                {
+                  error: "Internal server error",
+                  message: "An unexpected error occurred",
+                },
+                500,
+              );
+          }
+        },
+        onRight: (response) => c.json(response),
+      });
+    },
+  );
 
-	// GET /proposals/space/:spaceId/status - List proposals in a space
-	router.get(
-		"/space/:spaceId/status",
-		describeRoute({
-			tags: ["Proposals"],
-			summary: "List proposal statuses in a space",
-			description:
-				"Lists proposals with cursor pagination. Filter with actionTypes, excludeActionTypes, or status (comma-separated). Sort with orderBy and orderDirection.",
-			parameters: [
-				{
-					name: "spaceId",
-					in: "path",
-					required: true,
-					schema: {type: "string", format: "uuid"},
-				},
-				{
-					name: "limit",
-					in: "query",
-					schema: {type: "integer", minimum: 1, maximum: 100, default: 20},
-				},
-				{name: "cursor", in: "query", schema: {type: "string"}},
-				{
-					name: "actionTypes",
-					in: "query",
-					description: "Include only these action types (comma-separated)",
-					schema: {type: "string"},
-				},
-				{
-					name: "excludeActionTypes",
-					in: "query",
-					description: "Exclude these action types (comma-separated)",
-					schema: {type: "string"},
-				},
-				{
-					name: "status",
-					in: "query",
-					description:
-						"Filter by proposal status (comma-separated): PROPOSED, EXECUTABLE, ACCEPTED, REJECTED",
-					schema: {type: "string"},
-				},
-				{
-					name: "orderBy",
-					in: "query",
-					description: "Field to order by: created_at (default), end_time, start_time",
-					schema: {type: "string", enum: ["created_at", "end_time", "start_time"]},
-				},
-				{
-					name: "orderDirection",
-					in: "query",
-					description: "Sort direction: desc (default), asc",
-					schema: {type: "string", enum: ["asc", "desc"]},
-				},
-				{
-					name: "voterId",
-					in: "query",
-					description: "UUID of the voter to check for their vote on each proposal",
-					schema: {type: "string", format: "uuid"},
-				},
-			],
-			responses: {
-				200: {
-					description: "List of proposal statuses",
-					content: {
-						"application/json": {
-							schema: {$ref: "#/components/schemas/ProposalListResponse"},
-						},
-					},
-				},
-				400: {description: "Invalid parameter"},
-				500: {description: "Internal server error"},
-			},
-		}),
-		async (c) => {
-			const spaceId = c.req.param("spaceId")
-			const requestId = c.get("requestId") ?? "unknown"
-			const limitParam = c.req.query("limit")
-			const cursor = c.req.query("cursor")
-			const actionTypesParam = c.req.query("actionTypes")
-			const excludeActionTypesParam = c.req.query("excludeActionTypes")
-			const statusParam = c.req.query("status")
-			const orderByParam = c.req.query("orderBy")
-			const orderDirectionParam = c.req.query("orderDirection")
-			const voterId = c.req.query("voterId")
+  // GET /proposals/space/:spaceId/status - List proposals in a space
+  router.get(
+    "/space/:spaceId/status",
+    describeRoute({
+      tags: ["Proposals"],
+      summary: "List proposal statuses in a space",
+      description:
+        "Lists proposals with cursor pagination. Filter with actionTypes, excludeActionTypes, or status (comma-separated). Sort with orderBy and orderDirection.",
+      parameters: [
+        {
+          name: "spaceId",
+          in: "path",
+          required: true,
+          schema: { type: "string", format: "uuid" },
+        },
+        {
+          name: "limit",
+          in: "query",
+          schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+        },
+        { name: "cursor", in: "query", schema: { type: "string" } },
+        {
+          name: "actionTypes",
+          in: "query",
+          description: "Include only these action types (comma-separated)",
+          schema: { type: "string" },
+        },
+        {
+          name: "excludeActionTypes",
+          in: "query",
+          description: "Exclude these action types (comma-separated)",
+          schema: { type: "string" },
+        },
+        {
+          name: "status",
+          in: "query",
+          description:
+            "Filter by proposal status (comma-separated): PROPOSED, EXECUTABLE, ACCEPTED, REJECTED",
+          schema: { type: "string" },
+        },
+        {
+          name: "orderBy",
+          in: "query",
+          description:
+            "Field to order by: created_at (default), end_time, start_time",
+          schema: {
+            type: "string",
+            enum: ["created_at", "end_time", "start_time"],
+          },
+        },
+        {
+          name: "orderDirection",
+          in: "query",
+          description: "Sort direction: desc (default), asc",
+          schema: { type: "string", enum: ["asc", "desc"] },
+        },
+        {
+          name: "voterId",
+          in: "query",
+          description:
+            "UUID of the voter to check for their vote on each proposal",
+          schema: { type: "string", format: "uuid" },
+        },
+      ],
+      responses: {
+        200: {
+          description: "List of proposal statuses",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ProposalListResponse" },
+            },
+          },
+        },
+        400: { description: "Invalid parameter" },
+        500: { description: "Internal server error" },
+      },
+    }),
+    async (c) => {
+      const spaceId = c.req.param("spaceId");
+      const requestId = c.get("requestId") ?? "unknown";
+      const limitParam = c.req.query("limit");
+      const cursor = c.req.query("cursor");
+      const actionTypesParam = c.req.query("actionTypes");
+      const excludeActionTypesParam = c.req.query("excludeActionTypes");
+      const statusParam = c.req.query("status");
+      const orderByParam = c.req.query("orderBy");
+      const orderDirectionParam = c.req.query("orderDirection");
+      const voterId = c.req.query("voterId");
 
-			const program = Effect.gen(function* () {
-				yield* Effect.logInfo("ListProposalStatuses started", {
-					spaceId,
-					limit: limitParam,
-					cursor,
-					actionTypes: actionTypesParam,
-					excludeActionTypes: excludeActionTypesParam,
-					status: statusParam,
-					orderBy: orderByParam,
-					orderDirection: orderDirectionParam,
-					voterId,
-				})
+      const program = Effect.gen(function* () {
+        yield* Effect.logInfo("ListProposalStatuses started", {
+          spaceId,
+          limit: limitParam,
+          cursor,
+          actionTypes: actionTypesParam,
+          excludeActionTypes: excludeActionTypesParam,
+          status: statusParam,
+          orderBy: orderByParam,
+          orderDirection: orderDirectionParam,
+          voterId,
+        });
 
-				if (!isValidUuid(spaceId)) {
-					return yield* Effect.fail(new ValidationError({message: "Space ID must be a valid UUID"}))
-				}
+        if (!isValidUuid(spaceId)) {
+          return yield* Effect.fail(
+            new ValidationError({ message: "Space ID must be a valid UUID" }),
+          );
+        }
 
-				if (voterId && !isValidUuid(voterId)) {
-					return yield* Effect.fail(new ValidationError({message: "Voter ID must be a valid UUID"}))
-				}
+        if (voterId && !isValidUuid(voterId)) {
+          return yield* Effect.fail(
+            new ValidationError({ message: "Voter ID must be a valid UUID" }),
+          );
+        }
 
-				const limit = limitParam ? parseInt(limitParam, 10) : 20
-				if (Number.isNaN(limit) || limit < 1 || limit > 100) {
-					return yield* Effect.fail(new ValidationError({message: "Limit must be between 1 and 100"}))
-				}
+        const limit = limitParam ? parseInt(limitParam, 10) : 20;
+        if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+          return yield* Effect.fail(
+            new ValidationError({ message: "Limit must be between 1 and 100" }),
+          );
+        }
 
-				const actionTypes = yield* parseActionTypes(actionTypesParam)
-				const excludeActionTypes = yield* parseActionTypes(excludeActionTypesParam)
+        const actionTypes = yield* parseActionTypes(actionTypesParam);
+        const excludeActionTypes = yield* parseActionTypes(
+          excludeActionTypesParam,
+        );
 
-				// Validate that actionTypes and excludeActionTypes are mutually exclusive
-				if (actionTypes && excludeActionTypes) {
-					return yield* Effect.fail(
-						new ValidationError({
-							message: "Cannot specify both actionTypes and excludeActionTypes. Use one or the other.",
-						}),
-					)
-				}
+        // Validate that actionTypes and excludeActionTypes are mutually exclusive
+        if (actionTypes && excludeActionTypes) {
+          return yield* Effect.fail(
+            new ValidationError({
+              message:
+                "Cannot specify both actionTypes and excludeActionTypes. Use one or the other.",
+            }),
+          );
+        }
 
-				const status = yield* parseStatuses(statusParam)
-				const orderBy = yield* parseOrderBy(orderByParam)
-				const orderDirection = yield* parseOrderDirection(orderDirectionParam)
+        const status = yield* parseStatuses(statusParam);
+        const orderBy = yield* parseOrderBy(orderByParam);
+        const orderDirection = yield* parseOrderDirection(orderDirectionParam);
 
-				const {proposals, nextCursor} = yield* listProposalsInSpace(db, {
-					spaceId,
-					limit,
-					cursor,
-					actionTypes,
-					excludeActionTypes,
-					status,
-					orderBy,
-					orderDirection,
-				})
+        const normalizedVoterId = voterId ? normalizeUuid(voterId) : undefined;
+        const { proposals, nextCursor } = yield* listProposalsInSpace(db, {
+          spaceId,
+          limit,
+          cursor,
+          actionTypes,
+          excludeActionTypes,
+          status,
+          orderBy,
+          orderDirection,
+          voterId: normalizedVoterId,
+        });
 
-				const nowSeconds = getCurrentTimeSeconds()
-				const proposalResponses = proposals.map((p) => buildProposalResponse(p, nowSeconds, voterId))
+        const nowSeconds = getCurrentTimeSeconds();
+        const proposalResponses = proposals.map((p) =>
+          buildProposalResponse(p, nowSeconds, voterId),
+        );
 
-				return {
-					proposals: proposalResponses,
-					nextCursor,
-				}
-			}).pipe(
-				Effect.tapError((error) => {
-					switch (error._tag) {
-						case "QueryError":
-							return Effect.logError("ListProposalStatuses failed", {
-								errorType: "database_error",
-								operation: error.operation,
-								message: error.cause.message,
-							})
-						case "ValidationError":
-							return Effect.logWarning("ListProposalStatuses failed", {
-								errorType: "validation_error",
-								message: error.message,
-							})
-					}
-				}),
-				Effect.withSpan("GET /proposals/space/:spaceId/status"),
-				Effect.annotateLogs({requestId, spaceId}),
-				Effect.annotateSpans({requestId, spaceId}),
-			)
+        return {
+          proposals: proposalResponses,
+          nextCursor,
+        };
+      }).pipe(
+        Effect.tapError((error) => {
+          switch (error._tag) {
+            case "QueryError":
+              return Effect.logError("ListProposalStatuses failed", {
+                errorType: "database_error",
+                operation: error.operation,
+                message: error.cause.message,
+              });
+            case "ValidationError":
+              return Effect.logWarning("ListProposalStatuses failed", {
+                errorType: "validation_error",
+                message: error.message,
+              });
+          }
+        }),
+        Effect.withSpan("GET /proposals/space/:spaceId/status"),
+        Effect.annotateLogs({ requestId, spaceId }),
+        Effect.annotateSpans({ requestId, spaceId }),
+      );
 
-			const result = await runtime.runPromise(Effect.either(program))
+      const result = await runtime.runPromise(Effect.either(program));
 
-			return Either.match(result, {
-				onLeft: (error: ProposalListError) => {
-					switch (error._tag) {
-						case "ValidationError":
-							return c.json({error: "Invalid parameter", message: error.message}, 400)
-						case "QueryError":
-							return c.json(
-								{
-									error: "Internal server error",
-									message: "An unexpected error occurred",
-								},
-								500,
-							)
-					}
-				},
-				onRight: (response) => c.json(response),
-			})
-		},
-	)
+      return Either.match(result, {
+        onLeft: (error: ProposalListError) => {
+          switch (error._tag) {
+            case "ValidationError":
+              return c.json(
+                { error: "Invalid parameter", message: error.message },
+                400,
+              );
+            case "QueryError":
+              return c.json(
+                {
+                  error: "Internal server error",
+                  message: "An unexpected error occurred",
+                },
+                500,
+              );
+          }
+        },
+        onRight: (response) => c.json(response),
+      });
+    },
+  );
 
-	return router
+  return router;
 }


### PR DESCRIPTION
## Summary

- **userVote was always null in list responses**: The list endpoint (`GET /proposals/space/:spaceId/status`) intentionally omits individual voter records (`voters: []`) for performance, but `buildProposalResponse` tried to resolve `userVote` from that empty array. Now when `voterId` is passed as a query param, a `LEFT JOIN LATERAL` fetches just the user's single vote per proposal in the paginated result set.
- **Memory leak fix** (prior commit on this branch): Unbounded PostGraphile schema cache and watcher cleanup.

## Changes

### `api/src/proposals/queries.ts`
- Added `voterId?: string` to `ListProposalsOptions`
- When `voterId` is provided, adds a conditional `LEFT JOIN LATERAL` on `proposal_votes` scoped to the paginated proposals
- Maps the user's vote into the `votes` array so `buildProposalResponse` can resolve `userVote`
- Uses Drizzle `sql` tagged template with `::uuid` cast for parameterization

### `api/src/proposals/router.ts`
- Normalizes `voterId` query param and passes it through to `listProposalsInSpace`

## Performance note
The LATERAL join runs against the already-paginated result set (typically 20 rows), so it's one index lookup per proposal. Depends on a composite index on `proposal_votes(proposal_id, voter_id)` — verify this exists in production.

## Companion PR
- **geogenesis**: geobrowser/geogenesis#1402 — frontend uses count-based percentages and reads `userVote` directly

## Formatting note
The diff is large because the file was reformatted (tab → 2-space + semicolons). The semantic changes are the LATERAL join addition and voterId passthrough.