### PR TITLE
fix(api): only shed pool traffic on sustained saturation

### DIFF
--- a/api/src/services/dbSaturation.test.ts
+++ b/api/src/services/dbSaturation.test.ts
@@ -97,11 +97,25 @@ describe("dbSaturation pressure reasons", () => {
 })
 
 describe("dbSaturation load shedding", () => {
-	it("sheds when clients are waiting for a connection", () => {
+	it("does not shed on a momentary waiting client before activation", () => {
 		const poolName = uniquePoolName("waiting")
 		const snapshot = getPoolSaturationSnapshot(poolName, {...baseStats, waitingCount: 1}, 1_000)
 
-		expect(shouldShedPoolTraffic(snapshot)).toBe(true)
+		expect(snapshot.isPressured).toBe(true)
+		expect(snapshot.isSaturated).toBe(false)
+		expect(shouldShedPoolTraffic(snapshot)).toBe(false)
+	})
+
+	it("does not shed on recent acquire timeouts before activation", () => {
+		const poolName = uniquePoolName("timeouts-only")
+		recordPoolAcquireTimeout(poolName, 1_000)
+		recordPoolAcquireTimeout(poolName, 1_500)
+
+		const snapshot = getPoolSaturationSnapshot(poolName, baseStats, 2_000)
+
+		expect(snapshot.reasons).toContain("acquire_timeouts")
+		expect(snapshot.isSaturated).toBe(false)
+		expect(shouldShedPoolTraffic(snapshot)).toBe(false)
 	})
 
 	it("sheds once saturation has activated", () => {
@@ -113,6 +127,22 @@ describe("dbSaturation load shedding", () => {
 
 		expect(snapshot.isSaturated).toBe(true)
 		expect(shouldShedPoolTraffic(snapshot)).toBe(true)
+	})
+
+	it("continues shedding while saturated even after raw signals drop", () => {
+		const poolName = uniquePoolName("sticky-saturated")
+		const pressuredStats: PoolStats = {...baseStats, waitingCount: 1}
+
+		getPoolSaturationSnapshot(poolName, pressuredStats, 10_000)
+		const atSaturation = getPoolSaturationSnapshot(poolName, pressuredStats, 25_000)
+		expect(atSaturation.isSaturated).toBe(true)
+
+		// Signal drops, but release window has not elapsed.
+		const normalStats: PoolStats = {...baseStats, waitingCount: 0}
+		const stillSaturated = getPoolSaturationSnapshot(poolName, normalStats, 30_000)
+		expect(stillSaturated.reasons).toEqual([])
+		expect(stillSaturated.isSaturated).toBe(true)
+		expect(shouldShedPoolTraffic(stillSaturated)).toBe(true)
 	})
 
 	it("does not shed on high utilization alone", () => {
@@ -130,5 +160,19 @@ describe("dbSaturation load shedding", () => {
 
 		expect(snapshot.reasons).toContain("high_utilization")
 		expect(shouldShedPoolTraffic(snapshot)).toBe(false)
+	})
+
+	it("stops shedding after the release window elapses", () => {
+		const poolName = uniquePoolName("release-shed")
+		const pressuredStats: PoolStats = {...baseStats, waitingCount: 1}
+
+		getPoolSaturationSnapshot(poolName, pressuredStats, 10_000)
+		const saturated = getPoolSaturationSnapshot(poolName, pressuredStats, 25_000)
+		expect(shouldShedPoolTraffic(saturated)).toBe(true)
+
+		const normalStats: PoolStats = {...baseStats, waitingCount: 0}
+		const afterRelease = getPoolSaturationSnapshot(poolName, normalStats, 55_001)
+		expect(afterRelease.isSaturated).toBe(false)
+		expect(shouldShedPoolTraffic(afterRelease)).toBe(false)
 	})
 })

--- a/api/src/services/dbSaturation.ts
+++ b/api/src/services/dbSaturation.ts
@@ -193,10 +193,16 @@ export function recordGraphqlAcquireTimeout(nowMs = Date.now()): void {
 	recordPoolAcquireTimeout("graphql", nowMs)
 }
 
+/**
+ * Shed traffic only when saturation has been sustained through the activation
+ * window. Raw `waiting_clients` / `acquire_timeouts` reasons are transient
+ * signals — they advance the saturation FSM so a sustained signal will flip
+ * `isSaturated` — but shedding on them directly bypasses the activation delay
+ * and drops requests on momentary bursts (e.g. `waitingCount=1` for 30ms under
+ * normal bursty traffic). The pool's own `connectionTimeoutMillis` is the
+ * short-circuit fuse for truly stuck acquires; this gate is for sustained
+ * pressure.
+ */
 export function shouldShedPoolTraffic(snapshot: SaturationSnapshot): boolean {
-	return (
-		snapshot.isSaturated ||
-		snapshot.reasons.includes("waiting_clients") ||
-		snapshot.reasons.includes("acquire_timeouts")
-	)
+	return snapshot.isSaturated
 }


### PR DESCRIPTION
## Summary

`shouldShedPoolTraffic` returned true on the raw `waiting_clients` and `acquire_timeouts` reasons in addition to `isSaturated`. That bypassed the 15s `SATURATION_ACTIVATION_MS` window — a single momentary waiter (threshold=1) sheds the current request immediately, even when the pool is lightly loaded.

Prod evidence: **~60-130 `pool_pressure_shed` / minute** (7,732 in a 60m window) with a sampled pool state of `totalConnections: 4/50, utilizationPercent: 8`. The FSM reported `isSaturated: false, reasons: []` at sample time — meaning the sheds came from the direct-reasons OR path firing on sub-second waiters.

## Fix

Gate shedding on `snapshot.isSaturated` only.

- Raw signals still advance the saturation FSM, so sustained pressure still flips `isSaturated` and sheds begin as intended
- Transient bursts no longer drop requests
- The pool's own `connectionTimeoutMillis = 3000` remains the short-circuit fuse for genuinely stuck acquires

## Test plan

- [x] Replaced the prior *"sheds on a momentary waiter"* test (which encoded the bug) with its inverse — pre-activation + `waiting_clients` → **does not shed**
- [x] Added `acquire_timeouts`-only pre-activation case → **does not shed**
- [x] Verified sheds still fire after 15s sustained pressure flips `isSaturated`
- [x] Verified sheds persist across signal dropouts until release window elapses (sticky saturation)
- [x] Verified release window still exits shedding
- [x] `bun run test src/services/dbSaturation.test.ts` — 11 passing
- [x] `bun run check` (tsc) clean
- [x] `bun x biome check` clean on changed files
- [ ] After merge: `graphql.pool_shed` rate (kubectl `grep -c pool_pressure_shed`) should drop by >90% under normal traffic, still spike on genuine saturation

## Follow-ups (not in this PR)

- Observability at the shed site (sampled warn + Sentry counter) — unblocked by this merge
- Consider raising `PG_POOL_PRESSURE_WAITING_THRESHOLD` from 1 → 5 via env once we have shed metrics to validate