### PR TITLE
fix(api): write log.warn to stdout even when Sentry is enabled

### DIFF
--- a/api/src/services/telemetry.ts
+++ b/api/src/services/telemetry.ts
@@ -92,9 +92,9 @@ export const log = {
 		if (sentryInitialized) {
 			// Breadcrumb only - provides context for subsequent errors without creating issues
 			Sentry.addBreadcrumb({message, data, level: "warning", category: "log"})
-		} else {
-			console.warn(formatConsoleLog("warn", message, data))
 		}
+		// Always write to stdout so warnings are visible in kubectl logs
+		console.warn(formatConsoleLog("warn", message, data))
 	},
 	error: (message: string, data?: LogData) => {
 		if (sentryInitialized) {


### PR DESCRIPTION
## Summary
- Change `log.warn()` to always write to `console.warn` (stdout) in addition to the Sentry breadcrumb

## Problem
When Sentry is enabled, `log.warn()` only writes a Sentry breadcrumb — which is invisible unless a subsequent error event carries it. This made slow query (>3s) and large response (>1MB) warnings from #555 unobservable via `kubectl logs`.

## Solution
One-line change in `api/src/services/telemetry.ts`: remove the `else` so `console.warn` always runs, not just when Sentry is disabled. The Sentry breadcrumb is still written when Sentry is initialized.

Affects all `log.warn()` callers across the API, not just the GraphQL instrumentation.

## Test plan
- [ ] Deploy to staging and verify `kubectl logs -l app=api -n api | grep "warn"` shows warning output
- [ ] Verify Sentry breadcrumbs still appear on error events