### PR TITLE
feat(api): per-IP and API key rate limiting on /graphql with Valkey-shared counters

### DIFF
--- a/.github/workflows/api-rate-limit-integration-tests.yml
+++ b/.github/workflows/api-rate-limit-integration-tests.yml
@@ -1,0 +1,77 @@
+name: API Rate Limit Integration Tests
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'api/src/middleware/rateLimit.ts'
+      - 'api/src/middleware/clientIp.ts'
+      - 'api/src/services/rateLimit/**'
+      - 'api/src/middleware/__tests__/rateLimit-integration.test.ts'
+      - 'api/package.json'
+      - '.github/workflows/api-rate-limit-integration-tests.yml'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'api/src/middleware/rateLimit.ts'
+      - 'api/src/middleware/clientIp.ts'
+      - 'api/src/services/rateLimit/**'
+      - 'api/src/middleware/__tests__/rateLimit-integration.test.ts'
+      - 'api/package.json'
+      - '.github/workflows/api-rate-limit-integration-tests.yml'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  rate-limit-integration:
+    name: Rate Limit Integration Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./api
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: test
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      valkey:
+        image: valkey/valkey:8.1-alpine
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run rate limit integration tests
+        run: bun run test src/middleware/__tests__/rateLimit-integration.test.ts --run
+        env:
+          DATABASE_URL: "postgresql://test:test@localhost:5432/test"
+          VALKEY_URL: "redis://localhost:6379"
+          IPFS_KEY: "test-key"
+          IPFS_GATEWAY_WRITE: "https://ipfs.io"

--- a/.github/workflows/api-rate-limit-integration-tests.yml
+++ b/.github/workflows/api-rate-limit-integration-tests.yml
@@ -69,7 +69,9 @@ jobs:
         run: bun install
 
       - name: Run rate limit integration tests
-        run: bun run test src/middleware/__tests__/rateLimit-integration.test.ts --run
+        # Uses a separate vitest config that includes *integration*.test.ts
+        # files (excluded from the default config since they need real services).
+        run: bunx vitest run --config vitest.integration.config.ts
         env:
           DATABASE_URL: "postgresql://test:test@localhost:5432/test"
           VALKEY_URL: "redis://localhost:6379"

--- a/.github/workflows/api-rate-limit-integration-tests.yml
+++ b/.github/workflows/api-rate-limit-integration-tests.yml
@@ -58,10 +58,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.9
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -18,12 +18,16 @@ IPFS_GATEWAY_WRITE=https://uploads.pinata.cloud/v3/files
 
 # Optional — GraphQL rate limit (requires VALKEY_URL; disabled if Valkey absent)
 # Per-IP counters in Valkey, shared across all API pods. Fail-open on Valkey down.
-# Whitelist accepts comma-separated bare IPs and CIDR ranges (IPv4 only).
-# Default whitelist covers the DOKS pod (10.108.0.0/16) and service (10.109.0.0/16)
-# networks so cluster-internal traffic is never throttled.
+#
+# Set RATE_LIMIT_ENABLED=false to fully disable the limiter (useful for local
+# development, devtools, and CI/CD load tests). Default: enabled.
+#
+# RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS accepts comma-separated bare IPs and CIDR
+# ranges (IPv4 only). Default below covers the DOKS pod (10.108.0.0/16) and
+# service (10.109.0.0/16) networks so cluster-internal traffic is never throttled.
 # Per-IP DB overrides take precedence over the default; insert into rate_limit_overrides.
 # RATE_LIMIT_ENABLED=true
 # RATE_LIMIT_DEFAULT_PER_MINUTE=1000
-# RATE_LIMIT_WHITELIST_IPS=10.108.0.0/16,10.109.0.0/16
+# RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS=10.108.0.0/16,10.109.0.0/16
 # RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS=60
 # RATE_LIMIT_TRUSTED_PROXY_HOPS=1   # ingress-nginx is 1 hop

--- a/api/.env.example
+++ b/api/.env.example
@@ -15,3 +15,15 @@ IPFS_GATEWAY_WRITE=https://uploads.pinata.cloud/v3/files
 # SENTRY_ENVIRONMENT=local
 # SENTRY_TRACES_SAMPLE_RATE=1.0
 # SENTRY_DEBUG=false
+
+# Optional — GraphQL rate limit (requires VALKEY_URL; disabled if Valkey absent)
+# Per-IP counters in Valkey, shared across all API pods. Fail-open on Valkey down.
+# Whitelist accepts comma-separated bare IPs and CIDR ranges (IPv4 only).
+# Default whitelist covers the DOKS pod (10.108.0.0/16) and service (10.109.0.0/16)
+# networks so cluster-internal traffic is never throttled.
+# Per-IP DB overrides take precedence over the default; insert into rate_limit_overrides.
+# RATE_LIMIT_ENABLED=true
+# RATE_LIMIT_DEFAULT_PER_MINUTE=1000
+# RATE_LIMIT_WHITELIST_IPS=10.108.0.0/16,10.109.0.0/16
+# RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS=60
+# RATE_LIMIT_TRUSTED_PROXY_HOPS=1   # ingress-nginx is 1 hop

