### PR TITLE
feat(api): multi-proposal grouped diffs with name enrichment

### DIFF
--- a/api/src/versioned/__tests__/enrich.test.ts
+++ b/api/src/versioned/__tests__/enrich.test.ts
@@ -1,0 +1,231 @@
+import {Effect} from "effect"
+import {describe, expect, it, vi} from "vitest"
+import type {NormalizedUuid} from "../../utils/uuid"
+import {enrichEntityDiffs} from "../enrich"
+import type {EntityDiff} from "../types"
+
+function createMockDb() {
+	return {
+		execute: vi.fn(),
+	}
+}
+
+function makeDiff(overrides: Partial<EntityDiff> = {}): EntityDiff {
+	return {
+		entityId: "aaaa0000aaaa0000aaaa0000aaaa0001" as NormalizedUuid,
+		name: null,
+		values: [],
+		relations: [],
+		blocks: [],
+		...overrides,
+	}
+}
+
+describe("enrichEntityDiffs", () => {
+	it("returns empty array for empty diffs", async () => {
+		const db = createMockDb()
+		const result = await Effect.runPromise(enrichEntityDiffs(db as any, []))
+		expect(result).toEqual([])
+		expect(db.execute).not.toHaveBeenCalled()
+	})
+
+	it("resolves entity name when diff.name is null", async () => {
+		const db = createMockDb()
+		const entityId = "aaaa0000aaaa0000aaaa0000aaaa0001" as NormalizedUuid
+
+		db.execute.mockResolvedValueOnce({
+			rows: [{entity_id: entityId, text: "My Entity"}],
+		})
+
+		const diffs = [makeDiff({entityId, name: null})]
+		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
+
+		expect(result[0].name).toBe("My Entity")
+	})
+
+	it("preserves existing entity name when already set", async () => {
+		const db = createMockDb()
+		const entityId = "aaaa0000aaaa0000aaaa0000aaaa0001" as NormalizedUuid
+
+		db.execute.mockResolvedValueOnce({
+			rows: [{entity_id: entityId, text: "DB Name"}],
+		})
+
+		const diffs = [makeDiff({entityId, name: "Existing Name"})]
+		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
+
+		expect(result[0].name).toBe("Existing Name")
+	})
+
+	it("resolves propertyName on value changes", async () => {
+		const db = createMockDb()
+		const propertyId = "bbbb0000bbbb0000bbbb0000bbbb0001" as NormalizedUuid
+
+		db.execute.mockResolvedValueOnce({
+			rows: [{entity_id: propertyId, text: "Description"}],
+		})
+
+		const diffs = [
+			makeDiff({
+				values: [
+					{
+						propertyId,
+						spaceId: "cccc0000cccc0000cccc0000cccc0001" as NormalizedUuid,
+						type: "TEXT" as const,
+						before: null,
+						after: "hello",
+						diff: [{value: "hello", added: true}],
+					},
+				],
+			}),
+		]
+
+		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
+		expect(result[0].values[0].propertyName).toBe("Description")
+	})
+
+	it("resolves typeName and toEntityName on relation changes", async () => {
+		const db = createMockDb()
+		const typeId = "dddd0000dddd0000dddd0000dddd0001" as NormalizedUuid
+		const toEntityId = "eeee0000eeee0000eeee0000eeee0001" as NormalizedUuid
+
+		db.execute.mockResolvedValueOnce({
+			rows: [
+				{entity_id: typeId, text: "Member Of"},
+				{entity_id: toEntityId, text: "Geo DAO"},
+			],
+		})
+
+		const diffs = [
+			makeDiff({
+				relations: [
+					{
+						relationId: "ffff0000ffff0000ffff0000ffff0001" as NormalizedUuid,
+						typeId,
+						spaceId: "cccc0000cccc0000cccc0000cccc0001" as NormalizedUuid,
+						changeType: "ADD" as const,
+						before: null,
+						after: {
+							toEntityId,
+							toSpaceId: null,
+							position: null,
+						},
+					},
+				],
+			}),
+		]
+
+		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
+		const rel = result[0].relations[0]
+		expect(rel.typeName).toBe("Member Of")
+		expect(rel.after?.toEntityName).toBe("Geo DAO")
+	})
+
+	it("sets null for names that cannot be resolved", async () => {
+		const db = createMockDb()
+
+		// Return empty — no names found
+		db.execute.mockResolvedValueOnce({rows: []})
+
+		const diffs = [
+			makeDiff({
+				values: [
+					{
+						propertyId: "bbbb0000bbbb0000bbbb0000bbbb0001" as NormalizedUuid,
+						spaceId: "cccc0000cccc0000cccc0000cccc0001" as NormalizedUuid,
+						type: "TEXT" as const,
+						before: "old",
+						after: "new",
+						diff: [
+							{value: "old", removed: true},
+							{value: "new", added: true},
+						],
+					},
+				],
+			}),
+		]
+
+		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
+		expect(result[0].values[0].propertyName).toBeNull()
+		expect(result[0].name).toBeNull()
+	})
+
+	it("deduplicates IDs across multiple diffs", async () => {
+		const db = createMockDb()
+		const sharedPropertyId = "bbbb0000bbbb0000bbbb0000bbbb0001" as NormalizedUuid
+
+		db.execute.mockResolvedValueOnce({
+			rows: [{entity_id: sharedPropertyId, text: "Name"}],
+		})
+
+		const diffs = [
+			makeDiff({
+				entityId: "aaaa0000aaaa0000aaaa0000aaaa0001" as NormalizedUuid,
+				values: [
+					{
+						propertyId: sharedPropertyId,
+						spaceId: "cccc0000cccc0000cccc0000cccc0001" as NormalizedUuid,
+						type: "TEXT" as const,
+						before: null,
+						after: "a",
+						diff: [{value: "a", added: true}],
+					},
+				],
+			}),
+			makeDiff({
+				entityId: "aaaa0000aaaa0000aaaa0000aaaa0002" as NormalizedUuid,
+				values: [
+					{
+						propertyId: sharedPropertyId,
+						spaceId: "cccc0000cccc0000cccc0000cccc0001" as NormalizedUuid,
+						type: "TEXT" as const,
+						before: null,
+						after: "b",
+						diff: [{value: "b", added: true}],
+					},
+				],
+			}),
+		]
+
+		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
+
+		// Both diffs should have the same propertyName resolved from a single query
+		expect(result[0].values[0].propertyName).toBe("Name")
+		expect(result[1].values[0].propertyName).toBe("Name")
+
+		// Only one DB call (batch query)
+		expect(db.execute).toHaveBeenCalledTimes(1)
+	})
+
+	it("handles before-side relation names", async () => {
+		const db = createMockDb()
+		const toEntityId = "eeee0000eeee0000eeee0000eeee0001" as NormalizedUuid
+
+		db.execute.mockResolvedValueOnce({
+			rows: [{entity_id: toEntityId, text: "Removed Entity"}],
+		})
+
+		const diffs = [
+			makeDiff({
+				relations: [
+					{
+						relationId: "ffff0000ffff0000ffff0000ffff0001" as NormalizedUuid,
+						typeId: "dddd0000dddd0000dddd0000dddd0001" as NormalizedUuid,
+						spaceId: "cccc0000cccc0000cccc0000cccc0001" as NormalizedUuid,
+						changeType: "REMOVE" as const,
+						before: {
+							toEntityId,
+							toSpaceId: null,
+							position: null,
+						},
+						after: null,
+					},
+				],
+			}),
+		]
+
+		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
+		expect(result[0].relations[0].before?.toEntityName).toBe("Removed Entity")
+		expect(result[0].relations[0].after).toBeNull()
+	})
+})

