### PR TITLE
chore(scoring): increase scoring cronjob memory

### DIFF
--- a/scoring-service/deployment/production/cronjob.yaml
+++ b/scoring-service/deployment/production/cronjob.yaml
@@ -87,8 +87,8 @@ spec:
                       optional: true
               resources:
                 requests:
-                  memory: "2048Mi"
+                  memory: "3072Mi"
                   cpu: "1000m"
                 limits:
-                  memory: "4096Mi"
+                  memory: "6144Mi"
                   cpu: "2000m"

--- a/scoring-service/deployment/production/cronjob.yaml
+++ b/scoring-service/deployment/production/cronjob.yaml
@@ -87,8 +87,8 @@ spec:
                       optional: true
               resources:
                 requests:
-                  memory: "3072Mi"
+                  memory: "4096Mi"
                   cpu: "1000m"
                 limits:
-                  memory: "6144Mi"
+                  memory: "8192Mi"
                   cpu: "2000m"

--- a/scoring-service/deployment/staging/cronjob.yaml
+++ b/scoring-service/deployment/staging/cronjob.yaml
@@ -62,8 +62,8 @@ spec:
                   value: "z_score_sigmoid"
               resources:
                 requests:
-                  memory: "2048Mi"
+                  memory: "3072Mi"
                   cpu: "1000m"
                 limits:
-                  memory: "4096Mi"
+                  memory: "6144Mi"
                   cpu: "2000m"

--- a/scoring-service/deployment/staging/cronjob.yaml
+++ b/scoring-service/deployment/staging/cronjob.yaml
@@ -62,8 +62,8 @@ spec:
                   value: "z_score_sigmoid"
               resources:
                 requests:
-                  memory: "3072Mi"
+                  memory: "4096Mi"
                   cpu: "1000m"
                 limits:
-                  memory: "6144Mi"
+                  memory: "8192Mi"
                   cpu: "2000m"


### PR DESCRIPTION
## Summary
  - The scoring cronjob has been failing for the last couple of days, suspected OOM.
  - Doubles memory request 2Gi→4Gi and limit 4Gi→8Gi in both production and staging to restore successful daily
  runs.

  ## Test plan
  - [ ] CI passes
  - [ ] After merge to `dev`, confirm staging cronjob deploy workflow applies the updated manifest
  - [ ] Observe next staging 3am UTC run completes without OOMKilled
  - [ ] After promoting to `main`, observe next production 3am UTC run completes successfully
  - [ ] Follow-up: open issue to investigate root cause of memory growth