### PR TITLE
ci: migrate remaining workflows off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/delivery-worker-deploy-staging.yml
+++ b/.github/workflows/delivery-worker-deploy-staging.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: delivery-worker
 

--- a/.github/workflows/delivery-worker-deploy.yml
+++ b/.github/workflows/delivery-worker-deploy.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: delivery-worker
 

--- a/.github/workflows/kafka-ui-deploy-staging.yml
+++ b/.github/workflows/kafka-ui-deploy-staging.yml
@@ -14,6 +14,9 @@ concurrency:
   group: kafka-ui-staging
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/kafka-ui-deploy.yml
+++ b/.github/workflows/kafka-ui-deploy.yml
@@ -14,6 +14,9 @@ concurrency:
   group: kafka-ui-production
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/notification-indexer-deploy-staging.yml
+++ b/.github/workflows/notification-indexer-deploy-staging.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: notification-indexer
 

--- a/.github/workflows/notification-indexer-deploy.yml
+++ b/.github/workflows/notification-indexer-deploy.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: notification-indexer
 

--- a/.github/workflows/search-indexer-e2e-tests.yml
+++ b/.github/workflows/search-indexer-e2e-tests.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Start Search API
         working-directory: ./api


### PR DESCRIPTION
## Summary
Node 20 goes EOL on 2026-04-30. This PR closes two gaps left by #481:

1. **`search-indexer-e2e-tests.yml`** explicitly pinned `node-version: '20'` in its `setup-node` step → bump to `22` (current LTS, supported until April 2027).

2. **6 deploy workflows** were missing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` even though they use `digitalocean/action-doctl@v2`, which still declares `using: node20` in its `action.yml`:
   - `delivery-worker-deploy.yml` / `-staging.yml`
   - `notification-indexer-deploy.yml` / `-staging.yml`
   - `kafka-ui-deploy.yml` / `-staging.yml`

## Audit
All other JS actions we use (`actions/checkout@v6`, `actions/cache@v5`, `actions/setup-node@v6`, `actions/upload-artifact@v7`, `oven-sh/setup-bun@v2`, `astral-sh/setup-uv@v8`, `Swatinem/rust-cache@v2`, `azure/setup-kubectl@v5`) already declare `using: node24` — the env var is a no-op on workflows that don't touch `doctl@v2`, `docker/build-push-action@v6`, or `docker/login-action@v3`.

## Test plan
- [ ] Re-run one staging deploy (e.g. delivery-worker) and confirm no Node 20 deprecation warnings in the `Install doctl` step