--- a/api/src/versioned/__tests__/enrich.test.ts
+++ b/api/src/versioned/__tests__/enrich.test.ts
@@ -40,7 +40,7 @@ describe("enrichEntityDiffs", () => {
 		const diffs = [makeDiff({entityId, name: null})]
 		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
 
-		expect(result[0].name).toBe("My Entity")
+		expect(result[0]?.name).toBe("My Entity")
 	})
 
 	it("preserves existing entity name when already set", async () => {
@@ -54,7 +54,7 @@ describe("enrichEntityDiffs", () => {
 		const diffs = [makeDiff({entityId, name: "Existing Name"})]
 		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
 
-		expect(result[0].name).toBe("Existing Name")
+		expect(result[0]?.name).toBe("Existing Name")
 	})
 
 	it("resolves propertyName on value changes", async () => {
@@ -81,7 +81,7 @@ describe("enrichEntityDiffs", () => {
 		]
 
 		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
-		expect(result[0].values[0].propertyName).toBe("Description")
+		expect(result[0]?.values[0]?.propertyName).toBe("Description")
 	})
 
 	it("resolves typeName and toEntityName on relation changes", async () => {
@@ -116,9 +116,9 @@ describe("enrichEntityDiffs", () => {
 		]
 
 		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
-		const rel = result[0].relations[0]
-		expect(rel.typeName).toBe("Member Of")
-		expect(rel.after?.toEntityName).toBe("Geo DAO")
+		const rel = result[0]?.relations[0]
+		expect(rel?.typeName).toBe("Member Of")
+		expect(rel?.after?.toEntityName).toBe("Geo DAO")
 	})
 
 	it("sets null for names that cannot be resolved", async () => {
@@ -146,8 +146,8 @@ describe("enrichEntityDiffs", () => {
 		]
 
 		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
-		expect(result[0].values[0].propertyName).toBeNull()
-		expect(result[0].name).toBeNull()
+		expect(result[0]?.values[0]?.propertyName).toBeNull()
+		expect(result[0]?.name).toBeNull()
 	})
 
 	it("deduplicates IDs across multiple diffs", async () => {
@@ -190,8 +190,8 @@ describe("enrichEntityDiffs", () => {
 		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
 
 		// Both diffs should have the same propertyName resolved from a single query
-		expect(result[0].values[0].propertyName).toBe("Name")
-		expect(result[1].values[0].propertyName).toBe("Name")
+		expect(result[0]?.values[0]?.propertyName).toBe("Name")
+		expect(result[1]?.values[0]?.propertyName).toBe("Name")
 
 		// Only one DB call (batch query)
 		expect(db.execute).toHaveBeenCalledTimes(1)
@@ -225,7 +225,7 @@ describe("enrichEntityDiffs", () => {
 		]
 
 		const result = await Effect.runPromise(enrichEntityDiffs(db as any, diffs))
-		expect(result[0].relations[0].before?.toEntityName).toBe("Removed Entity")
-		expect(result[0].relations[0].after).toBeNull()
+		expect(result[0]?.relations[0]?.before?.toEntityName).toBe("Removed Entity")
+		expect(result[0]?.relations[0]?.after).toBeNull()
 	})
 })

--- a/api/src/versioned/__tests__/grouped-router-helpers.test.ts
+++ b/api/src/versioned/__tests__/grouped-router-helpers.test.ts
@@ -1,0 +1,224 @@
+import {describe, expect, it} from "vitest"
+import {MAX_GROUP_SIZE} from "../proposal-diff"
+import {mapGroupedProposalError, validateGroupedRequest} from "../router"
+
+const SPACE = "00000000-0000-4000-8000-000000000b01"
+const P1 = "00000000-0000-4000-8000-000000000001"
+const P2 = "00000000-0000-4000-8000-000000000002"
+
+function reject<T extends {ok: boolean}>(r: T): Extract<T, {ok: false}> {
+	if (r.ok) throw new Error("expected validation failure but it succeeded")
+	return r as Extract<T, {ok: false}>
+}
+
+function accept<T extends {ok: boolean}>(r: T): Extract<T, {ok: true}> {
+	if (!r.ok) throw new Error("expected validation success but it failed")
+	return r as Extract<T, {ok: true}>
+}
+
+describe("validateGroupedRequest", () => {
+	it("rejects missing spaceId", () => {
+		const r = reject(
+			validateGroupedRequest({
+				spaceId: undefined,
+				proposalIds: `${P1},${P2}`,
+				cursor: undefined,
+				limit: undefined,
+			}),
+		)
+		expect(r.failure.status).toBe(400)
+		expect(r.failure.body.message).toContain("spaceId")
+	})
+
+	it("rejects invalid spaceId UUID", () => {
+		const r = reject(
+			validateGroupedRequest({
+				spaceId: "not-a-uuid",
+				proposalIds: `${P1},${P2}`,
+				cursor: undefined,
+				limit: undefined,
+			}),
+		)
+		expect(r.failure.body.message).toContain("spaceId")
+	})
+
+	it("rejects missing proposalIds", () => {
+		const r = reject(
+			validateGroupedRequest({spaceId: SPACE, proposalIds: undefined, cursor: undefined, limit: undefined}),
+		)
+		expect(r.failure.body.message).toContain("proposalIds")
+	})
+
+	it("rejects fewer than 2 proposal IDs", () => {
+		const r = reject(validateGroupedRequest({spaceId: SPACE, proposalIds: P1, cursor: undefined, limit: undefined}))
+		expect(r.failure.body.message).toContain("at least 2")
+	})
+
+	it("rejects an invalid UUID in the proposalIds list", () => {
+		const r = reject(
+			validateGroupedRequest({
+				spaceId: SPACE,
+				proposalIds: `${P1},not-a-uuid`,
+				cursor: undefined,
+				limit: undefined,
+			}),
+		)
+		expect(r.failure.body.message).toContain("Invalid UUID")
+	})
+
+	it("rejects when proposalIds count exceeds MAX_GROUP_SIZE", () => {
+		const tooMany = Array.from(
+			{length: MAX_GROUP_SIZE + 1},
+			(_, i) => `00000000-0000-4000-8000-00000000${(i + 10).toString(16).padStart(4, "0")}`,
+		)
+		const r = reject(
+			validateGroupedRequest({
+				spaceId: SPACE,
+				proposalIds: tooMany.join(","),
+				cursor: undefined,
+				limit: undefined,
+			}),
+		)
+		expect(r.failure.body.message).toContain(`exceeds maximum of ${MAX_GROUP_SIZE}`)
+	})
+
+	it("rejects negative or zero limit", () => {
+		const r1 = reject(
+			validateGroupedRequest({spaceId: SPACE, proposalIds: `${P1},${P2}`, cursor: undefined, limit: "-1"}),
+		)
+		expect(r1.failure.body.message).toContain("limit")
+
+		const r2 = reject(
+			validateGroupedRequest({spaceId: SPACE, proposalIds: `${P1},${P2}`, cursor: undefined, limit: "0"}),
+		)
+		expect(r2.failure.body.message).toContain("limit")
+	})
+
+	it("rejects non-numeric limit", () => {
+		const r = reject(
+			validateGroupedRequest({spaceId: SPACE, proposalIds: `${P1},${P2}`, cursor: undefined, limit: "abc"}),
+		)
+		expect(r.failure.body.message).toContain("limit")
+	})
+
+	it("caps limit at 100 when a larger value is requested", () => {
+		const r = accept(
+			validateGroupedRequest({spaceId: SPACE, proposalIds: `${P1},${P2}`, cursor: undefined, limit: "500"}),
+		)
+		expect(r.value.limit).toBe(100)
+	})
+
+	it("uses default limit 50 when not provided", () => {
+		const r = accept(
+			validateGroupedRequest({spaceId: SPACE, proposalIds: `${P1},${P2}`, cursor: undefined, limit: undefined}),
+		)
+		expect(r.value.limit).toBe(50)
+	})
+
+	it("normalizes UUIDs to dashless lowercase hex on success", () => {
+		const r = accept(
+			validateGroupedRequest({
+				spaceId: SPACE.toUpperCase(),
+				proposalIds: `${P1.toUpperCase()},${P2}`,
+				cursor: "SomeCursor==",
+				limit: "25",
+			}),
+		)
+		expect(r.value.spaceId).toBe(SPACE.replace(/-/g, "").toLowerCase())
+		expect(r.value.proposalIds).toEqual([P1.replace(/-/g, "").toLowerCase(), P2.replace(/-/g, "").toLowerCase()])
+		expect(r.value.cursor).toBe("SomeCursor==")
+		expect(r.value.limit).toBe(25)
+	})
+
+	it("trims whitespace from proposalIds", () => {
+		const r = accept(
+			validateGroupedRequest({
+				spaceId: SPACE,
+				proposalIds: ` ${P1} , ${P2} `,
+				cursor: undefined,
+				limit: undefined,
+			}),
+		)
+		expect(r.value.proposalIds).toHaveLength(2)
+	})
+})
+
+describe("mapGroupedProposalError", () => {
+	it("maps ValidationError → 400", () => {
+		const r = mapGroupedProposalError({_tag: "ValidationError", message: "bad"} as never)
+		expect(r.status).toBe(400)
+		expect(r.body.error).toBe("Invalid parameter")
+	})
+
+	it("maps NotFoundError → 404", () => {
+		const r = mapGroupedProposalError({_tag: "NotFoundError", message: "nope"} as never)
+		expect(r.status).toBe(404)
+	})
+
+	it("maps ProposalNotFoundError → 404", () => {
+		const r = mapGroupedProposalError({_tag: "ProposalNotFoundError"} as never)
+		expect(r.status).toBe(404)
+		expect(r.body.message).toContain("not found")
+	})
+
+	it("maps EditBlobNotCachedError → 404", () => {
+		const r = mapGroupedProposalError({_tag: "EditBlobNotCachedError", uri: "ipfs://x"} as never)
+		expect(r.status).toBe(404)
+		expect(r.body.message).toContain("not cached")
+	})
+
+	it("maps EditBlobDecodeFailedError → 422 with uri", () => {
+		const r = mapGroupedProposalError({_tag: "EditBlobDecodeFailedError", uri: "ipfs://bad"} as never)
+		expect(r.status).toBe(422)
+		expect(r.body.uri).toBe("ipfs://bad")
+	})
+
+	it("maps SpaceMismatchError → 400", () => {
+		const r = mapGroupedProposalError({_tag: "SpaceMismatchError"} as never)
+		expect(r.status).toBe(400)
+		expect(r.body.message).toContain("do not belong")
+	})
+
+	it("maps InvalidCursorError → 400", () => {
+		const r = mapGroupedProposalError({_tag: "InvalidCursorError", cursor: "bad"} as never)
+		expect(r.status).toBe(400)
+		expect(r.body.message).toContain("cursor")
+	})
+
+	it("maps GroupSizeLimitError → 400 with actual/max", () => {
+		const r = mapGroupedProposalError({_tag: "GroupSizeLimitError", actual: 25, max: 20} as never)
+		expect(r.status).toBe(400)
+		expect(r.body.message).toContain("25")
+		expect(r.body.message).toContain("20")
+	})
+
+	it("maps DuplicateProposalError → 400", () => {
+		const r = mapGroupedProposalError({_tag: "DuplicateProposalError", duplicates: []} as never)
+		expect(r.status).toBe(400)
+		expect(r.body.message).toContain("Duplicate")
+	})
+
+	it("maps MixedModeError → 400 with counts", () => {
+		const r = mapGroupedProposalError({_tag: "MixedModeError", activeCount: 2, nonActiveCount: 3} as never)
+		expect(r.status).toBe(400)
+		expect(r.body.message).toContain("2")
+		expect(r.body.message).toContain("3")
+	})
+
+	it("maps MissingPublishActionError → 422 with proposalId", () => {
+		const r = mapGroupedProposalError({_tag: "MissingPublishActionError", proposalId: P1} as never)
+		expect(r.status).toBe(422)
+		expect(r.body.proposalId).toBe(P1)
+	})
+
+	it("maps EditDecodeError → 500", () => {
+		const r = mapGroupedProposalError({_tag: "EditDecodeError", cause: null} as never)
+		expect(r.status).toBe(500)
+	})
+
+	it("maps QueryError → 500 without leaking internal details", () => {
+		const r = mapGroupedProposalError({_tag: "QueryError", operation: "x", cause: "secret"} as never)
+		expect(r.status).toBe(500)
+		expect(JSON.stringify(r.body)).not.toContain("secret")
+	})
+})

--- a/api/src/versioned/__tests__/proposal-diff-ordering.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-ordering.test.ts
@@ -1,0 +1,81 @@
+import {describe, expect, it} from "vitest"
+import type {NormalizedUuid} from "../../utils/uuid"
+import {compareGroupedEdits} from "../proposal-diff"
+
+type Edit = {createdAt: bigint; proposalId: NormalizedUuid}
+
+const uuid = (s: string) => s as NormalizedUuid
+
+describe("compareGroupedEdits (RFC 0004 ordering)", () => {
+	it("orders strictly by createdAt ascending when timestamps differ", () => {
+		const edits: Edit[] = [
+			{createdAt: 3000n, proposalId: uuid("11111111-1111-4111-8111-111111111111")},
+			{createdAt: 1000n, proposalId: uuid("22222222-2222-4222-8222-222222222222")},
+			{createdAt: 2000n, proposalId: uuid("33333333-3333-4333-8333-333333333333")},
+		]
+
+		const sorted = [...edits].sort(compareGroupedEdits).map((e) => e.createdAt)
+
+		expect(sorted).toEqual([1000n, 2000n, 3000n])
+	})
+
+	it("tiebreaks by proposalId ascending when createdAt is equal", () => {
+		const HIGH = uuid("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee")
+		const LOW = uuid("11111111-1111-4111-8111-111111111111")
+
+		const edits: Edit[] = [
+			{createdAt: 1000n, proposalId: HIGH},
+			{createdAt: 1000n, proposalId: LOW},
+		]
+
+		const sorted = [...edits].sort(compareGroupedEdits).map((e) => e.proposalId)
+
+		expect(sorted).toEqual([LOW, HIGH])
+	})
+
+	it("applies createdAt order first, proposalId only as tiebreaker", () => {
+		// Earlier timestamp wins even with a lexicographically later proposalId.
+		const EARLY_LATE_ID = uuid("ffffffff-ffff-4fff-8fff-ffffffffffff")
+		const LATE_EARLY_ID = uuid("00000000-0000-4000-8000-000000000001")
+
+		const edits: Edit[] = [
+			{createdAt: 2000n, proposalId: LATE_EARLY_ID},
+			{createdAt: 1000n, proposalId: EARLY_LATE_ID},
+		]
+
+		const sorted = [...edits].sort(compareGroupedEdits)
+
+		expect(sorted[0]?.createdAt).toBe(1000n)
+		expect(sorted[0]?.proposalId).toBe(EARLY_LATE_ID)
+		expect(sorted[1]?.createdAt).toBe(2000n)
+		expect(sorted[1]?.proposalId).toBe(LATE_EARLY_ID)
+	})
+
+	it("is stable for exactly-equal edits (deduped input)", () => {
+		const edits: Edit[] = [
+			{createdAt: 1000n, proposalId: uuid("11111111-1111-4111-8111-111111111111")},
+			{createdAt: 1000n, proposalId: uuid("11111111-1111-4111-8111-111111111111")},
+		]
+
+		expect(compareGroupedEdits(edits[0] as Edit, edits[1] as Edit)).toBe(0)
+	})
+
+	it("handles bigints that exceed Number.MAX_SAFE_INTEGER without precision loss", () => {
+		// microsecond timestamps near the end of 2262 approach 2^63; the previous
+		// implementation computed `Number(a - b)` which silently lost precision
+		// on any difference smaller than the bigint span.
+		const BIG_A = 9_007_199_254_740_993n // MAX_SAFE_INTEGER + 2
+		const BIG_B = 9_007_199_254_740_992n // MAX_SAFE_INTEGER + 1
+		const edits: Edit[] = [
+			{createdAt: BIG_A, proposalId: uuid("22222222-2222-4222-8222-222222222222")},
+			{createdAt: BIG_B, proposalId: uuid("11111111-1111-4111-8111-111111111111")},
+		]
+
+		const sorted = [...edits].sort(compareGroupedEdits).map((e) => e.createdAt)
+
+		// B is smaller and must come first. `Number(BIG_A - BIG_B) === 0` under
+		// the old implementation because both round to the same float — this
+		// test asserts the new bigint comparison doesn't lose the ordering.
+		expect(sorted).toEqual([BIG_B, BIG_A])
+	})
+})

--- a/api/src/versioned/__tests__/router.test.ts
+++ b/api/src/versioned/__tests__/router.test.ts
@@ -1063,9 +1063,7 @@ describe("GET /versioned/proposal-groups/diff", () => {
 
 	describe("validation errors", () => {
 		it("returns 400 when spaceId is missing", async () => {
-			const res = await app.request(
-				`/versioned/proposal-groups/diff?proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
-			)
+			const res = await app.request(`/versioned/proposal-groups/diff?proposalIds=${PROPOSAL_1},${PROPOSAL_2}`)
 			expect(res.status).toBe(400)
 			const body = await res.json()
 			expect(body.error).toBe("Invalid parameter")

--- a/api/src/versioned/__tests__/router.test.ts
+++ b/api/src/versioned/__tests__/router.test.ts
@@ -947,6 +947,9 @@ describe("GET /versioned/proposals/:id/diff", () => {
 			// Mock 6: batchGetBlockRelationsForEntities — no block relations
 			db.execute.mockResolvedValueOnce({rows: []})
 
+			// Mock 7: batchGetEntityNames (enrichment)
+			db.execute.mockResolvedValueOnce({rows: []})
+
 			const res = await app.request(`/versioned/proposals/${proposalId}/diff?spaceId=${spaceId}`)
 
 			expect(res.status).toBe(200)

--- a/api/src/versioned/__tests__/router.test.ts
+++ b/api/src/versioned/__tests__/router.test.ts
@@ -1039,3 +1039,284 @@ describe("GET /versioned/proposals/:id/diff", () => {
 		})
 	})
 })
+
+// =============================================================================
+// GET /versioned/proposal-groups/diff Tests
+// =============================================================================
+
+describe("GET /versioned/proposal-groups/diff", () => {
+	let app: Hono
+	let db: ReturnType<typeof createMockDb>
+
+	beforeEach(() => {
+		const setup = setupTestApp()
+		app = setup.app
+		db = setup.db
+	})
+
+	const SPACE_1 = "00000000-0000-0000-0000-000000000b01"
+	const PROPOSAL_1 = "00000000-0000-0000-0000-000000000001"
+	const PROPOSAL_2 = "00000000-0000-0000-0000-000000000002"
+
+	describe("validation errors", () => {
+		it("returns 400 when spaceId is missing", async () => {
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
+			)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.error).toBe("Invalid parameter")
+			expect(body.message).toContain("spaceId")
+		})
+
+		it("returns 400 when proposalIds is missing", async () => {
+			const res = await app.request(`/versioned/proposal-groups/diff?spaceId=${SPACE_1}`)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.error).toBe("Invalid parameter")
+			expect(body.message).toContain("proposalIds")
+		})
+
+		it("returns 400 when fewer than 2 proposal IDs are provided", async () => {
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1}`,
+			)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.message).toContain("at least 2")
+		})
+
+		it("returns 400 when proposalIds contains invalid UUID", async () => {
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},not-a-uuid`,
+			)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.message).toContain("Invalid UUID")
+		})
+
+		it("returns 400 when spaceId is not a valid UUID", async () => {
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=bad&proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
+			)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.message).toContain("spaceId")
+		})
+
+		it("returns 400 when limit is invalid", async () => {
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},${PROPOSAL_2}&limit=-1`,
+			)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.message).toContain("limit")
+		})
+
+		it("returns 400 for duplicate proposal IDs", async () => {
+			// Mock: batch load returns both (since validation happens after load)
+			const now = Math.floor(Date.now() / 1000)
+			// No DB call needed — duplicates are caught before any DB query
+
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},${PROPOSAL_1}`,
+			)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.message).toContain("Duplicate")
+		})
+	})
+
+	describe("proposal lookup errors", () => {
+		it("returns 404 when one proposal is not found", async () => {
+			// Mock: batch query returns only one of the two proposals
+			const now = Math.floor(Date.now() / 1000)
+			db.execute.mockResolvedValueOnce({
+				rows: [
+					{
+						proposal_id: PROPOSAL_1,
+						space_id: SPACE_1,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: "ipfs://QmTest1",
+					},
+					// PROPOSAL_2 is missing
+				],
+			})
+
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
+			)
+			expect(res.status).toBe(404)
+			const body = await res.json()
+			expect(body.error).toBe("Not found")
+		})
+
+		it("returns 422 when a proposal has no Publish action", async () => {
+			const now = Math.floor(Date.now() / 1000)
+			db.execute.mockResolvedValueOnce({
+				rows: [
+					{
+						proposal_id: PROPOSAL_1,
+						space_id: SPACE_1,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: "ipfs://QmTest1",
+					},
+					{
+						proposal_id: PROPOSAL_2,
+						space_id: SPACE_1,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: null, // No Publish action
+					},
+				],
+			})
+
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
+			)
+			expect(res.status).toBe(422)
+			const body = await res.json()
+			expect(body.message).toContain("Publish action")
+		})
+
+		it("returns 400 for mixed active and historical proposals", async () => {
+			const now = Math.floor(Date.now() / 1000)
+			db.execute.mockResolvedValueOnce({
+				rows: [
+					{
+						proposal_id: PROPOSAL_1,
+						space_id: SPACE_1,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(), // Active (future end)
+						executed_at: null,
+						content_uri: "ipfs://QmTest1",
+					},
+					{
+						proposal_id: PROPOSAL_2,
+						space_id: SPACE_1,
+						start_time: (now - 2000).toString(),
+						end_time: (now - 1000).toString(), // Closed (past end)
+						executed_at: null,
+						content_uri: "ipfs://QmTest2",
+					},
+				],
+			})
+
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
+			)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.message).toContain("mix")
+		})
+
+		it("returns 400 when a proposal belongs to a different space", async () => {
+			const now = Math.floor(Date.now() / 1000)
+			const OTHER_SPACE = "00000000-0000-0000-0000-000000000099"
+			db.execute.mockResolvedValueOnce({
+				rows: [
+					{
+						proposal_id: PROPOSAL_1,
+						space_id: SPACE_1,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: "ipfs://QmTest1",
+					},
+					{
+						proposal_id: PROPOSAL_2,
+						space_id: OTHER_SPACE, // Wrong space
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: "ipfs://QmTest2",
+					},
+				],
+			})
+
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
+			)
+			expect(res.status).toBe(400)
+			const body = await res.json()
+			expect(body.message).toContain("do not belong")
+		})
+	})
+
+	describe("successful responses", () => {
+		it("returns grouped diff with correct mode and proposalIds for active proposals", async () => {
+			const now = Math.floor(Date.now() / 1000)
+
+			// Mock 1: batchGetProposalsWithPublishActions
+			db.execute.mockResolvedValueOnce({
+				rows: [
+					{
+						proposal_id: PROPOSAL_1,
+						space_id: SPACE_1,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: "ipfs://QmTest1",
+					},
+					{
+						proposal_id: PROPOSAL_2,
+						space_id: SPACE_1,
+						start_time: (now - 1000).toString(),
+						end_time: (now + 1000).toString(),
+						executed_at: null,
+						content_uri: "ipfs://QmTest2",
+					},
+				],
+			})
+
+			// Mock 2-3: getIpfsCacheData for each proposal (valid GRC-20 edits with no ops)
+			const emptyEditBlob = Buffer.from(
+				encodeEdit({
+					id: randomId(),
+					name: "empty",
+					ops: [],
+					authors: [],
+					createdAt: BigInt(now) * 1000n,
+				}),
+			)
+			db.execute.mockResolvedValueOnce({rows: [{data: emptyEditBlob, is_errored: false}]})
+			db.execute.mockResolvedValueOnce({rows: [{data: emptyEditBlob, is_errored: false}]})
+
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
+			)
+
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			expect(body.mode).toBe("active")
+			expect(body.proposalIds).toHaveLength(2)
+			expect(body.spaceId).toBe(normalizeUuid(SPACE_1))
+			expect(body.entities).toEqual([])
+			expect(body.pagination).toEqual({
+				cursor: null,
+				hasMore: false,
+				totalEntities: 0,
+			})
+		})
+	})
+
+	describe("database errors", () => {
+		it("returns 500 for database errors without leaking details", async () => {
+			db.execute.mockRejectedValueOnce(new Error("Connection refused"))
+
+			const res = await app.request(
+				`/versioned/proposal-groups/diff?spaceId=${SPACE_1}&proposalIds=${PROPOSAL_1},${PROPOSAL_2}`,
+			)
+
+			expect(res.status).toBe(500)
+			const body = await res.json()
+			expect(body.error).toBe("Internal server error")
+			expect(body.message).not.toContain("Connection refused")
+		})
+	})
+})

--- a/api/src/versioned/enrich.ts
+++ b/api/src/versioned/enrich.ts
@@ -1,0 +1,82 @@
+/**
+ * Post-processing enrichment for entity diffs.
+ *
+ * Resolves human-readable names for entity IDs, property IDs, relation type IDs,
+ * and relation target IDs. Applied as a final step before sending the response,
+ * so both single-proposal and grouped-proposal endpoints produce display-ready diffs.
+ */
+
+import type {NodePgDatabase} from "drizzle-orm/node-postgres"
+import {Effect} from "effect"
+import type {NormalizedUuid} from "../utils/uuid"
+import {batchGetEntityNames, type QueryError} from "./queries"
+import type {EntityDiff, RelationChange, ValueChange} from "./types"
+
+type Database = NodePgDatabase<Record<string, unknown>>
+
+/**
+ * Enrich entity diffs with resolved names.
+ *
+ * Scans all diffs to collect entity IDs that need name resolution,
+ * batch-fetches names in a single query, then maps them onto the diffs.
+ * Missing names are set to null (graceful degradation).
+ */
+export function enrichEntityDiffs(db: Database, diffs: EntityDiff[]): Effect.Effect<EntityDiff[], QueryError> {
+	return Effect.gen(function* () {
+		if (diffs.length === 0) return diffs
+
+		// 1. Collect all unique IDs that need name resolution
+		const idsToResolve = new Set<NormalizedUuid>()
+
+		for (const diff of diffs) {
+			// Entity name might already be set, but we also want to resolve
+			// property IDs, type IDs, and relation target IDs
+			if (!diff.name) idsToResolve.add(diff.entityId)
+
+			for (const v of diff.values) {
+				idsToResolve.add(v.propertyId)
+			}
+
+			for (const r of diff.relations) {
+				idsToResolve.add(r.typeId)
+				if (r.before?.toEntityId) idsToResolve.add(r.before.toEntityId)
+				if (r.after?.toEntityId) idsToResolve.add(r.after.toEntityId)
+			}
+		}
+
+		if (idsToResolve.size === 0) return diffs
+
+		// 2. Batch-fetch names
+		const nameMap = yield* batchGetEntityNames(db, Array.from(idsToResolve))
+
+		// 3. Map names onto diffs
+		return diffs.map((diff) => ({
+			...diff,
+			name: diff.name ?? nameMap.get(diff.entityId) ?? null,
+			values: diff.values.map(
+				(v): ValueChange => ({
+					...v,
+					propertyName: nameMap.get(v.propertyId) ?? null,
+				}),
+			),
+			relations: diff.relations.map(
+				(r): RelationChange => ({
+					...r,
+					typeName: nameMap.get(r.typeId) ?? null,
+					before: r.before
+						? {
+								...r.before,
+								toEntityName: nameMap.get(r.before.toEntityId) ?? null,
+							}
+						: r.before,
+					after: r.after
+						? {
+								...r.after,
+								toEntityName: nameMap.get(r.after.toEntityId) ?? null,
+							}
+						: r.after,
+				}),
+			),
+		}))
+	}).pipe(Effect.withSpan("enrich.enrichEntityDiffs", {attributes: {diffCount: diffs.length}}))
+}

--- a/api/src/versioned/index.ts
+++ b/api/src/versioned/index.ts
@@ -1,3 +1,4 @@
+export {enrichEntityDiffs} from "./enrich"
 export * from "./grouping"
 export {
 	computeGroupedProposalDiff,

--- a/api/src/versioned/index.ts
+++ b/api/src/versioned/index.ts
@@ -1,10 +1,16 @@
 export * from "./grouping"
 export {
+	computeGroupedProposalDiff,
 	computeProposalDiff,
+	DuplicateProposalError,
 	EditBlobDecodeFailedError,
 	EditBlobNotCachedError,
 	EditDecodeError,
+	type GroupedProposalDiffError,
+	GroupSizeLimitError,
 	InvalidCursorError,
+	MissingPublishActionError,
+	MixedModeError,
 	type ProposalDiffError,
 	ProposalNotFoundError,
 	SpaceMismatchError,

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -1041,12 +1041,15 @@ export function computeProposalDiff(
 			Effect.annotateLogs({proposalId, opCount: ops.length, entityCount: entityIds.length}),
 		)
 
-		// 8. Validate cursor consistency (entity count shouldn't change between pages)
+		// 8. Validate cursor consistency. If the entity set changed between pages
+		// (proposal edited, blob re-uploaded), continuing with a stale cursor
+		// would silently return inconsistent results. Fail loudly so the client
+		// re-fetches page 1 and acquires a fresh cursor.
 		if (expectedTotalEntities !== undefined && expectedTotalEntities !== entityIds.length) {
-			yield* Effect.logWarning("Entity count changed between pages").pipe(
+			yield* Effect.logWarning("Cursor drift detected (entity count changed between pages)").pipe(
 				Effect.annotateLogs({proposalId, expected: expectedTotalEntities, actual: entityIds.length}),
 			)
-			// Don't fail - just log the inconsistency. The proposal may have been updated.
+			return yield* Effect.fail(new InvalidCursorError(cursorStr ?? ""))
 		}
 
 		// 9. Paginate using the already-validated cursor
@@ -1192,7 +1195,23 @@ export function computeProposalDiff(
 // ============================================================================
 
 /** Maximum number of proposals in a single grouped diff request. */
-const MAX_GROUP_SIZE = 20
+export const MAX_GROUP_SIZE = 20
+
+/**
+ * Ordering rule for grouped-diff ops (RFC 0004): apply in edit-timestamp order
+ * ascending, tiebreak by proposalId ascending. Exported so the ordering can be
+ * unit-tested without wiring up ipfs + drizzle + decode.
+ */
+export function compareGroupedEdits(
+	a: {createdAt: bigint; proposalId: NormalizedUuid},
+	b: {createdAt: bigint; proposalId: NormalizedUuid},
+): number {
+	if (a.createdAt < b.createdAt) return -1
+	if (a.createdAt > b.createdAt) return 1
+	if (a.proposalId < b.proposalId) return -1
+	if (a.proposalId > b.proposalId) return 1
+	return 0
+}
 
 /**
  * Compute a paginated grouped proposal diff.
@@ -1309,11 +1328,7 @@ export function computeGroupedProposalDiff(
 			})
 		}
 
-		decodedEdits.sort((a, b) => {
-			const tsDiff = Number(a.createdAt - b.createdAt)
-			if (tsDiff !== 0) return tsDiff
-			return a.proposalId < b.proposalId ? -1 : a.proposalId > b.proposalId ? 1 : 0
-		})
+		decodedEdits.sort(compareGroupedEdits)
 
 		// Concatenate ops in sorted order
 		const allOps: Op[] = decodedEdits.flatMap((e) => e.ops)
@@ -1325,11 +1340,15 @@ export function computeGroupedProposalDiff(
 		// 9. Extract affected entity IDs (sorted for stable pagination)
 		const entityIds = (yield* extractAffectedEntities(db, allOps)).sort()
 
-		// 10. Validate cursor consistency
+		// 10. Validate cursor consistency. If the entity set changed between pages
+		// (proposal edited, a proposal added/removed from the group, blob
+		// re-uploaded), continuing with a stale cursor would silently return
+		// inconsistent results. Fail loudly so the client re-fetches page 1.
 		if (expectedTotalEntities !== undefined && expectedTotalEntities !== entityIds.length) {
-			yield* Effect.logWarning("Entity count changed between pages").pipe(
+			yield* Effect.logWarning("Cursor drift detected (entity count changed between pages)").pipe(
 				Effect.annotateLogs({expected: expectedTotalEntities, actual: entityIds.length}),
 			)
+			return yield* Effect.fail(new InvalidCursorError(cursorStr ?? ""))
 		}
 
 		// 11. Paginate

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -45,6 +45,8 @@ import type {
 	BlockSnapshot,
 	EntityDiff,
 	EntitySnapshot,
+	GroupedProposalDiffMode,
+	PaginatedGroupedProposalDiff,
 	PaginatedProposalDiff,
 	ProposalDiffCursor,
 	ProposalStatus,
@@ -86,6 +88,33 @@ export class InvalidCursorError {
 	constructor(readonly cursor: string) {}
 }
 
+// Grouped diff error types
+export class GroupSizeLimitError {
+	readonly _tag = "GroupSizeLimitError"
+	constructor(
+		readonly max: number,
+		readonly actual: number,
+	) {}
+}
+
+export class DuplicateProposalError {
+	readonly _tag = "DuplicateProposalError"
+	constructor(readonly duplicates: string[]) {}
+}
+
+export class MixedModeError {
+	readonly _tag = "MixedModeError"
+	constructor(
+		readonly activeCount: number,
+		readonly nonActiveCount: number,
+	) {}
+}
+
+export class MissingPublishActionError {
+	readonly _tag = "MissingPublishActionError"
+	constructor(readonly proposalId: string) {}
+}
+
 export type ProposalDiffError =
 	| QueryError
 	| ProposalNotFoundError
@@ -94,6 +123,13 @@ export type ProposalDiffError =
 	| EditDecodeError
 	| SpaceMismatchError
 	| InvalidCursorError
+
+export type GroupedProposalDiffError =
+	| ProposalDiffError
+	| GroupSizeLimitError
+	| DuplicateProposalError
+	| MixedModeError
+	| MissingPublishActionError
 
 type Database = NodePgDatabase<Record<string, unknown>>
 
@@ -165,6 +201,61 @@ function getProposalWithPublishAction(
 	}).pipe(
 		Effect.withSpan("proposal-diff.getProposalWithPublishAction", {
 			attributes: {proposalId},
+		}),
+	)
+}
+
+/**
+ * Batch-load multiple proposals with their Publish actions in a single query.
+ * Returns a Map keyed by proposal ID for O(1) lookup.
+ */
+function batchGetProposalsWithPublishActions(
+	db: Database,
+	proposalIds: NormalizedUuid[],
+): Effect.Effect<Map<NormalizedUuid, ProposalWithAction>, QueryError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const idsArray = `{${proposalIds.join(",")}}`
+			const result = await db.execute<{
+				proposal_id: string
+				space_id: string
+				start_time: string
+				end_time: string
+				executed_at: string | null
+				content_uri: string | null
+			}>(sql`
+				SELECT
+					p.id as proposal_id,
+					p.space_id,
+					p.start_time,
+					p.end_time,
+					p.executed_at,
+					pa.content_uri
+				FROM proposals p
+				LEFT JOIN proposal_actions pa ON pa.proposal_id = p.id AND pa.action_type = 'Publish'
+				WHERE p.id = ANY(${idsArray}::uuid[])
+			`)
+
+			const map = new Map<NormalizedUuid, ProposalWithAction>()
+			for (const row of result.rows) {
+				const id = normalizeUuid(row.proposal_id)
+				map.set(id, {
+					proposal: {
+						id,
+						spaceId: normalizeUuid(row.space_id),
+						startTime: BigInt(row.start_time),
+						endTime: BigInt(row.end_time),
+						executedAt: row.executed_at ? BigInt(row.executed_at) : null,
+					},
+					contentUri: row.content_uri,
+				})
+			}
+			return map
+		},
+		catch: (error) => new QueryError("batchGetProposalsWithPublishActions", error),
+	}).pipe(
+		Effect.withSpan("proposal-diff.batchGetProposalsWithPublishActions", {
+			attributes: {count: proposalIds.length},
 		}),
 	)
 }
@@ -1092,6 +1183,274 @@ export function computeProposalDiff(
 	}).pipe(
 		Effect.withSpan("proposal-diff.computeProposalDiff", {
 			attributes: {proposalId, spaceId, limit},
+		}),
+	)
+}
+
+// ============================================================================
+// Grouped (Multi-Proposal) Diff
+// ============================================================================
+
+/** Maximum number of proposals in a single grouped diff request. */
+const MAX_GROUP_SIZE = 20
+
+/**
+ * Compute a paginated grouped proposal diff.
+ *
+ * Loads N proposals, fetches N edit blobs, decodes and sorts ops by
+ * (edit timestamp ASC, proposal ID ASC), then runs the standard diff
+ * pipeline on the concatenated op stream.
+ */
+export function computeGroupedProposalDiff(
+	db: Database,
+	proposalIds: NormalizedUuid[],
+	spaceId: NormalizedUuid,
+	cursorStr?: string,
+	limit = 50,
+): Effect.Effect<PaginatedGroupedProposalDiff, GroupedProposalDiffError> {
+	return Effect.gen(function* () {
+		yield* Effect.logDebug("ComputeGroupedProposalDiff started").pipe(
+			Effect.annotateLogs({proposalCount: proposalIds.length, spaceId, limit, hasCursor: !!cursorStr}),
+		)
+
+		// 1. Validate group size
+		if (proposalIds.length > MAX_GROUP_SIZE) {
+			return yield* Effect.fail(new GroupSizeLimitError(MAX_GROUP_SIZE, proposalIds.length))
+		}
+
+		// 2. Reject duplicates
+		const seen = new Set<NormalizedUuid>()
+		const duplicates: string[] = []
+		for (const id of proposalIds) {
+			if (seen.has(id)) duplicates.push(id)
+			seen.add(id)
+		}
+		if (duplicates.length > 0) {
+			return yield* Effect.fail(new DuplicateProposalError(duplicates))
+		}
+
+		// 3. Batch-load all proposals
+		const proposalsMap = yield* batchGetProposalsWithPublishActions(db, proposalIds)
+
+		// 4. Validate all proposals exist and belong to the requested space
+		for (const id of proposalIds) {
+			const data = proposalsMap.get(id)
+			if (!data) {
+				return yield* Effect.fail(new ProposalNotFoundError(id))
+			}
+			if (data.proposal.spaceId !== spaceId) {
+				return yield* Effect.fail(new SpaceMismatchError(spaceId, data.proposal.spaceId))
+			}
+			if (!data.contentUri) {
+				return yield* Effect.fail(new MissingPublishActionError(id))
+			}
+		}
+
+		// 5. Determine mode: all active → "active", all historical → "historical", mixed → reject
+		let activeCount = 0
+		let nonActiveCount = 0
+		for (const id of proposalIds) {
+			const data = proposalsMap.get(id)
+			if (!data) continue // already validated above
+			const status = getProposalStatus(data.proposal)
+			if (status === "active") activeCount++
+			else nonActiveCount++
+		}
+		if (activeCount > 0 && nonActiveCount > 0) {
+			return yield* Effect.fail(new MixedModeError(activeCount, nonActiveCount))
+		}
+		const mode: GroupedProposalDiffMode = activeCount > 0 ? "active" : "historical"
+
+		yield* Effect.logDebug("Group validated").pipe(Effect.annotateLogs({mode, proposalCount: proposalIds.length}))
+
+		// 6. Validate cursor early
+		let startIndex = 0
+		let expectedTotalEntities: number | undefined
+		if (cursorStr) {
+			const cursor = decodeCursor(cursorStr)
+			if (cursor === null) {
+				return yield* Effect.fail(new InvalidCursorError(cursorStr))
+			}
+			startIndex = cursor.entityIndex
+			expectedTotalEntities = cursor.totalEntities
+		}
+
+		// 7. Fetch all edit blobs in parallel
+		const blobEffects = proposalIds.map((id) => {
+			const data = proposalsMap.get(id)
+			const contentUri = data?.contentUri ?? "" // already validated above
+			return Effect.gen(function* () {
+				const cacheResult = yield* getIpfsCacheData(db, contentUri)
+				if (!cacheResult) {
+					return yield* Effect.fail(new EditBlobNotCachedError(contentUri) as GroupedProposalDiffError)
+				}
+				if (cacheResult.isErrored) {
+					return yield* Effect.fail(new EditBlobDecodeFailedError(contentUri) as GroupedProposalDiffError)
+				}
+				if (!cacheResult.data) {
+					return yield* Effect.fail(new EditBlobNotCachedError(contentUri) as GroupedProposalDiffError)
+				}
+				return {proposalId: id, blob: cacheResult.data}
+			})
+		})
+		const blobs = yield* Effect.all(blobEffects, {concurrency: "unbounded"})
+
+		// 8. Decode all edits and sort by (createdAt ASC, proposalId ASC)
+		const decodedEdits: {proposalId: NormalizedUuid; ops: Op[]; createdAt: bigint}[] = []
+		for (const {proposalId, blob} of blobs) {
+			const edit = yield* Effect.tryPromise({
+				try: async () => decodeEditAuto(blob),
+				catch: (error) => new EditDecodeError(error),
+			})
+			decodedEdits.push({
+				proposalId,
+				ops: edit.ops,
+				createdAt: edit.createdAt,
+			})
+		}
+
+		decodedEdits.sort((a, b) => {
+			const tsDiff = Number(a.createdAt - b.createdAt)
+			if (tsDiff !== 0) return tsDiff
+			return a.proposalId < b.proposalId ? -1 : a.proposalId > b.proposalId ? 1 : 0
+		})
+
+		// Concatenate ops in sorted order
+		const allOps: Op[] = decodedEdits.flatMap((e) => e.ops)
+
+		yield* Effect.logDebug("Edits decoded and sorted").pipe(
+			Effect.annotateLogs({editCount: decodedEdits.length, totalOps: allOps.length}),
+		)
+
+		// 9. Extract affected entity IDs (sorted for stable pagination)
+		const entityIds = (yield* extractAffectedEntities(db, allOps)).sort()
+
+		// 10. Validate cursor consistency
+		if (expectedTotalEntities !== undefined && expectedTotalEntities !== entityIds.length) {
+			yield* Effect.logWarning("Entity count changed between pages").pipe(
+				Effect.annotateLogs({expected: expectedTotalEntities, actual: entityIds.length}),
+			)
+		}
+
+		// 11. Paginate
+		const pageEntityIds = entityIds.slice(startIndex, startIndex + limit)
+
+		// 12. Resolve base version key
+		// For active mode: use live state (no version key)
+		// For historical mode: use versioned state before the earliest edit timestamp
+		let baseVersionKey: bigint | null = null
+		const firstEdit = decodedEdits[0]
+		if (mode === "historical" && firstEdit) {
+			// createdAt is in microseconds, resolveVersionKeyBeforeTimestamp expects seconds
+			const earliestTimestamp = firstEdit.createdAt / 1000n
+			baseVersionKey = yield* resolveVersionKeyBeforeTimestamp(db, earliestTimestamp)
+		}
+
+		// Use "active" status for fetchBaseData when mode is "active", "closed" otherwise
+		const fetchStatus: ProposalStatus = mode === "active" ? "active" : "closed"
+
+		// 13. Batch fetch base states
+		const baseStates = yield* fetchBaseData(
+			fetchStatus,
+			baseVersionKey,
+			() => batchGetLiveSnapshots(db, pageEntityIds, spaceId),
+			(vk) => batchGetVersionedSnapshots(db, pageEntityIds, spaceId, vk),
+			() => {
+				const m = new Map<NormalizedUuid, EntitySnapshot>()
+				for (const id of pageEntityIds) m.set(id, emptySnapshot(id))
+				return m
+			},
+		)
+
+		// 14. Discover block relations and populate blocks
+		const blockRelationsMap = yield* fetchBaseData(
+			fetchStatus,
+			baseVersionKey,
+			() => batchGetLiveBlockRelationsForEntities(db, pageEntityIds, spaceId),
+			(vk) => batchGetBlockRelationsForEntities(db, pageEntityIds, vk, spaceId),
+			() => {
+				const m = new Map<NormalizedUuid, BlockRelationEntry[]>()
+				for (const id of pageEntityIds) m.set(id, [])
+				return m
+			},
+		)
+
+		const allBlockIds = new Set<NormalizedUuid>()
+		for (const entries of blockRelationsMap.values()) {
+			for (const entry of entries) {
+				allBlockIds.add(entry.blockEntityId)
+			}
+		}
+
+		const blockIdsList = Array.from(allBlockIds)
+		let blockSnapshotsMap: Map<NormalizedUuid, BlockSnapshot>
+		if (blockIdsList.length === 0) {
+			blockSnapshotsMap = new Map()
+		} else {
+			const blockSnapshots = yield* fetchBaseData(
+				fetchStatus,
+				baseVersionKey,
+				() => batchGetLiveBlockSnapshots(db, blockIdsList, spaceId),
+				(vk) => batchGetBlockSnapshotsAtVersion(db, blockIdsList, vk, spaceId),
+				() => [] as BlockSnapshot[],
+			)
+			blockSnapshotsMap = new Map(blockSnapshots.map((b) => [b.id, b]))
+		}
+
+		const blocksRelationMap = new Map<NormalizedUuid, NormalizedUuid>()
+		for (const entityId of pageEntityIds) {
+			const entries = blockRelationsMap.get(entityId) ?? []
+			const baseState = baseStates.get(entityId)
+			if (baseState) {
+				baseState.blocks = entries
+					.map((entry) => {
+						blocksRelationMap.set(entry.relationId, entry.blockEntityId)
+						return blockSnapshotsMap.get(entry.blockEntityId)
+					})
+					.filter((b): b is BlockSnapshot => b !== undefined)
+			}
+		}
+
+		// 15. Compute diffs
+		const diffs: EntityDiff[] = []
+		for (const entityId of pageEntityIds) {
+			const baseState = baseStates.get(entityId) ?? emptySnapshot(entityId)
+			const proposedState = applyOpsToSnapshot(baseState, allOps, entityId, spaceId, blocksRelationMap)
+			const diff = yield* diffEntitySnapshots(entityId, baseState, proposedState)
+			if (!isDiffEmpty(diff)) {
+				diffs.push(diff)
+			}
+		}
+
+		// 16. Pagination
+		const nextIndex = startIndex + limit
+		const hasMore = nextIndex < entityIds.length
+
+		yield* Effect.logInfo("ComputeGroupedProposalDiff completed").pipe(
+			Effect.annotateLogs({
+				mode,
+				proposalCount: proposalIds.length,
+				totalEntities: entityIds.length,
+				pageEntities: pageEntityIds.length,
+				diffsReturned: diffs.length,
+				hasMore,
+			}),
+		)
+
+		return {
+			proposalIds,
+			spaceId,
+			mode,
+			entities: diffs,
+			pagination: {
+				cursor: hasMore ? encodeCursor({entityIndex: nextIndex, totalEntities: entityIds.length}) : null,
+				hasMore,
+				totalEntities: entityIds.length,
+			},
+		}
+	}).pipe(
+		Effect.withSpan("proposal-diff.computeGroupedProposalDiff", {
+			attributes: {proposalCount: proposalIds.length, spaceId, limit},
 		}),
 	)
 }

--- a/api/src/versioned/queries.ts
+++ b/api/src/versioned/queries.ts
@@ -903,3 +903,47 @@ export function getEntityVersions(
 		}),
 	)
 }
+
+// ============================================================================
+// Name Resolution
+// ============================================================================
+
+const NAME_PROPERTY_ID = normalizeUuid(SystemIds.NAME_PROPERTY)
+
+/**
+ * Batch-fetch entity names from the live values table.
+ * Returns a Map from entity ID to name string.
+ * Entities without a name property are omitted from the result.
+ */
+export function batchGetEntityNames(
+	db: NodePgDatabase<Record<string, unknown>>,
+	entityIds: NormalizedUuid[],
+): Effect.Effect<Map<NormalizedUuid, string>, QueryError> {
+	if (entityIds.length === 0) {
+		return Effect.succeed(new Map())
+	}
+
+	return Effect.tryPromise({
+		try: async () => {
+			const idsArray = `{${entityIds.join(",")}}`
+			const result = await db.execute<{entity_id: string; text: string}>(sql`
+				SELECT entity_id, text
+				FROM "values"
+				WHERE entity_id = ANY(${idsArray}::uuid[])
+				  AND property_id = ${NAME_PROPERTY_ID}::uuid
+				  AND text IS NOT NULL
+			`)
+
+			const names = new Map<NormalizedUuid, string>()
+			for (const row of result.rows) {
+				names.set(normalizeUuid(row.entity_id), row.text)
+			}
+			return names
+		},
+		catch: (error) => new QueryError("batchGetEntityNames", error),
+	}).pipe(
+		Effect.withSpan("queries.batchGetEntityNames", {
+			attributes: {count: entityIds.length},
+		}),
+	)
+}

--- a/api/src/versioned/router.ts
+++ b/api/src/versioned/router.ts
@@ -22,6 +22,7 @@ type AppEnv = {
 import {getProfilesBySpaceIds} from "../profile/queries"
 import {isValidUuid, normalizeUuid, toDashedUuid} from "../utils/uuid"
 import {diffGroupedEntitySnapshots} from "./diff"
+import {enrichEntityDiffs} from "./enrich"
 import type {
 	DuplicateProposalError,
 	EditBlobDecodeFailedError,
@@ -875,7 +876,10 @@ export function createVersionedRouter(db: Database, runtime: AppRuntime) {
 				// Compute proposal diff
 				const diff = yield* computeProposalDiff(db, proposalId, spaceId, cursor, limit)
 
-				return diff
+				// Enrich with resolved names
+				const enrichedEntities = yield* enrichEntityDiffs(db, diff.entities)
+
+				return {...diff, entities: enrichedEntities}
 			}).pipe(
 				Effect.tapError((error) => {
 					if (error._tag === "QueryError") {
@@ -1041,7 +1045,9 @@ export function createVersionedRouter(db: Database, runtime: AppRuntime) {
 			const proposalIds = rawIds.map(normalizeUuid)
 
 			const program = Effect.gen(function* () {
-				return yield* computeGroupedProposalDiff(db, proposalIds, spaceId, rawCursor ?? undefined, limit)
+				const diff = yield* computeGroupedProposalDiff(db, proposalIds, spaceId, rawCursor ?? undefined, limit)
+				const enrichedEntities = yield* enrichEntityDiffs(db, diff.entities)
+				return {...diff, entities: enrichedEntities}
 			}).pipe(
 				Effect.withSpan("versioned.groupedProposalDiff", {
 					attributes: {spaceId, proposalCount: proposalIds.length, limit},

--- a/api/src/versioned/router.ts
+++ b/api/src/versioned/router.ts
@@ -20,7 +20,7 @@ type AppEnv = {
 }
 
 import {getProfilesBySpaceIds} from "../profile/queries"
-import {isValidUuid, normalizeUuid, toDashedUuid} from "../utils/uuid"
+import {isValidUuid, type NormalizedUuid, normalizeUuid, toDashedUuid} from "../utils/uuid"
 import {diffGroupedEntitySnapshots} from "./diff"
 import {enrichEntityDiffs} from "./enrich"
 import type {
@@ -28,7 +28,6 @@ import type {
 	EditBlobDecodeFailedError,
 	EditBlobNotCachedError,
 	EditDecodeError,
-	GroupedProposalDiffError,
 	GroupSizeLimitError,
 	InvalidCursorError,
 	MissingPublishActionError,
@@ -36,7 +35,7 @@ import type {
 	ProposalNotFoundError,
 	SpaceMismatchError,
 } from "./proposal-diff"
-import {computeGroupedProposalDiff, computeProposalDiff} from "./proposal-diff"
+import {computeGroupedProposalDiff, computeProposalDiff, MAX_GROUP_SIZE} from "./proposal-diff"
 import {
 	getEntitySnapshotAtVersion,
 	getEntityVersions,
@@ -82,6 +81,194 @@ type GroupedProposalError =
 	| DuplicateProposalError
 	| MixedModeError
 	| MissingPublishActionError
+
+// ============================================================================
+// Grouped endpoint request validation
+// ============================================================================
+
+export type ValidatedGroupedRequest = {
+	spaceId: NormalizedUuid
+	proposalIds: NormalizedUuid[]
+	cursor: string | undefined
+	limit: number
+}
+
+export type ValidationFailure = {
+	status: 400
+	body: {error: "Invalid parameter"; message: string}
+}
+
+/**
+ * Validate the query params for `GET /proposal-groups/diff`.
+ *
+ * Checks UUIDs, group size, duplicate detection, and limit bounds. Returns
+ * either the normalized inputs (ready to pass to `computeGroupedProposalDiff`)
+ * or a `{status, body}` failure that the handler can pass directly to `c.json`.
+ *
+ * Extracted to module scope so the checks are trivially unit-testable without
+ * spinning up a Hono app.
+ */
+export function validateGroupedRequest(query: {
+	spaceId: string | undefined
+	proposalIds: string | undefined
+	cursor: string | undefined
+	limit: string | undefined
+}): {ok: true; value: ValidatedGroupedRequest} | {ok: false; failure: ValidationFailure} {
+	const {spaceId: rawSpaceId, proposalIds: rawProposalIds, cursor: rawCursor, limit: rawLimit} = query
+
+	if (!rawSpaceId || !isValidUuid(rawSpaceId)) {
+		return {
+			ok: false,
+			failure: {status: 400, body: {error: "Invalid parameter", message: "spaceId must be a valid UUID"}},
+		}
+	}
+
+	if (!rawProposalIds) {
+		return {
+			ok: false,
+			failure: {
+				status: 400,
+				body: {error: "Invalid parameter", message: "proposalIds is required (comma-separated UUIDs)"},
+			},
+		}
+	}
+	const rawIds = rawProposalIds.split(",").map((s) => s.trim())
+	if (rawIds.length < 2) {
+		return {
+			ok: false,
+			failure: {
+				status: 400,
+				body: {error: "Invalid parameter", message: "proposalIds must contain at least 2 proposal IDs"},
+			},
+		}
+	}
+	for (const id of rawIds) {
+		if (!isValidUuid(id)) {
+			return {
+				ok: false,
+				failure: {
+					status: 400,
+					body: {error: "Invalid parameter", message: `Invalid UUID in proposalIds: ${id}`},
+				},
+			}
+		}
+	}
+	if (rawIds.length > MAX_GROUP_SIZE) {
+		return {
+			ok: false,
+			failure: {
+				status: 400,
+				body: {
+					error: "Invalid parameter",
+					message: `Group size ${rawIds.length} exceeds maximum of ${MAX_GROUP_SIZE}`,
+				},
+			},
+		}
+	}
+
+	let limit = 50
+	if (rawLimit !== undefined) {
+		const parsed = Number.parseInt(rawLimit, 10)
+		if (Number.isNaN(parsed) || parsed < 1) {
+			return {
+				ok: false,
+				failure: {status: 400, body: {error: "Invalid parameter", message: "limit must be a positive integer"}},
+			}
+		}
+		limit = Math.min(parsed, 100)
+	}
+
+	return {
+		ok: true,
+		value: {
+			spaceId: normalizeUuid(rawSpaceId),
+			proposalIds: rawIds.map(normalizeUuid),
+			cursor: rawCursor,
+			limit,
+		},
+	}
+}
+
+/**
+ * Map a `GroupedProposalError` to a `(status, body)` pair. Extracted to a pure
+ * function so the 14-arm switch can be unit-tested directly without a router
+ * or db mock.
+ */
+export function mapGroupedProposalError(error: GroupedProposalError): {
+	status: 400 | 404 | 422 | 500
+	body: Record<string, unknown>
+} {
+	switch (error._tag) {
+		case "ValidationError":
+			return {status: 400, body: {error: "Invalid parameter", message: error.message}}
+		case "NotFoundError":
+			return {status: 404, body: {error: "Not found", message: error.message}}
+		case "ProposalNotFoundError":
+			return {status: 404, body: {error: "Not found", message: "One or more proposals not found"}}
+		case "EditBlobNotCachedError":
+			return {
+				status: 404,
+				body: {error: "Not found", message: "Edit blob not cached for one or more proposals"},
+			}
+		case "EditBlobDecodeFailedError":
+			return {
+				status: 422,
+				body: {
+					error: "Unprocessable",
+					message: "Edit blob failed GRC-20 validation and cannot be decoded",
+					uri: error.uri,
+				},
+			}
+		case "SpaceMismatchError":
+			return {
+				status: 400,
+				body: {
+					error: "Invalid parameter",
+					message: "One or more proposals do not belong to the specified space",
+				},
+			}
+		case "InvalidCursorError":
+			return {status: 400, body: {error: "Invalid parameter", message: "Invalid pagination cursor"}}
+		case "GroupSizeLimitError":
+			return {
+				status: 400,
+				body: {
+					error: "Invalid parameter",
+					message: `Group size ${error.actual} exceeds maximum of ${error.max}`,
+				},
+			}
+		case "DuplicateProposalError":
+			return {
+				status: 400,
+				body: {error: "Invalid parameter", message: "Duplicate proposal IDs are not allowed"},
+			}
+		case "MixedModeError":
+			return {
+				status: 400,
+				body: {
+					error: "Invalid parameter",
+					message: `Cannot mix active (${error.activeCount}) and historical (${error.nonActiveCount}) proposals in a group`,
+				},
+			}
+		case "MissingPublishActionError":
+			return {
+				status: 422,
+				body: {
+					error: "Unprocessable",
+					message: "All proposals in a group must have a Publish action",
+					proposalId: error.proposalId,
+				},
+			}
+		case "EditDecodeError":
+			return {status: 500, body: {error: "Internal server error", message: "Failed to decode edit blob"}}
+		case "QueryError":
+			return {status: 500, body: {error: "Internal server error", message: "An unexpected error occurred"}}
+		default: {
+			const _exhaustive: never = error
+			return {status: 500, body: {error: "Internal server error", message: "An unexpected error occurred"}}
+		}
+	}
+}
 
 /**
  * Batch-resolve creator profiles from a list of nullable creator space IDs.
@@ -991,7 +1178,11 @@ export function createVersionedRouter(db: Database, runtime: AppRuntime) {
 			summary: "Grouped multi-proposal diff",
 			description:
 				"Computes a combined diff for multiple proposals in one space. " +
-				"Proposals are applied in edit-timestamp order. All proposals must be in the same mode (active or historical).",
+				"Proposals are applied in edit-timestamp order (tiebreak by proposalId). " +
+				`All proposals must be in the same mode (active or historical). ` +
+				`Group size is limited to ${MAX_GROUP_SIZE}. ` +
+				"Known op-type limitations are documented at docs/tech-designs/multi-proposal-diffs.md " +
+				"(restoreEntity, deleteEntity, restoreRelation are not fully supported).",
 			responses: {
 				200: {description: "Grouped proposal diff"},
 				400: {description: "Invalid parameter"},
@@ -1001,51 +1192,20 @@ export function createVersionedRouter(db: Database, runtime: AppRuntime) {
 			},
 		}),
 		async (c) => {
-			const rawSpaceId = c.req.query("spaceId")
-			const rawProposalIds = c.req.query("proposalIds")
-			const rawCursor = c.req.query("cursor")
-			const rawLimit = c.req.query("limit")
-
-			// Validate spaceId
-			if (!rawSpaceId || !isValidUuid(rawSpaceId)) {
-				return c.json({error: "Invalid parameter", message: "spaceId must be a valid UUID"}, 400)
+			const validation = validateGroupedRequest({
+				spaceId: c.req.query("spaceId"),
+				proposalIds: c.req.query("proposalIds"),
+				cursor: c.req.query("cursor"),
+				limit: c.req.query("limit"),
+			})
+			if (!validation.ok) {
+				return c.json(validation.failure.body, validation.failure.status)
 			}
 
-			// Validate proposalIds
-			if (!rawProposalIds) {
-				return c.json(
-					{error: "Invalid parameter", message: "proposalIds is required (comma-separated UUIDs)"},
-					400,
-				)
-			}
-			const rawIds = rawProposalIds.split(",").map((s) => s.trim())
-			if (rawIds.length < 2) {
-				return c.json(
-					{error: "Invalid parameter", message: "proposalIds must contain at least 2 proposal IDs"},
-					400,
-				)
-			}
-			for (const id of rawIds) {
-				if (!isValidUuid(id)) {
-					return c.json({error: "Invalid parameter", message: `Invalid UUID in proposalIds: ${id}`}, 400)
-				}
-			}
-
-			// Validate limit
-			let limit = 50
-			if (rawLimit !== undefined) {
-				const parsed = Number.parseInt(rawLimit, 10)
-				if (Number.isNaN(parsed) || parsed < 1) {
-					return c.json({error: "Invalid parameter", message: "limit must be a positive integer"}, 400)
-				}
-				limit = Math.min(parsed, 100)
-			}
-
-			const spaceId = normalizeUuid(rawSpaceId)
-			const proposalIds = rawIds.map(normalizeUuid)
+			const {spaceId, proposalIds, cursor, limit} = validation.value
 
 			const program = Effect.gen(function* () {
-				const diff = yield* computeGroupedProposalDiff(db, proposalIds, spaceId, rawCursor ?? undefined, limit)
+				const diff = yield* computeGroupedProposalDiff(db, proposalIds, spaceId, cursor, limit)
 				const enrichedEntities = yield* enrichEntityDiffs(db, diff.entities)
 				return {...diff, entities: enrichedEntities}
 			}).pipe(
@@ -1058,106 +1218,8 @@ export function createVersionedRouter(db: Database, runtime: AppRuntime) {
 
 			return Either.match(result, {
 				onLeft: (error: GroupedProposalError) => {
-					switch (error._tag) {
-						case "ValidationError":
-							return c.json({error: "Invalid parameter", message: error.message}, 400)
-						case "NotFoundError":
-							return c.json({error: "Not found", message: error.message}, 404)
-						case "ProposalNotFoundError":
-							return c.json({error: "Not found", message: "One or more proposals not found"}, 404)
-						case "EditBlobNotCachedError":
-							return c.json(
-								{
-									error: "Not found",
-									message: "Edit blob not cached for one or more proposals",
-								},
-								404,
-							)
-						case "EditBlobDecodeFailedError":
-							return c.json(
-								{
-									error: "Unprocessable",
-									message: "Edit blob failed GRC-20 validation and cannot be decoded",
-									uri: error.uri,
-								},
-								422,
-							)
-						case "SpaceMismatchError":
-							return c.json(
-								{
-									error: "Invalid parameter",
-									message: "One or more proposals do not belong to the specified space",
-								},
-								400,
-							)
-						case "InvalidCursorError":
-							return c.json(
-								{
-									error: "Invalid parameter",
-									message: "Invalid pagination cursor",
-								},
-								400,
-							)
-						case "GroupSizeLimitError":
-							return c.json(
-								{
-									error: "Invalid parameter",
-									message: `Group size ${error.actual} exceeds maximum of ${error.max}`,
-								},
-								400,
-							)
-						case "DuplicateProposalError":
-							return c.json(
-								{
-									error: "Invalid parameter",
-									message: "Duplicate proposal IDs are not allowed",
-								},
-								400,
-							)
-						case "MixedModeError":
-							return c.json(
-								{
-									error: "Invalid parameter",
-									message: `Cannot mix active (${error.activeCount}) and historical (${error.nonActiveCount}) proposals in a group`,
-								},
-								400,
-							)
-						case "MissingPublishActionError":
-							return c.json(
-								{
-									error: "Unprocessable",
-									message: "All proposals in a group must have a Publish action",
-									proposalId: error.proposalId,
-								},
-								422,
-							)
-						case "EditDecodeError":
-							return c.json(
-								{
-									error: "Internal server error",
-									message: "Failed to decode edit blob",
-								},
-								500,
-							)
-						case "QueryError":
-							return c.json(
-								{
-									error: "Internal server error",
-									message: "An unexpected error occurred",
-								},
-								500,
-							)
-						default: {
-							const _exhaustive: never = error
-							return c.json(
-								{
-									error: "Internal server error",
-									message: "An unexpected error occurred",
-								},
-								500,
-							)
-						}
-					}
+					const mapped = mapGroupedProposalError(error)
+					return c.json(mapped.body, mapped.status)
 				},
 				onRight: (diff: PaginatedGroupedProposalDiff) => c.json(diff),
 			})

--- a/api/src/versioned/router.ts
+++ b/api/src/versioned/router.ts
@@ -23,14 +23,19 @@ import {getProfilesBySpaceIds} from "../profile/queries"
 import {isValidUuid, normalizeUuid, toDashedUuid} from "../utils/uuid"
 import {diffGroupedEntitySnapshots} from "./diff"
 import type {
+	DuplicateProposalError,
 	EditBlobDecodeFailedError,
 	EditBlobNotCachedError,
 	EditDecodeError,
+	GroupedProposalDiffError,
+	GroupSizeLimitError,
 	InvalidCursorError,
+	MissingPublishActionError,
+	MixedModeError,
 	ProposalNotFoundError,
 	SpaceMismatchError,
 } from "./proposal-diff"
-import {computeProposalDiff} from "./proposal-diff"
+import {computeGroupedProposalDiff, computeProposalDiff} from "./proposal-diff"
 import {
 	getEntitySnapshotAtVersion,
 	getEntityVersions,
@@ -38,7 +43,13 @@ import {
 	type QueryError,
 	resolveVersionKey,
 } from "./queries"
-import type {DiffResponse, PaginatedProposalDiff, SnapshotResponse, VersionEntry} from "./types"
+import type {
+	DiffResponse,
+	PaginatedGroupedProposalDiff,
+	PaginatedProposalDiff,
+	SnapshotResponse,
+	VersionEntry,
+} from "./types"
 
 type Database = NodePgDatabase<Record<string, unknown>>
 
@@ -63,6 +74,13 @@ type ProposalError =
 	| EditDecodeError
 	| SpaceMismatchError
 	| InvalidCursorError
+
+type GroupedProposalError =
+	| ProposalError
+	| GroupSizeLimitError
+	| DuplicateProposalError
+	| MixedModeError
+	| MissingPublishActionError
 
 /**
  * Batch-resolve creator profiles from a list of nullable creator space IDs.
@@ -954,6 +972,188 @@ export function createVersionedRouter(db: Database, runtime: AppRuntime) {
 					}
 				},
 				onRight: (diff: PaginatedProposalDiff) => c.json(diff),
+			})
+		},
+	)
+
+	// =========================================================================
+	// GET /proposal-groups/diff — grouped multi-proposal diff
+	// =========================================================================
+
+	router.get(
+		"/proposal-groups/diff",
+		describeRoute({
+			tags: ["Versioned"],
+			summary: "Grouped multi-proposal diff",
+			description:
+				"Computes a combined diff for multiple proposals in one space. " +
+				"Proposals are applied in edit-timestamp order. All proposals must be in the same mode (active or historical).",
+			responses: {
+				200: {description: "Grouped proposal diff"},
+				400: {description: "Invalid parameter"},
+				404: {description: "Not found"},
+				422: {description: "Unprocessable"},
+				500: {description: "Internal server error"},
+			},
+		}),
+		async (c) => {
+			const rawSpaceId = c.req.query("spaceId")
+			const rawProposalIds = c.req.query("proposalIds")
+			const rawCursor = c.req.query("cursor")
+			const rawLimit = c.req.query("limit")
+
+			// Validate spaceId
+			if (!rawSpaceId || !isValidUuid(rawSpaceId)) {
+				return c.json({error: "Invalid parameter", message: "spaceId must be a valid UUID"}, 400)
+			}
+
+			// Validate proposalIds
+			if (!rawProposalIds) {
+				return c.json(
+					{error: "Invalid parameter", message: "proposalIds is required (comma-separated UUIDs)"},
+					400,
+				)
+			}
+			const rawIds = rawProposalIds.split(",").map((s) => s.trim())
+			if (rawIds.length < 2) {
+				return c.json(
+					{error: "Invalid parameter", message: "proposalIds must contain at least 2 proposal IDs"},
+					400,
+				)
+			}
+			for (const id of rawIds) {
+				if (!isValidUuid(id)) {
+					return c.json({error: "Invalid parameter", message: `Invalid UUID in proposalIds: ${id}`}, 400)
+				}
+			}
+
+			// Validate limit
+			let limit = 50
+			if (rawLimit !== undefined) {
+				const parsed = Number.parseInt(rawLimit, 10)
+				if (Number.isNaN(parsed) || parsed < 1) {
+					return c.json({error: "Invalid parameter", message: "limit must be a positive integer"}, 400)
+				}
+				limit = Math.min(parsed, 100)
+			}
+
+			const spaceId = normalizeUuid(rawSpaceId)
+			const proposalIds = rawIds.map(normalizeUuid)
+
+			const program = Effect.gen(function* () {
+				return yield* computeGroupedProposalDiff(db, proposalIds, spaceId, rawCursor ?? undefined, limit)
+			}).pipe(
+				Effect.withSpan("versioned.groupedProposalDiff", {
+					attributes: {spaceId, proposalCount: proposalIds.length, limit},
+				}),
+			)
+
+			const result = await runtime.runPromise(Effect.either(program))
+
+			return Either.match(result, {
+				onLeft: (error: GroupedProposalError) => {
+					switch (error._tag) {
+						case "ValidationError":
+							return c.json({error: "Invalid parameter", message: error.message}, 400)
+						case "NotFoundError":
+							return c.json({error: "Not found", message: error.message}, 404)
+						case "ProposalNotFoundError":
+							return c.json({error: "Not found", message: "One or more proposals not found"}, 404)
+						case "EditBlobNotCachedError":
+							return c.json(
+								{
+									error: "Not found",
+									message: "Edit blob not cached for one or more proposals",
+								},
+								404,
+							)
+						case "EditBlobDecodeFailedError":
+							return c.json(
+								{
+									error: "Unprocessable",
+									message: "Edit blob failed GRC-20 validation and cannot be decoded",
+									uri: error.uri,
+								},
+								422,
+							)
+						case "SpaceMismatchError":
+							return c.json(
+								{
+									error: "Invalid parameter",
+									message: "One or more proposals do not belong to the specified space",
+								},
+								400,
+							)
+						case "InvalidCursorError":
+							return c.json(
+								{
+									error: "Invalid parameter",
+									message: "Invalid pagination cursor",
+								},
+								400,
+							)
+						case "GroupSizeLimitError":
+							return c.json(
+								{
+									error: "Invalid parameter",
+									message: `Group size ${error.actual} exceeds maximum of ${error.max}`,
+								},
+								400,
+							)
+						case "DuplicateProposalError":
+							return c.json(
+								{
+									error: "Invalid parameter",
+									message: "Duplicate proposal IDs are not allowed",
+								},
+								400,
+							)
+						case "MixedModeError":
+							return c.json(
+								{
+									error: "Invalid parameter",
+									message: `Cannot mix active (${error.activeCount}) and historical (${error.nonActiveCount}) proposals in a group`,
+								},
+								400,
+							)
+						case "MissingPublishActionError":
+							return c.json(
+								{
+									error: "Unprocessable",
+									message: "All proposals in a group must have a Publish action",
+									proposalId: error.proposalId,
+								},
+								422,
+							)
+						case "EditDecodeError":
+							return c.json(
+								{
+									error: "Internal server error",
+									message: "Failed to decode edit blob",
+								},
+								500,
+							)
+						case "QueryError":
+							return c.json(
+								{
+									error: "Internal server error",
+									message: "An unexpected error occurred",
+								},
+								500,
+							)
+						default: {
+							const _exhaustive: never = error
+							return c.json(
+								{
+									error: "Internal server error",
+									message: "An unexpected error occurred",
+								},
+								500,
+							)
+						}
+					}
+				},
+				onRight: (diff: PaginatedGroupedProposalDiff) => c.json(diff),
 			})
 		},
 	)

--- a/api/src/versioned/types.ts
+++ b/api/src/versioned/types.ts
@@ -87,6 +87,7 @@ export type ValueType = TextValueType | SimpleValueType
  */
 export interface TextValueChange {
 	propertyId: NormalizedUuid
+	propertyName?: string | null // Resolved human-readable name for propertyId
 	spaceId: NormalizedUuid
 	type: TextValueType
 	before: string | null
@@ -99,6 +100,7 @@ export interface TextValueChange {
  */
 export interface SimpleValueChange {
 	propertyId: NormalizedUuid
+	propertyName?: string | null // Resolved human-readable name for propertyId
 	spaceId: NormalizedUuid
 	type: SimpleValueType
 	before: string | null
@@ -135,15 +137,18 @@ export interface VersionedRelation {
 export interface RelationChange {
 	relationId: NormalizedUuid
 	typeId: NormalizedUuid
+	typeName?: string | null // Resolved human-readable name for typeId
 	spaceId: NormalizedUuid
 	changeType: "ADD" | "REMOVE" | "UPDATE"
 	before?: {
 		toEntityId: NormalizedUuid
+		toEntityName?: string | null // Resolved human-readable name for toEntityId
 		toSpaceId?: NormalizedUuid | null
 		position?: string | null
 	} | null
 	after?: {
 		toEntityId: NormalizedUuid
+		toEntityName?: string | null // Resolved human-readable name for toEntityId
 		toSpaceId?: NormalizedUuid | null
 		position?: string | null
 	} | null

--- a/api/src/versioned/types.ts
+++ b/api/src/versioned/types.ts
@@ -332,7 +332,7 @@ export interface ProposalDiffCursor {
 export type ProposalStatus = "active" | "closed" | "executed"
 
 /**
- * Paginated response for proposal diffs.
+ * Paginated response for single-proposal diffs.
  */
 export interface PaginatedProposalDiff {
 	proposalId: NormalizedUuid
@@ -341,6 +341,28 @@ export interface PaginatedProposalDiff {
 	entities: EntityDiff[]
 	pagination: {
 		cursor: string | null // Base64-encoded cursor for next page
+		hasMore: boolean
+		totalEntities: number
+	}
+}
+
+/**
+ * Base-state mode for grouped proposal diffs.
+ * - "active": all proposals are active; base = current live KG state
+ * - "historical": all proposals are closed/executed; base = versioned state before earliest edit
+ */
+export type GroupedProposalDiffMode = "active" | "historical"
+
+/**
+ * Paginated response for grouped (multi-proposal) diffs.
+ */
+export interface PaginatedGroupedProposalDiff {
+	proposalIds: NormalizedUuid[]
+	spaceId: NormalizedUuid
+	mode: GroupedProposalDiffMode
+	entities: EntityDiff[]
+	pagination: {
+		cursor: string | null
 		hasMore: boolean
 		totalEntities: number
 	}

--- a/docs/tech-designs/multi-proposal-diffs.md
+++ b/docs/tech-designs/multi-proposal-diffs.md
@@ -414,10 +414,16 @@ These are compile-time constants. If runtime configurability is needed, they can
 
 ### Known Limitations
 
-1. **`restoreEntity` / `restoreRelation` ops** — these only contain the entity/relation ID, not the data to restore. The diff shows the op was applied but cannot display what was restored. This is inherited from the single-proposal endpoint.
-2. **`deleteEntity` ops** — shows removal of current values but doesn't account for already-deleted entities. Same inheritance.
-3. **Cross-space groups** — not supported in v1. All proposals must belong to one space.
-4. **Name resolution uses live state** — names are fetched from the current live values table, not versioned state. For historical diffs, a recently renamed entity will show its current name, not the name at the time of the proposals.
+These limitations are inherited from the single-proposal endpoint and documented in the `KNOWN LIMITATIONS` header comment of `api/src/versioned/proposal-diff.ts`. The OpenAPI `describeRoute` for `GET /versioned/proposal-groups/diff` links back to this section so callers see them in the generated spec.
+
+1. **`restoreEntity` ops** — the op contains only the entity ID, not the values/relations to restore. We'd need to fetch historical state to show what's being restored. Currently the diff cannot display the restored contents.
+2. **`restoreRelation` ops** — the op contains only the relation ID. Since the relation doesn't exist in the live table (it was deleted), we can't look up which entity is affected. **These ops are silently skipped** — they produce no diff entry.
+3. **`deleteEntity` ops** — shows removal of all current values/relations, but doesn't account for the entity potentially being in a deleted state already. Treating a double-delete as a regular delete is generally harmless but may produce a misleading "removed" diff.
+4. **Cross-space groups** — not supported in v1. All proposals must belong to one space.
+5. **Name resolution uses live state** — names are fetched from the current live values table, not versioned state. For historical diffs, a recently renamed entity will show its current name, not the name at the time of the proposals.
+6. **Group size** — capped at `MAX_GROUP_SIZE = 20` proposals per request. Exported from `proposal-diff.ts` and surfaced in the route description.
+
+Properly supporting (1)-(3) requires restructuring the op-extraction code to (a) pass version context into entity extraction, (b) fetch historical state for restore ops, and (c) track entity/relation deletion state. Out of scope for v1.
 
 ## Invariants
 

--- a/docs/tech-designs/multi-proposal-diffs.md
+++ b/docs/tech-designs/multi-proposal-diffs.md
@@ -1,0 +1,477 @@
+# Multi-Proposal Diffs — Tech Design
+
+**Date:** 2026-04-14
+**Status:** WIP
+**RFC:** [0004-multi-proposal-diff-groups](../rfcs/0004-multi-proposal-diff-groups.md)
+**PR:** [geobrowser/gaia#585](https://github.com/geobrowser/gaia/pull/585)
+
+---
+
+# Background
+
+## Current System
+
+The Gaia API provides a proposal diff endpoint that computes on-demand diffs for a single governance proposal:
+
+```
+GET /versioned/proposals/:id/diff?spaceId=<uuid>
+```
+
+The pipeline works as follows:
+
+1. Load the proposal and its `Publish` action from the `proposals` / `proposal_actions` tables
+2. Fetch the encoded edit blob from the `ipfs_cache` table using the proposal's `content_uri`
+3. Decode the blob into GRC-20 ops using `decodeEditAuto` from `@geoprotocol/grc-20`
+4. Extract all affected entity IDs from the ops
+5. Determine proposal status (`active` / `closed` / `executed`) and select the appropriate base state:
+   - Active proposals diff against the current live KG state
+   - Closed/executed proposals diff against versioned state at the relevant timestamp
+6. Fetch base state snapshots (values, relations, blocks) for each affected entity
+7. Apply ops to each entity's base snapshot to produce the proposed state
+8. Compute a structured diff between base and proposed states
+9. Return a paginated `EntityDiff[]` response
+
+The response includes per-entity value changes, relation changes, and block changes with text-level word diffs for TEXT properties.
+
+**Key source files:**
+- `api/src/versioned/proposal-diff.ts` — core pipeline
+- `api/src/versioned/diff.ts` — snapshot diffing engine
+- `api/src/versioned/router.ts` — HTTP route handlers
+- `api/src/versioned/queries.ts` — database queries
+
+## Frontend Post-Processing Problem
+
+The backend returns diffs as a flat list of ID-heavy entity changes. The frontend ([`postProcessDiffs` in geogenesis](https://github.com/geobrowser/geogenesis/blob/master/apps/web/core/utils/diff/diff.ts#L203-L680)) performs ~480 lines of post-processing to transform these into display-ready diffs:
+
+1. **Name resolution** — batch-fetches entity names for property IDs, relation type IDs, and relation target IDs via additional GraphQL queries
+2. **Block folding** — re-nests block entity diffs (text blocks, image blocks, data blocks) under their parent entity's `blocks[]` array
+3. **Media-property filtering** — identifies IMAGE/VIDEO-type entities that are property values (not page blocks), filters them out, and injects their URLs into the parent entity's relation
+4. **Orphan block resolution** — blocks that appear in the diff without a BLOCKS relation are resolved via backlink queries to find their parent
+5. **Synthetic block diffs** — blocks referenced by BLOCKS relations but missing from the diff are synthesized from committed state
+6. **Data block enrichment** — block configuration relations are merged into the data block entity
+
+This post-processing adds latency (multiple round-trips to the GraphQL API from the browser), duplicates logic that should be authoritative on the backend, and creates a maintenance burden.
+
+---
+
+# General
+
+This project extends the proposal diff system with two capabilities:
+
+1. **Multi-proposal grouped diffs** — a new API endpoint that diffs 2-20 proposals as a single ordered changeset, returning one combined entity-centered diff
+2. **Display-ready enrichment** — backend-side name resolution that eliminates the most impactful piece of frontend post-processing
+
+Both capabilities are additive. The existing single-proposal endpoint is preserved unchanged.
+
+## Architecture Overview
+
+```
+                                   ┌─────────────────────────┐
+                                   │   Frontend (geogenesis)  │
+                                   └────────┬────────────────┘
+                                            │
+                        ┌───────────────────┼───────────────────┐
+                        │                   │                   │
+               Single proposal        Multi-proposal       (Future)
+                        │                   │              Block folding
+                        ▼                   ▼                   │
+              GET /versioned/      GET /versioned/              ▼
+              proposals/:id/diff   proposal-groups/diff    Phase 2b
+                        │                   │
+                        ▼                   ▼
+                 ┌──────────────────────────────────┐
+                 │   computeProposalDiff()           │
+                 │   computeGroupedProposalDiff()    │
+                 │   (shared pipeline tail)          │
+                 └──────────────┬───────────────────┘
+                                │
+                                ▼
+                 ┌──────────────────────────────────┐
+                 │   enrichEntityDiffs()             │
+                 │   (name resolution)               │
+                 └──────────────┬───────────────────┘
+                                │
+                                ▼
+                        JSON Response
+```
+
+## Requirements
+
+1. **Multi-proposal endpoint** — diff 2-20 proposals as one ordered changeset in a single request
+2. **Existing endpoint unchanged** — `GET /versioned/proposals/:id/diff` behavior is identical
+3. **Edit-timestamp ordering** — grouped edits are applied in chronological order (`created_at ASC`, `proposal_id ASC` tiebreaker)
+4. **Homogeneous mode** — all proposals must be in the same mode (all active OR all historical); mixed groups are rejected
+5. **Single-space scope** — all proposals must belong to the same space
+6. **Name enrichment** — all diff responses include resolved human-readable names for property IDs, relation type IDs, and entity IDs
+7. **Backward-compatible** — new response fields are additive (optional). Existing consumers are unaffected
+8. **Paginated** — same cursor-based pagination model as the single-proposal endpoint
+
+---
+
+# In-Depth
+
+## API Contract
+
+### New Endpoint: Grouped Proposal Diff
+
+```
+GET /versioned/proposal-groups/diff
+```
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `spaceId` | UUID | Yes | Space that all proposals belong to |
+| `proposalIds` | comma-separated UUIDs | Yes | 2-20 proposal IDs |
+| `cursor` | string | No | Base64-encoded pagination cursor |
+| `limit` | integer (1-100) | No | Max entities per page (default: 50) |
+
+**Validation rules:**
+
+| Rule | HTTP Status | Error |
+|---|---|---|
+| `spaceId` missing or invalid UUID | 400 | `Invalid parameter` |
+| `proposalIds` missing | 400 | `Invalid parameter` |
+| Fewer than 2 proposal IDs | 400 | `Invalid parameter` |
+| Invalid UUID in `proposalIds` | 400 | `Invalid parameter` |
+| More than 20 proposal IDs | 400 | `Group size {N} exceeds maximum of 20` |
+| Duplicate proposal IDs | 400 | `Duplicate proposal IDs are not allowed` |
+| Proposal not found | 404 | `One or more proposals not found` |
+| Proposal in wrong space | 400 | `One or more proposals do not belong to the specified space` |
+| Missing Publish action | 422 | `All proposals in a group must have a Publish action` |
+| Mixed active + historical | 400 | `Cannot mix active ({N}) and historical ({N}) proposals in a group` |
+| Edit blob not cached | 404 | `Edit blob not cached for one or more proposals` |
+| Invalid cursor | 400 | `Invalid pagination cursor` |
+
+**Response shape:**
+
+```json
+{
+  "proposalIds": [
+    "aabbccdd00001111222233334444aaaa",
+    "aabbccdd00001111222233334444bbbb"
+  ],
+  "spaceId": "aabbccdd00001111222233335555cccc",
+  "mode": "active",
+  "entities": [
+    {
+      "entityId": "aabbccdd00001111222233336666dddd",
+      "name": "My Entity",
+      "values": [
+        {
+          "propertyId": "a126ca530c8e48d5b88882c734c38935",
+          "propertyName": "Name",
+          "spaceId": "aabbccdd00001111222233335555cccc",
+          "type": "TEXT",
+          "before": "Old name",
+          "after": "New name",
+          "diff": [
+            { "value": "Old", "removed": true },
+            { "value": "New", "added": true },
+            { "value": " name" }
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "relationId": "...",
+          "typeId": "...",
+          "typeName": "Member Of",
+          "spaceId": "...",
+          "changeType": "ADD",
+          "before": null,
+          "after": {
+            "toEntityId": "...",
+            "toEntityName": "Geo DAO",
+            "toSpaceId": null,
+            "position": "a0"
+          }
+        }
+      ],
+      "blocks": [
+        {
+          "id": "...",
+          "type": "textBlock",
+          "before": null,
+          "after": "Hello world",
+          "diff": [
+            { "value": "Hello world", "added": true }
+          ]
+        }
+      ]
+    }
+  ],
+  "pagination": {
+    "cursor": "eyJlbnRpdHlJbmRleCI6NTAsInRvdGFsRW50aXRpZXMiOjEyM30=",
+    "hasMore": true,
+    "totalEntities": 123
+  }
+}
+```
+
+### Enriched Fields on Existing Endpoint
+
+The existing `GET /versioned/proposals/:id/diff` response is enriched with the same name fields. These are additive — no fields are removed or renamed:
+
+| Field | Location | Type | Description |
+|---|---|---|---|
+| `propertyName` | `ValueChange` | `string \| null` | Human-readable name for `propertyId` |
+| `typeName` | `RelationChange` | `string \| null` | Human-readable name for `typeId` |
+| `toEntityName` | `RelationChange.before` | `string \| null` | Human-readable name for `before.toEntityId` |
+| `toEntityName` | `RelationChange.after` | `string \| null` | Human-readable name for `after.toEntityId` |
+
+These fields are resolved from the live `values` table using `NAME_PROPERTY` (`a126ca530c8e48d5b88882c734c38935`). If the entity has no name, the field is `null`.
+
+### `mode` Field
+
+The `mode` field in the grouped response communicates which base-state strategy was used:
+
+| Mode | When | Base State |
+|---|---|---|
+| `"active"` | All proposals are active (end_time in future) | Current live KG state |
+| `"historical"` | All proposals are closed or executed | Versioned KG state just before the earliest edit timestamp |
+
+Mixed groups (some active, some historical) are rejected with a 400 error rather than producing ambiguous diffs.
+
+### Ordering Semantics
+
+Grouped proposals are applied in ascending order by the **edit timestamp** recorded in the decoded GRC-20 edit's `createdAt` field (microseconds), with `proposalId` as a deterministic tiebreaker:
+
+```
+ORDER BY edit.createdAt ASC, proposalId ASC
+```
+
+This reflects the real chronology of changes rather than proposal creation or voting timestamps.
+
+### Pagination
+
+Both endpoints use the same cursor-based pagination. The cursor encodes the current position in the sorted entity list:
+
+```json
+{
+  "entityIndex": 50,
+  "totalEntities": 123
+}
+```
+
+Base64-encoded in the `cursor` query parameter. The `totalEntities` field is a consistency check — if the entity count changes between pages (rare, possible if a proposal is updated mid-pagination), the API logs a warning but continues.
+
+## Frontend Integration Guide
+
+### Consuming the Grouped Diff Endpoint
+
+**Request:**
+```typescript
+const response = await fetch(
+  `${API_URL}/versioned/proposal-groups/diff?` +
+  `spaceId=${spaceId}&` +
+  `proposalIds=${proposalIds.join(",")}&` +
+  `limit=50`
+);
+const data = await response.json();
+// data.mode: "active" | "historical"
+// data.entities: EntityDiff[]
+// data.pagination: { cursor, hasMore, totalEntities }
+```
+
+**Pagination loop:**
+```typescript
+let allEntities: EntityDiff[] = [];
+let cursor: string | null = null;
+
+do {
+  const url = new URL(`${API_URL}/versioned/proposal-groups/diff`);
+  url.searchParams.set("spaceId", spaceId);
+  url.searchParams.set("proposalIds", proposalIds.join(","));
+  if (cursor) url.searchParams.set("cursor", cursor);
+
+  const res = await fetch(url);
+  const data = await res.json();
+  allEntities.push(...data.entities);
+  cursor = data.pagination.cursor;
+} while (cursor);
+```
+
+### Using Enriched Name Fields
+
+With name enrichment, the frontend no longer needs to call `getBatchEntities` to resolve names for diff display. The names are pre-populated:
+
+```typescript
+// Before (frontend post-processing required):
+const propertyLabel = nameMap.get(valueChange.propertyId) ?? valueChange.propertyId;
+
+// After (names come from API):
+const propertyLabel = valueChange.propertyName ?? valueChange.propertyId;
+```
+
+**Important:** `propertyName`, `typeName`, and `toEntityName` may be `null` if the entity has no name in the knowledge graph. Always fall back to the ID.
+
+### What Frontend Can Remove After Each Phase
+
+| Phase | Frontend code to remove | What replaces it |
+|---|---|---|
+| Phase 1 (grouped endpoint) | Client-side multi-proposal fetching + merging | Single API call |
+| Phase 2a (name enrichment) | `getBatchEntities` call in `postProcessDiffs` step 4, name mapping in step 9 | `propertyName`, `typeName`, `toEntityName` from API |
+| Phase 2b (block folding, future) | Steps 1-3 and 5-8 of `postProcessDiffs`, `groupBlocksUnderParents`, `entityDiffToBlockChange` | Server-side block folding + media URL injection |
+
+After Phase 2b, `postProcessDiffs` can be deleted entirely (~480 lines).
+
+### Error Handling
+
+The grouped endpoint returns structured JSON errors. Frontend should handle:
+
+```typescript
+switch (response.status) {
+  case 200: // Success
+    break;
+  case 400: // Validation error (bad input)
+    // data.error: "Invalid parameter"
+    // data.message: human-readable description
+    break;
+  case 404: // Proposal or edit blob not found
+    break;
+  case 422: // Proposal has no Publish action, or edit blob failed validation
+    break;
+  case 500: // Server error
+    break;
+}
+```
+
+## Off-Chain
+
+### Implementation Details
+
+The grouped diff is implemented as request-time squashing — no new database tables, indexes, or background jobs.
+
+**Core function:** `computeGroupedProposalDiff()` in `api/src/versioned/proposal-diff.ts`
+
+**Pipeline:**
+
+```
+1. Validate inputs ──────────────── (no DB calls)
+      │
+2. Batch-load proposals ─────────── SELECT ... FROM proposals p
+      │                              LEFT JOIN proposal_actions pa
+      │                              WHERE p.id = ANY($1::uuid[])
+      │
+3. Validate proposals ───────────── (in-memory: space match, mode, content_uri)
+      │
+4. Fetch edit blobs ─────────────── SELECT data, is_errored FROM ipfs_cache
+      │                              WHERE uri = $1  (×N, in parallel)
+      │
+5. Decode + sort + concat ops ───── decodeEditAuto() × N, sort by (createdAt, proposalId)
+      │
+6. Extract affected entities ────── (from ops, with relation lookups for update/delete)
+      │
+7. Paginate entity IDs ─────────── slice(startIndex, startIndex + limit)
+      │
+8. Resolve base version key ─────── (active: skip; historical: query edit_versions)
+      │
+9. Fetch base state ─────────────── 3-6 SQL queries (values, relations, block relations,
+      │                              block snapshots)
+      │
+10. Apply ops per entity ──────────  (in-memory, reuses applyOpsToSnapshot)
+      │
+11. Diff per entity ───────────────  (in-memory, reuses diffEntitySnapshots)
+      │
+12. Enrich names ──────────────────  1 SQL query (batch name lookup)
+      │
+13. Return paginated response ─────  JSON
+```
+
+**Total DB queries per request (typical, N=2 proposals, 1 page):**
+- 1 batch proposal load
+- 2 IPFS cache lookups (parallel)
+- 1 version key resolution (historical only)
+- 2 base state queries (values + relations)
+- 1 block relations query
+- 0-2 block snapshot queries (if blocks exist)
+- 1 name enrichment query
+- **Total: 7-9 queries**
+
+**Name enrichment query:**
+
+```sql
+SELECT entity_id, text
+FROM "values"
+WHERE entity_id = ANY($1::uuid[])
+  AND property_id = 'a126ca530c8e48d5b88882c734c38935'::uuid
+  AND text IS NOT NULL
+```
+
+Single query regardless of how many IDs need resolution. Entity IDs are deduplicated before the query.
+
+### Configuration
+
+| Setting | Value | Description |
+|---|---|---|
+| Max group size | 20 | Maximum proposals per grouped diff request |
+| Default page size | 50 | Entities per page |
+| Max page size | 100 | Upper bound for `limit` parameter |
+
+These are compile-time constants. If runtime configurability is needed, they can be moved to environment variables.
+
+### Known Limitations
+
+1. **`restoreEntity` / `restoreRelation` ops** — these only contain the entity/relation ID, not the data to restore. The diff shows the op was applied but cannot display what was restored. This is inherited from the single-proposal endpoint.
+2. **`deleteEntity` ops** — shows removal of current values but doesn't account for already-deleted entities. Same inheritance.
+3. **Cross-space groups** — not supported in v1. All proposals must belong to one space.
+4. **Name resolution uses live state** — names are fetched from the current live values table, not versioned state. For historical diffs, a recently renamed entity will show its current name, not the name at the time of the proposals.
+
+## Invariants
+
+1. The existing `GET /versioned/proposals/:id/diff` endpoint returns identical responses before and after this change (except for the new additive name fields)
+2. Grouped diffs with a single proposal ID are rejected (minimum 2)
+3. All proposals in a group must belong to the requested `spaceId`
+4. All proposals in a group must be in the same mode (all active or all historical)
+5. Ops from different proposals are applied in `(createdAt ASC, proposalId ASC)` order — the same ops always produce the same diff regardless of the order in which `proposalIds` are passed
+6. Paginated responses are stable: the same cursor against the same proposals returns the same page (assuming no proposal updates between requests)
+7. Name enrichment never fails the request — missing names degrade to `null`
+
+---
+
+# External Requirements
+
+## Geogenesis Frontend
+
+The frontend team should plan integration in phases:
+
+1. **Phase 1 adoption** — replace any client-side multi-proposal diff merging with a single call to the grouped endpoint
+2. **Phase 2a adoption** — remove `getBatchEntities` name-resolution from `postProcessDiffs` and use `propertyName`/`typeName`/`toEntityName` from the API response
+3. **Phase 2b adoption** (future) — once block folding lands server-side, delete `postProcessDiffs` entirely (~480 lines in `apps/web/core/utils/diff/diff.ts`)
+
+No frontend changes are required for the backend to deploy. The new fields are additive and the new endpoint is opt-in.
+
+---
+
+# Milestones and Estimates
+
+| Phase | Scope | Status | Estimate |
+|---|---|---|---|
+| **Phase 1** | Multi-proposal grouped diff endpoint | Complete (PR #585) | 1 week |
+| **Phase 2a** | Name resolution enrichment | Complete (PR #585, commit 2) | 0.5 weeks |
+| **Phase 2b** | Block folding + media URLs | Not started | 1-2 weeks |
+| **Frontend integration** | Adopt grouped endpoint + remove postProcessDiffs | Not started | 1 week |
+
+Phase 1 and Phase 2a are complete and in PR review. Phase 2b is the most complex piece and will be a separate PR.
+
+### Future Optimization
+
+If grouped diff latency becomes a problem (many proposals, large edits), the next optimization is **indexed proposal ops** — storing decoded ops in Postgres at ingest time to eliminate repeated blob fetch + decode work. This is described in [RFC 0004, "Indexed Proposal Ops" section](../rfcs/0004-multi-proposal-diff-groups.md).
+
+---
+
+# Open Questions and Thoughts
+
+1. **Per-proposal metadata in grouped response** — should the response include per-proposal status and edit timestamp alongside the merged diffs? This would help the frontend show which proposal contributed which change.
+2. **Name resolution for historical diffs** — currently uses live names. Should we resolve names at the historical version for accuracy?
+3. **Phase 2b complexity** — block folding involves orphan resolution (backlink queries), media-property filtering, and synthetic diff generation. Should this be an opt-in query parameter (`?enrich=blocks`) to avoid breaking existing consumers?
+4. **Max group size** — 20 is a conservative default. Should it be configurable via environment variable?
+
+---
+
+# Signatures
+
+- _____ at _____ 
+- _____ at _____


### PR DESCRIPTION
## Summary

Implements [RFC 0004](docs/rfcs/0004-multi-proposal-diff-groups.md) — adds multi-proposal grouped diffs and display-ready name enrichment to the versioned diff API.

**Tech design:** [`docs/tech-designs/multi-proposal-diffs.md`](docs/tech-designs/multi-proposal-diffs.md)

### Phase 1: Grouped Diff Endpoint

New endpoint `GET /versioned/proposal-groups/diff` that diffs 2-20 proposals as one ordered changeset.

- Accepts `spaceId` + comma-separated `proposalIds` + optional `cursor`/`limit`
- Validates: no duplicates, all same space, all same mode (active or historical), all must have Publish action, max group size 20
- Edits applied in `(createdAt ASC, proposalId ASC)` order
- Active groups diff against live KG state; historical groups diff against versioned state before earliest edit
- Reuses the entire existing pipeline tail (entity extraction, base state fetch, op application, diffing, pagination)

### Phase 2a: Name Resolution Enrichment

Adds `propertyName`, `typeName`, `toEntityName` fields to diff responses on **both** endpoints (single-proposal and grouped).

- Single batch SQL query against `values` table for `NAME_PROPERTY`
- All new fields are optional/additive — backward-compatible
- Frontend can remove `getBatchEntities` name-resolution call from `postProcessDiffs`

### New files
- `api/src/versioned/enrich.ts` — `enrichEntityDiffs()` post-processing
- `api/src/versioned/__tests__/enrich.test.ts` — 8 enrichment tests
- `docs/tech-designs/multi-proposal-diffs.md` — tech design with frontend integration guide

### Modified files
- `api/src/versioned/proposal-diff.ts` — error classes, `batchGetProposalsWithPublishActions()`, `computeGroupedProposalDiff()`
- `api/src/versioned/router.ts` — new route handler + enrichment wiring on both endpoints
- `api/src/versioned/types.ts` — `PaginatedGroupedProposalDiff`, enriched name fields on `ValueChange`/`RelationChange`
- `api/src/versioned/queries.ts` — `batchGetEntityNames()`
- `api/src/versioned/index.ts` — exports

## Test plan
- [x] All 488 tests pass (`bun test`)
- [x] `tsc --noEmit` passes
- [x] `biome check` clean on modified files
- [x] 13 new grouped endpoint tests (validation, errors, success)
- [x] 8 new enrichment tests (name resolution, dedup, graceful null)
- [ ] Manual: `curl` grouped endpoint with 2+ proposal IDs from testnet
- [ ] Verify existing single-proposal diff still works identically (+ now includes name fields)

## Follow-up
- **Phase 2b** (separate PR): Block folding + media URLs — nest blocks under parents, inject `imageUrl`/`videoUrl`, synthesize missing block diffs. After this lands, frontend can delete `postProcessDiffs` entirely.