### PR TITLE
fix: proposal-executor DB SSL self-signed cert rejection

### DIFF
--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -89,6 +89,9 @@ export function connectDb(databaseUrl: string): Effect.Effect<PgClient, InfraErr
 		try: async () => {
 			const client = new Pg.Client({
 				connectionString: databaseUrl,
+				// DigitalOcean managed Postgres uses a self-signed CA. pg v8.19+ treats
+				// sslmode=require as verify-full, which rejects self-signed certs.
+				ssl: {rejectUnauthorized: false},
 				connectionTimeoutMillis: 5_000,
 				statement_timeout: 30_000,
 				idle_in_transaction_session_timeout: 60_000,


### PR DESCRIPTION
## Summary
- Adds `ssl: { rejectUnauthorized: false }` to the pg Client config

## Problem
Pod fails on startup with `SELF_SIGNED_CERT_IN_CHAIN`. pg v8.19 treats `sslmode=require` (in the DATABASE_URL) as `verify-full`, which rejects DigitalOcean's self-signed CA cert.