### PR TITLE
fix(api): distinguish decode-failed from not-cached in proposal diff

### DIFF
--- a/api/src/versioned/__tests__/router.test.ts
+++ b/api/src/versioned/__tests__/router.test.ts
@@ -644,6 +644,69 @@ describe("GET /versioned/proposals/:id/diff", () => {
 			expect(body.message).not.toContain("QmTest123")
 		})
 
+		it("returns 422 when edit blob failed GRC-20 validation (is_errored=true)", async () => {
+			const proposalId = "00000000-0000-0000-0000-000000000001"
+			const spaceId = "00000000-0000-0000-0000-000000000002"
+			const now = Math.floor(Date.now() / 1000)
+
+			// Mock: getProposalWithPublishAction returns proposal with content_uri
+			db.execute.mockResolvedValueOnce({
+				rows: [
+					{
+						proposal_id: proposalId,
+						space_id: spaceId,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: "ipfs://QmTestErroredBlob",
+					},
+				],
+			})
+
+			// Mock: getIpfsCacheData returns row with is_errored=true
+			db.execute.mockResolvedValueOnce({rows: [{data: null, is_errored: true}]})
+
+			const res = await app.request(`/versioned/proposals/${proposalId}/diff?spaceId=${spaceId}`)
+
+			expect(res.status).toBe(422)
+			const body = await res.json()
+			expect(body.error).toBe("Unprocessable")
+			expect(body.message).toContain("GRC-20 validation")
+			// Verify IPFS URI is NOT leaked
+			expect(body.message).not.toContain("ipfs://")
+			expect(body.message).not.toContain("QmTestErroredBlob")
+		})
+
+		it("returns 404 when ipfs_cache row exists but data is null and not errored", async () => {
+			const proposalId = "00000000-0000-0000-0000-000000000001"
+			const spaceId = "00000000-0000-0000-0000-000000000002"
+			const now = Math.floor(Date.now() / 1000)
+
+			// Mock: getProposalWithPublishAction returns proposal with content_uri
+			db.execute.mockResolvedValueOnce({
+				rows: [
+					{
+						proposal_id: proposalId,
+						space_id: spaceId,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: "ipfs://QmTestNullData",
+					},
+				],
+			})
+
+			// Mock: getIpfsCacheData returns row with data=null, is_errored=false
+			db.execute.mockResolvedValueOnce({rows: [{data: null, is_errored: false}]})
+
+			const res = await app.request(`/versioned/proposals/${proposalId}/diff?spaceId=${spaceId}`)
+
+			expect(res.status).toBe(404)
+			const body = await res.json()
+			expect(body.error).toBe("Not found")
+			expect(body.message).toContain("Edit blob not cached")
+		})
+
 		it("returns 400 when spaceId does not match proposal's space", async () => {
 			const proposalId = "00000000-0000-0000-0000-000000000001"
 			const proposalSpaceId = "00000000-0000-0000-0000-000000000002"

--- a/api/src/versioned/index.ts
+++ b/api/src/versioned/index.ts
@@ -1,6 +1,7 @@
 export * from "./grouping"
 export {
 	computeProposalDiff,
+	EditBlobDecodeFailedError,
 	EditBlobNotCachedError,
 	EditDecodeError,
 	InvalidCursorError,

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -63,6 +63,11 @@ export class EditBlobNotCachedError {
 	constructor(readonly uri: string) {}
 }
 
+export class EditBlobDecodeFailedError {
+	readonly _tag = "EditBlobDecodeFailedError"
+	constructor(readonly uri: string) {}
+}
+
 export class EditDecodeError {
 	readonly _tag = "EditDecodeError"
 	constructor(readonly cause: unknown) {}
@@ -85,6 +90,7 @@ export type ProposalDiffError =
 	| QueryError
 	| ProposalNotFoundError
 	| EditBlobNotCachedError
+	| EditBlobDecodeFailedError
 	| EditDecodeError
 	| SpaceMismatchError
 	| InvalidCursorError
@@ -165,16 +171,23 @@ function getProposalWithPublishAction(
 
 /**
  * Get edit blob from IPFS cache.
+ * Returns { data, isErrored } so callers can distinguish between
+ * "not cached" (no row), "cached but decode failed" (row with is_errored=true),
+ * and "cached successfully" (row with data).
  */
-function getIpfsCacheData(db: Database, uri: string): Effect.Effect<Buffer | null, QueryError> {
+function getIpfsCacheData(
+	db: Database,
+	uri: string,
+): Effect.Effect<{data: Buffer | null; isErrored: boolean} | null, QueryError> {
 	return Effect.tryPromise({
 		try: async () => {
-			const result = await db.execute<{data: Buffer | null}>(sql`
-				SELECT data FROM ipfs_cache WHERE uri = ${uri} LIMIT 1
+			const result = await db.execute<{data: Buffer | null; is_errored: boolean}>(sql`
+				SELECT data, is_errored FROM ipfs_cache WHERE uri = ${uri} LIMIT 1
 			`)
 
 			const row = result.rows[0]
-			return row?.data ?? null
+			if (!row) return null
+			return {data: row.data, isErrored: row.is_errored}
 		},
 		catch: (error) => new QueryError("getIpfsCacheData", error),
 	}).pipe(
@@ -908,10 +921,17 @@ export function computeProposalDiff(
 		}
 
 		// 5. Fetch edit blob from IPFS cache
-		const blob = yield* getIpfsCacheData(db, contentUri)
-		if (!blob) {
+		const cacheResult = yield* getIpfsCacheData(db, contentUri)
+		if (!cacheResult) {
 			return yield* Effect.fail(new EditBlobNotCachedError(contentUri))
 		}
+		if (cacheResult.isErrored) {
+			return yield* Effect.fail(new EditBlobDecodeFailedError(contentUri))
+		}
+		if (!cacheResult.data) {
+			return yield* Effect.fail(new EditBlobNotCachedError(contentUri))
+		}
+		const blob = cacheResult.data
 
 		// 6. Decode using @geoprotocol/grc-20
 		const ops = yield* Effect.tryPromise({

--- a/api/src/versioned/router.ts
+++ b/api/src/versioned/router.ts
@@ -23,6 +23,7 @@ import {getProfilesBySpaceIds} from "../profile/queries"
 import {isValidUuid, normalizeUuid, toDashedUuid} from "../utils/uuid"
 import {diffGroupedEntitySnapshots} from "./diff"
 import type {
+	EditBlobDecodeFailedError,
 	EditBlobNotCachedError,
 	EditDecodeError,
 	InvalidCursorError,
@@ -58,6 +59,7 @@ type ProposalError =
 	| QueryError
 	| ProposalNotFoundError
 	| EditBlobNotCachedError
+	| EditBlobDecodeFailedError
 	| EditDecodeError
 	| SpaceMismatchError
 	| InvalidCursorError
@@ -896,6 +898,15 @@ export function createVersionedRouter(db: Database, runtime: AppRuntime) {
 									message: "Edit blob not cached for this proposal",
 								},
 								404,
+							)
+						case "EditBlobDecodeFailedError":
+							return c.json(
+								{
+									error: "Unprocessable",
+									message: "Edit blob failed GRC-20 validation and cannot be decoded",
+									uri: error.uri,
+								},
+								422,
 							)
 						case "SpaceMismatchError":
 							return c.json(


### PR DESCRIPTION
## Problem

The `/versioned/proposals/:id/diff` endpoint returns the same 404 "Edit blob not cached" for two different cases:
1. The blob was never fetched from IPFS (row doesn't exist in `ipfs_cache`)
2. The blob was fetched but failed GRC-20 validation (row exists with `is_errored=true`, `data=NULL`)

This makes it impossible for frontend/callers to distinguish between a temporary caching gap (retry later) and a permanently broken edit (will never work).

## Fix

Query `is_errored` alongside `data` from `ipfs_cache` and return distinct responses:

| Case | Status | Response |
|---|---|---|
| No row in `ipfs_cache` | 404 | `{"error": "Not found", "message": "Edit blob not cached for this proposal"}` |
| Row exists, `is_errored=true` | **422** | `{"error": "Unprocessable", "message": "Edit blob failed GRC-20 validation and cannot be decoded", "uri": "ipfs://..."}` |
| Row exists, data present | 200 | Normal diff response |

## Context

This was discovered investigating proposal `7dd5982f...` at block 113387, which has a malformed GRC-20 edit (context index out of bounds). The blob exists on IPFS and was fetched by `hermes-ipfs-cache`, but the 404 response gave no indication that the issue was a decode failure rather than a missing cache entry.

## Test plan
- [x] Format, lint, type check pass
- [ ] Hit `/versioned/proposals/7dd5982f7d2e4320bdcd885f4bd78543/diff?spaceId=41e851610e13a19441c4d980f2f2ce6b` and verify 422 response with uri
- [ ] Hit a proposal with a valid cached blob and verify normal 200 diff response
- [ ] Hit a proposal with no cached blob and verify 404 response