### PR TITLE
chore(monitoring): broaden api capacity alert from 503 to 5xx

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -99,7 +99,7 @@ The observability stack consists of:
 |-------|----------|-----------|-------------|
 | `ApiReadinessDegraded` | warning | <75% of running pods ready for 5m | `kubectl get pods -n api` — check for unready pods |
 | `ApiHpaMaxedWithHighP99` | critical | HPA at max replicas AND p99 > 2s for 10m | Check HPA status and latency dashboard |
-| `Api503RateHigh` | warning | 503 ratio > 2% for 10m | Check API Ingress dashboard failure-class panel |
+| `Api5xxRateHigh` | warning | 5xx ratio > 2% for 10m | Check API Ingress dashboard failure-class panel |
 
 **Config:** [`monitoring/k8s/api-capacity-alerts.yaml`](monitoring/k8s/api-capacity-alerts.yaml)
 

--- a/monitoring/k8s/api-capacity-alerts.yaml
+++ b/monitoring/k8s/api-capacity-alerts.yaml
@@ -38,12 +38,12 @@ spec:
             summary: API HPA is maxed while p99 latency is high
             description: API is at max replicas with sustained p99 latency above 2s.
 
-        - alert: Api503RateHigh
-          expr: api:ingress_503_ratio:rate5m > 0.02
+        - alert: Api5xxRateHigh
+          expr: api:ingress_5xx_ratio:rate5m > 0.02
           for: 10m
           labels:
             severity: warning
             service: api
           annotations:
-            summary: API 503 ratio is elevated
-            description: More than 2% of API ingress requests are returning 503 over 10 minutes.
+            summary: API 5xx ratio is elevated
+            description: More than 2% of API ingress requests are returning 5xx over 10 minutes.


### PR DESCRIPTION
## Summary
  - Rename `Api503RateHigh` → `Api5xxRateHigh` and switch the expression from `api:ingress_503_ratio:rate5m` to `api:ingress_5xx_ratio:rate5m` so the alert catches all server-error classes, not just upstream-unavailable.
  - Threshold (>2%) and `for: 10m` window are unchanged — same sensitivity, wider signal.
  - Update the alerts table in `docs/observability.md` to match.

  ## Why
  503s alone miss 500/502/504 failures that indicate real API degradation. The `api:ingress_5xx_ratio:rate5m` recording rule already exists in `monitoring/k8s/api-ingress-rules.yaml`, so no new recording rules are needed.

  ## Out of scope
  - The HPA still scales on `api_ingress_503_ratio_rate5m` (`api/k8s/production/hpa.yaml`). Left intact 503-specific scaling behavior is deliberate and separate from alerting.

  ## Test plan
  - [ ] `kubectl apply --dry-run=server -f monitoring/k8s/api-capacity-alerts.yaml` succeeds
  - [ ] After deploy, confirm `Api5xxRateHigh` appears in Prometheus `/alerts` and `Api503RateHigh` is gone
  - [ ] Confirm `api:ingress_5xx_ratio:rate5m` returns a value in Prometheus UI