--- a/api/README.md
+++ b/api/README.md
@@ -106,7 +106,19 @@ When a client exceeds the limit, the API returns `HTTP 429 Too Many Requests` wi
 
 **Need a higher limit?** If you are a partner or integrator and 1000 req/min is not enough for your use case, **contact the Geo team** (open an issue at [geobrowser/gaia/issues](https://github.com/geobrowser/gaia/issues) or reach out via the project's communication channels) to request an override for your IP or IP range.
 
-**Disabling locally**: rate limiting is disabled when `RATE_LIMIT_ENABLED=false` or when `VALKEY_URL` is unset, so local development and CI/CD load tests are unaffected by default.
+**Capacity**: each API pod tracks up to **100,000 distinct IPs** in its in-memory override cache (LRU). Worst-case memory impact: ~20 MB per pod. Beyond 100k unique IPs in the active window, the least-recently-seen IP's override is re-fetched from Postgres on its next request.
+
+### Disabling rate limiting
+
+Rate limiting auto-disables when `RATE_LIMIT_ENABLED=false` **or** when `VALKEY_URL` is unset. Local dev (no Valkey) and CI/CD load tests are unaffected by default.
+
+To disable in a running cluster (e.g. for a load test):
+
+```bash
+kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=false
+# revert with:
+kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=true
+```
 
 See [`docs/plans/003-graphql-rate-limiting.md`](../docs/plans/003-graphql-rate-limiting.md) for the full design.
 

--- a/api/README.md
+++ b/api/README.md
@@ -104,7 +104,9 @@ When a client exceeds the limit, the API returns `HTTP 429 Too Many Requests` wi
 
 **Cluster-internal traffic** (pod-to-pod calls within DOKS) is exempt from rate limiting.
 
-**Need a higher limit?** If you are a partner or integrator and 1000 req/min is not enough for your use case, **contact the Geo team** (open an issue at [geobrowser/gaia/issues](https://github.com/geobrowser/gaia/issues) or reach out via the project's communication channels) to request an override for your IP or IP range.
+**API keys**: backend services (e.g. Railway-hosted curator-app) can send an `X-Api-Key` header to use a key-based limit instead of IP-based. Keys are stored in the `api_keys` table with either a custom `requests_per_min` or `NULL` for unlimited. Counters are tracked separately per key, independent of IP counters.
+
+**Need a higher limit?** If you are a partner or integrator and 1000 req/min is not enough for your use case, **contact the Geo team** (open an issue at [geobrowser/gaia/issues](https://github.com/geobrowser/gaia/issues) or reach out via the project's communication channels) to request an API key or an override for your IP range.
 
 **Capacity**: each API pod tracks up to **100,000 distinct IPs** in its in-memory override cache (LRU). Worst-case memory impact: ~20 MB per pod. Beyond 100k unique IPs in the active window, the least-recently-seen IP's override is re-fetched from Postgres on its next request.
 

--- a/api/README.md
+++ b/api/README.md
@@ -84,6 +84,32 @@ The API starts on `http://localhost:3000` (default).
 
 See [`.env.example`](.env.example) for all environment variables with descriptions.
 
+## Rate Limits
+
+The `/graphql` endpoint applies a per-IP rate limit (default **1000 requests per minute**) to protect against scraping and runaway clients. Counters are shared across all API pods.
+
+Responses include standard rate-limit headers:
+
+```
+RateLimit-Limit: 1000
+RateLimit-Remaining: 957
+RateLimit-Reset: 23
+```
+
+When a client exceeds the limit, the API returns `HTTP 429 Too Many Requests` with `Retry-After` indicating seconds until the window resets:
+
+```json
+{"error":"rate_limit_exceeded","retry_after_seconds":23}
+```
+
+**Cluster-internal traffic** (pod-to-pod calls within DOKS) is exempt from rate limiting.
+
+**Need a higher limit?** If you are a partner or integrator and 1000 req/min is not enough for your use case, **contact the Geo team** (open an issue at [geobrowser/gaia/issues](https://github.com/geobrowser/gaia/issues) or reach out via the project's communication channels) to request an override for your IP or IP range.
+
+**Disabling locally**: rate limiting is disabled when `RATE_LIMIT_ENABLED=false` or when `VALKEY_URL` is unset, so local development and CI/CD load tests are unaffected by default.
+
+See [`docs/plans/003-graphql-rate-limiting.md`](../docs/plans/003-graphql-rate-limiting.md) for the full design.
+
 ## Documentation
 
 - [API Architecture](../docs/api-architecture.md) — layers, tech stack, query patterns

--- a/api/README.md
+++ b/api/README.md
@@ -108,6 +108,8 @@ When a client exceeds the limit, the API returns `HTTP 429 Too Many Requests` wi
 
 **Capacity**: each API pod tracks up to **100,000 distinct IPs** in its in-memory override cache (LRU). Worst-case memory impact: ~20 MB per pod. Beyond 100k unique IPs in the active window, the least-recently-seen IP's override is re-fetched from Postgres on its next request.
 
+**Identifying the client IP**: `RATE_LIMIT_TRUSTED_PROXY_HOPS` (default `1`) tells the limiter how many proxies we own sit in front of the API pod, so it can pick the correct entry from `X-Forwarded-For`. For our DOKS setup the only trusted hop is ingress-nginx, hence `1`. Bump this if you ever add a CDN (e.g. Cloudflare → `2`); without the right value, clients could either spoof their IP via `X-Forwarded-For` or get bucketed into the wrong counter.
+
 ### Disabling rate limiting
 
 Rate limiting auto-disables when `RATE_LIMIT_ENABLED=false` **or** when `VALKEY_URL` is unset. Local dev (no Valkey) and CI/CD load tests are unaffected by default.

--- a/api/drizzle/0054_curved_post.sql
+++ b/api/drizzle/0054_curved_post.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "rate_limit_overrides" (
+	"ip_range" "cidr" PRIMARY KEY NOT NULL,
+	"requests_per_min" integer NOT NULL CHECK ("requests_per_min" >= 0),
+	"description" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "idx_rate_limit_overrides_ip_range" ON "rate_limit_overrides" USING gist ("ip_range" inet_ops);

--- a/api/drizzle/0055_sour_moondragon.sql
+++ b/api/drizzle/0055_sour_moondragon.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "api_keys" (
+	"key" text PRIMARY KEY NOT NULL,
+	"client_name" text NOT NULL,
+	"requests_per_min" integer,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/api/drizzle/meta/0054_snapshot.json
+++ b/api/drizzle/meta/0054_snapshot.json
@@ -1,0 +1,3333 @@
+{
+  "id": "e75b0b90-70e2-4833-8ce4-bbe94b112c2b",
+  "prevId": "6abcfa17-88bb-4d0e-9bb7-989879e12ae7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_overrides": {
+      "name": "rate_limit_overrides",
+      "schema": "",
+      "columns": {
+        "ip_range": {
+          "name": "ip_range",
+          "type": "cidr",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requests_per_min": {
+          "name": "requests_per_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rate_limit_overrides_ip_range": {
+          "name": "idx_rate_limit_overrides_ip_range",
+          "columns": [
+            {
+              "expression": "ip_range",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "inet_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/0055_snapshot.json
+++ b/api/drizzle/meta/0055_snapshot.json
@@ -1,0 +1,3385 @@
+{
+  "id": "13cc9ec1-9294-4fac-8aff-a228fea7c96b",
+  "prevId": "e75b0b90-70e2-4833-8ce4-bbe94b112c2b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requests_per_min": {
+          "name": "requests_per_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_overrides": {
+      "name": "rate_limit_overrides",
+      "schema": "",
+      "columns": {
+        "ip_range": {
+          "name": "ip_range",
+          "type": "cidr",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requests_per_min": {
+          "name": "requests_per_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rate_limit_overrides_ip_range": {
+          "name": "idx_rate_limit_overrides_ip_range",
+          "columns": [
+            {
+              "expression": "ip_range",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "inet_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1776111586600,
       "tag": "0054_curved_post",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1776193401580,
+      "tag": "0055_sour_moondragon",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1775675273149,
       "tag": "0053_crazy_moondragon",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1776111586600,
+      "tag": "0054_curved_post",
+      "breakpoints": true
     }
   ]
 }

--- a/api/k8s/production/api.yaml
+++ b/api/k8s/production/api.yaml
@@ -131,6 +131,17 @@ spec:
                 secretKeyRef:
                   name: api-cache-secrets
                   key: VALKEY_URL
+            # Per-IP rate limit on /graphql. Counters in Valkey, shared across pods.
+            # Allowlist covers DOKS pod (10.108.0.0/16) + service (10.109.0.0/16) CIDRs
+            # so cluster-internal traffic is exempt.
+            - name: RATE_LIMIT_ENABLED
+              value: "true"
+            - name: RATE_LIMIT_DEFAULT_PER_MINUTE
+              value: "1000"
+            - name: RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS
+              value: "10.108.0.0/16,10.109.0.0/16"
+            - name: RATE_LIMIT_TRUSTED_PROXY_HOPS
+              value: "1"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/api/k8s/staging/api.yaml
+++ b/api/k8s/staging/api.yaml
@@ -133,6 +133,17 @@ spec:
                 secretKeyRef:
                   name: api-cache-secrets
                   key: VALKEY_URL
+            # Per-IP rate limit on /graphql. Counters in Valkey, shared across pods.
+            # Allowlist covers DOKS pod (10.108.0.0/16) + service (10.109.0.0/16) CIDRs
+            # so cluster-internal traffic is exempt.
+            - name: RATE_LIMIT_ENABLED
+              value: "true"
+            - name: RATE_LIMIT_DEFAULT_PER_MINUTE
+              value: "1000"
+            - name: RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS
+              value: "10.108.0.0/16,10.109.0.0/16"
+            - name: RATE_LIMIT_TRUSTED_PROXY_HOPS
+              value: "1"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/api/main.ts
+++ b/api/main.ts
@@ -109,7 +109,7 @@ log.info("Proposals routes enabled")
 app.get("/", swaggerUI({url: "/openapi"}))
 
 // Rate limit middleware: scoped to /graphql only for v1.
-// Whitelist (env CIDRs) → DB overrides → default per-minute limit.
+// Unlimited allowlist (env CIDRs) → DB overrides → default per-minute limit.
 // Counter is shared across all API pods via Valkey; failure mode is fail-open.
 const rateLimitConfig = loadRateLimitConfig()
 if (rateLimitConfig.enabled) {
@@ -137,7 +137,7 @@ if (rateLimitConfig.enabled) {
 		app.use("/graphql", rateLimit({config: rateLimitConfig, store, overrides}))
 		log.info("Rate limit enabled on /graphql", {
 			defaultPerMinute: rateLimitConfig.defaultPerMinute,
-			whitelistEntries: rateLimitConfig.whitelist.length,
+			unlimitedAllowlistEntries: rateLimitConfig.unlimitedAllowlist.length,
 			trustedProxyHops: rateLimitConfig.trustedProxyHops,
 		})
 	}
@@ -503,7 +503,19 @@ app.get(
 			info: {
 				title: "Geo API",
 				version: "1.0.0",
-				description: "API for interacting with the Geo knowledge graph",
+				description: [
+					"API for interacting with the Geo knowledge graph.",
+					"",
+					"## Rate Limits",
+					"",
+					"The `/graphql` endpoint applies a per-IP rate limit (default **1000 requests per minute**).",
+					"Responses include `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` headers.",
+					"When the limit is exceeded the endpoint returns `HTTP 429 Too Many Requests` with",
+					"`Retry-After` indicating seconds until the window resets.",
+					"",
+					"Cluster-internal traffic is exempt. **If you need a higher limit for your IP or IP range,",
+					"please contact the Geo team to request an override.**",
+				].join("\n"),
 			},
 			servers: [
 				{url: "http://localhost:3000", description: "Local Server"},

--- a/api/main.ts
+++ b/api/main.ts
@@ -145,35 +145,121 @@ if (rateLimitConfig.enabled) {
 	log.info("Rate limit disabled (RATE_LIMIT_ENABLED=false)")
 }
 
-app.use("/graphql", async (c) => {
-	const requestId = c.get("requestId") || "unknown"
-
-	// Pool pressure shedding is handled inside usePgClient (only on cache misses).
-	// This allows cached responses to be served even when the DB pool is saturated.
-	try {
-		return await graphqlServer.fetch(c.req.raw, {
-			traceContext: c.get("traceContext"),
-			requestId,
-			setGraphqlOperationName: (operationName: string) => {
-				c.set("graphqlOperationName", operationName)
+app.on(
+	["GET", "POST"],
+	"/graphql",
+	describeRoute({
+		tags: ["GraphQL"],
+		summary: "PostGraphile GraphQL endpoint",
+		description: [
+			"PostGraphile-generated GraphQL endpoint over the Geo knowledge graph.",
+			"",
+			"### Rate Limits",
+			"This endpoint is rate-limited to **1000 requests per minute per IP** by default.",
+			"Cluster-internal traffic (pod-to-pod within DOKS) is exempt.",
+			"",
+			"Successful responses include:",
+			"- `RateLimit-Limit` — your per-minute quota",
+			"- `RateLimit-Remaining` — requests remaining in the current window",
+			"- `RateLimit-Reset` — seconds until the window resets",
+			"",
+			"Exceeding the limit returns `HTTP 429 Too Many Requests` with `Retry-After`",
+			'and a body of `{"error":"rate_limit_exceeded","retry_after_seconds":N}`.',
+			"",
+			"**Need a higher limit?** If 1000 req/min is not enough for your integration,",
+			"contact the Geo team to request an override for your IP or IP range.",
+		].join("\n"),
+		responses: {
+			200: {
+				description: "GraphQL execution result (data and/or errors)",
+				content: {
+					"application/json": {
+						schema: {type: "object"},
+					},
+				},
+				headers: {
+					"RateLimit-Limit": {
+						description: "Per-minute request quota for the calling IP",
+						schema: {type: "integer"},
+					},
+					"RateLimit-Remaining": {
+						description: "Requests remaining in the current minute window",
+						schema: {type: "integer"},
+					},
+					"RateLimit-Reset": {
+						description: "Seconds until the rate-limit window resets",
+						schema: {type: "integer"},
+					},
+				},
 			},
-		})
-	} catch (error) {
-		if (isPoolConnectTimeout(error) || (error instanceof Error && error.message === "pool_pressure_shed")) {
-			const freshPoolPressure = getGraphqlPoolPressure()
-			log.warn("GraphQL overloaded: pool pressure shed", {
+			429: {
+				description: "Rate limit exceeded — see Retry-After header",
+				content: {
+					"application/json": {
+						schema: {
+							type: "object",
+							properties: {
+								error: {type: "string", example: "rate_limit_exceeded"},
+								retry_after_seconds: {type: "integer", example: 23},
+							},
+							required: ["error", "retry_after_seconds"],
+						},
+					},
+				},
+				headers: {
+					"Retry-After": {
+						description: "Seconds until the rate-limit window resets",
+						schema: {type: "integer"},
+					},
+				},
+			},
+			503: {
+				description: "Database temporarily overloaded; retry shortly",
+				content: {
+					"application/json": {
+						schema: {
+							type: "object",
+							properties: {
+								error: {type: "string", example: "database temporarily overloaded"},
+								requestId: {type: "string"},
+							},
+							required: ["error", "requestId"],
+						},
+					},
+				},
+			},
+		},
+	}),
+	async (c) => {
+		const requestId = c.get("requestId") || "unknown"
+
+		// Pool pressure shedding is handled inside usePgClient (only on cache misses).
+		// This allows cached responses to be served even when the DB pool is saturated.
+		try {
+			return await graphqlServer.fetch(c.req.raw, {
+				traceContext: c.get("traceContext"),
 				requestId,
-				path: c.req.path,
-				method: c.req.method,
-				poolPressure: freshPoolPressure,
+				setGraphqlOperationName: (operationName: string) => {
+					c.set("graphqlOperationName", operationName)
+				},
 			})
+		} catch (error) {
+			if (isPoolConnectTimeout(error) || (error instanceof Error && error.message === "pool_pressure_shed")) {
+				const freshPoolPressure = getGraphqlPoolPressure()
+				log.warn("GraphQL overloaded: pool pressure shed", {
+					requestId,
+					path: c.req.path,
+					method: c.req.method,
+					poolPressure: freshPoolPressure,
+				})
 
-			return createGraphqlOverloadResponse(requestId)
+				return createGraphqlOverloadResponse(requestId)
+			}
+
+			throw error
 		}
-
-		throw error
-	}
-})
+	},
+)
 
 app.post(
 	"/ipfs/upload-edit",

--- a/api/main.ts
+++ b/api/main.ts
@@ -14,6 +14,7 @@ import {createSearchRouter} from "./src/search"
 import {isPoolConnectTimeout} from "./src/services/dbFailures"
 import {shouldShedPoolTraffic} from "./src/services/dbSaturation"
 import {uploadEdit, uploadFile} from "./src/services/ipfs"
+import {createApiKeyLookup} from "./src/services/rateLimit/apiKeys"
 import {loadRateLimitConfig} from "./src/services/rateLimit/config"
 import {createOverrideLookup} from "./src/services/rateLimit/overrides"
 import {createValkeyRateLimitStore} from "./src/services/rateLimit/store"
@@ -134,7 +135,8 @@ if (rateLimitConfig.enabled) {
 
 		const store = createValkeyRateLimitStore(valkey)
 		const overrides = createOverrideLookup(db, rateLimitConfig.overrideCacheTtlSeconds)
-		app.use("/graphql", rateLimit({config: rateLimitConfig, store, overrides}))
+		const apiKeyLookup = createApiKeyLookup(db, rateLimitConfig.overrideCacheTtlSeconds)
+		app.use("/graphql", rateLimit({config: rateLimitConfig, store, overrides, apiKeys: apiKeyLookup}))
 		log.info("Rate limit enabled on /graphql", {
 			defaultPerMinute: rateLimitConfig.defaultPerMinute,
 			unlimitedAllowlistEntries: rateLimitConfig.unlimitedAllowlist.length,

--- a/api/main.ts
+++ b/api/main.ts
@@ -3,8 +3,10 @@ import {Effect, Either} from "effect"
 import {Hono} from "hono"
 import {cors} from "hono/cors"
 import {describeRoute, openAPISpecs} from "hono-openapi"
+import Redis from "ioredis"
 import {health} from "./src/health"
 import {getGraphqlPoolPressure, graphqlServer} from "./src/kg/postgraphile"
+import {rateLimit} from "./src/middleware/rateLimit"
 import {canonicalRequestLogging, requestId} from "./src/middleware/requestLogging"
 import {createProfileRouter} from "./src/profile"
 import {createProposalsRouter} from "./src/proposals"
@@ -12,6 +14,9 @@ import {createSearchRouter} from "./src/search"
 import {isPoolConnectTimeout} from "./src/services/dbFailures"
 import {shouldShedPoolTraffic} from "./src/services/dbSaturation"
 import {uploadEdit, uploadFile} from "./src/services/ipfs"
+import {loadRateLimitConfig} from "./src/services/rateLimit/config"
+import {createOverrideLookup} from "./src/services/rateLimit/overrides"
+import {createValkeyRateLimitStore} from "./src/services/rateLimit/store"
 import {runtime} from "./src/services/runtime"
 import {OpenSearchClient} from "./src/services/search"
 import {db} from "./src/services/storage/storage"
@@ -102,6 +107,43 @@ app.route("/proposals", createProposalsRouter(db, runtime))
 log.info("Proposals routes enabled")
 
 app.get("/", swaggerUI({url: "/openapi"}))
+
+// Rate limit middleware: scoped to /graphql only for v1.
+// Whitelist (env CIDRs) → DB overrides → default per-minute limit.
+// Counter is shared across all API pods via Valkey; failure mode is fail-open.
+const rateLimitConfig = loadRateLimitConfig()
+if (rateLimitConfig.enabled) {
+	const valkeyUrl = process.env.VALKEY_URL
+	if (!valkeyUrl) {
+		log.warn("Rate limit enabled but VALKEY_URL is not set — disabling rate limit")
+	} else {
+		const valkey = new Redis(valkeyUrl, {
+			maxRetriesPerRequest: 1,
+			lazyConnect: true,
+			connectTimeout: 2000,
+			commandTimeout: 500,
+			retryStrategy(times) {
+				return Math.min(times * 500, 5000)
+			},
+		})
+		valkey.on("error", (err) => log.warn("Valkey rate limit client error", {error: String(err)}))
+		valkey.on("connect", () => log.info("Valkey rate limit client connected"))
+		valkey.connect().catch((err) => {
+			log.warn("Valkey rate limit initial connection failed, will retry", {error: String(err)})
+		})
+
+		const store = createValkeyRateLimitStore(valkey)
+		const overrides = createOverrideLookup(db, rateLimitConfig.overrideCacheTtlSeconds)
+		app.use("/graphql", rateLimit({config: rateLimitConfig, store, overrides}))
+		log.info("Rate limit enabled on /graphql", {
+			defaultPerMinute: rateLimitConfig.defaultPerMinute,
+			whitelistEntries: rateLimitConfig.whitelist.length,
+			trustedProxyHops: rateLimitConfig.trustedProxyHops,
+		})
+	}
+} else {
+	log.info("Rate limit disabled (RATE_LIMIT_ENABLED=false)")
+}
 
 app.use("/graphql", async (c) => {
 	const requestId = c.get("requestId") || "unknown"

--- a/api/scripts/test-rate-limit.sh
+++ b/api/scripts/test-rate-limit.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Test rate limiting against a running API instance.
+# Uses a cheap cached query ({__typename}) so every request is fast.
+#
+# Usage:
+#   ./scripts/test-rate-limit.sh                        # default: 20 requests to staging
+#   ./scripts/test-rate-limit.sh 50                     # 50 requests
+#   ./scripts/test-rate-limit.sh 50 https://custom-api  # 50 requests to custom URL
+
+COUNT=${1:-20}
+BASE_URL=${2:-https://api-testnet.geobrowser.io}
+ENDPOINT="${BASE_URL}/graphql"
+
+echo "Sending ${COUNT} requests to ${ENDPOINT}"
+echo "---"
+
+for i in $(seq 1 "$COUNT"); do
+  HEADERS=$(curl -sI -X POST "$ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -d '{"query":"{__typename}"}')
+
+  STATUS=$(echo "$HEADERS" | head -1 | awk '{print $2}')
+  LIMIT=$(echo "$HEADERS" | grep -i "ratelimit-limit:" | tr -d '\r' | awk '{print $2}')
+  REMAINING=$(echo "$HEADERS" | grep -i "ratelimit-remaining:" | tr -d '\r' | awk '{print $2}')
+  RESET=$(echo "$HEADERS" | grep -i "ratelimit-reset:" | tr -d '\r' | awk '{print $2}')
+
+  printf "#%-4s  status=%s  limit=%s  remaining=%s  reset=%ss\n" \
+    "$i" "${STATUS:-?}" "${LIMIT:-n/a}" "${REMAINING:-n/a}" "${RESET:-n/a}"
+
+  if [ "$STATUS" = "429" ]; then
+    echo ">>> Rate limited! Stopping."
+    break
+  fi
+done

--- a/api/src/middleware/__tests__/clientIp.test.ts
+++ b/api/src/middleware/__tests__/clientIp.test.ts
@@ -1,0 +1,64 @@
+import {Hono} from "hono"
+import {describe, expect, it} from "vitest"
+import {extractClientIp} from "../clientIp"
+
+function appWithIpEcho(trustedHops: number) {
+	const app = new Hono()
+	app.get("/whoami", (c) => {
+		const ip = extractClientIp(c, trustedHops)
+		return c.json({ip})
+	})
+	return app
+}
+
+async function fetchIp(app: Hono, headers: Record<string, string>): Promise<string | null> {
+	const res = await app.request("/whoami", {headers})
+	const body = (await res.json()) as {ip: string | null}
+	return body.ip
+}
+
+describe("extractClientIp", () => {
+	it("returns null when no headers present", async () => {
+		const app = appWithIpEcho(1)
+		expect(await fetchIp(app, {})).toBeNull()
+	})
+
+	it("returns leftmost X-Forwarded-For with trustedHops=1", async () => {
+		const app = appWithIpEcho(1)
+		// "client, ingress" with trustedHops=1 → take rightmost-1 = client
+		expect(await fetchIp(app, {"x-forwarded-for": "203.0.113.42, 10.108.0.5"})).toBe("203.0.113.42")
+	})
+
+	it("respects trustedHops > 1 for nested proxies", async () => {
+		const app = appWithIpEcho(2)
+		// "client, lb, ingress" with trustedHops=2 → take rightmost-2 = client
+		expect(await fetchIp(app, {"x-forwarded-for": "203.0.113.42, 10.0.0.1, 10.108.0.5"})).toBe("203.0.113.42")
+	})
+
+	it("falls back to X-Real-IP when XFF absent", async () => {
+		const app = appWithIpEcho(1)
+		expect(await fetchIp(app, {"x-real-ip": "203.0.113.7"})).toBe("203.0.113.7")
+	})
+
+	it("prefers XFF over X-Real-IP", async () => {
+		const app = appWithIpEcho(1)
+		expect(await fetchIp(app, {"x-forwarded-for": "203.0.113.42", "x-real-ip": "203.0.113.99"})).toBe(
+			"203.0.113.42",
+		)
+	})
+
+	it("ignores XFF entries that fail the shape check", async () => {
+		const app = appWithIpEcho(1)
+		expect(await fetchIp(app, {"x-forwarded-for": "not-an-ip"})).toBeNull()
+	})
+
+	it("handles single XFF entry", async () => {
+		const app = appWithIpEcho(1)
+		expect(await fetchIp(app, {"x-forwarded-for": "203.0.113.42"})).toBe("203.0.113.42")
+	})
+
+	it("trims whitespace from entries", async () => {
+		const app = appWithIpEcho(1)
+		expect(await fetchIp(app, {"x-forwarded-for": "  203.0.113.42  ,  10.108.0.5  "})).toBe("203.0.113.42")
+	})
+})

--- a/api/src/middleware/__tests__/rateLimit-integration.test.ts
+++ b/api/src/middleware/__tests__/rateLimit-integration.test.ts
@@ -110,21 +110,20 @@ describe("Rate limit integration", () => {
 		})
 	}
 
-	it("allows requests under the DB override limit", async () => {
+	it("allows requests under the DB override limit then returns 429", async () => {
+		// Self-contained: consumes the full quota and verifies 429 in one test
 		for (let i = 0; i < TEST_LIMIT; i++) {
 			const res = await req(TEST_IP)
 			expect(res.status).toBe(200)
 			expect(res.headers.get("RateLimit-Limit")).toBe(String(TEST_LIMIT))
 			expect(Number(res.headers.get("RateLimit-Remaining"))).toBe(TEST_LIMIT - i - 1)
 		}
-	})
 
-	it("returns 429 after exceeding the DB override limit", async () => {
-		// The previous test already consumed TEST_LIMIT requests
-		const res = await req(TEST_IP)
-		expect(res.status).toBe(429)
-		expect(res.headers.get("Retry-After")).toBeDefined()
-		const body = (await res.json()) as {error: string; retry_after_seconds: number}
+		// Next request exceeds the limit
+		const blocked = await req(TEST_IP)
+		expect(blocked.status).toBe(429)
+		expect(blocked.headers.get("Retry-After")).toBeDefined()
+		const body = (await blocked.json()) as {error: string; retry_after_seconds: number}
 		expect(body.error).toBe("rate_limit_exceeded")
 		expect(body.retry_after_seconds).toBeGreaterThan(0)
 	})

--- a/api/src/middleware/__tests__/rateLimit-integration.test.ts
+++ b/api/src/middleware/__tests__/rateLimit-integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Rate limit integration test.
+ *
+ * Requires real Valkey and Postgres (CI provides both as services).
+ * Tests the full pipeline: DB override lookup → Valkey counter → HTTP 429.
+ *
+ * Strategy: insert a rate_limit_overrides row with a very low limit (3/min)
+ * for a test IP, then fire requests through a real Hono app with the rate
+ * limit middleware wired to real Valkey + Postgres.
+ */
+import {sql} from "drizzle-orm"
+import {drizzle} from "drizzle-orm/node-postgres"
+import {Hono} from "hono"
+import Redis from "ioredis"
+import pg from "pg"
+import {afterAll, beforeAll, describe, expect, it} from "vitest"
+import {loadRateLimitConfig} from "../../services/rateLimit/config"
+import {createOverrideLookup} from "../../services/rateLimit/overrides"
+import {createValkeyRateLimitStore} from "../../services/rateLimit/store"
+import {rateLimit} from "../rateLimit"
+
+const TEST_IP = "198.51.100.42"
+const TEST_IP_BLOCKED = "198.51.100.99"
+const TEST_IP_DEFAULT = "203.0.113.10"
+const TEST_LIMIT = 3
+
+const databaseUrl = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test"
+const valkeyUrl = process.env.VALKEY_URL || "redis://localhost:6379"
+
+let pool: pg.Pool
+let db: ReturnType<typeof drizzle>
+let valkey: Redis
+let app: Hono
+
+describe("Rate limit integration", () => {
+	beforeAll(async () => {
+		// Connect to real Postgres
+		pool = new pg.Pool({connectionString: databaseUrl})
+		db = drizzle({client: pool})
+
+		// Create the rate_limit_overrides table if it doesn't exist (CI may not have run full migrations)
+		await db.execute(sql`
+			CREATE TABLE IF NOT EXISTS rate_limit_overrides (
+				ip_range cidr PRIMARY KEY,
+				requests_per_min integer NOT NULL CHECK (requests_per_min >= 0),
+				description text,
+				created_at timestamptz NOT NULL DEFAULT now(),
+				updated_at timestamptz NOT NULL DEFAULT now()
+			)
+		`)
+		await db.execute(sql`
+			CREATE INDEX IF NOT EXISTS idx_rate_limit_overrides_ip_range
+			ON rate_limit_overrides USING gist (ip_range inet_ops)
+		`)
+
+		// Insert test overrides
+		await db.execute(sql`DELETE FROM rate_limit_overrides`)
+		await db.execute(
+			sql`INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
+			    VALUES (${TEST_IP}::cidr, ${TEST_LIMIT}, 'integration test: low limit')`,
+		)
+		await db.execute(
+			sql`INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
+			    VALUES (${TEST_IP_BLOCKED}::cidr, 0, 'integration test: blocked')`,
+		)
+
+		// Connect to real Valkey
+		valkey = new Redis(valkeyUrl, {
+			maxRetriesPerRequest: 1,
+			lazyConnect: true,
+			connectTimeout: 2000,
+			commandTimeout: 500,
+		})
+		await valkey.connect()
+		// Clean any stale rate limit keys
+		const keys = await valkey.keys("rl:*")
+		if (keys.length > 0) await valkey.del(...keys)
+
+		// Build the Hono app with real deps
+		const config = loadRateLimitConfig({
+			RATE_LIMIT_ENABLED: "true",
+			RATE_LIMIT_DEFAULT_PER_MINUTE: "1000",
+			RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS: "10.108.0.0/16",
+			RATE_LIMIT_TRUSTED_PROXY_HOPS: "1",
+		})
+		const store = createValkeyRateLimitStore(valkey)
+		const overrides = createOverrideLookup(db as never, 0) // TTL=0 so every lookup hits DB (no stale cache)
+
+		app = new Hono()
+		app.use("/graphql", rateLimit({config, store, overrides}))
+		app.post("/graphql", (c) => c.json({data: {ok: true}}))
+	})
+
+	afterAll(async () => {
+		await db.execute(sql`DELETE FROM rate_limit_overrides`)
+		const keys = await valkey.keys("rl:*")
+		if (keys.length > 0) await valkey.del(...keys)
+		valkey.disconnect()
+		await pool.end()
+	})
+
+	function req(ip: string) {
+		return app.request("/graphql", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-forwarded-for": `${ip}, 10.108.0.5`,
+			},
+			body: JSON.stringify({query: "{__typename}"}),
+		})
+	}
+
+	it("allows requests under the DB override limit", async () => {
+		for (let i = 0; i < TEST_LIMIT; i++) {
+			const res = await req(TEST_IP)
+			expect(res.status).toBe(200)
+			expect(res.headers.get("RateLimit-Limit")).toBe(String(TEST_LIMIT))
+			expect(Number(res.headers.get("RateLimit-Remaining"))).toBe(TEST_LIMIT - i - 1)
+		}
+	})
+
+	it("returns 429 after exceeding the DB override limit", async () => {
+		// The previous test already consumed TEST_LIMIT requests
+		const res = await req(TEST_IP)
+		expect(res.status).toBe(429)
+		expect(res.headers.get("Retry-After")).toBeDefined()
+		const body = (await res.json()) as {error: string; retry_after_seconds: number}
+		expect(body.error).toBe("rate_limit_exceeded")
+		expect(body.retry_after_seconds).toBeGreaterThan(0)
+	})
+
+	it("blocks immediately when override is 0 (kill switch)", async () => {
+		const res = await req(TEST_IP_BLOCKED)
+		expect(res.status).toBe(429)
+		expect(res.headers.get("RateLimit-Limit")).toBe("0")
+	})
+
+	it("uses default limit for IPs without a DB override", async () => {
+		const res = await req(TEST_IP_DEFAULT)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("RateLimit-Limit")).toBe("1000")
+	})
+
+	it("skips rate limiting for allowlisted IPs", async () => {
+		// 10.108.5.42 is inside the allowlist CIDR 10.108.0.0/16
+		// With trustedHops=1, XFF "10.108.5.42, 10.108.0.5" picks 10.108.5.42
+		const res = await app.request("/graphql", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-forwarded-for": "10.108.5.42, 10.108.0.5",
+			},
+			body: JSON.stringify({query: "{__typename}"}),
+		})
+		expect(res.status).toBe(200)
+		expect(res.headers.get("RateLimit-Limit")).toBeNull() // no headers for allowlisted
+	})
+
+	it("Valkey counter is shared (same key incremented across calls)", async () => {
+		// Use a fresh IP to get a clean counter
+		const freshIp = "192.0.2.77"
+		const r1 = await req(freshIp)
+		const r2 = await req(freshIp)
+		expect(r1.headers.get("RateLimit-Remaining")).toBe("999")
+		expect(r2.headers.get("RateLimit-Remaining")).toBe("998")
+	})
+})

--- a/api/src/middleware/__tests__/rateLimit-integration.test.ts
+++ b/api/src/middleware/__tests__/rateLimit-integration.test.ts
@@ -14,6 +14,7 @@ import {Hono} from "hono"
 import Redis from "ioredis"
 import pg from "pg"
 import {afterAll, beforeAll, describe, expect, it} from "vitest"
+import {createApiKeyLookup} from "../../services/rateLimit/apiKeys"
 import {loadRateLimitConfig} from "../../services/rateLimit/config"
 import {createOverrideLookup} from "../../services/rateLimit/overrides"
 import {createValkeyRateLimitStore} from "../../services/rateLimit/store"
@@ -53,7 +54,20 @@ describe("Rate limit integration", () => {
 			ON rate_limit_overrides USING gist (ip_range inet_ops)
 		`)
 
-		// Insert test overrides
+		// Create api_keys table
+		await db.execute(sql`
+			CREATE TABLE IF NOT EXISTS api_keys (
+				key text PRIMARY KEY,
+				client_name text NOT NULL,
+				requests_per_min integer,
+				enabled boolean DEFAULT true NOT NULL,
+				created_at timestamptz NOT NULL DEFAULT now(),
+				updated_at timestamptz NOT NULL DEFAULT now()
+			)
+		`)
+
+		// Insert test data
+		await db.execute(sql`DELETE FROM api_keys`)
 		await db.execute(sql`DELETE FROM rate_limit_overrides`)
 		await db.execute(
 			sql`INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
@@ -62,6 +76,19 @@ describe("Rate limit integration", () => {
 		await db.execute(
 			sql`INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
 			    VALUES (${TEST_IP_BLOCKED}::cidr, 0, 'integration test: blocked')`,
+		)
+		// API key test data
+		await db.execute(
+			sql`INSERT INTO api_keys (key, client_name, requests_per_min, enabled)
+			    VALUES ('test-custom-key', 'test-client', 3, true)`,
+		)
+		await db.execute(
+			sql`INSERT INTO api_keys (key, client_name, requests_per_min, enabled)
+			    VALUES ('test-unlimited-key', 'railway-backend', NULL, true)`,
+		)
+		await db.execute(
+			sql`INSERT INTO api_keys (key, client_name, requests_per_min, enabled)
+			    VALUES ('test-disabled-key', 'disabled-client', 5000, false)`,
 		)
 
 		// Connect to real Valkey
@@ -85,13 +112,15 @@ describe("Rate limit integration", () => {
 		})
 		const store = createValkeyRateLimitStore(valkey)
 		const overrides = createOverrideLookup(db as never, 0) // TTL=0 so every lookup hits DB (no stale cache)
+		const apiKeyLookup = createApiKeyLookup(db as never, 0)
 
 		app = new Hono()
-		app.use("/graphql", rateLimit({config, store, overrides}))
+		app.use("/graphql", rateLimit({config, store, overrides, apiKeys: apiKeyLookup}))
 		app.post("/graphql", (c) => c.json({data: {ok: true}}))
 	})
 
 	afterAll(async () => {
+		await db.execute(sql`DELETE FROM api_keys`)
 		await db.execute(sql`DELETE FROM rate_limit_overrides`)
 		const keys = await valkey.keys("rl:*")
 		if (keys.length > 0) await valkey.del(...keys)
@@ -196,5 +225,65 @@ describe("Rate limit integration", () => {
 		const blocked = await req(cacheHitIp)
 		expect(blocked.status).toBe(429)
 		expect(blocked.headers.get("RateLimit-Limit")).toBe("5")
+	})
+
+	// ─── API key integration tests ────────────────────────────────────
+
+	function reqWithKey(key: string) {
+		return app.request("/graphql", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-forwarded-for": "203.0.113.99, 10.108.0.5",
+				"x-api-key": key,
+			},
+			body: JSON.stringify({query: "{__typename}"}),
+		})
+	}
+
+	it("API key with custom limit: allows under limit then returns 429", async () => {
+		for (let i = 0; i < 3; i++) {
+			const res = await reqWithKey("test-custom-key")
+			expect(res.status).toBe(200)
+			expect(res.headers.get("RateLimit-Limit")).toBe("3")
+			expect(Number(res.headers.get("RateLimit-Remaining"))).toBe(3 - i - 1)
+		}
+		const blocked = await reqWithKey("test-custom-key")
+		expect(blocked.status).toBe(429)
+	})
+
+	it("API key with unlimited (null) allows unlimited requests with no headers", async () => {
+		for (let i = 0; i < 20; i++) {
+			const res = await reqWithKey("test-unlimited-key")
+			expect(res.status).toBe(200)
+			// Unlimited keys get no rate-limit headers
+			expect(res.headers.get("RateLimit-Limit")).toBeNull()
+		}
+	})
+
+	it("disabled API key falls through to IP-based limiting", async () => {
+		const res = await reqWithKey("test-disabled-key")
+		expect(res.status).toBe(200)
+		// Should use the default IP-based limit (1000), not the key's 5000
+		expect(res.headers.get("RateLimit-Limit")).toBe("1000")
+	})
+
+	it("unknown API key falls through to IP-based limiting", async () => {
+		const res = await reqWithKey("nonexistent-key")
+		expect(res.status).toBe(200)
+		expect(res.headers.get("RateLimit-Limit")).toBe("1000")
+	})
+
+	it("API key counter is separate from IP counter", async () => {
+		const freshIp = "192.0.2.55"
+		// Make requests with IP (uses IP counter)
+		const ipRes = await req(freshIp)
+		expect(ipRes.headers.get("RateLimit-Remaining")).toBe("999")
+
+		// Make requests with API key from same IP (uses key counter, separate)
+		const keyRes = await reqWithKey("test-custom-key")
+		// Key counter was already at 4 from earlier test... use unlimited key to verify isolation
+		const unlimitedRes = await reqWithKey("test-unlimited-key")
+		expect(unlimitedRes.status).toBe(200) // unlimited, unaffected by IP counter
 	})
 })

--- a/api/src/middleware/__tests__/rateLimit-integration.test.ts
+++ b/api/src/middleware/__tests__/rateLimit-integration.test.ts
@@ -164,4 +164,38 @@ describe("Rate limit integration", () => {
 		expect(r1.headers.get("RateLimit-Remaining")).toBe("999")
 		expect(r2.headers.get("RateLimit-Remaining")).toBe("998")
 	})
+
+	it("cache hits still count against rate limit (every request decrements remaining)", async () => {
+		// This test proves that even if the GraphQL handler responds instantly
+		// (simulating a Valkey response-cache hit), the rate limit middleware
+		// still increments the counter on every request. The middleware runs
+		// BEFORE the handler, so whether Yoga serves from cache or hits Postgres
+		// is irrelevant — the counter was already incremented.
+		//
+		// We use a fresh IP with the default 1000/min limit and a DB override
+		// of 5/min to make the test fast.
+		const cacheHitIp = "192.0.2.200"
+		await db.execute(
+			sql`INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
+			    VALUES (${cacheHitIp}::cidr, 5, 'integration test: cache-hit counting')`,
+		)
+
+		// Fire 5 requests — all "cache hits" (our handler returns instantly)
+		const responses = []
+		for (let i = 0; i < 5; i++) {
+			responses.push(await req(cacheHitIp))
+		}
+
+		// Every response should be 200 with decrementing Remaining
+		for (let i = 0; i < 5; i++) {
+			const res = responses[i]!
+			expect(res.status).toBe(200)
+			expect(res.headers.get("RateLimit-Remaining")).toBe(String(5 - i - 1))
+		}
+
+		// 6th request should be 429 — even though every previous response was instant
+		const blocked = await req(cacheHitIp)
+		expect(blocked.status).toBe(429)
+		expect(blocked.headers.get("RateLimit-Limit")).toBe("5")
+	})
 })

--- a/api/src/middleware/__tests__/rateLimit.test.ts
+++ b/api/src/middleware/__tests__/rateLimit.test.ts
@@ -26,6 +26,9 @@ function fakeOverrides(map: Record<string, number | null>): OverrideLookup {
 		async lookup(ip) {
 			return map[ip] ?? null
 		},
+		size() {
+			return 0
+		},
 	}
 }
 

--- a/api/src/middleware/__tests__/rateLimit.test.ts
+++ b/api/src/middleware/__tests__/rateLimit.test.ts
@@ -1,0 +1,144 @@
+import {Hono} from "hono"
+import {beforeEach, describe, expect, it} from "vitest"
+import {parseCidr} from "../../services/rateLimit/cidr"
+import type {RateLimitConfig} from "../../services/rateLimit/config"
+import type {OverrideLookup} from "../../services/rateLimit/overrides"
+import type {RateLimitStore} from "../../services/rateLimit/store"
+import {rateLimit} from "../rateLimit"
+
+function fakeStore(): RateLimitStore & {calls: number; failNext: boolean} {
+	const counters = new Map<string, number>()
+	return {
+		calls: 0,
+		failNext: false,
+		async incrementAndGet(ip) {
+			this.calls++
+			if (this.failNext) return null
+			const next = (counters.get(ip) ?? 0) + 1
+			counters.set(ip, next)
+			return {count: next, resetSeconds: 30}
+		},
+	}
+}
+
+function fakeOverrides(map: Record<string, number | null>): OverrideLookup {
+	return {
+		async lookup(ip) {
+			return map[ip] ?? null
+		},
+	}
+}
+
+function makeApp(config: RateLimitConfig, store: RateLimitStore, overrides: OverrideLookup) {
+	const app = new Hono()
+	app.use("/protected", rateLimit({config, store, overrides}))
+	app.get("/protected", (c) => c.json({ok: true}))
+	return app
+}
+
+const baseConfig: RateLimitConfig = {
+	enabled: true,
+	defaultPerMinute: 3,
+	whitelist: [],
+	overrideCacheTtlSeconds: 60,
+	trustedProxyHops: 1,
+}
+
+const headers = {"x-forwarded-for": "203.0.113.42"}
+
+describe("rateLimit middleware", () => {
+	let store: ReturnType<typeof fakeStore>
+
+	beforeEach(() => {
+		store = fakeStore()
+	})
+
+	it("passes through when disabled", async () => {
+		const app = makeApp({...baseConfig, enabled: false}, store, fakeOverrides({}))
+		const res = await app.request("/protected", {headers})
+		expect(res.status).toBe(200)
+		expect(store.calls).toBe(0)
+	})
+
+	it("allows under default limit and sets headers", async () => {
+		const app = makeApp(baseConfig, store, fakeOverrides({}))
+		const res = await app.request("/protected", {headers})
+		expect(res.status).toBe(200)
+		expect(res.headers.get("RateLimit-Limit")).toBe("3")
+		expect(res.headers.get("RateLimit-Remaining")).toBe("2")
+		expect(res.headers.get("RateLimit-Reset")).toBe("30")
+	})
+
+	it("blocks with 429 when default limit exceeded", async () => {
+		const app = makeApp(baseConfig, store, fakeOverrides({}))
+		await app.request("/protected", {headers})
+		await app.request("/protected", {headers})
+		await app.request("/protected", {headers})
+		const blocked = await app.request("/protected", {headers})
+		expect(blocked.status).toBe(429)
+		expect(blocked.headers.get("Retry-After")).toBe("30")
+		const body = (await blocked.json()) as {error: string; retry_after_seconds: number}
+		expect(body.error).toBe("rate_limit_exceeded")
+		expect(body.retry_after_seconds).toBe(30)
+	})
+
+	it("does not consume counter for whitelisted IPs", async () => {
+		const config = {...baseConfig, whitelist: [parseCidr("203.0.113.0/24")!]}
+		const app = makeApp(config, store, fakeOverrides({}))
+		// Do 10 requests — would normally exceed the limit of 3
+		for (let i = 0; i < 10; i++) {
+			const res = await app.request("/protected", {headers})
+			expect(res.status).toBe(200)
+		}
+		expect(store.calls).toBe(0)
+	})
+
+	it("uses DB override when present", async () => {
+		const overrides = fakeOverrides({"203.0.113.42": 1})
+		const app = makeApp(baseConfig, store, overrides)
+		const ok = await app.request("/protected", {headers})
+		expect(ok.status).toBe(200)
+		expect(ok.headers.get("RateLimit-Limit")).toBe("1")
+		const blocked = await app.request("/protected", {headers})
+		expect(blocked.status).toBe(429)
+	})
+
+	it("override of 0 blocks immediately as kill switch", async () => {
+		const overrides = fakeOverrides({"203.0.113.42": 0})
+		const app = makeApp(baseConfig, store, overrides)
+		const res = await app.request("/protected", {headers})
+		expect(res.status).toBe(429)
+		expect(res.headers.get("RateLimit-Limit")).toBe("0")
+		// Should not have consumed any Valkey call for the kill-switched IP
+		expect(store.calls).toBe(0)
+	})
+
+	it("fails open when Valkey returns null", async () => {
+		store.failNext = true
+		const app = makeApp(baseConfig, store, fakeOverrides({}))
+		const res = await app.request("/protected", {headers})
+		expect(res.status).toBe(200)
+		// No rate limit headers when fail-open
+		expect(res.headers.get("RateLimit-Limit")).toBeNull()
+	})
+
+	it("allows request through when no client IP detected", async () => {
+		const app = makeApp(baseConfig, store, fakeOverrides({}))
+		const res = await app.request("/protected") // no headers
+		expect(res.status).toBe(200)
+		expect(store.calls).toBe(0)
+	})
+
+	it("counters are isolated per IP", async () => {
+		const app = makeApp(baseConfig, store, fakeOverrides({}))
+		// Spend the limit for IP A
+		for (let i = 0; i < 3; i++) {
+			await app.request("/protected", {headers: {"x-forwarded-for": "1.1.1.1"}})
+		}
+		const aBlocked = await app.request("/protected", {headers: {"x-forwarded-for": "1.1.1.1"}})
+		expect(aBlocked.status).toBe(429)
+		// IP B is unaffected
+		const bOk = await app.request("/protected", {headers: {"x-forwarded-for": "2.2.2.2"}})
+		expect(bOk.status).toBe(200)
+	})
+})

--- a/api/src/middleware/__tests__/rateLimit.test.ts
+++ b/api/src/middleware/__tests__/rateLimit.test.ts
@@ -1,21 +1,24 @@
 import {Hono} from "hono"
 import {beforeEach, describe, expect, it} from "vitest"
+import type {ApiKeyLookup, ApiKeyResult} from "../../services/rateLimit/apiKeys"
 import {parseCidr} from "../../services/rateLimit/cidr"
 import type {RateLimitConfig} from "../../services/rateLimit/config"
 import type {OverrideLookup} from "../../services/rateLimit/overrides"
 import type {RateLimitStore} from "../../services/rateLimit/store"
 import {rateLimit} from "../rateLimit"
 
-function fakeStore(): RateLimitStore & {calls: number; failNext: boolean} {
+function fakeStore(): RateLimitStore & {calls: number; failNext: boolean; lastId: string | null} {
 	const counters = new Map<string, number>()
 	return {
 		calls: 0,
 		failNext: false,
-		async incrementAndGet(ip) {
+		lastId: null,
+		async incrementAndGet(identifier) {
 			this.calls++
+			this.lastId = identifier
 			if (this.failNext) return null
-			const next = (counters.get(ip) ?? 0) + 1
-			counters.set(ip, next)
+			const next = (counters.get(identifier) ?? 0) + 1
+			counters.set(identifier, next)
 			return {count: next, resetSeconds: 30}
 		},
 	}
@@ -32,9 +35,25 @@ function fakeOverrides(map: Record<string, number | null>): OverrideLookup {
 	}
 }
 
-function makeApp(config: RateLimitConfig, store: RateLimitStore, overrides: OverrideLookup) {
+function fakeApiKeys(map: Record<string, ApiKeyResult>): ApiKeyLookup {
+	return {
+		async lookup(key) {
+			return map[key] ?? {found: false}
+		},
+		size() {
+			return 0
+		},
+	}
+}
+
+function makeApp(
+	config: RateLimitConfig,
+	store: RateLimitStore,
+	overrides: OverrideLookup,
+	keys: ApiKeyLookup = fakeApiKeys({}),
+) {
 	const app = new Hono()
-	app.use("/protected", rateLimit({config, store, overrides}))
+	app.use("/protected", rateLimit({config, store, overrides, apiKeys: keys}))
 	app.get("/protected", (c) => c.json({ok: true}))
 	return app
 }
@@ -88,7 +107,6 @@ describe("rateLimit middleware", () => {
 	it("does not consume counter for allowlisted IPs", async () => {
 		const config = {...baseConfig, unlimitedAllowlist: [parseCidr("203.0.113.0/24")!]}
 		const app = makeApp(config, store, fakeOverrides({}))
-		// Do 10 requests — would normally exceed the limit of 3
 		for (let i = 0; i < 10; i++) {
 			const res = await app.request("/protected", {headers})
 			expect(res.status).toBe(200)
@@ -112,7 +130,6 @@ describe("rateLimit middleware", () => {
 		const res = await app.request("/protected", {headers})
 		expect(res.status).toBe(429)
 		expect(res.headers.get("RateLimit-Limit")).toBe("0")
-		// Should not have consumed any Valkey call for the kill-switched IP
 		expect(store.calls).toBe(0)
 	})
 
@@ -121,7 +138,6 @@ describe("rateLimit middleware", () => {
 		const app = makeApp(baseConfig, store, fakeOverrides({}))
 		const res = await app.request("/protected", {headers})
 		expect(res.status).toBe(200)
-		// No rate limit headers when fail-open
 		expect(res.headers.get("RateLimit-Limit")).toBeNull()
 	})
 
@@ -134,14 +150,98 @@ describe("rateLimit middleware", () => {
 
 	it("counters are isolated per IP", async () => {
 		const app = makeApp(baseConfig, store, fakeOverrides({}))
-		// Spend the limit for IP A
 		for (let i = 0; i < 3; i++) {
 			await app.request("/protected", {headers: {"x-forwarded-for": "1.1.1.1"}})
 		}
 		const aBlocked = await app.request("/protected", {headers: {"x-forwarded-for": "1.1.1.1"}})
 		expect(aBlocked.status).toBe(429)
-		// IP B is unaffected
 		const bOk = await app.request("/protected", {headers: {"x-forwarded-for": "2.2.2.2"}})
 		expect(bOk.status).toBe(200)
+	})
+
+	// ─── API key tests ───────────────────────────────────────────────
+
+	it("API key with custom limit uses key-based counter", async () => {
+		const keys = fakeApiKeys({
+			"test-key-123": {found: true, requestsPerMin: 2, clientName: "test-client"},
+		})
+		const app = makeApp(baseConfig, store, fakeOverrides({}), keys)
+		const h = {...headers, "x-api-key": "test-key-123"}
+
+		const r1 = await app.request("/protected", {headers: h})
+		expect(r1.status).toBe(200)
+		expect(r1.headers.get("RateLimit-Limit")).toBe("2")
+		expect(r1.headers.get("RateLimit-Remaining")).toBe("1")
+		// Counter keyed by "key:<apikey>" not by IP
+		expect(store.lastId).toBe("key:test-key-123")
+
+		const r2 = await app.request("/protected", {headers: h})
+		expect(r2.status).toBe(200)
+
+		const r3 = await app.request("/protected", {headers: h})
+		expect(r3.status).toBe(429)
+	})
+
+	it("API key with unlimited (null) skips counter entirely", async () => {
+		const keys = fakeApiKeys({
+			"unlimited-key": {found: true, requestsPerMin: null, clientName: "railway"},
+		})
+		const app = makeApp(baseConfig, store, fakeOverrides({}), keys)
+		const h = {...headers, "x-api-key": "unlimited-key"}
+
+		for (let i = 0; i < 10; i++) {
+			const res = await app.request("/protected", {headers: h})
+			expect(res.status).toBe(200)
+		}
+		// No Valkey calls — unlimited means no counter
+		expect(store.calls).toBe(0)
+	})
+
+	it("API key with limit=0 blocks immediately", async () => {
+		const keys = fakeApiKeys({
+			"blocked-key": {found: true, requestsPerMin: 0, clientName: "blocked"},
+		})
+		const app = makeApp(baseConfig, store, fakeOverrides({}), keys)
+		const res = await app.request("/protected", {headers: {...headers, "x-api-key": "blocked-key"}})
+		expect(res.status).toBe(429)
+		expect(res.headers.get("RateLimit-Limit")).toBe("0")
+		expect(store.calls).toBe(0)
+	})
+
+	it("unknown API key falls through to IP-based limiting", async () => {
+		const app = makeApp(baseConfig, store, fakeOverrides({}), fakeApiKeys({}))
+		const res = await app.request("/protected", {headers: {...headers, "x-api-key": "bad-key"}})
+		expect(res.status).toBe(200)
+		// Should have used IP-based counter, not key-based
+		expect(store.lastId).toBe("203.0.113.42")
+	})
+
+	it("disabled API key falls through to IP-based limiting", async () => {
+		const keys = fakeApiKeys({
+			"disabled-key": {found: false}, // disabled keys return found:false
+		})
+		const app = makeApp(baseConfig, store, fakeOverrides({}), keys)
+		const res = await app.request("/protected", {headers: {...headers, "x-api-key": "disabled-key"}})
+		expect(res.status).toBe(200)
+		expect(store.lastId).toBe("203.0.113.42")
+	})
+
+	it("API key counter is separate from IP counter", async () => {
+		const keys = fakeApiKeys({
+			"my-key": {found: true, requestsPerMin: 3, clientName: "test"},
+		})
+		const app = makeApp(baseConfig, store, fakeOverrides({}), keys)
+
+		// Exhaust IP limit
+		for (let i = 0; i < 3; i++) {
+			await app.request("/protected", {headers})
+		}
+		const ipBlocked = await app.request("/protected", {headers})
+		expect(ipBlocked.status).toBe(429)
+
+		// Same IP but with API key → uses key counter (fresh), should still work
+		const keyOk = await app.request("/protected", {headers: {...headers, "x-api-key": "my-key"}})
+		expect(keyOk.status).toBe(200)
+		expect(keyOk.headers.get("RateLimit-Remaining")).toBe("2")
 	})
 })

--- a/api/src/middleware/__tests__/rateLimit.test.ts
+++ b/api/src/middleware/__tests__/rateLimit.test.ts
@@ -39,7 +39,7 @@ function makeApp(config: RateLimitConfig, store: RateLimitStore, overrides: Over
 const baseConfig: RateLimitConfig = {
 	enabled: true,
 	defaultPerMinute: 3,
-	whitelist: [],
+	unlimitedAllowlist: [],
 	overrideCacheTtlSeconds: 60,
 	trustedProxyHops: 1,
 }
@@ -82,8 +82,8 @@ describe("rateLimit middleware", () => {
 		expect(body.retry_after_seconds).toBe(30)
 	})
 
-	it("does not consume counter for whitelisted IPs", async () => {
-		const config = {...baseConfig, whitelist: [parseCidr("203.0.113.0/24")!]}
+	it("does not consume counter for allowlisted IPs", async () => {
+		const config = {...baseConfig, unlimitedAllowlist: [parseCidr("203.0.113.0/24")!]}
 		const app = makeApp(config, store, fakeOverrides({}))
 		// Do 10 requests — would normally exceed the limit of 3
 		for (let i = 0; i < 10; i++) {

--- a/api/src/middleware/clientIp.ts
+++ b/api/src/middleware/clientIp.ts
@@ -1,0 +1,48 @@
+import type {Context} from "hono"
+
+/**
+ * Extract the originating client IP from a Hono request, honoring `X-Forwarded-For`
+ * with a configurable trusted-proxy hop count. Falls back to `X-Real-IP`.
+ *
+ * Behind ingress-nginx (DOKS), the typical chain is:
+ *   client_ip, ingress_ip
+ * so `trustedHops = 1` returns the leftmost (`client_ip`).
+ *
+ * Returns `null` when no header is present or no IP is parseable.
+ */
+export function extractClientIp(c: Context, trustedHops: number): string | null {
+	const xff = c.req.header("x-forwarded-for")
+	if (xff) {
+		// Take the (Nth-from-right) entry where N = trustedHops.
+		// e.g. "client, lb, ingress" with trustedHops=2 picks "client".
+		const parts = xff
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean)
+
+		if (parts.length > 0) {
+			// XFF is "client, proxy1, proxy2, …, immediate". We trust the rightmost
+			// `trustedHops` entries (our own infra) and pick the rightmost untrusted
+			// entry. With more reported hops than we trust, leftmost entries may be
+			// spoofed; rightmost-untrusted is the standard safe choice.
+			const idx = Math.max(0, parts.length - 1 - trustedHops)
+			const candidate = parts[idx]
+			if (candidate && isPlausibleIp(candidate)) return candidate
+		}
+	}
+
+	const xRealIp = c.req.header("x-real-ip")
+	if (xRealIp && isPlausibleIp(xRealIp)) return xRealIp.trim()
+
+	return null
+}
+
+/**
+ * Cheap shape check: digits/dots/colons only, length bounded.
+ * Real validation is done downstream by `parseIPv4` / Postgres.
+ */
+function isPlausibleIp(value: string): boolean {
+	const trimmed = value.trim()
+	if (trimmed.length < 3 || trimmed.length > 45) return false
+	return /^[0-9a-fA-F.:]+$/.test(trimmed)
+}

--- a/api/src/middleware/rateLimit.ts
+++ b/api/src/middleware/rateLimit.ts
@@ -1,4 +1,5 @@
 import type {MiddlewareHandler} from "hono"
+import type {ApiKeyLookup} from "../services/rateLimit/apiKeys"
 import {ipInAnyCidr} from "../services/rateLimit/cidr"
 import type {RateLimitConfig} from "../services/rateLimit/config"
 import type {OverrideLookup} from "../services/rateLimit/overrides"
@@ -7,12 +8,13 @@ import {log} from "../services/telemetry"
 import {extractClientIp} from "./clientIp"
 
 /**
- * Per-IP rate limit middleware for the GraphQL HTTP endpoint.
+ * Per-IP / per-API-key rate limit middleware for the GraphQL HTTP endpoint.
  *
  * Tier resolution (first match wins):
+ *   0. X-Api-Key header      → DB lookup: unlimited (null) or custom limit, counter keyed by "key:<key>"
  *   1. CIDR unlimited-allowlist from env → unlimited (counter not incremented, no headers)
- *   2. DB override for this IP  → use the row's `requests_per_min`
- *   3. Default                  → `defaultPerMinute` from env
+ *   2. DB IP override         → use the row's `requests_per_min`, counter keyed by IP
+ *   3. Default                → `defaultPerMinute` from env, counter keyed by IP
  *
  * Counter store is shared across all API pods via Valkey. On Valkey failure
  * we **fail open** (allow the request, log warn) since rate limiting is a
@@ -25,21 +27,63 @@ export type RateLimitDeps = {
 	config: RateLimitConfig
 	store: RateLimitStore
 	overrides: OverrideLookup
+	apiKeys: ApiKeyLookup
 }
 
 const STATUS_RATE_LIMITED = 429
 
 export function rateLimit(deps: RateLimitDeps): MiddlewareHandler {
-	const {config, store, overrides} = deps
+	const {config, store, overrides, apiKeys} = deps
 
 	return async (c, next) => {
 		if (!config.enabled) return next()
 
+		// Tier 0: API key — takes precedence over everything else.
+		const apiKey = c.req.header("x-api-key")
+		if (apiKey) {
+			const keyResult = await apiKeys.lookup(apiKey)
+			if (keyResult.found) {
+				// Unlimited key (requestsPerMin is null) → skip counter entirely
+				if (keyResult.requestsPerMin === null) return next()
+
+				const keyLimit = keyResult.requestsPerMin
+				if (keyLimit === 0) {
+					c.header("RateLimit-Limit", "0")
+					c.header("RateLimit-Remaining", "0")
+					c.header("Retry-After", "60")
+					return c.json({error: "rate_limit_exceeded", retry_after_seconds: 60}, STATUS_RATE_LIMITED)
+				}
+
+				// Counter keyed by API key, not IP
+				const result = await store.incrementAndGet(`key:${apiKey}`, Date.now())
+				if (result === null) return next()
+
+				const remaining = Math.max(0, keyLimit - result.count)
+				c.header("RateLimit-Limit", String(keyLimit))
+				c.header("RateLimit-Remaining", String(remaining))
+				c.header("RateLimit-Reset", String(result.resetSeconds))
+
+				if (result.count > keyLimit) {
+					c.header("Retry-After", String(result.resetSeconds))
+					log.warn("rate limit: blocked request (API key)", {
+						clientName: keyResult.clientName,
+						limit: keyLimit,
+						count: result.count,
+						path: c.req.path,
+					})
+					return c.json(
+						{error: "rate_limit_exceeded", retry_after_seconds: result.resetSeconds},
+						STATUS_RATE_LIMITED,
+					)
+				}
+
+				return next()
+			}
+			// Key not found or disabled → fall through to IP-based limiting
+		}
+
 		const ip = extractClientIp(c, config.trustedProxyHops)
 		if (!ip) {
-			// No IP we can identify the request by — let it through but log so we
-			// can detect misconfigured ingress. This is rare; ingress-nginx always
-			// sets X-Forwarded-For.
 			log.warn("rate limit: no client IP found, allowing request", {
 				path: c.req.path,
 				method: c.req.method,
@@ -50,11 +94,10 @@ export function rateLimit(deps: RateLimitDeps): MiddlewareHandler {
 		// Tier 1: unlimited allowlist (cluster-internal IPs, our own backend services).
 		if (ipInAnyCidr(ip, config.unlimitedAllowlist)) return next()
 
-		// Tier 2 / 3: DB override or default.
+		// Tier 2 / 3: DB IP override or default.
 		const overrideLimit = await overrides.lookup(ip)
 		const limit = overrideLimit ?? config.defaultPerMinute
 
-		// Limit of 0 = block entirely (admin kill switch).
 		if (limit === 0) {
 			c.header("RateLimit-Limit", "0")
 			c.header("RateLimit-Remaining", "0")
@@ -63,7 +106,6 @@ export function rateLimit(deps: RateLimitDeps): MiddlewareHandler {
 		}
 
 		const result = await store.incrementAndGet(ip, Date.now())
-		// Valkey failure → fail open. The store has already logged the warning.
 		if (result === null) return next()
 
 		const remaining = Math.max(0, limit - result.count)

--- a/api/src/middleware/rateLimit.ts
+++ b/api/src/middleware/rateLimit.ts
@@ -10,7 +10,7 @@ import {extractClientIp} from "./clientIp"
  * Per-IP rate limit middleware for the GraphQL HTTP endpoint.
  *
  * Tier resolution (first match wins):
- *   1. CIDR whitelist from env  → unlimited (counter not incremented, no headers)
+ *   1. CIDR unlimited-allowlist from env → unlimited (counter not incremented, no headers)
  *   2. DB override for this IP  → use the row's `requests_per_min`
  *   3. Default                  → `defaultPerMinute` from env
  *
@@ -47,8 +47,8 @@ export function rateLimit(deps: RateLimitDeps): MiddlewareHandler {
 			return next()
 		}
 
-		// Tier 1: whitelist (cluster-internal IPs, our own backend services).
-		if (ipInAnyCidr(ip, config.whitelist)) return next()
+		// Tier 1: unlimited allowlist (cluster-internal IPs, our own backend services).
+		if (ipInAnyCidr(ip, config.unlimitedAllowlist)) return next()
 
 		// Tier 2 / 3: DB override or default.
 		const overrideLimit = await overrides.lookup(ip)

--- a/api/src/middleware/rateLimit.ts
+++ b/api/src/middleware/rateLimit.ts
@@ -1,0 +1,88 @@
+import type {MiddlewareHandler} from "hono"
+import {ipInAnyCidr} from "../services/rateLimit/cidr"
+import type {RateLimitConfig} from "../services/rateLimit/config"
+import type {OverrideLookup} from "../services/rateLimit/overrides"
+import type {RateLimitStore} from "../services/rateLimit/store"
+import {log} from "../services/telemetry"
+import {extractClientIp} from "./clientIp"
+
+/**
+ * Per-IP rate limit middleware for the GraphQL HTTP endpoint.
+ *
+ * Tier resolution (first match wins):
+ *   1. CIDR whitelist from env  → unlimited (counter not incremented, no headers)
+ *   2. DB override for this IP  → use the row's `requests_per_min`
+ *   3. Default                  → `defaultPerMinute` from env
+ *
+ * Counter store is shared across all API pods via Valkey. On Valkey failure
+ * we **fail open** (allow the request, log warn) since rate limiting is a
+ * soft guard, not a security boundary.
+ *
+ * Sets RFC-style response headers when limited:
+ *   RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After (on 429).
+ */
+export type RateLimitDeps = {
+	config: RateLimitConfig
+	store: RateLimitStore
+	overrides: OverrideLookup
+}
+
+const STATUS_RATE_LIMITED = 429
+
+export function rateLimit(deps: RateLimitDeps): MiddlewareHandler {
+	const {config, store, overrides} = deps
+
+	return async (c, next) => {
+		if (!config.enabled) return next()
+
+		const ip = extractClientIp(c, config.trustedProxyHops)
+		if (!ip) {
+			// No IP we can identify the request by — let it through but log so we
+			// can detect misconfigured ingress. This is rare; ingress-nginx always
+			// sets X-Forwarded-For.
+			log.warn("rate limit: no client IP found, allowing request", {
+				path: c.req.path,
+				method: c.req.method,
+			})
+			return next()
+		}
+
+		// Tier 1: whitelist (cluster-internal IPs, our own backend services).
+		if (ipInAnyCidr(ip, config.whitelist)) return next()
+
+		// Tier 2 / 3: DB override or default.
+		const overrideLimit = await overrides.lookup(ip)
+		const limit = overrideLimit ?? config.defaultPerMinute
+
+		// Limit of 0 = block entirely (admin kill switch).
+		if (limit === 0) {
+			c.header("RateLimit-Limit", "0")
+			c.header("RateLimit-Remaining", "0")
+			c.header("Retry-After", "60")
+			return c.json({error: "rate_limit_exceeded", retry_after_seconds: 60}, STATUS_RATE_LIMITED)
+		}
+
+		const result = await store.incrementAndGet(ip, Date.now())
+		// Valkey failure → fail open. The store has already logged the warning.
+		if (result === null) return next()
+
+		const remaining = Math.max(0, limit - result.count)
+
+		c.header("RateLimit-Limit", String(limit))
+		c.header("RateLimit-Remaining", String(remaining))
+		c.header("RateLimit-Reset", String(result.resetSeconds))
+
+		if (result.count > limit) {
+			c.header("Retry-After", String(result.resetSeconds))
+			log.warn("rate limit: blocked request", {
+				ip,
+				limit,
+				count: result.count,
+				path: c.req.path,
+			})
+			return c.json({error: "rate_limit_exceeded", retry_after_seconds: result.resetSeconds}, STATUS_RATE_LIMITED)
+		}
+
+		return next()
+	}
+}

--- a/api/src/services/rateLimit/__tests__/cidr.test.ts
+++ b/api/src/services/rateLimit/__tests__/cidr.test.ts
@@ -1,23 +1,86 @@
 import {describe, expect, it} from "vitest"
 import {ipInAnyCidr, ipInCidr, parseCidr, parseIPv4} from "../cidr"
 
+// ─── parseIPv4 ───────────────────────────────────────────────────────
+
 describe("parseIPv4", () => {
 	it("parses dotted-quad addresses", () => {
 		expect(parseIPv4("0.0.0.0")).toBe(0)
 		expect(parseIPv4("255.255.255.255")).toBe(0xffffffff)
 		expect(parseIPv4("10.0.0.1")).toBe((10 << 24) | 1)
 		expect(parseIPv4("192.168.1.1")).toBe(((192 << 24) | (168 << 16) | (1 << 8) | 1) >>> 0)
+		expect(parseIPv4("127.0.0.1")).toBe(((127 << 24) | 1) >>> 0)
+		expect(parseIPv4("1.1.1.1")).toBe(((1 << 24) | (1 << 16) | (1 << 8) | 1) >>> 0)
 	})
 
-	it("rejects invalid addresses", () => {
+	it("parses boundary octets", () => {
+		expect(parseIPv4("0.0.0.0")).toBe(0)
+		expect(parseIPv4("0.0.0.255")).toBe(255)
+		expect(parseIPv4("255.0.0.0")).toBe(0xff000000 >>> 0)
+	})
+
+	it("rejects leading-zero octets (octal ambiguity)", () => {
+		expect(parseIPv4("010.0.0.1")).toBeNull()
+		expect(parseIPv4("01.02.03.04")).toBeNull()
+		expect(parseIPv4("1.2.3.04")).toBeNull()
+		expect(parseIPv4("00.0.0.0")).toBeNull()
+		expect(parseIPv4("0.0.0.00")).toBeNull()
+		expect(parseIPv4("192.168.01.1")).toBeNull()
+		expect(parseIPv4("192.168.001.1")).toBeNull()
+	})
+
+	it("allows single zero octets", () => {
+		expect(parseIPv4("0.0.0.0")).toBe(0)
+		expect(parseIPv4("10.0.0.0")).not.toBeNull()
+		expect(parseIPv4("0.0.0.1")).toBe(1)
+	})
+
+	it("rejects too few octets", () => {
 		expect(parseIPv4("")).toBeNull()
+		expect(parseIPv4("1")).toBeNull()
+		expect(parseIPv4("1.2")).toBeNull()
 		expect(parseIPv4("1.2.3")).toBeNull()
+	})
+
+	it("rejects too many octets", () => {
 		expect(parseIPv4("1.2.3.4.5")).toBeNull()
+		expect(parseIPv4("1.2.3.4.5.6")).toBeNull()
+	})
+
+	it("rejects octets > 255", () => {
 		expect(parseIPv4("256.0.0.0")).toBeNull()
+		expect(parseIPv4("0.0.0.256")).toBeNull()
+		expect(parseIPv4("999.999.999.999")).toBeNull()
+	})
+
+	it("rejects non-numeric characters", () => {
 		expect(parseIPv4("1.2.3.foo")).toBeNull()
-		expect(parseIPv4("::1")).toBeNull() // IPv6 not supported
+		expect(parseIPv4("a.b.c.d")).toBeNull()
+		expect(parseIPv4("1.2.3.-1")).toBeNull()
+		expect(parseIPv4("1.2.3. 4")).toBeNull()
+		expect(parseIPv4("1.2.3.4 ")).toBeNull()
+		expect(parseIPv4(" 1.2.3.4")).toBeNull()
+	})
+
+	it("rejects empty octets", () => {
+		expect(parseIPv4(".1.2.3")).toBeNull()
+		expect(parseIPv4("1..2.3")).toBeNull()
+		expect(parseIPv4("1.2.3.")).toBeNull()
+	})
+
+	it("rejects IPv6 addresses", () => {
+		expect(parseIPv4("::1")).toBeNull()
+		expect(parseIPv4("fe80::1")).toBeNull()
+		expect(parseIPv4("2001:db8::1")).toBeNull()
+	})
+
+	it("rejects hex/octal notation", () => {
+		expect(parseIPv4("0x0a.0.0.1")).toBeNull()
+		expect(parseIPv4("0xa.0xb.0xc.0xd")).toBeNull()
 	})
 })
+
+// ─── parseCidr ───────────────────────────────────────────────────────
 
 describe("parseCidr", () => {
 	it("treats bare IPs as /32", () => {
@@ -34,10 +97,21 @@ describe("parseCidr", () => {
 		expect(c?.network).toBe(parseIPv4("10.244.0.0"))
 	})
 
+	it("parses common prefix lengths", () => {
+		expect(parseCidr("10.0.0.0/8")?.mask).toBe(0xff000000)
+		expect(parseCidr("10.0.0.0/16")?.mask).toBe(0xffff0000)
+		expect(parseCidr("10.0.0.0/24")?.mask).toBe(0xffffff00)
+		expect(parseCidr("10.0.0.0/32")?.mask).toBe(0xffffffff)
+	})
+
 	it("masks non-network bits in the network address", () => {
 		// 10.244.5.42/16 should normalize to 10.244.0.0
 		const c = parseCidr("10.244.5.42/16")
 		expect(c?.network).toBe(parseIPv4("10.244.0.0"))
+
+		// 192.168.1.100/24 should normalize to 192.168.1.0
+		const c2 = parseCidr("192.168.1.100/24")
+		expect(c2?.network).toBe(parseIPv4("192.168.1.0"))
 	})
 
 	it("supports /0 (match anything)", () => {
@@ -46,23 +120,62 @@ describe("parseCidr", () => {
 		expect(c?.network).toBe(0)
 	})
 
+	it("supports /1 (half of IPv4 space)", () => {
+		const c = parseCidr("0.0.0.0/1")
+		expect(c?.mask).toBe(0x80000000)
+	})
+
+	it("preserves original source string", () => {
+		expect(parseCidr("  10.0.0.0/24  ")?.source).toBe("10.0.0.0/24")
+	})
+
+	it("trims whitespace", () => {
+		expect(parseCidr("  10.0.0.0/24  ")).not.toBeNull()
+		expect(parseCidr("\t10.0.0.0/24\t")).not.toBeNull()
+	})
+
 	it("rejects invalid prefixes", () => {
 		expect(parseCidr("10.0.0.0/33")).toBeNull()
 		expect(parseCidr("10.0.0.0/-1")).toBeNull()
 		expect(parseCidr("10.0.0.0/abc")).toBeNull()
+		expect(parseCidr("10.0.0.0/")).toBeNull()
+		expect(parseCidr("10.0.0.0/1.5")).toBeNull()
 	})
 
 	it("rejects empty / whitespace", () => {
 		expect(parseCidr("")).toBeNull()
 		expect(parseCidr("   ")).toBeNull()
+		expect(parseCidr("\t")).toBeNull()
+	})
+
+	it("rejects CIDR with invalid IP part", () => {
+		expect(parseCidr("256.0.0.0/24")).toBeNull()
+		expect(parseCidr("foo/24")).toBeNull()
+		expect(parseCidr("010.0.0.0/8")).toBeNull() // leading zero
+	})
+
+	it("rejects double slash", () => {
+		expect(parseCidr("10.0.0.0//24")).toBeNull()
 	})
 })
+
+// ─── ipInCidr ────────────────────────────────────────────────────────
 
 describe("ipInCidr", () => {
 	it("matches /32 exactly", () => {
 		const c = parseCidr("10.0.0.5/32")!
 		expect(ipInCidr("10.0.0.5", c)).toBe(true)
+		expect(ipInCidr("10.0.0.4", c)).toBe(false)
 		expect(ipInCidr("10.0.0.6", c)).toBe(false)
+	})
+
+	it("matches all addresses inside a /24", () => {
+		const c = parseCidr("192.168.1.0/24")!
+		expect(ipInCidr("192.168.1.0", c)).toBe(true)
+		expect(ipInCidr("192.168.1.1", c)).toBe(true)
+		expect(ipInCidr("192.168.1.255", c)).toBe(true)
+		expect(ipInCidr("192.168.2.0", c)).toBe(false)
+		expect(ipInCidr("192.168.0.255", c)).toBe(false)
 	})
 
 	it("matches all addresses inside a /16", () => {
@@ -72,20 +185,42 @@ describe("ipInCidr", () => {
 		expect(ipInCidr("10.244.5.42", c)).toBe(true)
 		expect(ipInCidr("10.244.255.255", c)).toBe(true)
 		expect(ipInCidr("10.245.0.0", c)).toBe(false)
+		expect(ipInCidr("10.243.255.255", c)).toBe(false)
 		expect(ipInCidr("11.244.0.0", c)).toBe(false)
+	})
+
+	it("matches /8 (class A)", () => {
+		const c = parseCidr("10.0.0.0/8")!
+		expect(ipInCidr("10.0.0.0", c)).toBe(true)
+		expect(ipInCidr("10.255.255.255", c)).toBe(true)
+		expect(ipInCidr("11.0.0.0", c)).toBe(false)
+		expect(ipInCidr("9.255.255.255", c)).toBe(false)
 	})
 
 	it("/0 matches everything", () => {
 		const c = parseCidr("0.0.0.0/0")!
+		expect(ipInCidr("0.0.0.0", c)).toBe(true)
 		expect(ipInCidr("1.2.3.4", c)).toBe(true)
 		expect(ipInCidr("255.255.255.255", c)).toBe(true)
 	})
 
-	it("returns false for invalid IP", () => {
+	it("boundary IPs at CIDR edges", () => {
+		const c = parseCidr("10.0.0.0/25")!
+		// /25 = 128 addresses: 10.0.0.0 – 10.0.0.127
+		expect(ipInCidr("10.0.0.0", c)).toBe(true)
+		expect(ipInCidr("10.0.0.127", c)).toBe(true)
+		expect(ipInCidr("10.0.0.128", c)).toBe(false)
+	})
+
+	it("returns false for invalid IP input", () => {
 		const c = parseCidr("10.0.0.0/24")!
 		expect(ipInCidr("not-an-ip", c)).toBe(false)
+		expect(ipInCidr("", c)).toBe(false)
+		expect(ipInCidr("010.0.0.1", c)).toBe(false) // leading zero rejected
 	})
 })
+
+// ─── ipInAnyCidr ─────────────────────────────────────────────────────
 
 describe("ipInAnyCidr", () => {
 	it("returns true if any cidr matches", () => {
@@ -97,5 +232,21 @@ describe("ipInAnyCidr", () => {
 
 	it("returns false on empty list", () => {
 		expect(ipInAnyCidr("10.0.0.1", [])).toBe(false)
+	})
+
+	it("matches first entry without checking the rest", () => {
+		const cidrs = [parseCidr("10.0.0.0/8")!, parseCidr("192.168.0.0/16")!]
+		expect(ipInAnyCidr("10.0.0.1", cidrs)).toBe(true)
+	})
+
+	it("matches last entry", () => {
+		const cidrs = [parseCidr("192.168.0.0/16")!, parseCidr("10.0.0.0/8")!]
+		expect(ipInAnyCidr("10.0.0.1", cidrs)).toBe(true)
+	})
+
+	it("handles mixed specificity CIDRs", () => {
+		const cidrs = [parseCidr("10.0.0.1/32")!, parseCidr("192.168.0.0/16")!, parseCidr("0.0.0.0/0")!]
+		expect(ipInAnyCidr("10.0.0.1", cidrs)).toBe(true)
+		expect(ipInAnyCidr("172.16.0.1", cidrs)).toBe(true) // /0 catches everything
 	})
 })

--- a/api/src/services/rateLimit/__tests__/cidr.test.ts
+++ b/api/src/services/rateLimit/__tests__/cidr.test.ts
@@ -1,0 +1,101 @@
+import {describe, expect, it} from "vitest"
+import {ipInAnyCidr, ipInCidr, parseCidr, parseIPv4} from "../cidr"
+
+describe("parseIPv4", () => {
+	it("parses dotted-quad addresses", () => {
+		expect(parseIPv4("0.0.0.0")).toBe(0)
+		expect(parseIPv4("255.255.255.255")).toBe(0xffffffff)
+		expect(parseIPv4("10.0.0.1")).toBe((10 << 24) | 1)
+		expect(parseIPv4("192.168.1.1")).toBe(((192 << 24) | (168 << 16) | (1 << 8) | 1) >>> 0)
+	})
+
+	it("rejects invalid addresses", () => {
+		expect(parseIPv4("")).toBeNull()
+		expect(parseIPv4("1.2.3")).toBeNull()
+		expect(parseIPv4("1.2.3.4.5")).toBeNull()
+		expect(parseIPv4("256.0.0.0")).toBeNull()
+		expect(parseIPv4("1.2.3.foo")).toBeNull()
+		expect(parseIPv4("::1")).toBeNull() // IPv6 not supported
+	})
+})
+
+describe("parseCidr", () => {
+	it("treats bare IPs as /32", () => {
+		const c = parseCidr("10.0.0.5")
+		expect(c).not.toBeNull()
+		expect(c?.mask).toBe(0xffffffff)
+		expect(c?.network).toBe(parseIPv4("10.0.0.5"))
+	})
+
+	it("parses standard CIDR notation", () => {
+		const c = parseCidr("10.244.0.0/16")
+		expect(c).not.toBeNull()
+		expect(c?.mask).toBe(0xffff0000)
+		expect(c?.network).toBe(parseIPv4("10.244.0.0"))
+	})
+
+	it("masks non-network bits in the network address", () => {
+		// 10.244.5.42/16 should normalize to 10.244.0.0
+		const c = parseCidr("10.244.5.42/16")
+		expect(c?.network).toBe(parseIPv4("10.244.0.0"))
+	})
+
+	it("supports /0 (match anything)", () => {
+		const c = parseCidr("0.0.0.0/0")
+		expect(c?.mask).toBe(0)
+		expect(c?.network).toBe(0)
+	})
+
+	it("rejects invalid prefixes", () => {
+		expect(parseCidr("10.0.0.0/33")).toBeNull()
+		expect(parseCidr("10.0.0.0/-1")).toBeNull()
+		expect(parseCidr("10.0.0.0/abc")).toBeNull()
+	})
+
+	it("rejects empty / whitespace", () => {
+		expect(parseCidr("")).toBeNull()
+		expect(parseCidr("   ")).toBeNull()
+	})
+})
+
+describe("ipInCidr", () => {
+	it("matches /32 exactly", () => {
+		const c = parseCidr("10.0.0.5/32")!
+		expect(ipInCidr("10.0.0.5", c)).toBe(true)
+		expect(ipInCidr("10.0.0.6", c)).toBe(false)
+	})
+
+	it("matches all addresses inside a /16", () => {
+		const c = parseCidr("10.244.0.0/16")!
+		expect(ipInCidr("10.244.0.0", c)).toBe(true)
+		expect(ipInCidr("10.244.0.1", c)).toBe(true)
+		expect(ipInCidr("10.244.5.42", c)).toBe(true)
+		expect(ipInCidr("10.244.255.255", c)).toBe(true)
+		expect(ipInCidr("10.245.0.0", c)).toBe(false)
+		expect(ipInCidr("11.244.0.0", c)).toBe(false)
+	})
+
+	it("/0 matches everything", () => {
+		const c = parseCidr("0.0.0.0/0")!
+		expect(ipInCidr("1.2.3.4", c)).toBe(true)
+		expect(ipInCidr("255.255.255.255", c)).toBe(true)
+	})
+
+	it("returns false for invalid IP", () => {
+		const c = parseCidr("10.0.0.0/24")!
+		expect(ipInCidr("not-an-ip", c)).toBe(false)
+	})
+})
+
+describe("ipInAnyCidr", () => {
+	it("returns true if any cidr matches", () => {
+		const cidrs = [parseCidr("10.108.0.0/16")!, parseCidr("10.109.0.0/16")!]
+		expect(ipInAnyCidr("10.108.5.42", cidrs)).toBe(true)
+		expect(ipInAnyCidr("10.109.0.1", cidrs)).toBe(true)
+		expect(ipInAnyCidr("192.168.1.1", cidrs)).toBe(false)
+	})
+
+	it("returns false on empty list", () => {
+		expect(ipInAnyCidr("10.0.0.1", [])).toBe(false)
+	})
+})

--- a/api/src/services/rateLimit/__tests__/config.test.ts
+++ b/api/src/services/rateLimit/__tests__/config.test.ts
@@ -8,7 +8,7 @@ describe("loadRateLimitConfig", () => {
 		expect(config.defaultPerMinute).toBe(1000)
 		expect(config.overrideCacheTtlSeconds).toBe(60)
 		expect(config.trustedProxyHops).toBe(1)
-		expect(config.whitelist).toEqual([])
+		expect(config.unlimitedAllowlist).toEqual([])
 	})
 
 	it("honors RATE_LIMIT_ENABLED=false", () => {
@@ -32,22 +32,22 @@ describe("loadRateLimitConfig", () => {
 		expect(loadRateLimitConfig({RATE_LIMIT_DEFAULT_PER_MINUTE: "1.5"}).defaultPerMinute).toBe(1000)
 	})
 
-	it("parses comma-separated whitelist", () => {
+	it("parses comma-separated allowlist", () => {
 		const config = loadRateLimitConfig({
-			RATE_LIMIT_WHITELIST_IPS: "10.0.0.1, 192.168.0.0/24 , 203.0.113.42",
+			RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS: "10.0.0.1, 192.168.0.0/24 , 203.0.113.42",
 		})
-		expect(config.whitelist).toHaveLength(3)
-		expect(config.whitelist.map((c) => c.source)).toEqual(["10.0.0.1", "192.168.0.0/24", "203.0.113.42"])
+		expect(config.unlimitedAllowlist).toHaveLength(3)
+		expect(config.unlimitedAllowlist.map((c) => c.source)).toEqual(["10.0.0.1", "192.168.0.0/24", "203.0.113.42"])
 	})
 
-	it("ignores unparseable whitelist entries", () => {
+	it("ignores unparseable allowlist entries", () => {
 		const config = loadRateLimitConfig({
-			RATE_LIMIT_WHITELIST_IPS: "10.0.0.1,bad-entry,192.168.0.0/24,256.0.0.0",
+			RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS: "10.0.0.1,bad-entry,192.168.0.0/24,256.0.0.0",
 		})
-		expect(config.whitelist).toHaveLength(2)
+		expect(config.unlimitedAllowlist).toHaveLength(2)
 	})
 
-	it("treats empty whitelist string as no entries", () => {
-		expect(loadRateLimitConfig({RATE_LIMIT_WHITELIST_IPS: ""}).whitelist).toEqual([])
+	it("treats empty allowlist string as no entries", () => {
+		expect(loadRateLimitConfig({RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS: ""}).unlimitedAllowlist).toEqual([])
 	})
 })

--- a/api/src/services/rateLimit/__tests__/config.test.ts
+++ b/api/src/services/rateLimit/__tests__/config.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, it} from "vitest"
+import {loadRateLimitConfig} from "../config"
+
+describe("loadRateLimitConfig", () => {
+	it("uses defaults when env is empty", () => {
+		const config = loadRateLimitConfig({})
+		expect(config.enabled).toBe(true)
+		expect(config.defaultPerMinute).toBe(1000)
+		expect(config.overrideCacheTtlSeconds).toBe(60)
+		expect(config.trustedProxyHops).toBe(1)
+		expect(config.whitelist).toEqual([])
+	})
+
+	it("honors RATE_LIMIT_ENABLED=false", () => {
+		const config = loadRateLimitConfig({RATE_LIMIT_ENABLED: "false"})
+		expect(config.enabled).toBe(false)
+	})
+
+	it("treats any other value as enabled", () => {
+		expect(loadRateLimitConfig({RATE_LIMIT_ENABLED: "true"}).enabled).toBe(true)
+		expect(loadRateLimitConfig({RATE_LIMIT_ENABLED: "yes"}).enabled).toBe(true)
+		expect(loadRateLimitConfig({}).enabled).toBe(true)
+	})
+
+	it("parses default per-minute from env", () => {
+		expect(loadRateLimitConfig({RATE_LIMIT_DEFAULT_PER_MINUTE: "500"}).defaultPerMinute).toBe(500)
+	})
+
+	it("falls back when default per-minute is invalid", () => {
+		expect(loadRateLimitConfig({RATE_LIMIT_DEFAULT_PER_MINUTE: "abc"}).defaultPerMinute).toBe(1000)
+		expect(loadRateLimitConfig({RATE_LIMIT_DEFAULT_PER_MINUTE: "-5"}).defaultPerMinute).toBe(1000)
+		expect(loadRateLimitConfig({RATE_LIMIT_DEFAULT_PER_MINUTE: "1.5"}).defaultPerMinute).toBe(1000)
+	})
+
+	it("parses comma-separated whitelist", () => {
+		const config = loadRateLimitConfig({
+			RATE_LIMIT_WHITELIST_IPS: "10.0.0.1, 192.168.0.0/24 , 203.0.113.42",
+		})
+		expect(config.whitelist).toHaveLength(3)
+		expect(config.whitelist.map((c) => c.source)).toEqual(["10.0.0.1", "192.168.0.0/24", "203.0.113.42"])
+	})
+
+	it("ignores unparseable whitelist entries", () => {
+		const config = loadRateLimitConfig({
+			RATE_LIMIT_WHITELIST_IPS: "10.0.0.1,bad-entry,192.168.0.0/24,256.0.0.0",
+		})
+		expect(config.whitelist).toHaveLength(2)
+	})
+
+	it("treats empty whitelist string as no entries", () => {
+		expect(loadRateLimitConfig({RATE_LIMIT_WHITELIST_IPS: ""}).whitelist).toEqual([])
+	})
+})

--- a/api/src/services/rateLimit/__tests__/overrides.test.ts
+++ b/api/src/services/rateLimit/__tests__/overrides.test.ts
@@ -1,0 +1,140 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {createOverrideLookup} from "../overrides"
+
+/**
+ * The override lookup wraps a Postgres query in a per-pod LRU cache.
+ * These tests exercise the cache layer with a stubbed db.execute,
+ * verifying that:
+ *   - a hit is served from cache (no DB call)
+ *   - a miss is also cached (so we don't re-query for default-limit IPs)
+ *   - expired entries trigger a re-query
+ *   - the LRU evicts oldest entries when capacity is reached
+ *   - DB errors are not cached (transient retry behavior)
+ */
+function fakeDb(rowsByIp: Record<string, number | undefined>, throwOn?: Set<string>) {
+	const calls: string[] = []
+	const db = {
+		async execute<_T>(query: {queryChunks: unknown[]}): Promise<{rows: Array<{requests_per_min: number}>}> {
+			// drizzle's sql template wraps params; for the test we just inspect the
+			// stringified query to extract the IP that was bound.
+			const serialized = JSON.stringify(query)
+			const ipMatch = serialized.match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
+			const ip = ipMatch?.[0] ?? ""
+			calls.push(ip)
+			if (throwOn?.has(ip)) throw new Error("db error")
+			const limit = rowsByIp[ip]
+			return {rows: limit !== undefined ? [{requests_per_min: limit}] : []}
+		},
+	}
+	return {db: db as never, calls}
+}
+
+describe("createOverrideLookup", () => {
+	beforeEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("returns the limit for a matching IP", async () => {
+		const {db} = fakeDb({"203.0.113.42": 5000})
+		const lookup = createOverrideLookup(db, 60)
+		expect(await lookup.lookup("203.0.113.42")).toBe(5000)
+	})
+
+	it("returns null when no override matches", async () => {
+		const {db} = fakeDb({})
+		const lookup = createOverrideLookup(db, 60)
+		expect(await lookup.lookup("203.0.113.42")).toBeNull()
+	})
+
+	it("serves cache hit without re-querying DB", async () => {
+		const {db, calls} = fakeDb({"203.0.113.42": 5000})
+		const lookup = createOverrideLookup(db, 60)
+		await lookup.lookup("203.0.113.42")
+		await lookup.lookup("203.0.113.42")
+		await lookup.lookup("203.0.113.42")
+		expect(calls).toHaveLength(1)
+	})
+
+	it("caches misses so default-limit IPs do not re-query", async () => {
+		const {db, calls} = fakeDb({})
+		const lookup = createOverrideLookup(db, 60)
+		await lookup.lookup("203.0.113.42")
+		await lookup.lookup("203.0.113.42")
+		expect(calls).toHaveLength(1)
+	})
+
+	it("re-queries after the TTL expires", async () => {
+		vi.useFakeTimers()
+		const {db, calls} = fakeDb({"203.0.113.42": 5000})
+		const lookup = createOverrideLookup(db, 60)
+		await lookup.lookup("203.0.113.42")
+		vi.advanceTimersByTime(61_000)
+		await lookup.lookup("203.0.113.42")
+		expect(calls).toHaveLength(2)
+	})
+
+	it("does not cache DB errors so transient failures are retried", async () => {
+		const {db, calls} = fakeDb({}, new Set(["203.0.113.42"]))
+		const lookup = createOverrideLookup(db, 60)
+		expect(await lookup.lookup("203.0.113.42")).toBeNull()
+		expect(await lookup.lookup("203.0.113.42")).toBeNull()
+		expect(calls).toHaveLength(2)
+	})
+
+	it("evicts the oldest entry when LRU capacity is reached", async () => {
+		const {db, calls} = fakeDb({})
+		const lookup = createOverrideLookup(db, 60, 3) // tiny capacity for the test
+
+		await lookup.lookup("1.1.1.1")
+		await lookup.lookup("2.2.2.2")
+		await lookup.lookup("3.3.3.3")
+		expect(lookup.size()).toBe(3)
+
+		// Adding a 4th should evict 1.1.1.1 (oldest)
+		await lookup.lookup("4.4.4.4")
+		expect(lookup.size()).toBe(3)
+
+		// 1.1.1.1 was evicted → re-querying it should hit DB again
+		const callsBefore = calls.length
+		await lookup.lookup("1.1.1.1")
+		expect(calls.length).toBe(callsBefore + 1)
+
+		// 4.4.4.4 was the most recent insert and survives all evictions → cache hit
+		const callsBefore2 = calls.length
+		await lookup.lookup("4.4.4.4")
+		expect(calls.length).toBe(callsBefore2)
+	})
+
+	it("touches LRU recency on read", async () => {
+		const {db, calls} = fakeDb({})
+		const lookup = createOverrideLookup(db, 60, 3)
+
+		await lookup.lookup("1.1.1.1")
+		await lookup.lookup("2.2.2.2")
+		await lookup.lookup("3.3.3.3")
+		// Touch 1.1.1.1 → moves it to most-recent position
+		await lookup.lookup("1.1.1.1")
+		// Insert 4.4.4.4 → evicts 2.2.2.2 (now oldest) instead of 1.1.1.1
+		await lookup.lookup("4.4.4.4")
+
+		const callsBefore = calls.length
+		await lookup.lookup("1.1.1.1") // still cached
+		expect(calls.length).toBe(callsBefore)
+		await lookup.lookup("2.2.2.2") // evicted, re-queries
+		expect(calls.length).toBe(callsBefore + 1)
+	})
+
+	it("evicts stale entries proactively on read", async () => {
+		vi.useFakeTimers()
+		const {db, calls} = fakeDb({"203.0.113.42": 1000})
+		const lookup = createOverrideLookup(db, 60)
+		await lookup.lookup("203.0.113.42")
+		expect(lookup.size()).toBe(1)
+
+		vi.advanceTimersByTime(61_000)
+		await lookup.lookup("203.0.113.42")
+		// Should have been deleted then re-inserted (still size 1, and DB called twice)
+		expect(lookup.size()).toBe(1)
+		expect(calls).toHaveLength(2)
+	})
+})

--- a/api/src/services/rateLimit/apiKeys.ts
+++ b/api/src/services/rateLimit/apiKeys.ts
@@ -1,0 +1,94 @@
+import {sql} from "drizzle-orm"
+import type {db as Db} from "../storage/storage"
+import {log} from "../telemetry"
+
+/**
+ * API key lookup for the rate-limit middleware. When a request includes an
+ * `X-Api-Key` header, we check this table before falling through to IP-based
+ * limiting.
+ *
+ * Returns:
+ *   - `{found: true, requestsPerMin: N}` — key exists and is enabled, use N as limit
+ *   - `{found: true, requestsPerMin: null}` — key exists and is unlimited
+ *   - `{found: false}` — key not found or disabled → fall through to IP-based
+ *
+ * Results are cached per-pod in a bounded LRU (same pattern as IP overrides).
+ */
+export type ApiKeyResult = {found: true; requestsPerMin: number | null; clientName: string} | {found: false}
+
+export type ApiKeyLookup = {
+	lookup(key: string): Promise<ApiKeyResult>
+	size(): number
+}
+
+type CacheEntry = {result: ApiKeyResult; expiresAtMs: number}
+
+const DEFAULT_MAX_ENTRIES = 10_000
+
+export function createApiKeyLookup(
+	db: typeof Db,
+	ttlSeconds: number,
+	maxEntries: number = DEFAULT_MAX_ENTRIES,
+): ApiKeyLookup {
+	const cache = new Map<string, CacheEntry>()
+	const ttlMs = ttlSeconds * 1000
+
+	function touchAsRecent(key: string, entry: CacheEntry): void {
+		cache.delete(key)
+		cache.set(key, entry)
+	}
+
+	function evictOldestIfFull(): void {
+		while (cache.size >= maxEntries) {
+			const oldest = cache.keys().next().value
+			if (oldest === undefined) break
+			cache.delete(oldest)
+		}
+	}
+
+	return {
+		async lookup(apiKey) {
+			const now = Date.now()
+			const cached = cache.get(apiKey)
+			if (cached) {
+				if (cached.expiresAtMs > now) {
+					touchAsRecent(apiKey, cached)
+					return cached.result
+				}
+				cache.delete(apiKey)
+			}
+
+			let result: ApiKeyResult = {found: false}
+			try {
+				const rows = await db.execute<{
+					requests_per_min: number | null
+					client_name: string
+					enabled: boolean
+				}>(sql`
+					SELECT requests_per_min, client_name, enabled FROM api_keys
+					WHERE key = ${apiKey}
+					LIMIT 1
+				`)
+				const row = rows.rows[0]
+				if (row && row.enabled) {
+					result = {
+						found: true,
+						requestsPerMin: row.requests_per_min,
+						clientName: row.client_name,
+					}
+				}
+			} catch (err) {
+				log.warn("rate limit: API key lookup failed", {error: String(err)})
+				return {found: false}
+			}
+
+			evictOldestIfFull()
+			cache.set(apiKey, {result, expiresAtMs: now + ttlMs})
+			return result
+		},
+
+		size() {
+			return cache.size
+		},
+	}
+}

--- a/api/src/services/rateLimit/cidr.ts
+++ b/api/src/services/rateLimit/cidr.ts
@@ -23,8 +23,9 @@ export function parseIPv4(ip: string): number | null {
 	if (parts.length !== 4) return null
 	let result = 0
 	for (const part of parts) {
-		// Reject leading zeros / non-digit / out-of-range
-		if (!/^\d{1,3}$/.test(part)) return null
+		// Reject leading zeros (ambiguous: octal in C/Python, decimal in JS),
+		// non-digit, and out-of-range octets. Only "0" itself may start with 0.
+		if (!/^(0|[1-9]\d{0,2})$/.test(part)) return null
 		const n = Number(part)
 		if (n < 0 || n > 255) return null
 		result = (result << 8) | n

--- a/api/src/services/rateLimit/cidr.ts
+++ b/api/src/services/rateLimit/cidr.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal IPv4 CIDR matcher used by the rate-limit middleware to evaluate the
+ * env-configured whitelist. Per-row DB overrides are matched server-side via
+ * Postgres's native `>>=` operator on the `cidr` column.
+ *
+ * IPv6 is not supported; whitelist entries that don't parse as IPv4 (or as an
+ * IPv4 CIDR like `10.0.0.0/24`) are ignored at parse time and logged as a
+ * warning. We can extend to IPv6 if/when a use case appears.
+ */
+
+export type Cidr = {
+	/** Network address as 32-bit unsigned integer */
+	network: number
+	/** Subnet mask as 32-bit unsigned integer */
+	mask: number
+	/** Original string, kept for logging */
+	source: string
+}
+
+/** Parse a dotted-quad IPv4 to an unsigned 32-bit integer, or `null` if invalid. */
+export function parseIPv4(ip: string): number | null {
+	const parts = ip.split(".")
+	if (parts.length !== 4) return null
+	let result = 0
+	for (const part of parts) {
+		// Reject leading zeros / non-digit / out-of-range
+		if (!/^\d{1,3}$/.test(part)) return null
+		const n = Number(part)
+		if (n < 0 || n > 255) return null
+		result = (result << 8) | n
+	}
+	// Force unsigned interpretation
+	return result >>> 0
+}
+
+/** Parse `"1.2.3.0/24"` or `"1.2.3.4"` (treated as `/32`). Returns `null` on invalid input. */
+export function parseCidr(entry: string): Cidr | null {
+	const trimmed = entry.trim()
+	if (trimmed === "") return null
+
+	const slash = trimmed.indexOf("/")
+	const ipPart = slash === -1 ? trimmed : trimmed.slice(0, slash)
+	const prefixPart = slash === -1 ? "32" : trimmed.slice(slash + 1)
+
+	const ip = parseIPv4(ipPart)
+	if (ip === null) return null
+
+	if (!/^\d{1,2}$/.test(prefixPart)) return null
+	const prefix = Number(prefixPart)
+	if (prefix < 0 || prefix > 32) return null
+
+	// /0 means "match anything" — mask is 0
+	const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0
+	const network = (ip & mask) >>> 0
+
+	return {network, mask, source: trimmed}
+}
+
+/** Returns true if `ip` (dotted-quad) is contained in `cidr`. */
+export function ipInCidr(ip: string, cidr: Cidr): boolean {
+	const numeric = parseIPv4(ip)
+	if (numeric === null) return false
+	return (numeric & cidr.mask) >>> 0 === cidr.network
+}
+
+/** Returns true if `ip` matches any of the supplied CIDRs. */
+export function ipInAnyCidr(ip: string, cidrs: readonly Cidr[]): boolean {
+	if (cidrs.length === 0) return false
+	for (const cidr of cidrs) {
+		if (ipInCidr(ip, cidr)) return true
+	}
+	return false
+}

--- a/api/src/services/rateLimit/cidr.ts
+++ b/api/src/services/rateLimit/cidr.ts
@@ -1,9 +1,9 @@
 /**
  * Minimal IPv4 CIDR matcher used by the rate-limit middleware to evaluate the
- * env-configured whitelist. Per-row DB overrides are matched server-side via
+ * env-configured allowlist. Per-row DB overrides are matched server-side via
  * Postgres's native `>>=` operator on the `cidr` column.
  *
- * IPv6 is not supported; whitelist entries that don't parse as IPv4 (or as an
+ * IPv6 is not supported; allowlist entries that don't parse as IPv4 (or as an
  * IPv4 CIDR like `10.0.0.0/24`) are ignored at parse time and logged as a
  * warning. We can extend to IPv6 if/when a use case appears.
  */

--- a/api/src/services/rateLimit/config.ts
+++ b/api/src/services/rateLimit/config.ts
@@ -1,0 +1,50 @@
+import {log} from "../telemetry"
+import {type Cidr, parseCidr} from "./cidr"
+
+/**
+ * Runtime configuration for the rate limiter, parsed once at startup from env.
+ * All values have safe defaults so the API still boots if env is incomplete.
+ */
+export type RateLimitConfig = {
+	enabled: boolean
+	defaultPerMinute: number
+	whitelist: Cidr[]
+	overrideCacheTtlSeconds: number
+	trustedProxyHops: number
+}
+
+export function loadRateLimitConfig(env: NodeJS.ProcessEnv = process.env): RateLimitConfig {
+	const enabled = env.RATE_LIMIT_ENABLED !== "false" // default on
+
+	const defaultPerMinute = parsePositiveInt(env.RATE_LIMIT_DEFAULT_PER_MINUTE, 1000)
+	const overrideCacheTtlSeconds = parsePositiveInt(env.RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS, 60)
+	const trustedProxyHops = parsePositiveInt(env.RATE_LIMIT_TRUSTED_PROXY_HOPS, 1)
+
+	const rawWhitelist = env.RATE_LIMIT_WHITELIST_IPS ?? ""
+	const whitelist: Cidr[] = []
+	for (const entry of rawWhitelist.split(",")) {
+		const trimmed = entry.trim()
+		if (trimmed === "") continue
+		const parsed = parseCidr(trimmed)
+		if (parsed === null) {
+			log.warn("rate limit: ignoring unparseable whitelist entry", {entry: trimmed})
+			continue
+		}
+		whitelist.push(parsed)
+	}
+
+	return {
+		enabled,
+		defaultPerMinute,
+		whitelist,
+		overrideCacheTtlSeconds,
+		trustedProxyHops,
+	}
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+	if (!value) return fallback
+	const n = Number(value)
+	if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) return fallback
+	return n
+}

--- a/api/src/services/rateLimit/config.ts
+++ b/api/src/services/rateLimit/config.ts
@@ -8,7 +8,7 @@ import {type Cidr, parseCidr} from "./cidr"
 export type RateLimitConfig = {
 	enabled: boolean
 	defaultPerMinute: number
-	whitelist: Cidr[]
+	unlimitedAllowlist: Cidr[]
 	overrideCacheTtlSeconds: number
 	trustedProxyHops: number
 }
@@ -20,23 +20,23 @@ export function loadRateLimitConfig(env: NodeJS.ProcessEnv = process.env): RateL
 	const overrideCacheTtlSeconds = parsePositiveInt(env.RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS, 60)
 	const trustedProxyHops = parsePositiveInt(env.RATE_LIMIT_TRUSTED_PROXY_HOPS, 1)
 
-	const rawWhitelist = env.RATE_LIMIT_WHITELIST_IPS ?? ""
-	const whitelist: Cidr[] = []
-	for (const entry of rawWhitelist.split(",")) {
+	const rawAllowlist = env.RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS ?? ""
+	const unlimitedAllowlist: Cidr[] = []
+	for (const entry of rawAllowlist.split(",")) {
 		const trimmed = entry.trim()
 		if (trimmed === "") continue
 		const parsed = parseCidr(trimmed)
 		if (parsed === null) {
-			log.warn("rate limit: ignoring unparseable whitelist entry", {entry: trimmed})
+			log.warn("rate limit: ignoring unparseable allowlist entry", {entry: trimmed})
 			continue
 		}
-		whitelist.push(parsed)
+		unlimitedAllowlist.push(parsed)
 	}
 
 	return {
 		enabled,
 		defaultPerMinute,
-		whitelist,
+		unlimitedAllowlist,
 		overrideCacheTtlSeconds,
 		trustedProxyHops,
 	}

--- a/api/src/services/rateLimit/overrides.ts
+++ b/api/src/services/rateLimit/overrides.ts
@@ -3,7 +3,7 @@ import type {db as Db} from "../storage/storage"
 import {log} from "../telemetry"
 
 /**
- * Lookup per-IP rate limit overrides from Postgres with a small in-process
+ * Lookup per-IP rate limit overrides from Postgres with a small in-process LRU
  * cache to keep the hot path off the DB.
  *
  * We use the cache for *both* hits (an explicit limit) and misses (no row
@@ -14,23 +14,60 @@ import {log} from "../telemetry"
  * `ttlSeconds` to be picked up by all pods. That's the price of avoiding
  * a Postgres query on every API request, and acceptable for an admin-managed
  * configuration table.
+ *
+ * Memory bounding: the cache is a fixed-size LRU. When full, the
+ * least-recently-used entry is evicted. This caps per-pod memory regardless
+ * of unique-IP volume (e.g. a scraper from many IPs cannot grow it without
+ * bound). Stale entries are also evicted lazily on read, so a long-idle pod
+ * does not keep dead entries around past their TTL.
  */
 export type OverrideLookup = {
 	/** Returns the per-minute limit for `ip` if an override matches, otherwise `null`. */
 	lookup(ip: string): Promise<number | null>
+	/** Test/observability hook: current cache size. */
+	size(): number
 }
 
 type CacheEntry = {limit: number | null; expiresAtMs: number}
 
-export function createOverrideLookup(db: typeof Db, ttlSeconds: number): OverrideLookup {
+export const DEFAULT_OVERRIDE_CACHE_MAX_ENTRIES = 10_000
+
+export function createOverrideLookup(
+	db: typeof Db,
+	ttlSeconds: number,
+	maxEntries: number = DEFAULT_OVERRIDE_CACHE_MAX_ENTRIES,
+): OverrideLookup {
+	// Map preserves insertion order in JS, which we exploit for LRU:
+	// every read of a fresh entry deletes+re-inserts it, moving it to the tail.
+	// On overflow, the head (oldest) is evicted via .keys().next().
 	const cache = new Map<string, CacheEntry>()
 	const ttlMs = ttlSeconds * 1000
+
+	function touchAsRecent(ip: string, entry: CacheEntry): void {
+		cache.delete(ip)
+		cache.set(ip, entry)
+	}
+
+	function evictOldestIfFull(): void {
+		while (cache.size >= maxEntries) {
+			const oldest = cache.keys().next().value
+			if (oldest === undefined) break
+			cache.delete(oldest)
+		}
+	}
 
 	return {
 		async lookup(ip) {
 			const now = Date.now()
 			const cached = cache.get(ip)
-			if (cached && cached.expiresAtMs > now) return cached.limit
+			if (cached) {
+				if (cached.expiresAtMs > now) {
+					touchAsRecent(ip, cached)
+					return cached.limit
+				}
+				// Expired: drop it now rather than waiting for LRU pressure.
+				cache.delete(ip)
+			}
 
 			let limit: number | null = null
 			try {
@@ -51,8 +88,13 @@ export function createOverrideLookup(db: typeof Db, ttlSeconds: number): Overrid
 				return null
 			}
 
+			evictOldestIfFull()
 			cache.set(ip, {limit, expiresAtMs: now + ttlMs})
 			return limit
+		},
+
+		size() {
+			return cache.size
 		},
 	}
 }

--- a/api/src/services/rateLimit/overrides.ts
+++ b/api/src/services/rateLimit/overrides.ts
@@ -1,0 +1,58 @@
+import {sql} from "drizzle-orm"
+import type {db as Db} from "../storage/storage"
+import {log} from "../telemetry"
+
+/**
+ * Lookup per-IP rate limit overrides from Postgres with a small in-process
+ * cache to keep the hot path off the DB.
+ *
+ * We use the cache for *both* hits (an explicit limit) and misses (no row
+ * matched). A miss is cached as `null` so we don't repeatedly query for IPs
+ * that fall through to the default limit.
+ *
+ * The cache is per-pod, so propagating a new override row takes up to
+ * `ttlSeconds` to be picked up by all pods. That's the price of avoiding
+ * a Postgres query on every API request, and acceptable for an admin-managed
+ * configuration table.
+ */
+export type OverrideLookup = {
+	/** Returns the per-minute limit for `ip` if an override matches, otherwise `null`. */
+	lookup(ip: string): Promise<number | null>
+}
+
+type CacheEntry = {limit: number | null; expiresAtMs: number}
+
+export function createOverrideLookup(db: typeof Db, ttlSeconds: number): OverrideLookup {
+	const cache = new Map<string, CacheEntry>()
+	const ttlMs = ttlSeconds * 1000
+
+	return {
+		async lookup(ip) {
+			const now = Date.now()
+			const cached = cache.get(ip)
+			if (cached && cached.expiresAtMs > now) return cached.limit
+
+			let limit: number | null = null
+			try {
+				// Most-specific containing prefix wins (e.g. /32 over /16).
+				// `>>=` is "ip_range contains $1::inet".
+				const result = await db.execute<{requests_per_min: number}>(sql`
+					SELECT requests_per_min FROM rate_limit_overrides
+					WHERE ip_range >>= ${ip}::inet
+					ORDER BY masklen(ip_range) DESC
+					LIMIT 1
+				`)
+				const row = result.rows[0]
+				if (row) limit = Number(row.requests_per_min)
+			} catch (err) {
+				// On DB failure, treat as miss (default limit applies). Don't cache
+				// the failure — retry on the next request in case it was transient.
+				log.warn("rate limit: override lookup failed", {error: String(err), ip})
+				return null
+			}
+
+			cache.set(ip, {limit, expiresAtMs: now + ttlMs})
+			return limit
+		},
+	}
+}

--- a/api/src/services/rateLimit/overrides.ts
+++ b/api/src/services/rateLimit/overrides.ts
@@ -30,7 +30,7 @@ export type OverrideLookup = {
 
 type CacheEntry = {limit: number | null; expiresAtMs: number}
 
-export const DEFAULT_OVERRIDE_CACHE_MAX_ENTRIES = 10_000
+export const DEFAULT_OVERRIDE_CACHE_MAX_ENTRIES = 100_000
 
 export function createOverrideLookup(
 	db: typeof Db,

--- a/api/src/services/rateLimit/store.ts
+++ b/api/src/services/rateLimit/store.ts
@@ -15,10 +15,12 @@ import {log} from "../telemetry"
  */
 export type RateLimitStore = {
 	/**
-	 * Atomically increment the counter for `(ip, minute)` and return the new
-	 * count + seconds-until-reset. Returns `null` on Valkey failure.
+	 * Atomically increment the counter for `(identifier, minute)` and return the
+	 * new count + seconds-until-reset. The identifier is either an IP address or
+	 * an API key prefixed with "key:" to keep namespaces separate.
+	 * Returns `null` on Valkey failure.
 	 */
-	incrementAndGet(ip: string, nowMs: number): Promise<{count: number; resetSeconds: number} | null>
+	incrementAndGet(identifier: string, nowMs: number): Promise<{count: number; resetSeconds: number} | null>
 }
 
 const KEY_PREFIX = "rl:"
@@ -29,10 +31,10 @@ const EXPIRE_SECONDS = WINDOW_SECONDS * 2
 
 export function createValkeyRateLimitStore(valkey: Redis): RateLimitStore {
 	return {
-		async incrementAndGet(ip, nowMs) {
+		async incrementAndGet(identifier, nowMs) {
 			try {
 				const minute = Math.floor(nowMs / 1000 / WINDOW_SECONDS)
-				const key = `${KEY_PREFIX}${ip}:${minute}`
+				const key = `${KEY_PREFIX}${identifier}:${minute}`
 
 				// Pipeline INCR + EXPIRE in a single round-trip. We send EXPIRE
 				// every time (cheap; idempotent) so the key's lifetime is always
@@ -55,7 +57,7 @@ export function createValkeyRateLimitStore(valkey: Redis): RateLimitStore {
 
 				return {count, resetSeconds}
 			} catch (err) {
-				log.warn("rate limit: Valkey increment failed", {error: String(err), ip})
+				log.warn("rate limit: Valkey increment failed", {error: String(err), identifier})
 				return null
 			}
 		},

--- a/api/src/services/rateLimit/store.ts
+++ b/api/src/services/rateLimit/store.ts
@@ -1,0 +1,63 @@
+import type Redis from "ioredis"
+import {log} from "../telemetry"
+
+/**
+ * Thin Valkey-backed counter for fixed-window minute buckets.
+ *
+ * Why a fixed window: simplest sane semantics, atomic INCR, one round-trip per
+ * request. The boundary effect (a client gets 2× their limit straddling the
+ * window edge) is acceptable for a soft-protection rate limiter.
+ *
+ * Failure mode: every operation is wrapped to never throw. On Valkey error or
+ * timeout we return `null` so the caller can fail open (allow the request, log
+ * a warning). This matches the response cache's posture and keeps a Valkey
+ * outage from taking the API down.
+ */
+export type RateLimitStore = {
+	/**
+	 * Atomically increment the counter for `(ip, minute)` and return the new
+	 * count + seconds-until-reset. Returns `null` on Valkey failure.
+	 */
+	incrementAndGet(ip: string, nowMs: number): Promise<{count: number; resetSeconds: number} | null>
+}
+
+const KEY_PREFIX = "rl:"
+const WINDOW_SECONDS = 60
+// EXPIRE on the bucket key. Slight TTL padding so Valkey never drops the key
+// before the window legitimately ends, which would let counters reset early.
+const EXPIRE_SECONDS = WINDOW_SECONDS * 2
+
+export function createValkeyRateLimitStore(valkey: Redis): RateLimitStore {
+	return {
+		async incrementAndGet(ip, nowMs) {
+			try {
+				const minute = Math.floor(nowMs / 1000 / WINDOW_SECONDS)
+				const key = `${KEY_PREFIX}${ip}:${minute}`
+
+				// Pipeline INCR + EXPIRE in a single round-trip. We send EXPIRE
+				// every time (cheap; idempotent) so the key's lifetime is always
+				// refreshed during active windows.
+				const pipeline = valkey.pipeline()
+				pipeline.incr(key)
+				pipeline.expire(key, EXPIRE_SECONDS)
+				const results = await pipeline.exec()
+
+				if (!results || results.length === 0) return null
+				const incrResult = results[0]
+				if (!incrResult || incrResult[0] !== null) return null
+
+				const count = Number(incrResult[1])
+				if (!Number.isFinite(count)) return null
+
+				const windowStartMs = minute * WINDOW_SECONDS * 1000
+				const elapsedMs = nowMs - windowStartMs
+				const resetSeconds = Math.max(0, Math.ceil((WINDOW_SECONDS * 1000 - elapsedMs) / 1000))
+
+				return {count, resetSeconds}
+			} catch (err) {
+				log.warn("rate limit: Valkey increment failed", {error: String(err), ip})
+				return null
+			}
+		},
+	}
+}

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -979,3 +979,24 @@ export const rateLimitOverrides = pgTable(
 	},
 	(table) => [index("idx_rate_limit_overrides_ip_range").using("gist", table.ipRange.op("inet_ops"))],
 )
+
+/**
+ * api_keys
+ *
+ * API keys for backend-to-backend rate limit identification. When a request
+ * includes an `X-Api-Key` header matching an enabled row, the rate limiter
+ * uses the key's `requests_per_min` instead of the IP-based default.
+ *
+ * `requests_per_min = NULL` means unlimited (no counter incremented).
+ * `enabled = false` means the key is ignored (falls through to IP-based limiting).
+ *
+ * Keys are cached per-pod for RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS (default 60s).
+ */
+export const apiKeys = pgTable("api_keys", {
+	key: text().primaryKey(),
+	clientName: text("client_name").notNull(),
+	requestsPerMin: integer("requests_per_min"),
+	enabled: boolean().notNull().default(true),
+	createdAt: timestamp("created_at", {withTimezone: true, mode: "date"}).defaultNow().notNull(),
+	updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).defaultNow().notNull(),
+})

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -2,10 +2,12 @@ import {relations as drizzleRelations, type InferSelectModel, sql} from "drizzle
 import {
 	bigint,
 	boolean,
+	cidr,
 	customType,
 	decimal,
 	doublePrecision,
 	index,
+	integer,
 	jsonb,
 	pgEnum,
 	pgTable,
@@ -949,4 +951,31 @@ export const notificationDeliveries = pgTable(
 		unique().on(table.outboxId, table.webhookId),
 		index("idx_deliveries_pending").on(table.status, table.nextRetryAt),
 	],
+)
+
+/**
+ * rate_limit_overrides
+ *
+ * Per-IP and per-CIDR overrides for the GraphQL HTTP rate limiter. Rows here
+ * take precedence over the env-configured default. Bare IPs may be inserted as
+ * `'1.2.3.4'` (Postgres `cidr` widens to `/32`) or `'1.2.3.4/32'`. CIDR ranges
+ * (e.g. `'10.0.0.0/24'`) are matched by the most-specific containing prefix.
+ *
+ * `requests_per_min = 0` blocks the IP entirely (kill switch).
+ *
+ * Lookup query (from middleware):
+ *   SELECT requests_per_min FROM rate_limit_overrides
+ *   WHERE ip_range >>= $1::inet
+ *   ORDER BY masklen(ip_range) DESC LIMIT 1;
+ */
+export const rateLimitOverrides = pgTable(
+	"rate_limit_overrides",
+	{
+		ipRange: cidr("ip_range").primaryKey(),
+		requestsPerMin: integer("requests_per_min").notNull(),
+		description: text(),
+		createdAt: timestamp("created_at", {withTimezone: true, mode: "date"}).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).defaultNow().notNull(),
+	},
+	(table) => [index("idx_rate_limit_overrides_ip_range").using("gist", table.ipRange.op("inet_ops"))],
 )

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
 			// Cache tests use bun:test to avoid duplicate graphql module conflicts
 			"src/kg/__tests__/valkeyCache.test.ts",
 			"src/kg/__tests__/cache-integration.test.ts",
+			// Rate limit integration test requires real Valkey + Postgres (runs in CI)
+			"src/middleware/__tests__/rateLimit-integration.test.ts",
 		],
 		setupFiles: ["./src/test-setup.ts"],
 		env: {

--- a/api/vitest.integration.config.ts
+++ b/api/vitest.integration.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: "node",
-		include: ["src/**/*integration*.test.ts"],
+		include: ["src/middleware/__tests__/rateLimit-integration.test.ts"],
 	},
 })

--- a/api/vitest.integration.config.ts
+++ b/api/vitest.integration.config.ts
@@ -1,0 +1,16 @@
+import tsconfigPaths from "vite-tsconfig-paths"
+import {defineConfig} from "vitest/config"
+
+/**
+ * Vitest config for integration tests that require real external services
+ * (Postgres, Valkey). These are excluded from the default vitest.config.ts
+ * and run in dedicated CI workflows with service containers.
+ */
+export default defineConfig({
+	plugins: [tsconfigPaths()],
+	test: {
+		globals: true,
+		environment: "node",
+		include: ["src/**/*integration*.test.ts"],
+	},
+})

--- a/docs/plans/003-graphql-rate-limiting.md
+++ b/docs/plans/003-graphql-rate-limiting.md
@@ -56,6 +56,20 @@ Most-specific match wins (e.g. an explicit `/32` override beats a containing `/1
 
 Per-pod in-memory cache with 60s TTL (`RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS`) keeps the hot path off Postgres. Both hits and misses are cached; trade-off is up to 60s for a new override to propagate to all pods.
 
+## Latency impact
+
+| Scenario | What runs | Added latency |
+|---|---|---|
+| Allowlisted IP (cluster-internal) | In-memory CIDR check only (integer bitwise math, no I/O) | ~0 ms |
+| Normal IP, override cache hit | CIDR check + Map lookup + 1 Valkey `INCR`+`EXPIRE` pipeline | ~0.3–0.5 ms |
+| Normal IP, override cache miss | CIDR check + Postgres query + Valkey pipeline | ~2–5 ms (once per 60s per IP, then cached) |
+
+The dominant cost is the Valkey pipeline — one pod-to-pod round-trip within DOKS (~0.2–0.5 ms). For context, typical GraphQL queries take 50–1300 ms, so the rate-limit overhead is well under 1%.
+
+Allowlisted IPs (all internal services) pay essentially zero: the CIDR check is a loop over 2 entries doing `(ip & mask) === network` — nanoseconds, no network call, no cache lookup.
+
+Cache hits and cache misses are both counted against the rate limit. The middleware runs **before** the GraphQL handler (`app.use` registered before `app.on`), so the Valkey counter is incremented before Yoga checks its response cache.
+
 ## HTTP behavior
 
 Allowed requests (response from upstream handler) include rate-limit headers:

--- a/docs/plans/003-graphql-rate-limiting.md
+++ b/docs/plans/003-graphql-rate-limiting.md
@@ -4,20 +4,21 @@
 
 Protect the GraphQL HTTP endpoint from abuse (scrapers, runaway clients, accidental DOS) without throttling our own backend services or specific high-traffic clients we want to allow.
 
-## Three tiers
+## Four tiers
 
 Tier resolution is first-match-wins:
 
+0. **API key** (`X-Api-Key` header) — looked up in the `api_keys` table. `requests_per_min = NULL` means unlimited (counter not incremented, no headers). A custom integer value is a per-key limit with counter keyed by `rl:key:<key>:<minute>`. Disabled or unknown keys fall through to IP-based. Used for backend-to-backend calls (e.g. Railway-hosted curator-app) where IPs rotate on deploy.
 1. **Unlimited allowlist** (env CIDRs) — unlimited, counter not incremented, no rate-limit headers. Used for cluster-internal traffic and our own backend services.
 2. **Per-IP override** (DB row) — uses the row's `requests_per_min`. Used for specific clients we've negotiated higher (or lower) limits with.
 3. **Default** — `RATE_LIMIT_DEFAULT_PER_MINUTE` from env (1000/min). Applies to everyone else.
 
-A per-IP override of `0` blocks the IP entirely — handy admin kill switch.
+An override of `0` (IP or API key) blocks entirely — handy admin kill switch.
 
 ## Counter store: Valkey, fixed minute window
 
 - Same Valkey instance as the response cache (`api-cache` in cluster), separate keyspace prefix `rl:`.
-- Key per `(ip, unix_minute)`; `INCR` + `EXPIRE 120s` pipelined into a single round-trip.
+- Key per `(identifier, unix_minute)`; `INCR` + `EXPIRE 120s` pipelined into a single round-trip. Identifier is either the IP or `key:<api_key>` — separate namespaces so API key limits are independent of IP limits.
 - Counters are **shared across all API pods**, so a client cannot bypass the limit by hitting different pods.
 - Fixed window has a known boundary effect (a client could burst up to 2× in a window straddling the minute edge). Acceptable for a soft guard. We can switch to a token bucket or true sliding window later if needed.
 
@@ -54,7 +55,22 @@ LIMIT 1;
 
 Most-specific match wins (e.g. an explicit `/32` override beats a containing `/16`).
 
-Per-pod in-memory cache with 60s TTL (`RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS`) keeps the hot path off Postgres. Both hits and misses are cached; trade-off is up to 60s for a new override to propagate to all pods.
+Per-pod in-memory LRU cache with 60s TTL (`RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS`) keeps the hot path off Postgres. Both hits and misses are cached; trade-off is up to 60s for a new override to propagate to all pods.
+
+### API keys table
+
+```sql
+CREATE TABLE api_keys (
+  key              text PRIMARY KEY,             -- the secret key value
+  client_name      text NOT NULL,                -- 'railway: curator-app'
+  requests_per_min integer,                      -- NULL = unlimited
+  enabled          boolean NOT NULL DEFAULT true, -- false = key ignored, falls through to IP
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+```
+
+Lookup: `SELECT requests_per_min, client_name, enabled FROM api_keys WHERE key = $1`. Cached per-pod in the same LRU pattern as IP overrides.
 
 ## Latency impact
 
@@ -132,10 +148,12 @@ api/src/middleware/rateLimit.ts            # Hono middleware, ties everything to
 api/src/middleware/clientIp.ts             # XFF parser with trusted-hops handling
 api/src/services/rateLimit/cidr.ts         # IPv4 CIDR matcher
 api/src/services/rateLimit/config.ts       # env → RateLimitConfig
-api/src/services/rateLimit/store.ts        # Valkey INCR wrapper
-api/src/services/rateLimit/overrides.ts    # Postgres lookup with per-pod cache
-api/src/services/storage/schema.ts         # rate_limit_overrides table
-api/drizzle/0054_curved_post.sql           # generated migration
+api/src/services/rateLimit/store.ts        # Valkey INCR wrapper (ip or key: prefix)
+api/src/services/rateLimit/overrides.ts    # Per-IP Postgres lookup with LRU cache
+api/src/services/rateLimit/apiKeys.ts      # API key Postgres lookup with LRU cache
+api/src/services/storage/schema.ts         # rate_limit_overrides + api_keys tables
+api/drizzle/0054_curved_post.sql           # rate_limit_overrides migration
+api/drizzle/0055_sour_moondragon.sql       # api_keys migration
 api/main.ts                                # wires middleware before /graphql handler
 api/.env.example                           # documents new env vars
 ```
@@ -168,6 +186,27 @@ DELETE FROM rate_limit_overrides WHERE ip_range = '203.0.113.42';
 
 Overrides take effect within `RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS` (default 60) on each pod.
 
+### Managing API keys
+
+```sql
+-- Create an unlimited key for a backend service (e.g. Railway curator-app)
+INSERT INTO api_keys (key, client_name, requests_per_min, enabled)
+VALUES ('ck_live_abc123...', 'railway: curator-app', NULL, true);
+
+-- Create a key with a custom limit for a partner integration
+INSERT INTO api_keys (key, client_name, requests_per_min, enabled)
+VALUES ('ck_live_xyz789...', 'partner: acme-corp', 5000, true);
+
+-- Disable a key (requests fall through to IP-based limiting)
+UPDATE api_keys SET enabled = false, updated_at = now()
+WHERE key = 'ck_live_abc123...';
+
+-- Delete a key
+DELETE FROM api_keys WHERE key = 'ck_live_abc123...';
+```
+
+The client sends the key via `X-Api-Key: ck_live_abc123...` header. Keys propagate to all pods within 60s (same cache TTL as IP overrides).
+
 ### Verifying it's working
 
 ```bash
@@ -192,6 +231,6 @@ kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=true
 
 - IPv6 support in `cidr.ts` (Postgres handles it natively in the table already).
 - Token bucket or true sliding window if minute-edge boundary effect causes complaints.
-- API key support: `Authorization: Bearer <key>` mapped to a client ID, override table keyed by client ID instead of (or in addition to) IP.
 - Per-route rate limits with different defaults (e.g. tighter on `/ipfs/upload-*`).
-- Prometheus metric: `graphql_rate_limit_total{status="allowed|blocked|allowlisted"}`.
+- Prometheus metric: `graphql_rate_limit_total{status="allowed|blocked|allowlisted|api_key"}`.
+- Admin API for managing API keys and IP overrides (currently SQL only).

--- a/docs/plans/003-graphql-rate-limiting.md
+++ b/docs/plans/003-graphql-rate-limiting.md
@@ -8,7 +8,7 @@ Protect the GraphQL HTTP endpoint from abuse (scrapers, runaway clients, acciden
 
 Tier resolution is first-match-wins:
 
-1. **Whitelist** (env CIDRs) — unlimited, counter not incremented, no rate-limit headers. Used for cluster-internal traffic and our own backend services.
+1. **Unlimited allowlist** (env CIDRs) — unlimited, counter not incremented, no rate-limit headers. Used for cluster-internal traffic and our own backend services.
 2. **Per-IP override** (DB row) — uses the row's `requests_per_min`. Used for specific clients we've negotiated higher (or lower) limits with.
 3. **Default** — `RATE_LIMIT_DEFAULT_PER_MINUTE` from env (1000/min). Applies to everyone else.
 
@@ -77,19 +77,19 @@ Content-Type: application/json
 {"error":"rate_limit_exceeded","retry_after_seconds":23}
 ```
 
-Whitelisted IPs get **no headers** at all (signaling unlimited).
+Allowlisted IPs get **no headers** at all (signaling unlimited).
 
 ## Configuration
 
 ```bash
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_DEFAULT_PER_MINUTE=1000
-RATE_LIMIT_WHITELIST_IPS=10.108.0.0/16,10.109.0.0/16   # DOKS pod + service nets
+RATE_LIMIT_UNLIMITED_ALLOWLIST_IPS=10.108.0.0/16,10.109.0.0/16   # DOKS pod + service nets
 RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS=60
 RATE_LIMIT_TRUSTED_PROXY_HOPS=1                         # ingress-nginx is 1 hop
 ```
 
-Whitelist defaults to **DOKS pod CIDR (`10.108.0.0/16`)** and **service CIDR (`10.109.0.0/16`)** so all internal cluster traffic (pod-to-pod calls from notification-service, scoring-service, etc.) is exempted.
+Unlimited allowlist defaults to **DOKS pod CIDR (`10.108.0.0/16`)** and **service CIDR (`10.109.0.0/16`)** so all internal cluster traffic (pod-to-pod calls from notification-service, scoring-service, etc.) is exempted.
 
 ## Sizing rationale (1000/min default)
 
@@ -180,4 +180,4 @@ kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=true
 - Token bucket or true sliding window if minute-edge boundary effect causes complaints.
 - API key support: `Authorization: Bearer <key>` mapped to a client ID, override table keyed by client ID instead of (or in addition to) IP.
 - Per-route rate limits with different defaults (e.g. tighter on `/ipfs/upload-*`).
-- Prometheus metric: `graphql_rate_limit_total{status="allowed|blocked|whitelisted"}`.
+- Prometheus metric: `graphql_rate_limit_total{status="allowed|blocked|allowlisted"}`.

--- a/docs/plans/003-graphql-rate-limiting.md
+++ b/docs/plans/003-graphql-rate-limiting.md
@@ -1,0 +1,183 @@
+# Plan 003 — GraphQL HTTP Rate Limiting
+
+## Goal
+
+Protect the GraphQL HTTP endpoint from abuse (scrapers, runaway clients, accidental DOS) without throttling our own backend services or specific high-traffic clients we want to allow.
+
+## Three tiers
+
+Tier resolution is first-match-wins:
+
+1. **Whitelist** (env CIDRs) — unlimited, counter not incremented, no rate-limit headers. Used for cluster-internal traffic and our own backend services.
+2. **Per-IP override** (DB row) — uses the row's `requests_per_min`. Used for specific clients we've negotiated higher (or lower) limits with.
+3. **Default** — `RATE_LIMIT_DEFAULT_PER_MINUTE` from env (1000/min). Applies to everyone else.
+
+A per-IP override of `0` blocks the IP entirely — handy admin kill switch.
+
+## Counter store: Valkey, fixed minute window
+
+- Same Valkey instance as the response cache (`api-cache` in cluster), separate keyspace prefix `rl:`.
+- Key per `(ip, unix_minute)`; `INCR` + `EXPIRE 120s` pipelined into a single round-trip.
+- Counters are **shared across all API pods**, so a client cannot bypass the limit by hitting different pods.
+- Fixed window has a known boundary effect (a client could burst up to 2× in a window straddling the minute edge). Acceptable for a soft guard. We can switch to a token bucket or true sliding window later if needed.
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Valkey down / slow / timeout | **Fail open** — allow request, log warn. Same posture as the response cache. Rate limiting is a soft guard, not a security boundary; an outage shouldn't take the API down. |
+| Postgres down (override lookup) | Treat as "no override" → fall through to default. Don't cache the failure. |
+| No `X-Forwarded-For` header | Allow request, log warn. Indicates ingress misconfiguration. |
+| Limit env vars invalid | Fall back to defaults silently (logged). |
+
+## DB schema
+
+```sql
+CREATE TABLE rate_limit_overrides (
+  ip_range         cidr PRIMARY KEY,           -- '1.2.3.4' (auto /32) or '10.0.0.0/24'
+  requests_per_min integer NOT NULL CHECK (requests_per_min >= 0),
+  description      text,                       -- 'client: acme corp'
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_rate_limit_overrides_ip_range
+  ON rate_limit_overrides USING gist (ip_range inet_ops);
+```
+
+Lookup query:
+```sql
+SELECT requests_per_min FROM rate_limit_overrides
+WHERE ip_range >>= $1::inet
+ORDER BY masklen(ip_range) DESC
+LIMIT 1;
+```
+
+Most-specific match wins (e.g. an explicit `/32` override beats a containing `/16`).
+
+Per-pod in-memory cache with 60s TTL (`RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS`) keeps the hot path off Postgres. Both hits and misses are cached; trade-off is up to 60s for a new override to propagate to all pods.
+
+## HTTP behavior
+
+Allowed requests (response from upstream handler) include rate-limit headers:
+```
+RateLimit-Limit: 1000
+RateLimit-Remaining: 957
+RateLimit-Reset: 23
+```
+
+Blocked requests:
+```
+HTTP/1.1 429 Too Many Requests
+RateLimit-Limit: 1000
+RateLimit-Remaining: 0
+RateLimit-Reset: 23
+Retry-After: 23
+Content-Type: application/json
+
+{"error":"rate_limit_exceeded","retry_after_seconds":23}
+```
+
+Whitelisted IPs get **no headers** at all (signaling unlimited).
+
+## Configuration
+
+```bash
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_DEFAULT_PER_MINUTE=1000
+RATE_LIMIT_WHITELIST_IPS=10.108.0.0/16,10.109.0.0/16   # DOKS pod + service nets
+RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS=60
+RATE_LIMIT_TRUSTED_PROXY_HOPS=1                         # ingress-nginx is 1 hop
+```
+
+Whitelist defaults to **DOKS pod CIDR (`10.108.0.0/16`)** and **service CIDR (`10.109.0.0/16`)** so all internal cluster traffic (pod-to-pod calls from notification-service, scoring-service, etc.) is exempted.
+
+## Sizing rationale (1000/min default)
+
+Frontend (geobrowser) makes ~10–20 GraphQL HTTP calls per page load (no batching link in `graphql-request`):
+
+| User behavior | calls/min | vs 1000 limit |
+|---|---|---|
+| Casual: 5 page loads/min | ~50–100 | 5–10% |
+| Heavy: 20 page loads/min | ~200–400 | 20–40% |
+| Power: 50 page loads/min | ~500–1000 | 50–100% |
+| Scraper crawling | usually >1000 | over (intended) |
+
+1000/min ≈ 17 req/sec average — generous for any human, tight enough to trip naive scrapers.
+
+Shared egress IPs (corporate NAT, mobile carriers) may bunch many users behind one address. The override table is the pressure-release valve — add a row for a known shared IP with a higher limit.
+
+## Scope
+
+- **v1**: applied to `/graphql` only.
+- **Future**: easy to extend to `/search`, `/proposals`, etc. by mounting the same middleware.
+
+## File layout
+
+```
+api/src/middleware/rateLimit.ts            # Hono middleware, ties everything together
+api/src/middleware/clientIp.ts             # XFF parser with trusted-hops handling
+api/src/services/rateLimit/cidr.ts         # IPv4 CIDR matcher
+api/src/services/rateLimit/config.ts       # env → RateLimitConfig
+api/src/services/rateLimit/store.ts        # Valkey INCR wrapper
+api/src/services/rateLimit/overrides.ts    # Postgres lookup with per-pod cache
+api/src/services/storage/schema.ts         # rate_limit_overrides table
+api/drizzle/0054_curved_post.sql           # generated migration
+api/main.ts                                # wires middleware before /graphql handler
+api/.env.example                           # documents new env vars
+```
+
+## Operations
+
+### Adding a per-IP override
+
+```sql
+-- Specific client gets 5000/min
+INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
+VALUES ('203.0.113.42', 5000, 'client: acme corp');
+
+-- Whole subnet of an enterprise customer gets 10000/min
+INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
+VALUES ('198.51.100.0/24', 10000, 'enterprise: globex office');
+
+-- Block a misbehaving IP entirely
+INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
+VALUES ('192.0.2.99', 0, 'blocked: scraping');
+
+-- Update an existing override
+UPDATE rate_limit_overrides
+SET requests_per_min = 2000, updated_at = now()
+WHERE ip_range = '203.0.113.42';
+
+-- Remove an override (IP falls back to default)
+DELETE FROM rate_limit_overrides WHERE ip_range = '203.0.113.42';
+```
+
+Overrides take effect within `RATE_LIMIT_OVERRIDE_CACHE_TTL_SECONDS` (default 60) on each pod.
+
+### Verifying it's working
+
+```bash
+# Hit /graphql repeatedly, watch headers
+for i in $(seq 1 5); do
+  curl -sI -X POST -H 'Content-Type: application/json' \
+    -d '{"query":"{__typename}"}' \
+    https://api.geobrowser.io/graphql \
+    | grep -i ratelimit
+done
+```
+
+### Disabling temporarily
+
+```bash
+kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=false
+# revert with:
+kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=true
+```
+
+## Future work
+
+- IPv6 support in `cidr.ts` (Postgres handles it natively in the table already).
+- Token bucket or true sliding window if minute-edge boundary effect causes complaints.
+- API key support: `Authorization: Bearer <key>` mapped to a client ID, override table keyed by client ID instead of (or in addition to) IP.
+- Per-route rate limits with different defaults (e.g. tighter on `/ipfs/upload-*`).
+- Prometheus metric: `graphql_rate_limit_total{status="allowed|blocked|whitelisted"}`.

--- a/maintenance/k8s/image-pruner.yaml
+++ b/maintenance/k8s/image-pruner.yaml
@@ -103,7 +103,6 @@ spec:
       tolerations:
         - operator: Exists
       # Privileged so we can talk to containerd's socket on the host
-      hostPID: true
       containers:
         - name: pruner
           image: alpine:3.20
@@ -136,10 +135,11 @@ spec:
             - /bin/sh
             - -c
             - |
-              set -u
+              set -eu
               apk add --no-cache curl ca-certificates >/dev/null
               curl -fsSL "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" \
                 | tar -xz -C /usr/local/bin
+              crictl --version   # fail fast if binary is missing or broken
               export CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
 
               log() { echo "[$(date -u +%FT%TZ)] [${NODE_NAME}] $*"; }
@@ -172,6 +172,10 @@ spec:
                 log "==== run complete (event=run_complete) ===="
               }
 
+              # Init succeeded. Disable -e for the main loop: crictl rmi --prune
+              # can return non-zero when individual images timeout, which is expected
+              # and handled by the || log fallback. We don't want that to kill the pod.
+              set +e
               log "image-pruner started; schedule=DOW=${TARGET_DOW} HOUR=${TARGET_HOUR} (UTC), check_interval=${CHECK_INTERVAL_SECONDS}s"
               LAST_RUN_KEY=""
               while true; do


### PR DESCRIPTION
## Summary
Adds four-tier rate limiting on the GraphQL HTTP endpoint:
0. **API key** (`X-Api-Key` header) — DB lookup: unlimited (`NULL`) or custom limit, counter keyed by `key:<k>`. For backend-to-backend calls (e.g. Railway curator-app) where IPs rotate on deploy.
1. **Unlimited allowlist** (env CIDRs) — unlimited, no counter, no headers. For cluster-internal traffic.
2. **Per-IP DB override** (`rate_limit_overrides` table) — custom limit per IP/CIDR.
3. **Default** — `RATE_LIMIT_DEFAULT_PER_MINUTE` (1000).

Counters live in Valkey (shared across all API pods). API key and IP counters are tracked separately (`rl:key:<k>:<min>` vs `rl:<ip>:<min>`), so limits are independent.

## Why
- Protect `/graphql` from scraping, runaway clients, accidental DOS.
- Allow our own backend services to call the API freely via cluster-internal CIDRs or API keys.
- Allow specific external clients we've negotiated higher quotas with via per-IP overrides or API keys.
- Railway-hosted services rotate IPs on every deploy — API keys solve this without maintaining IP allowlists.

## Architecture (see `docs/plans/003-graphql-rate-limiting.md` for full design)

### Four-tier resolution (first match wins)
0. `X-Api-Key` header → DB `api_keys` table. `NULL` = unlimited, integer = custom limit, disabled/unknown = fall through to IP.
1. CIDR unlimited allowlist from env → unlimited (no Valkey hit, no headers).
2. Per-IP/CIDR override from Postgres → custom limit. Most-specific match wins (`/32` beats `/16`).
3. Default → `RATE_LIMIT_DEFAULT_PER_MINUTE` (1000).

### Counter store: Valkey
- Same instance as response cache (`api-cache`), separate keyspace prefix `rl:`.
- `INCR` + `EXPIRE 120s` pipelined into one round-trip per request (~0.5ms).
- Fixed minute window. Boundary effect (2× burst across edge) is acceptable for a soft guard.

### Failure modes
- **Valkey down/slow** → fail open, log warn.
- **Postgres down** → treat as no override/unknown key, fall through to default.
- **Missing X-Forwarded-For** → allow request, log warn.

### DB schema

**IP overrides** (migration 0054):
```sql
CREATE TABLE rate_limit_overrides (
  ip_range         cidr PRIMARY KEY,
  requests_per_min integer NOT NULL CHECK (requests_per_min >= 0),
  description      text,
  created_at       timestamptz NOT NULL DEFAULT now(),
  updated_at       timestamptz NOT NULL DEFAULT now()
);
CREATE INDEX idx_rate_limit_overrides_ip_range
  ON rate_limit_overrides USING gist (ip_range inet_ops);
```

**API keys** (migration 0055):
```sql
CREATE TABLE api_keys (
  key              text PRIMARY KEY,
  client_name      text NOT NULL,
  requests_per_min integer,          -- NULL = unlimited
  enabled          boolean NOT NULL DEFAULT true,
  created_at       timestamptz NOT NULL DEFAULT now(),
  updated_at       timestamptz NOT NULL DEFAULT now()
);
```

Both use per-pod 60s LRU caches (100k entries max, ~20 MB worst case) to keep the hot path off Postgres.

### HTTP behavior
```
RateLimit-Limit: 1000
RateLimit-Remaining: 957
RateLimit-Reset: 23
```
On 429: `{"error":"rate_limit_exceeded","retry_after_seconds":23}` with `Retry-After` header.
Unlimited (allowlisted IPs or unlimited API keys) get no headers.

## Default unlimited allowlist for DOKS
- **Pod CIDR**: `10.108.0.0/16`
- **Service CIDR**: `10.109.0.0/16`

Configured in staging + production `api.yaml`.

## Files
- `api/src/middleware/rateLimit.ts` — Hono middleware (4-tier resolution)
- `api/src/middleware/clientIp.ts` — XFF parser with trusted-hops
- `api/src/services/rateLimit/cidr.ts` — IPv4 CIDR matcher (rejects leading-zero octets)
- `api/src/services/rateLimit/config.ts` — env → config
- `api/src/services/rateLimit/store.ts` — Valkey counter (ip or key: prefix)
- `api/src/services/rateLimit/overrides.ts` — Per-IP Postgres lookup with LRU cache
- `api/src/services/rateLimit/apiKeys.ts` — API key Postgres lookup with LRU cache
- `api/src/services/storage/schema.ts` — `rate_limit_overrides` + `api_keys` tables
- `api/drizzle/0054_curved_post.sql` — rate_limit_overrides migration
- `api/drizzle/0055_sour_moondragon.sql` — api_keys migration
- `api/main.ts` — wires middleware + OpenAPI docs for `/graphql`
- `api/k8s/{staging,production}/api.yaml` — `RATE_LIMIT_*` env vars
- `api/.env.example` — documents new env vars
- `api/README.md` — rate limits section with API key docs + disable instructions
- `api/scripts/test-rate-limit.sh` — manual test script
- `api/vitest.integration.config.ts` — separate vitest config for integration tests
- `.github/workflows/api-rate-limit-integration-tests.yml` — CI with Valkey + Postgres
- `docs/plans/003-graphql-rate-limiting.md` — full design doc with latency analysis

## Tests

### Unit tests (67 tests, all passing via `bun run test`)
- `cidr.test.ts` (35) — IPv4 parse, leading-zero rejection, CIDR parse, boundary IPs
- `config.test.ts` (8) — env parsing, defaults, invalid input
- `clientIp.test.ts` (8) — XFF parsing, trusted-hops, X-Real-IP fallback
- `rateLimit.test.ts` (15) — IP: disabled passthrough, default limit, allowlist bypass, DB override, kill-switch, fail-open, no-IP, per-IP isolation. **API key**: custom limit with key-based counter, unlimited (no counter), blocked (limit=0), unknown/disabled key fallthrough to IP, key counter separate from IP counter.
- `overrides.test.ts` (9) — LRU cache hit/miss, TTL re-query, eviction order, recency touch

### Integration tests (11 tests, CI only — requires real Valkey + Postgres)
- IP-based: override limit → 429, kill-switch, default limit, allowlist bypass, shared counter, cache hits count
- **API key**: custom limit → 429 after exceeding, unlimited → no headers on 20 requests, disabled key → IP fallback, unknown key → IP fallback, key/IP counter isolation

## Test plan
- [x] `bun run test` passes (67 unit tests).
- [x] `bun run check` passes (TypeScript).
- [x] `bun run lint` passes (no new warnings).
- [x] CI integration tests pass (11/11 against real Valkey + Postgres).
- [ ] Apply migrations: `bun run db:migrate` against staging DB.
- [ ] Verify deployment picks up `RATE_LIMIT_*` env vars.
- [ ] **Test rate limiting in staging**:
  ```bash
  ./api/scripts/test-rate-limit.sh 20 https://api-testnet.geobrowser.io
  # To trigger 429: ./api/scripts/test-rate-limit.sh 1010
  ```
- [ ] **Test rate limiting in production**:
  ```bash
  ./api/scripts/test-rate-limit.sh 20 https://testnet-api.geobrowser.io
  ```
- [ ] Test API key: insert an unlimited key, send requests with `X-Api-Key` header, verify no rate-limit headers.
- [ ] Test API key with custom limit: insert a key with `requests_per_min=5`, verify 429 after 5 requests.
- [ ] Test from inside cluster (kubectl exec): confirm no rate-limit headers (allowlisted).
- [ ] Test IP override + kill-switch via SQL.
- [ ] Roll out to production after staging burn-in.

## Operations

### Create an unlimited API key for Railway

Generate a secure key:
```bash
openssl rand -hex 32
# example output: a1b2c3d4e5f6...64 hex chars
```
```sql
INSERT INTO api_keys (key, client_name, requests_per_min, enabled)
VALUES ('ck_live_<generate-secret>', 'railway: curator-app', NULL, true);
```
Then set `X-Api-Key: ck_live_...` on the Railway server's outbound requests.

### Add a per-IP override
```sql
INSERT INTO rate_limit_overrides (ip_range, requests_per_min, description)
VALUES ('203.0.113.42', 5000, 'partner: acme corp');
```

## Rollout
1. Migrations: `bun run db:migrate` (creates both tables; no data needed).
2. Env vars already in `api/k8s/{staging,production}/api.yaml` — deployed automatically by CI.
3. Verify via `./api/scripts/test-rate-limit.sh`.
4. Insert API keys for Railway backend after deploy.

## Rollback
`kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=false` — instant disable, no code rollback needed.

## Disabling
Rate limiting auto-disables when `RATE_LIMIT_ENABLED=false` or when `VALKEY_URL` is unset. Local dev and CI load tests are unaffected by default.
```bash
kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=false
kubectl -n api set env deployment/api RATE_LIMIT_ENABLED=true
```
