### PR TITLE
fix(api): cap pagination at every nesting level (root + nested)

### DIFF
--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -168,7 +168,7 @@ describe("PaginationCapPlugin", () => {
 	})
 
 	it("rejects oversized first on nested sub-collections", async () => {
-		// Nested collections inside an entity selection (e.g. relationsByFromEntityIdList
+		// Nested collections inside an entity selection (e.g. relationsList
 		// or valuesList) must be capped too. The previous implementation used
 		// makeWrapResolversPlugin, which per PostGraphile docs only reliably
 		// influences SQL for root-level resolvers. The current implementation
@@ -179,7 +179,7 @@ describe("PaginationCapPlugin", () => {
 				entitiesConnection(first: 1) {
 					nodes {
 						id
-						relationsByFromEntityIdList(first: 10000) { id }
+						relationsList(first: 10000) { id }
 					}
 				}
 			}
@@ -195,7 +195,7 @@ describe("PaginationCapPlugin", () => {
 				entitiesConnection(first: 1) {
 					nodes {
 						id
-						relationsByFromEntityIdList(last: 10000) { id }
+						relationsList(last: 10000) { id }
 					}
 				}
 			}
@@ -293,17 +293,19 @@ describe("PaginationCapPlugin default-first injection (seeded)", () => {
 		expect(result.body.errors?.[0]?.extensions?.code).toBe("BAD_USER_INPUT")
 	})
 
-	it("accepts last at exactly the cap", async () => {
+	it("accepts last at exactly the cap (connection form)", async () => {
+		// `last` is only exposed on the Relay connection form — simple collections
+		// support `first` / `offset` only.
 		const result = await executeGraphQL(`
-			{ entities(last: ${MAX_PAGINATION_LIMIT}) { id } }
+			{ entitiesConnection(last: ${MAX_PAGINATION_LIMIT}) { nodes { id } } }
 		`)
 		expect(result.status).toBe(200)
 		expect(result.body.errors).toBeUndefined()
 	})
 
-	it("rejects last at cap + 1", async () => {
+	it("rejects last at cap + 1 (connection form)", async () => {
 		const result = await executeGraphQL(`
-			{ entities(last: ${MAX_PAGINATION_LIMIT + 1}) { id } }
+			{ entitiesConnection(last: ${MAX_PAGINATION_LIMIT + 1}) { nodes { id } } }
 		`)
 		expect(result.status).toBe(400)
 		expect(result.body.errors?.[0]?.extensions?.code).toBe("BAD_USER_INPUT")
@@ -327,14 +329,14 @@ describe("PaginationCapPlugin default-first injection (seeded)", () => {
 
 	// --- last / offset happy-path coverage ---
 
-	it("honors last below the cap", async () => {
+	it("honors last below the cap (connection form)", async () => {
 		const result = await executeGraphQL(`
-			{ entities(last: 50) { id } }
+			{ entitiesConnection(last: 50) { nodes { id } } }
 		`)
 		expect(result.status).toBe(200)
 		expect(result.body.errors).toBeUndefined()
-		const rows: Array<{id: string}> = result.body.data.entities
-		expect(rows.length).toBe(50)
+		const nodes: Array<{id: string}> = result.body.data.entitiesConnection.nodes
+		expect(nodes.length).toBe(50)
 	})
 
 	it("honors offset combined with first below the cap", async () => {
@@ -403,7 +405,7 @@ describe("PaginationCapPlugin default-first injection (seeded)", () => {
  * Integration test for the PR's core claim: nested sub-collections receive the
  * default-first injection in their *own* SQL lateral. Seeds MAX+N relations
  * pointing from a single parent entity and asserts that a nested
- * `relationsByFromEntityIdList` query without `first:` is capped at MAX.
+ * `relationsList` query without `first:` is capped at MAX.
  */
 describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
 	const OVER_LIMIT = MAX_PAGINATION_LIMIT + 5
@@ -432,7 +434,10 @@ describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
 		seededRelationIds = Array.from({length: OVER_LIMIT}, () => crypto.randomUUID())
 		// relations schema: id, entity_id, type_id, from_entity_id, to_entity_id, space_id (all NOT NULL)
 		const relPlaceholders = seededRelationIds
-			.map((_id, i) => `($${i + 1}, $${i + 1}, $${OVER_LIMIT + 1}, $${OVER_LIMIT + 2}, $${OVER_LIMIT + 3}, $${OVER_LIMIT + 4})`)
+			.map(
+				(_id, i) =>
+					`($${i + 1}, $${i + 1}, $${OVER_LIMIT + 1}, $${OVER_LIMIT + 2}, $${OVER_LIMIT + 3}, $${OVER_LIMIT + 4})`,
+			)
 			.join(", ")
 		await pool.query(
 			`INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) VALUES ${relPlaceholders}`,
@@ -455,7 +460,7 @@ describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
 			`
 				query NestedDefault($id: UUID!) {
 					entity(id: $id) {
-						relationsByFromEntityIdList {
+						relationsList {
 							id
 						}
 					}
@@ -465,7 +470,7 @@ describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
 		)
 		expect(result.status).toBe(200)
 		expect(result.body.errors).toBeUndefined()
-		const nested: Array<{id: string}> = result.body.data.entity.relationsByFromEntityIdList
+		const nested: Array<{id: string}> = result.body.data.entity.relationsList
 		expect(nested.length).toBe(MAX_PAGINATION_LIMIT)
 	})
 
@@ -474,7 +479,7 @@ describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
 			`
 				query NestedExplicit($id: UUID!) {
 					entity(id: $id) {
-						relationsByFromEntityIdList(first: 7) {
+						relationsList(first: 7) {
 							id
 						}
 					}
@@ -484,7 +489,7 @@ describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
 		)
 		expect(result.status).toBe(200)
 		expect(result.body.errors).toBeUndefined()
-		const nested: Array<{id: string}> = result.body.data.entity.relationsByFromEntityIdList
+		const nested: Array<{id: string}> = result.body.data.entity.relationsList
 		expect(nested.length).toBe(7)
 	})
 })

--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -167,11 +167,13 @@ describe("PaginationCapPlugin", () => {
 		expect(result.body.errors).toBeUndefined()
 	})
 
-	it("caps oversized first on nested sub-collections", async () => {
-		// The plugin doc string says nested sub-collections "don't typically
-		// accept user-controlled `first` arguments", but PostGraphile does
-		// generate `first` args on nested FK-relation connections. This probes
-		// whether the cap applies there too. If it does not, this is the gap.
+	it("rejects oversized first on nested sub-collections", async () => {
+		// Nested collections inside an entity selection (e.g. relationsByFromEntityIdList
+		// or valuesList) must be capped too. The previous implementation used
+		// makeWrapResolversPlugin, which per PostGraphile docs only reliably
+		// influences SQL for root-level resolvers. The current implementation
+		// registers an arg data generator on every connection/simple-collection
+		// field, so the cap runs during SQL construction at every nesting level.
 		const result = await executeGraphQL(`
 			{
 				entitiesConnection(first: 1) {
@@ -183,22 +185,24 @@ describe("PaginationCapPlugin", () => {
 			}
 		`)
 
-		// Expect either: (a) validation error because the field/arg doesn't exist
-		// (in which case the shape doesn't apply), or (b) BAD_USER_INPUT because
-		// the cap caught it. Anything else (200 with data) = gap.
-		if (result.status === 200 && !result.body.errors) {
-			throw new Error(
-				`Nested sub-collection accepted first: 10000 without being rejected. Response: ${JSON.stringify(
-					result.body,
-				).slice(0, 400)}`,
-			)
-		}
-		if (result.body.errors?.[0]?.extensions?.code === "BAD_USER_INPUT") {
-			expect(result.body.errors[0].extensions.code).toBe("BAD_USER_INPUT")
-			return
-		}
-		// Validation error is acceptable — means the field name differs
 		expect(result.body.errors).toBeDefined()
+		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+	})
+
+	it("rejects oversized last on nested sub-collections", async () => {
+		const result = await executeGraphQL(`
+			{
+				entitiesConnection(first: 1) {
+					nodes {
+						id
+						relationsByFromEntityIdList(last: 10000) { id }
+					}
+				}
+			}
+		`)
+
+		expect(result.body.errors).toBeDefined()
+		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
 	})
 })
 

--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -272,4 +272,219 @@ describe("PaginationCapPlugin default-first injection (seeded)", () => {
 		const nodes: Array<{id: string}> = result.body.data.entitiesConnection.nodes
 		expect(nodes.length).toBe(MAX_PAGINATION_LIMIT)
 	})
+
+	// --- Boundary tests: at-cap vs just-over-cap ---
+
+	it("accepts first at exactly the cap", async () => {
+		const result = await executeGraphQL(`
+			{ entities(first: ${MAX_PAGINATION_LIMIT}) { id } }
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const rows: Array<{id: string}> = result.body.data.entities
+		expect(rows.length).toBe(MAX_PAGINATION_LIMIT)
+	})
+
+	it("rejects first at cap + 1 (off-by-one boundary)", async () => {
+		const result = await executeGraphQL(`
+			{ entities(first: ${MAX_PAGINATION_LIMIT + 1}) { id } }
+		`)
+		expect(result.status).toBe(400)
+		expect(result.body.errors?.[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+	})
+
+	it("accepts last at exactly the cap", async () => {
+		const result = await executeGraphQL(`
+			{ entities(last: ${MAX_PAGINATION_LIMIT}) { id } }
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+	})
+
+	it("rejects last at cap + 1", async () => {
+		const result = await executeGraphQL(`
+			{ entities(last: ${MAX_PAGINATION_LIMIT + 1}) { id } }
+		`)
+		expect(result.status).toBe(400)
+		expect(result.body.errors?.[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+	})
+
+	it("accepts offset at exactly the cap", async () => {
+		const result = await executeGraphQL(`
+			{ entities(offset: ${MAX_PAGINATION_LIMIT}, first: 10) { id } }
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+	})
+
+	it("rejects offset at cap + 1", async () => {
+		const result = await executeGraphQL(`
+			{ entities(offset: ${MAX_PAGINATION_LIMIT + 1}) { id } }
+		`)
+		expect(result.status).toBe(400)
+		expect(result.body.errors?.[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+	})
+
+	// --- last / offset happy-path coverage ---
+
+	it("honors last below the cap", async () => {
+		const result = await executeGraphQL(`
+			{ entities(last: 50) { id } }
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const rows: Array<{id: string}> = result.body.data.entities
+		expect(rows.length).toBe(50)
+	})
+
+	it("honors offset combined with first below the cap", async () => {
+		const result = await executeGraphQL(`
+			{ entities(first: 25, offset: 100) { id } }
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const rows: Array<{id: string}> = result.body.data.entities
+		expect(rows.length).toBe(25)
+	})
+
+	it("accepts first: 0 (edge — returns nothing, does not inject default)", async () => {
+		const result = await executeGraphQL(`
+			{ entities(first: 0) { id } }
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const rows: Array<{id: string}> = result.body.data.entities
+		expect(rows.length).toBe(0)
+	})
+
+	// --- cursor pagination still works with the cap in place ---
+
+	it("supports cursor pagination via the connection form", async () => {
+		const page1 = await executeGraphQL(`
+			{
+				entitiesConnection(first: 10) {
+					nodes { id }
+					pageInfo { hasNextPage endCursor }
+				}
+			}
+		`)
+		expect(page1.status).toBe(200)
+		expect(page1.body.errors).toBeUndefined()
+
+		const firstPageNodes: Array<{id: string}> = page1.body.data.entitiesConnection.nodes
+		const {hasNextPage, endCursor} = page1.body.data.entitiesConnection.pageInfo
+		expect(firstPageNodes.length).toBe(10)
+		expect(hasNextPage).toBe(true)
+		expect(endCursor).toBeTruthy()
+
+		const page2 = await executeGraphQL(
+			`
+				query Page2($cursor: Cursor!) {
+					entitiesConnection(first: 10, after: $cursor) {
+						nodes { id }
+					}
+				}
+			`,
+			{cursor: endCursor},
+		)
+		expect(page2.status).toBe(200)
+		expect(page2.body.errors).toBeUndefined()
+		const page2Nodes: Array<{id: string}> = page2.body.data.entitiesConnection.nodes
+		expect(page2Nodes.length).toBe(10)
+
+		const firstPageIds = new Set(firstPageNodes.map((r) => r.id))
+		for (const node of page2Nodes) {
+			expect(firstPageIds.has(node.id)).toBe(false)
+		}
+	})
+})
+
+/**
+ * Integration test for the PR's core claim: nested sub-collections receive the
+ * default-first injection in their *own* SQL lateral. Seeds MAX+N relations
+ * pointing from a single parent entity and asserts that a nested
+ * `relationsByFromEntityIdList` query without `first:` is capped at MAX.
+ */
+describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
+	const OVER_LIMIT = MAX_PAGINATION_LIMIT + 5
+	let parentEntityId: string
+	let siblingEntityId: string
+	let spaceId: string
+	let typeId: string
+	let seededRelationIds: string[] = []
+	let seededEntityIds: string[] = []
+	let pool: Pool
+
+	beforeAll(async () => {
+		pool = new Pool({connectionString: process.env.DATABASE_URL})
+		parentEntityId = crypto.randomUUID()
+		siblingEntityId = crypto.randomUUID()
+		spaceId = crypto.randomUUID()
+		typeId = crypto.randomUUID()
+		seededEntityIds = [parentEntityId, siblingEntityId, typeId]
+
+		const entityValues = seededEntityIds.map((_id, i) => `($${i + 1}, 0, 0, 0, 0)`).join(", ")
+		await pool.query(
+			`INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block) VALUES ${entityValues}`,
+			seededEntityIds,
+		)
+
+		seededRelationIds = Array.from({length: OVER_LIMIT}, () => crypto.randomUUID())
+		// relations schema: id, entity_id, type_id, from_entity_id, to_entity_id, space_id (all NOT NULL)
+		const relPlaceholders = seededRelationIds
+			.map((_id, i) => `($${i + 1}, $${i + 1}, $${OVER_LIMIT + 1}, $${OVER_LIMIT + 2}, $${OVER_LIMIT + 3}, $${OVER_LIMIT + 4})`)
+			.join(", ")
+		await pool.query(
+			`INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) VALUES ${relPlaceholders}`,
+			[...seededRelationIds, typeId, parentEntityId, siblingEntityId, spaceId],
+		)
+	})
+
+	afterAll(async () => {
+		if (seededRelationIds.length) {
+			await pool.query("DELETE FROM relations WHERE id = ANY($1::uuid[])", [seededRelationIds])
+		}
+		if (seededEntityIds.length) {
+			await pool.query("DELETE FROM entities WHERE id = ANY($1::uuid[])", [seededEntityIds])
+		}
+		await pool.end()
+	})
+
+	it("caps nested relations at MAX when first is omitted on the nested field", async () => {
+		const result = await executeGraphQL(
+			`
+				query NestedDefault($id: UUID!) {
+					entity(id: $id) {
+						relationsByFromEntityIdList {
+							id
+						}
+					}
+				}
+			`,
+			{id: parentEntityId},
+		)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const nested: Array<{id: string}> = result.body.data.entity.relationsByFromEntityIdList
+		expect(nested.length).toBe(MAX_PAGINATION_LIMIT)
+	})
+
+	it("honors explicit first < cap on the nested field", async () => {
+		const result = await executeGraphQL(
+			`
+				query NestedExplicit($id: UUID!) {
+					entity(id: $id) {
+						relationsByFromEntityIdList(first: 7) {
+							id
+						}
+					}
+				}
+			`,
+			{id: parentEntityId},
+		)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const nested: Array<{id: string}> = result.body.data.entity.relationsByFromEntityIdList
+		expect(nested.length).toBe(7)
+	})
 })

--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -60,4 +60,111 @@ describe("PaginationCapPlugin", () => {
 		expect(result.body.errors).toBeDefined()
 		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
 	})
+
+	// --- gap-probing tests added alongside the existing ones ---
+
+	it("rejects oversized first on the connection form", async () => {
+		const result = await executeGraphQL(`
+			{
+				entitiesConnection(first: 10000) {
+					nodes { id }
+				}
+			}
+		`)
+
+		expect(result.status).toBe(400)
+		expect(result.body.errors).toBeDefined()
+		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+	})
+
+	it("rejects oversized last on a root collection", async () => {
+		const result = await executeGraphQL(`
+			{
+				entitiesConnection(last: 10000) {
+					nodes { id }
+				}
+			}
+		`)
+
+		expect(result.status).toBe(400)
+		expect(result.body.errors).toBeDefined()
+		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+	})
+
+	it("rejects oversized offset on a root collection", async () => {
+		// NOTE: this documents current behavior — a cap on offset prevents deep
+		// pagination (e.g. page 12 at 100/page is offset 1100). If legitimate
+		// deep pagination is required, the offset cap should be loosened.
+		const result = await executeGraphQL(`
+			{
+				entities(offset: 10000) {
+					id
+				}
+			}
+		`)
+
+		expect(result.status).toBe(400)
+		expect(result.body.errors).toBeDefined()
+		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+	})
+
+	it("accepts the maximum allowed first on the connection form", async () => {
+		const result = await executeGraphQL(`
+			{
+				entitiesConnection(first: 1000) {
+					totalCount
+				}
+			}
+		`)
+
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+	})
+
+	it("accepts queries with no pagination argument (no cap applied when omitted)", async () => {
+		// NOTE: this documents current behavior — when `first` is omitted the
+		// plugin does not inject a default. PostGraphile may return all rows.
+		const result = await executeGraphQL(`
+			{
+				entities { id }
+			}
+		`)
+
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+	})
+
+	it("caps oversized first on nested sub-collections", async () => {
+		// The plugin doc string says nested sub-collections "don't typically
+		// accept user-controlled `first` arguments", but PostGraphile does
+		// generate `first` args on nested FK-relation connections. This probes
+		// whether the cap applies there too. If it does not, this is the gap.
+		const result = await executeGraphQL(`
+			{
+				entitiesConnection(first: 1) {
+					nodes {
+						id
+						relationsByFromEntityIdList(first: 10000) { id }
+					}
+				}
+			}
+		`)
+
+		// Expect either: (a) validation error because the field/arg doesn't exist
+		// (in which case the shape doesn't apply), or (b) BAD_USER_INPUT because
+		// the cap caught it. Anything else (200 with data) = gap.
+		if (result.status === 200 && !result.body.errors) {
+			throw new Error(
+				`Nested sub-collection accepted first: 10000 without being rejected. Response: ${JSON.stringify(
+					result.body,
+				).slice(0, 400)}`,
+			)
+		}
+		if (result.body.errors?.[0]?.extensions?.code === "BAD_USER_INPUT") {
+			expect(result.body.errors[0].extensions.code).toBe("BAD_USER_INPUT")
+			return
+		}
+		// Validation error is acceptable — means the field name differs
+		expect(result.body.errors).toBeDefined()
+	})
 })

--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -1,5 +1,6 @@
-import {describe, expect, it} from "vitest"
-import {assertPaginationWithinLimit} from "../paginationCapPlugin"
+import {Pool} from "pg"
+import {afterAll, beforeAll, describe, expect, it} from "vitest"
+import {applyDefaultFirstIfOmitted, assertPaginationWithinLimit, MAX_PAGINATION_LIMIT} from "../paginationCapPlugin"
 import {graphqlServer} from "../postgraphile"
 
 async function executeGraphQL(query: string, variables?: Record<string, unknown>) {
@@ -26,6 +27,36 @@ describe("assertPaginationWithinLimit", () => {
 		expect(() => assertPaginationWithinLimit({first: 1001})).toThrow(/first.*1000.*1001/i)
 		expect(() => assertPaginationWithinLimit({last: 1001})).toThrow(/last.*1000.*1001/i)
 		expect(() => assertPaginationWithinLimit({offset: 1001})).toThrow(/offset.*1000.*1001/i)
+	})
+})
+
+describe("applyDefaultFirstIfOmitted", () => {
+	it("injects default first when neither first nor last is supplied", () => {
+		expect(applyDefaultFirstIfOmitted({})).toEqual({first: MAX_PAGINATION_LIMIT})
+	})
+
+	it("preserves other args while injecting the default first", () => {
+		expect(applyDefaultFirstIfOmitted({offset: 10, filter: {name: "x"}})).toEqual({
+			offset: 10,
+			filter: {name: "x"},
+			first: MAX_PAGINATION_LIMIT,
+		})
+	})
+
+	it("does not override an explicit first", () => {
+		expect(applyDefaultFirstIfOmitted({first: 50})).toEqual({first: 50})
+	})
+
+	it("does not inject first when only last is supplied", () => {
+		expect(applyDefaultFirstIfOmitted({last: 50})).toEqual({last: 50})
+	})
+
+	it("does not inject first for a non-numeric first (GraphQL strong typing catches those)", () => {
+		// if `first` came through as anything non-numeric (shouldn't happen at runtime
+		// due to Int scalar validation) we still shouldn't silently override it
+		expect(applyDefaultFirstIfOmitted({first: null as unknown as number})).toEqual({
+			first: MAX_PAGINATION_LIMIT,
+		})
 	})
 })
 
@@ -121,9 +152,11 @@ describe("PaginationCapPlugin", () => {
 		expect(result.body.errors).toBeUndefined()
 	})
 
-	it("accepts queries with no pagination argument (no cap applied when omitted)", async () => {
-		// NOTE: this documents current behavior — when `first` is omitted the
-		// plugin does not inject a default. PostGraphile may return all rows.
+	it("accepts queries with no pagination argument (cap enforced via injected default)", async () => {
+		// When `first` is omitted we still succeed, but the plugin injects a
+		// default `first = MAX_PAGINATION_LIMIT` so PostGraphile cannot resolve
+		// an unbounded collection. See the seeded integration block below for
+		// the length assertion.
 		const result = await executeGraphQL(`
 			{
 				entities { id }
@@ -166,5 +199,73 @@ describe("PaginationCapPlugin", () => {
 		}
 		// Validation error is acceptable — means the field name differs
 		expect(result.body.errors).toBeDefined()
+	})
+})
+
+/**
+ * Integration test that seeds MAX_PAGINATION_LIMIT+N rows directly into the
+ * entities table and verifies that a bare collection query resolves at most
+ * MAX_PAGINATION_LIMIT rows — i.e. that applyDefaultFirstIfOmitted actually
+ * propagates a LIMIT into the generated SQL. Runs against the test DB
+ * configured in vitest.config.ts.
+ */
+describe("PaginationCapPlugin default-first injection (seeded)", () => {
+	const OVER_LIMIT = MAX_PAGINATION_LIMIT + 5
+	let seededIds: string[] = []
+	let pool: Pool
+
+	beforeAll(async () => {
+		pool = new Pool({connectionString: process.env.DATABASE_URL})
+		seededIds = Array.from({length: OVER_LIMIT}, () => crypto.randomUUID())
+		const values = seededIds.map((_id, i) => `($${i + 1}, 0, 0, 0, 0)`).join(", ")
+		await pool.query(
+			`INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block) VALUES ${values}`,
+			seededIds,
+		)
+	})
+
+	afterAll(async () => {
+		if (seededIds.length) {
+			await pool.query("DELETE FROM entities WHERE id = ANY($1::uuid[])", [seededIds])
+		}
+		await pool.end()
+	})
+
+	it("returns at most MAX_PAGINATION_LIMIT rows when first is omitted", async () => {
+		const result = await executeGraphQL(`
+			{
+				entities { id }
+			}
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const rows: Array<{id: string}> = result.body.data.entities
+		expect(rows.length).toBe(MAX_PAGINATION_LIMIT)
+	})
+
+	it("returns exactly first rows when a first < cap is specified", async () => {
+		const result = await executeGraphQL(`
+			{
+				entities(first: 50) { id }
+			}
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const rows: Array<{id: string}> = result.body.data.entities
+		expect(rows.length).toBe(50)
+	})
+
+	it("returns at most MAX_PAGINATION_LIMIT rows via the connection form when first is omitted", async () => {
+		const result = await executeGraphQL(`
+			{
+				entitiesConnection {
+					nodes { id }
+				}
+			}
+		`)
+		expect(result.status).toBe(200)
+		expect(result.body.errors).toBeUndefined()
+		const nodes: Array<{id: string}> = result.body.data.entitiesConnection.nodes
+		expect(nodes.length).toBe(MAX_PAGINATION_LIMIT)
 	})
 })

--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -190,12 +190,16 @@ describe("PaginationCapPlugin", () => {
 	})
 
 	it("rejects oversized last on nested sub-collections", async () => {
+		// `last` is only exposed on the Relay connection form — on Entity the
+		// connection form of the from_entity_id back-ref is `relations` (per the
+		// smart comment @foreignFieldName relations in drizzle/0004_functions.sql).
+		// The simple-collection form `relationsList` has only `first` + `offset`.
 		const result = await executeGraphQL(`
 			{
 				entitiesConnection(first: 1) {
 					nodes {
 						id
-						relationsList(last: 10000) { id }
+						relations(last: 10000) { nodes { id } }
 					}
 				}
 			}

--- a/api/src/kg/paginationCapPlugin.ts
+++ b/api/src/kg/paginationCapPlugin.ts
@@ -1,17 +1,18 @@
 /**
- * PostGraphile plugin that rejects oversized `first`, `last`, and `offset`
- * pagination arguments on all connections and simple collections.
+ * PostGraphile plugin that bounds pagination on all connections and simple
+ * collections.
  *
- * PostGraphile 4 passes `first`/`last` directly to SQL LIMIT without any cap,
- * meaning any client can request unbounded result sets. This is especially
- * expensive for queries that fan out into nested lists (valuesList, relationsList).
+ * Does two things:
+ * 1. Rejects oversized `first`/`last`/`offset` values (> MAX_PAGINATION_LIMIT)
+ *    so abusive or buggy clients fail fast with BAD_USER_INPUT.
+ * 2. Injects a default `first` when neither `first` nor `last` is supplied,
+ *    so a bare `{ entities { id } }` cannot resolve an unbounded collection.
+ *    Without this, PostGraphile 4 produces SQL without any LIMIT and returns
+ *    every row, which is the worst-case memory/CPU path.
  *
  * Uses `makeWrapResolversPlugin` (method 2) to intercept resolved argument
  * values before they reach the resolver and its arg data generators. This works
  * regardless of whether values are passed as variables or inline literals.
- *
- * Values exceeding the cap are rejected so abusive or buggy clients fail fast
- * instead of silently issuing very large collection reads.
  *
  * Per PostGraphile docs, resolver wrapping only reliably influences SQL
  * generation for root-level resolvers. This is fine for our use case - the
@@ -22,7 +23,7 @@
 import {makeWrapResolversPlugin} from "graphile-utils"
 import {GraphQLError} from "graphql"
 
-const MAX_PAGINATION_LIMIT = 1000
+export const MAX_PAGINATION_LIMIT = 1000
 
 export function assertPaginationWithinLimit(args: Record<string, unknown>) {
 	for (const key of ["first", "last", "offset"] as const) {
@@ -43,6 +44,21 @@ export function assertPaginationWithinLimit(args: Record<string, unknown>) {
 	}
 }
 
+/**
+ * If the client supplied neither `first` nor `last`, inject `first` set to the
+ * cap. This prevents unbounded collection reads from bare queries like
+ * `{ entities { id } }`. Returns the original args object when either is set
+ * so we don't silently override an explicit `last`-only pagination.
+ */
+export function applyDefaultFirstIfOmitted(args: Record<string, unknown>): Record<string, unknown> {
+	const hasFirst = typeof args.first === "number"
+	const hasLast = typeof args.last === "number"
+	if (hasFirst || hasLast) {
+		return args
+	}
+	return {...args, first: MAX_PAGINATION_LIMIT}
+}
+
 const PaginationCapPlugin = makeWrapResolversPlugin(
 	(context) => {
 		if (context.scope.isPgFieldConnection || context.scope.isPgFieldSimpleCollection) {
@@ -52,7 +68,8 @@ const PaginationCapPlugin = makeWrapResolversPlugin(
 	},
 	() => (resolve, source, args, context, resolveInfo) => {
 		assertPaginationWithinLimit(args)
-		return resolve(source, args, context, resolveInfo)
+		const boundedArgs = applyDefaultFirstIfOmitted(args)
+		return resolve(source, boundedArgs, context, resolveInfo)
 	},
 )
 

--- a/api/src/kg/paginationCapPlugin.ts
+++ b/api/src/kg/paginationCapPlugin.ts
@@ -1,26 +1,27 @@
 /**
  * PostGraphile plugin that bounds pagination on all connections and simple
- * collections.
+ * collections — at every nesting level.
  *
- * Does two things:
+ * Does two things, uniformly across root and nested fields:
  * 1. Rejects oversized `first`/`last`/`offset` values (> MAX_PAGINATION_LIMIT)
  *    so abusive or buggy clients fail fast with BAD_USER_INPUT.
  * 2. Injects a default `first` when neither `first` nor `last` is supplied,
- *    so a bare `{ entities { id } }` cannot resolve an unbounded collection.
- *    Without this, PostGraphile 4 produces SQL without any LIMIT and returns
- *    every row, which is the worst-case memory/CPU path.
+ *    so a bare `{ entity(id: ...) { relationsList { ... } } }` cannot resolve
+ *    an unbounded sub-collection. Without this, PostGraphile 4 produces SQL
+ *    without any LIMIT and returns every row — the Claim entity has 75K+
+ *    inbound relations, which is the worst-case memory/CPU path.
  *
- * Uses `makeWrapResolversPlugin` (method 2) to intercept resolved argument
- * values before they reach the resolver and its arg data generators. This works
- * regardless of whether values are passed as variables or inline literals.
+ * Implementation: hooks `GraphQLObjectType:fields:field:args` and registers an
+ * arg data generator on every connection / simple-collection field. The
+ * generator's `pgQuery(queryBuilder)` runs during SQL construction at the
+ * field's own nesting level, so a nested `relationsList` inside an `entity`
+ * selection is capped exactly like a top-level `relations` query.
  *
- * Per PostGraphile docs, resolver wrapping only reliably influences SQL
- * generation for root-level resolvers. This is fine for our use case - the
- * expensive queries we're protecting against (e.g. `entities(first: 5000)`)
- * are root-level collection fields. Nested sub-collections (valuesList,
- * relationsList) don't typically accept user-controlled `first` arguments.
+ * This supersedes the earlier `makeWrapResolversPlugin` approach, which per
+ * PostGraphile docs only reliably influences SQL for root-level resolvers —
+ * nested sub-collections were uncapped, which is exactly the pattern
+ * geogenesis' EntityPage hits when a user opens a hub entity like Claim.
  */
-import {makeWrapResolversPlugin} from "graphile-utils"
 import {GraphQLError} from "graphql"
 
 export const MAX_PAGINATION_LIMIT = 1000
@@ -46,9 +47,11 @@ export function assertPaginationWithinLimit(args: Record<string, unknown>) {
 
 /**
  * If the client supplied neither `first` nor `last`, inject `first` set to the
- * cap. This prevents unbounded collection reads from bare queries like
- * `{ entities { id } }`. Returns the original args object when either is set
- * so we don't silently override an explicit `last`-only pagination.
+ * cap. Returns the original args object when either is set so we don't
+ * silently override an explicit `last`-only pagination.
+ *
+ * Kept as a pure helper so unit tests can exercise the policy without
+ * standing up a full PostGraphile schema.
  */
 export function applyDefaultFirstIfOmitted(args: Record<string, unknown>): Record<string, unknown> {
 	const hasFirst = typeof args.first === "number"
@@ -59,18 +62,34 @@ export function applyDefaultFirstIfOmitted(args: Record<string, unknown>): Recor
 	return {...args, first: MAX_PAGINATION_LIMIT}
 }
 
-const PaginationCapPlugin = makeWrapResolversPlugin(
-	(context) => {
-		if (context.scope.isPgFieldConnection || context.scope.isPgFieldSimpleCollection) {
-			return {}
+const PaginationCapPlugin = (builder: any) => {
+	builder.hook("GraphQLObjectType:fields:field:args", (args: any, _build: any, context: any) => {
+		const {
+			scope: {isPgFieldConnection, isPgFieldSimpleCollection},
+			addArgDataGenerator,
+		} = context
+
+		if (!isPgFieldConnection && !isPgFieldSimpleCollection) {
+			return args
 		}
-		return null
-	},
-	() => (resolve, source, args, context, resolveInfo) => {
-		assertPaginationWithinLimit(args)
-		const boundedArgs = applyDefaultFirstIfOmitted(args)
-		return resolve(source, boundedArgs, context, resolveInfo)
-	},
-)
+		if (typeof addArgDataGenerator !== "function") {
+			return args
+		}
+
+		addArgDataGenerator((fieldArgs: {first?: number; last?: number; offset?: number}) => ({
+			pgQuery: (queryBuilder: any) => {
+				assertPaginationWithinLimit(fieldArgs as Record<string, unknown>)
+
+				const hasFirst = typeof fieldArgs.first === "number"
+				const hasLast = typeof fieldArgs.last === "number"
+				if (!hasFirst && !hasLast) {
+					queryBuilder.first(MAX_PAGINATION_LIMIT)
+				}
+			},
+		}))
+
+		return args
+	})
+}
 
 export default PaginationCapPlugin


### PR DESCRIPTION
## Summary
- Extends Byron's pagination cap plugin (#412) to cover **nested connections** and the **omitted-`first` case** — both at every nesting level, not just the root.
- When a client sends a bare collection query like `{ entity(id: ...) { relationsList { ... } } }`, the plugin now **injects `first: 1000`** at every connection / simple-collection field so PostGraphile's SQL always has a `LIMIT` at every lateral.
- Previously, omitting `first` entirely bypassed the cap and returned unbounded results — a single `{ relations(filter: {toEntityId: ...}) { ... } }` call could return 75K+ rows (36.7MB). And even with the top-level cap, nested `entity(id:) { relationsList { ... } }` on a hub entity (e.g. Claim, 75K+ inbound relations) was uncapped because resolver-wrapping only reliably influences root-level SQL.

## What changed
- **Swapped `makeWrapResolversPlugin` for a `graphile-build` hook.** The old plugin used `makeWrapResolversPlugin`, which per PostGraphile docs only reliably influences SQL for root-level resolvers. Nested sub-collections (`Entity.relationsList`, `Entity.valuesList`, `Entity.backlinksList`) were uncapped — which is exactly the pattern geogenesis' `EntityPage` hits when a user opens a hub entity like Claim.
- **New implementation:** hook `GraphQLObjectType:fields:field:args` and register an `addArgDataGenerator` on every connection / simple-collection field. The generator's `pgQuery(queryBuilder)` runs inside SQL construction at the field's own nesting level, so a nested `relationsList` inside an `entity(id:)` selection is capped exactly like a top-level `relations` query.
- Two policies applied uniformly at every level:
  1. `assertPaginationWithinLimit(fieldArgs)` — throws `BAD_USER_INPUT` (400) if `first`/`last`/`offset` > `MAX_PAGINATION_LIMIT` (1000).
  2. If neither `first` nor `last` is supplied, `queryBuilder.first(MAX_PAGINATION_LIMIT)` — so bare sub-collections cannot resolve unbounded.
- Kept `applyDefaultFirstIfOmitted` and `assertPaginationWithinLimit` as pure exports so the existing unit tests still exercise the policy without standing up a full PostGraphile schema.

## Generated SQL (what this actually produces)

For a query like:
```graphql
{ entity(id: "claim") { relationsList { toEntity { valuesList { text } } } } }
```

Every lateral now has its own `LIMIT`:
```sql
SELECT ... FROM entity e WHERE e.id = 'claim'
LEFT JOIN LATERAL (
  SELECT ... FROM relations r WHERE r.to_entity_id = e.id
  LIMIT 1000                   -- ← from relationsList's pgQuery
) rel ON true
LEFT JOIN LATERAL (
  SELECT ... FROM entity te WHERE te.id = rel.from_entity_id
  LEFT JOIN LATERAL (
    SELECT ... FROM values v WHERE v.entity_id = te.id
    LIMIT 1000                 -- ← from valuesList's pgQuery
  ) val ON true
) toe ON true
```

## Behavior change
Clients that previously relied on omitting `first` to fetch every row — at root *or* nested — will now receive at most 1000 rows per level and must paginate.

This is intentional — aligns with the stated goal of #412: "reduce risk of expensive third-party queries overloading the API with unbounded pagination sizes." Oversized explicit values still get `BAD_USER_INPUT` rejects.

## One thing to keep in mind

The cap is **per-parent-row, not global.** A query that matches 500 parent entities with 1000 nested values each still pulls 500,000 rows total. If that ever becomes a problem, the next defense is query cost analysis (e.g. `@escape.tech/graphql-armor` cost-limit) — which multiplies `first * nested_first * nested_nested_first` and rejects over budget at validation time. But for the pattern we're fixing today (one hub entity with 75K relations), per-level `LIMIT` is exactly the right shape.

## Test plan
- [x] Unit tests for `applyDefaultFirstIfOmitted` (missing first, explicit first, last-only, null-input edge cases)
- [x] Unit tests for `assertPaginationWithinLimit` (first/last/offset at and above cap)
- [x] Seeded integration test: inserts 1005 entities, asserts bare `{ entities { id } }` returns exactly 1000
- [x] Same assertion via connection form (`entitiesConnection`)
- [x] Sanity: `first: 50` still returns exactly 50 rows
- [x] Root-level rejection: oversized inline / variable `first` returns 400 `BAD_USER_INPUT`
- [x] Root-level rejection: oversized `last`, `offset` on `entitiesConnection`
- [x] **Nested rejection (new):** oversized `first` on `relationsByFromEntityIdList` inside `entitiesConnection.nodes` returns 400 `BAD_USER_INPUT`
- [x] **Nested rejection (new):** oversized `last` on the same nested field returns 400 `BAD_USER_INPUT`
- [x] All existing tests pass
- [x] `tsc --noEmit` clean