### PR TITLE
fix(api): grouped historical diff returning empty due to microseconds->seconds divisor

### DIFF
--- a/api/src/versioned/__tests__/proposal-diff-timestamp.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-timestamp.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from "vitest"
+import {editCreatedAtToSeconds} from "../proposal-diff"
+
+// Regression: grouped historical proposal diffs were returning empty pages
+// because the conversion from the edit's `createdAt` (microseconds) to the
+// seconds-based timestamp expected by PostgreSQL's `to_timestamp()` used the
+// wrong divisor (1_000 instead of 1_000_000). That made the base-version
+// lookup resolve to ~"now", so the base state already contained the proposal's
+// edits and `diffEntitySnapshots` produced empty results for every entity in
+// the group.
+
+describe("editCreatedAtToSeconds", () => {
+	it("converts exactly one second worth of microseconds to 1 second", () => {
+		expect(editCreatedAtToSeconds(1_000_000n)).toBe(1n)
+	})
+
+	it("converts zero to zero", () => {
+		expect(editCreatedAtToSeconds(0n)).toBe(0n)
+	})
+
+	it("converts a realistic 2024-era timestamp (~1.7e15 µs) to ~1.7e9 s", () => {
+		// 2024-01-01T00:00:00Z ≈ 1_704_067_200 seconds since epoch
+		// = 1_704_067_200_000_000 microseconds
+		expect(editCreatedAtToSeconds(1_704_067_200_000_000n)).toBe(1_704_067_200n)
+	})
+
+	it("truncates sub-second microsecond fragments (floor division)", () => {
+		// 1.5 seconds = 1_500_000 microseconds → 1 second (floor)
+		expect(editCreatedAtToSeconds(1_500_000n)).toBe(1n)
+	})
+})

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -1198,6 +1198,23 @@ export function computeProposalDiff(
 export const MAX_GROUP_SIZE = 20
 
 /**
+ * Convert an edit's `createdAt` to seconds-since-epoch for use with
+ * `resolveVersionKeyBeforeTimestamp` (which calls PostgreSQL `to_timestamp(bigint)`
+ * — seconds input).
+ *
+ * Per the grc-20 `Edit` type, `createdAt` is microseconds since the Unix epoch:
+ *   https://github.com/graphprotocol/grc-20-ts (Edit interface)
+ *
+ * Exported so the conversion is trivially unit-testable — getting the divisor
+ * wrong (e.g. dividing by 1_000 instead of 1_000_000) silently makes historical
+ * grouped-diffs return empty because the base version resolves to "now" and the
+ * diff is computed against already-applied state.
+ */
+export function editCreatedAtToSeconds(microseconds: bigint): bigint {
+	return microseconds / 1_000_000n
+}
+
+/**
  * Ordering rule for grouped-diff ops (RFC 0004): apply in edit-timestamp order
  * ascending, tiebreak by proposalId ascending. Exported so the ordering can be
  * unit-tested without wiring up ipfs + drizzle + decode.
@@ -1360,8 +1377,7 @@ export function computeGroupedProposalDiff(
 		let baseVersionKey: bigint | null = null
 		const firstEdit = decodedEdits[0]
 		if (mode === "historical" && firstEdit) {
-			// createdAt is in microseconds, resolveVersionKeyBeforeTimestamp expects seconds
-			const earliestTimestamp = firstEdit.createdAt / 1000n
+			const earliestTimestamp = editCreatedAtToSeconds(firstEdit.createdAt)
 			baseVersionKey = yield* resolveVersionKeyBeforeTimestamp(db, earliestTimestamp)
 		}
 


### PR DESCRIPTION
## Summary

Grouped historical proposal diffs were silently returning empty pages. Root cause: `computeGroupedProposalDiff` converted the earliest edit's `createdAt` (microseconds, per grc-20 `Edit` spec) to seconds for PostgreSQL's `to_timestamp()` using `/ 1000n` — which gives milliseconds, not seconds. The resulting \"timestamp\" is ~1000× in the future, so `resolveVersionKeyBeforeTimestamp` returns the latest version, `baseStates` already contains the proposal's own edits, and every entity diff comes back empty.

Single-proposal historical diffs were unaffected — `computeProposalDiff` passes `proposal.executedAt ?? proposal.endTime` directly (already in seconds) and never hits this path.

## What changed

- Extracted the conversion into an exported `editCreatedAtToSeconds(µs)` helper so the divisor is obvious and unit-testable.
- Fixed the divisor: `/ 1_000n` → `/ 1_000_000n`.
- New test file `proposal-diff-timestamp.test.ts` with 4 regression cases.

## Staging reproduction

| Endpoint | Before | After fix |
|---|---|---|
| `GET /versioned/proposals/C1/diff?spaceId=SPACE_C` | 2 entities ✅ | unchanged |
| `GET /versioned/proposals/C2/diff?spaceId=SPACE_C` | 2 entities ✅ | unchanged |
| `GET /versioned/proposal-groups/diff?spaceId=SPACE_C&proposalIds=C1,C2` | `{totalEntities:3, entities:[]}` ❌ | `{totalEntities:3, entities:[3 diffs]}` ✅ |

- `C1 = 4c4e8236395de7bdb5c8c5a04736d1fb`
- `C2 = dbe07f8b868079891c431f47d989ca38`
- `SPACE_C = 52c7ae149838b6d47ce0f3b2a5974546`

## Breaking-change risk

Low. Scope is narrow:

- `computeGroupedProposalDiff`, historical mode only (behind `mode === \"historical\"` guard).
- Active mode: unaffected.
- Single-proposal endpoint: unaffected.
- No other call sites of `editCreatedAtToSeconds` (brand-new export).

The endpoint is new (from the `feat/multi-proposal-diff` PR), not a long-lived production surface. Consumers got empty pages for historical groups — this restores the intended behavior. Anyone that built workflow around \"always empty\" would see correct data instead.

## Test plan

- [x] New unit tests in `proposal-diff-timestamp.test.ts` (4 cases) fail against the old divisor and pass with the fix
- [x] Full `src/versioned/` test suite passes (148 tests) excluding DB-backed integration tests that require live Postgres (verified green in CI)
- [x] Typecheck clean
- [ ] After merge: re-verify staging returns non-empty entities for the repro case above