### PR TITLE
fix(api): fix pgClient lifecycle in PostGraphile context

### DIFF
--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -1,8 +1,9 @@
 import SimplifyInflectionPlugin from "@graphile-contrib/pg-simplify-inflector"
 import {createInMemoryCache, useResponseCache} from "@graphql-yoga/plugin-response-cache"
-import {createYoga, useExecutionCancellation} from "graphql-yoga"
+import {createYoga, type Plugin, useExecutionCancellation} from "graphql-yoga"
+import type {PoolClient} from "pg"
 import {Pool} from "pg"
-import {createPostGraphileSchema, withPostGraphileContext} from "postgraphile"
+import {createPostGraphileSchema} from "postgraphile"
 import ConnectionFilterPlugin from "postgraphile-plugin-connection-filter"
 import EntitySpaceFilterPlugin from "./entitySpaceFilterPlugin"
 import {useGraphQLInstrumentation} from "./instrumentationPlugin"
@@ -79,31 +80,40 @@ const postgraphileOptions = {
 // Create PostGraphile schemas
 const postgraphileSchema = await createPostGraphileSchema(pgPool, ["public"], postgraphileOptions)
 
-// Helper to create context
-const createContext = async ({request}: {request: Request}) => {
-	const contextPromise = new Promise((resolve, reject) => {
-		withPostGraphileContext(
-			{
-				pgPool,
-			},
-			async (postgraphileContext) => {
-				resolve({
-					request,
-					...postgraphileContext,
-				})
+/**
+ * Yoga plugin that manages the pgClient lifecycle for PostGraphile resolvers.
+ *
+ * PostGraphile's generated resolvers expect `context.pgClient` — a pg.Client
+ * checked out from the pool. This plugin checks out a client before execution
+ * and releases it back to the pool after execution completes.
+ *
+ * The checkout happens in onExecute (not in the context factory) so that
+ * cache hits from useResponseCache never check out a client at all — the
+ * response cache short-circuits in onParams before onExecute fires.
+ *
+ * We don't use PostGraphile's `withPostGraphileContext` because we don't need
+ * its transaction wrapper or JWT/role features (mutations are disabled, all
+ * queries are reads). Checking out the client directly is simpler and avoids
+ * the unnecessary BEGIN/COMMIT overhead on every request.
+ */
+function usePgClient(pool: Pool): Plugin<{pgClient: PoolClient}> {
+	return {
+		async onExecute({extendContext}) {
+			const pgClient = await pool.connect()
+			extendContext({pgClient})
 
-				// Return a dummy result since withPostGraphileContext expects a result
-				// The actual result will be handled by GraphQL execution
-				return {data: null}
-			},
-		).catch(reject) // Propagate connection errors (e.g., pool timeout)
-	})
-
-	return await contextPromise
+			return {
+				onExecuteDone() {
+					pgClient.release()
+				},
+			}
+		},
+	}
 }
 
 // Shared plugins for GraphQL server
 const sharedPlugins = [
+	usePgClient(pgPool),
 	useExecutionCancellation(),
 	useResponseCache({
 		session: () => null,
@@ -120,5 +130,4 @@ export const graphqlServer = createYoga<GraphQLServerContext>({
 		title: "Geo API",
 	},
 	plugins: sharedPlugins,
-	context: createContext,
 })


### PR DESCRIPTION
## Summary

- **Fixes intermittent `Client has encountered a connection error and is not queryable` errors** caused by PostGraphile resolvers using a pgClient that was already released back to the pool.
- Removes `withPostGraphileContext` (unused transaction/JWT features) and replaces with a Yoga plugin that holds the pgClient for the full duration of GraphQL execution.
- Response cache hits no longer check out a pgClient at all, reducing pool pressure.

## Problem

The `createContext` helper has been broken since the initial benchmark commit (`e960295`). It used `withPostGraphileContext` incorrectly — resolving the outer promise with the context (including `pgClient`), then immediately returning `{data: null}` from the callback. This caused `withPostGraphileContext` to `COMMIT` the transaction and `release()` the client back to the pool *before* GraphQL Yoga started executing the query.

PostGraphile's resolvers (`PgAllRows`, `PgRowByUniqueConstraint`, etc.) then ran SQL against a released client. Under low concurrency this "worked" because the client stayed idle in the pool, but under load or when PgBouncer killed idle connections, the client would be reassigned or disconnected — producing the connection error.

Trace `ae1434810a6340c89edd6ef5d14f88c4` in Sentry (issue GAIA-API-D) shows this manifesting in production.

## Solution

Replace the broken `createContext` + `withPostGraphileContext` pattern with a `usePgClient` Yoga plugin:

- **`onExecute`**: checks out a `pgClient` from the pool and adds it to context via `extendContext`
- **`onExecuteDone`**: releases the client back to the pool

The checkout happens in `onExecute` (not the context factory) so that response cache hits — which short-circuit in `onParams` before `onExecute` fires — never touch the pool.

We don't need `withPostGraphileContext`'s transaction wrapper (`BEGIN`/`COMMIT`) or JWT/role features since mutations are disabled and all queries are reads.