### PR TITLE
refactor(api): import system IDs from @geoprotocol/geo-sdk instead of hardcoding

### DIFF
--- a/api/bun.lock
+++ b/api/bun.lock
@@ -5,6 +5,7 @@
       "name": "api",
       "dependencies": {
         "@effect/opentelemetry": "^0.53.0",
+        "@geoprotocol/geo-sdk": "^0.17.0",
         "@geoprotocol/grc-20": "^0.3.0",
         "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
         "@graphprotocol/grc-20": "0.32.3",
@@ -185,6 +186,8 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.4", "", { "os": "win32", "cpu": "x64" }, "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="],
 
     "@fastify/busboy": ["@fastify/busboy@3.1.1", "", {}, "sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw=="],
+
+    "@geoprotocol/geo-sdk": ["@geoprotocol/geo-sdk@0.17.0", "", { "dependencies": { "@geoprotocol/grc-20": "^0.4.1", "effect": "^3.17.13", "fflate": "^0.8.2", "fractional-indexing-jittered": "^1.0.0", "image-size": "^2.0.2", "permissionless": "^0.2.35", "uuid": "^13.0.0", "viem": "^2.37.6" } }, "sha512-2nFi/2OZVuRxe3uPR8bpTrbiACGzW0kqYGltB9/W0qRGzAgOcj6oaFiXE6V+au3fcO1KQV+yIBYn/8EdNfu/5A=="],
 
     "@geoprotocol/grc-20": ["@geoprotocol/grc-20@0.3.0", "", { "dependencies": { "@bokuweb/zstd-wasm": "^0.0.27" } }, "sha512-Nd8lge6lAZxOeNYxmMzoTC8cYCEwN1RDaLod3IQO1DQnMzu7Qhv7F/x9ZnbZryO1wkbSSRQ4Z62CL6xf+BNrVQ=="],
 
@@ -1315,6 +1318,12 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@geoprotocol/geo-sdk/@geoprotocol/grc-20": ["@geoprotocol/grc-20@0.4.1", "", { "dependencies": { "@bokuweb/zstd-wasm": "^0.0.27" } }, "sha512-J5trJZBydDOO5GsEMzy9ukX9GetblBMLnn4ugpTFOcwS4akA54Lxg/uYJbXUDh5EVPir3PAzC6UN6EiBz0K/Ww=="],
+
+    "@geoprotocol/geo-sdk/effect": ["effect@3.21.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ=="],
+
+    "@geoprotocol/geo-sdk/uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
     "@graphprotocol/grc-20/@geoprotocol/grc-20": ["@geoprotocol/grc-20@0.1.7", "", { "dependencies": { "@bokuweb/zstd-wasm": "^0.0.27" } }, "sha512-BJGUwG6exJnLkoRzCwzohybxgtwsYwuzEcnyJ2YPQQ1WwDXp7o8oNwLVUjzwEqjEabw1oIRpSnDNrH/LqSEaYA=="],
 

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
 	"description": "",
 	"dependencies": {
 		"@effect/opentelemetry": "^0.53.0",
+		"@geoprotocol/geo-sdk": "^0.17.0",
 		"@geoprotocol/grc-20": "^0.3.0",
 		"@graphile-contrib/pg-simplify-inflector": "^6.1.0",
 		"@graphprotocol/grc-20": "0.32.3",

--- a/api/src/kg/entitySpaceFilterPlugin.ts
+++ b/api/src/kg/entitySpaceFilterPlugin.ts
@@ -30,8 +30,9 @@
  *   - relations(from_entity_id, type_id, to_entity_id)
  */
 
-// SystemIds.Types - the relation type that defines an entity's type
-const SYSTEM_IDS_TYPES = "8f151ba4-de20-4e3c-9cb4-99ddf96f48f1"
+import {SystemIds} from "@geoprotocol/geo-sdk"
+
+const SYSTEM_IDS_TYPES = SystemIds.TYPES_PROPERTY
 
 // ============================================================================
 // Space filter helpers

--- a/api/src/profile/queries.ts
+++ b/api/src/profile/queries.ts
@@ -14,7 +14,7 @@
  * - spaces(address, type) WHERE type = 'Personal'
  */
 
-import {ContentIds, SystemIds} from "@graphprotocol/grc-20"
+import {ContentIds, SystemIds} from "@geoprotocol/geo-sdk"
 import {sql} from "drizzle-orm"
 import type {NodePgDatabase} from "drizzle-orm/node-postgres"
 import {Data, Effect} from "effect"
@@ -76,9 +76,8 @@ export function defaultProfile(address: string, spaceId?: string): Profile {
 	}
 }
 
-// SystemIds for finding space front page entity
-const TYPES_RELATION = "8f151ba4-de20-4e3c-9cb4-99ddf96f48f1"
-const SPACE_TYPE = "362c1dbd-dc64-44bb-a3c4-652f38a642d7"
+const TYPES_RELATION = SystemIds.TYPES_PROPERTY
+const SPACE_TYPE = SystemIds.SPACE_TYPE
 
 /**
  * SQL fragment for selecting profile fields from a space.

--- a/api/src/services/search/opensearch.ts
+++ b/api/src/services/search/opensearch.ts
@@ -7,6 +7,7 @@
  * All indexing/updating/deleting is done by the Rust search-indexer service.
  */
 
+import {ContentIds, SystemIds} from "@geoprotocol/geo-sdk"
 import {Client} from "@opensearch-project/opensearch"
 import {normalizeUuid, toDashedUuid} from "../../utils/uuid"
 import type {SearchClient} from "./client"
@@ -162,12 +163,10 @@ export const DEFAULT_PAGE_SIZE = 20
  */
 export const MAX_PAGE_SIZE = 100
 
-/**
- * GRC-20 relation type IDs used to identify avatar and cover relations.
- */
-const TYPE_RELATION_TYPE_ID = normalizeUuid("8f151ba4-de20-4e3c-9cb4-99ddf96f48f1") as string
-const AVATAR_RELATION_TYPE_ID = normalizeUuid("1155beff-fad5-49b7-a2e0-da4777b8792c") as string
-const COVER_RELATION_TYPE_ID = normalizeUuid("34f53507-2e6b-42c5-a844-43981a77cfa2") as string
+// System IDs from the SDK are already dashless — use directly for OpenSearch queries
+const TYPE_RELATION_TYPE_ID = SystemIds.TYPES_PROPERTY as string
+const AVATAR_RELATION_TYPE_ID = ContentIds.AVATAR_PROPERTY as string
+const COVER_RELATION_TYPE_ID = SystemIds.COVER_PROPERTY as string
 
 interface SubspacesResult {
 	subspaces: string[]


### PR DESCRIPTION
## Problem

5 well-known system UUIDs were hardcoded as string literals across 3 files in the API, duplicating values already available in \`@geoprotocol/geo-sdk\`.

## Fix

Added \`@geoprotocol/geo-sdk\` as a dependency (4 new packages, most deps already shared with \`@geoprotocol/grc-20\`) and replaced all hardcoded IDs with imports from \`SystemIds\` and \`ContentIds\`.

All IDs verified to match exactly:

| Hardcoded value | SDK import | File(s) |
|---|---|---|
| \`8f151ba4-de20-4e3c-9cb4-99ddf96f48f1\` | \`SystemIds.TYPES_PROPERTY\` | opensearch.ts, entitySpaceFilterPlugin.ts, queries.ts |
| \`1155beff-fad5-49b7-a2e0-da4777b8792c\` | \`ContentIds.AVATAR_PROPERTY\` | opensearch.ts |
| \`34f53507-2e6b-42c5-a844-43981a77cfa2\` | \`SystemIds.COVER_PROPERTY\` | opensearch.ts |
| \`362c1dbd-dc64-44bb-a3c4-652f38a642d7\` | \`SystemIds.SPACE_TYPE\` | queries.ts |

Also updated \`profile/queries.ts\` to import from \`@geoprotocol/geo-sdk\` instead of \`@graphprotocol/grc-20\` for consistency.

## Test plan
- [x] Format, lint, type check pass
- [x] All IDs verified identical via Node.js comparison
- [ ] Search API returns same results
- [ ] Profile API works (entity→space resolution unchanged)