### PR TITLE
feat(api): add Sentry metrics for GraphQL duration and response size

### DIFF
--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -192,6 +192,19 @@ export function useGraphQLInstrumentation(): Plugin {
 					if (responseSizeBytes !== undefined) {
 						span.setAttribute("graphql.response_size_bytes", responseSizeBytes)
 					}
+
+					// Sentry metrics for dashboards and alerting
+					Sentry.metrics.distribution("graphql.duration_ms", durationMs, {
+						attributes: {operation: operationLabel},
+						unit: "millisecond",
+					})
+					if (responseSizeBytes !== undefined) {
+						Sentry.metrics.distribution("graphql.large_response_size_bytes", responseSizeBytes, {
+							attributes: {operation: operationLabel},
+							unit: "byte",
+						})
+					}
+
 					span.end()
 				},
 			}


### PR DESCRIPTION
## Summary
- Emit `graphql.duration_ms` and `graphql.response_size_bytes` as Sentry distribution metrics on every GraphQL query

## Details
Adds two `Sentry.metrics.distribution()` calls to the GraphQL instrumentation plugin:

- **`graphql.duration_ms`** — emitted for every query, tagged by `operation` name
- **`graphql.response_size_bytes`** — emitted when response size is measured (queries >1s), tagged by `operation` name

These appear in **Sentry → Metrics** as distribution metrics, enabling:
- P50/P95/P99 percentile tracking per operation
- Alerting on response size spikes
- Per-operation breakdown dashboards

## Test plan
- [ ] Deploy to staging
- [ ] Run a few GraphQL queries
- [ ] Verify metrics appear in Sentry → Metrics → search for `graphql.duration_ms`
- [ ] Verify `operation` attribute allows filtering by query type