### PR TITLE
fix: proposal-executor Dockerfile uses wrong user commands

### DIFF
--- a/proposal-executor/Dockerfile
+++ b/proposal-executor/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 FROM oven/bun:1.3.9
 ENV NODE_ENV=production
-RUN addgroup --system --gid 1001 geo && adduser --system --uid 1001 geo
+RUN groupadd --system --gid 1001 geo && useradd --system --uid 1001 --gid geo geo
 WORKDIR /app
 COPY --from=builder --chown=geo:geo /app/package.json /app/bun.lock* ./
 RUN bun install --frozen-lockfile --production


### PR DESCRIPTION
## Summary
- Fixes broken Docker build: `oven/bun:1.3.9` is Debian slim which has `groupadd`/`useradd`, not `addgroup`/`adduser`

## Problem
The production deploy workflow failed immediately after merging #437 with `addgroup: not found`.