### PR TITLE
fix(search): lower default score for unscored entities from 0.5 to 0.08

### DIFF
--- a/api/src/services/search/opensearch.ts
+++ b/api/src/services/search/opensearch.ts
@@ -39,11 +39,12 @@ function uuidTermVariants(uuid: string): [string, string] {
 }
 
 /**
- * Default average score for entities without a specific score.
+ * Default score for entities without a specific score (global, space, or entity).
  * When an entity has no score value (missing or empty), this default is used.
- * Scores are normalized to [0, 1] with 0.5 being average.
+ * Set to 0.08 so unscored entities rank below most scored entities without
+ * being completely invisible in results.
  */
-export const DEFAULT_AVERAGE_SCORE = 0.5
+export const DEFAULT_AVERAGE_SCORE = 0.08
 
 /**
  * Minimum score threshold for search boosting.


### PR DESCRIPTION
## Summary
- Change `DEFAULT_AVERAGE_SCORE` from 0.5 to 0.08

## Problem
Entities without a global, space, or entity score default to 0.5 (the midpoint of the 0–1 range). This makes unscored entities rank as if they have average popularity, causing them to appear above actually-rated entities with lower scores.

With the score boost formula `(score + 1.0) * 75`:
- **Before (0.5):** unscored entities get `(0.5 + 1) * 75 = 112.5` boost
- **After (0.08):** unscored entities get `(0.08 + 1) * 75 = 81` boost

This ensures unscored entities rank near the bottom while still being visible in results.

## Test plan
- [ ] Deploy to staging and search for entities known to have no scores
- [ ] Verify they appear lower in results than scored entities
- [ ] Verify they still appear (not filtered out)