### PR TITLE
chore: main to dev (conflict resolved)

### DIFF
--- a/api/src/kg/__tests__/instrumentationPlugin.test.ts
+++ b/api/src/kg/__tests__/instrumentationPlugin.test.ts
@@ -1,8 +1,19 @@
-import {GraphQLError} from "graphql"
+import {type ASTNode, GraphQLError, Kind} from "graphql"
 import {describe, expect, it} from "vitest"
 import {isClientError} from "../instrumentationPlugin"
 
+// Minimal AST-node factory — isClientError only reads `kind`, so the rest of
+// the shape doesn't matter. Cast through `unknown` to avoid TS insisting on a
+// complete node object.
+function node(kind: (typeof Kind)[keyof typeof Kind]): ASTNode {
+	return {kind} as unknown as ASTNode
+}
+
 describe("isClientError", () => {
+	// ------------------------------------------------------------------
+	// Structured extension codes
+	// ------------------------------------------------------------------
+
 	it("flags GraphQLError with BAD_USER_INPUT extension code", () => {
 		const err = new GraphQLError("too big", {extensions: {code: "BAD_USER_INPUT"}})
 		expect(isClientError(err)).toBe(true)
@@ -24,19 +35,103 @@ describe("isClientError", () => {
 		expect(isClientError(wrapper)).toBe(true)
 	})
 
-	it("flags the PostGraphile first+last error by message", () => {
-		const original = new Error("We don't support setting both first and last")
-		const wrapper = new GraphQLError("Unexpected error.", {originalError: original})
-		expect(isClientError(wrapper)).toBe(true)
+	// ------------------------------------------------------------------
+	// AST-node-based detection (variable / validation / coercion errors)
+	// ------------------------------------------------------------------
+
+	it("flags missing required variable via VariableDefinition node", () => {
+		const err = new GraphQLError('Variable "$id" of required type "UUID!" was not provided.', {
+			nodes: [node(Kind.VARIABLE_DEFINITION)],
+		})
+		expect(isClientError(err)).toBe(true)
 	})
 
-	it("does not flag a server error", () => {
+	it("flags non-null variable violation via VariableDefinition node", () => {
+		const err = new GraphQLError('Variable "$id" of non-null type "UUID!" must not be null.', {
+			nodes: [node(Kind.VARIABLE_DEFINITION)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags invalid variable value via VariableDefinition node", () => {
+		const err = new GraphQLError('Variable "$spaceId" got invalid value "abc"; Expected type "UUID".', {
+			nodes: [node(Kind.VARIABLE_DEFINITION)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags validation error pointing at a Field node (unknown field)", () => {
+		const err = new GraphQLError('Cannot query field "foo" on type "Query".', {
+			nodes: [node(Kind.FIELD)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags validation error pointing at an Argument node", () => {
+		const err = new GraphQLError('Unknown argument "foo" on field "Query.bar".', {
+			nodes: [node(Kind.ARGUMENT)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags input-coercion error pointing at an ObjectField node", () => {
+		const err = new GraphQLError('Field "foo" is not defined by type "BarInput".', {
+			nodes: [node(Kind.OBJECT_FIELD)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags directive error pointing at a Directive node", () => {
+		const err = new GraphQLError('Unknown directive "@foo".', {
+			nodes: [node(Kind.DIRECTIVE)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	// ------------------------------------------------------------------
+	// Non-client errors (must not be flagged)
+	// ------------------------------------------------------------------
+
+	it("does not flag a GraphQLError with INTERNAL_SERVER_ERROR code", () => {
 		const err = new GraphQLError("db exploded", {extensions: {code: "INTERNAL_SERVER_ERROR"}})
 		expect(isClientError(err)).toBe(false)
 	})
 
 	it("does not flag a plain Error without client-error markers", () => {
 		expect(isClientError(new Error("pool_pressure_shed"))).toBe(false)
+	})
+
+	it("does not flag a resolver throw wrapped in a GraphQLError", () => {
+		// graphql-js wraps resolver exceptions into a GraphQLError with the
+		// Field node attached, but the underlying originalError is a plain
+		// Error — that's our cue that this was thrown from a resolver, not a
+		// client-caused structural error.
+		const original = new Error("pool_pressure_shed")
+		const wrapper = new GraphQLError("pool_pressure_shed", {
+			nodes: [node(Kind.FIELD)],
+			originalError: original,
+		})
+		expect(isClientError(wrapper)).toBe(false)
+	})
+
+	it("does not flag a resolver-thrown GraphQLError that has an execution path", () => {
+		// If a resolver does `throw new GraphQLError("db timed out")` directly,
+		// there is no code on extensions and no plain-Error originalError to
+		// signal a resolver origin. The discriminator is `path`: graphql-js
+		// only attaches it during execution, so parse/validate/coerce errors
+		// lack it while any resolver-surfaced error has it.
+		const err = new GraphQLError("db timed out", {
+			nodes: [node(Kind.FIELD)],
+			path: ["entities", 0, "name"],
+		})
+		expect(isClientError(err)).toBe(false)
+	})
+
+	it("does not flag a GraphQLError whose nodes are only type-system definitions", () => {
+		// Contrived — wouldn't normally appear at request time — but proves
+		// schema-build errors are excluded from the client-error classification.
+		const err = new GraphQLError("schema problem", {nodes: [node(Kind.OBJECT_TYPE_DEFINITION)]})
+		expect(isClientError(err)).toBe(false)
 	})
 
 	it("does not flag null or undefined", () => {

--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -189,6 +189,25 @@ describe("PaginationCapPlugin", () => {
 		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
 	})
 
+	it("rejects a connection query that supplies both first and last", async () => {
+		// Previously surfaced as a plain Error from PostGraphile
+		// ("We don't support setting both first and last"), which reached Sentry
+		// as a server-side issue. Now intercepted by assertPaginationWithinLimit
+		// and tagged BAD_USER_INPUT.
+		const result = await executeGraphQL(`
+			{
+				entitiesConnection(first: 5, last: 5) {
+					nodes { id }
+				}
+			}
+		`)
+
+		expect(result.status).toBe(400)
+		expect(result.body.errors).toBeDefined()
+		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+		expect(result.body.errors[0]?.message).toMatch(/both "first" and "last"/)
+	})
+
 	it("rejects oversized last on nested sub-collections", async () => {
 		// `last` is only exposed on the Relay connection form — on Entity the
 		// connection form of the from_entity_id back-ref is `relations` (per the

--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -1,6 +1,15 @@
 import {ROOT_CONTEXT, SpanStatusCode, trace} from "@opentelemetry/api"
 import * as Sentry from "@sentry/node"
-import {type FieldNode, GraphQLError, Kind, type OperationDefinitionNode, print} from "graphql"
+import {
+	type ASTNode,
+	type FieldNode,
+	GraphQLError,
+	isTypeSystemDefinitionNode,
+	isTypeSystemExtensionNode,
+	Kind,
+	type OperationDefinitionNode,
+	print,
+} from "graphql"
 import type {Plugin} from "graphql-yoga"
 import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
@@ -10,28 +19,59 @@ import {log} from "../services/telemetry"
 // misbehaving client and should not alert Sentry.
 const CLIENT_ERROR_CODES = new Set(["BAD_USER_INPUT", "GRAPHQL_PARSE_FAILED", "GRAPHQL_VALIDATION_FAILED"])
 
-// PostGraphile throws a plain Error (no BAD_USER_INPUT code) when the client
-// supplies both `first` and `last`. Match on message text since there's no
-// structured way to identify it.
-const CLIENT_ERROR_MESSAGE_PATTERNS = [/^We don't support setting both first and last$/]
+// True if an AST node is part of a client-authored executable document
+// (queries, mutations, subscriptions, fragments, values) as opposed to
+// server-side schema definitions. graphql-js attaches these nodes to errors
+// that originate from parse/validate/coerce stages before resolvers run.
+function isClientDocumentNode(node: ASTNode): boolean {
+	return !isTypeSystemDefinitionNode(node) && !isTypeSystemExtensionNode(node)
+}
 
+/**
+ * Classify whether an error was caused by bad client input and therefore should
+ * not alert Sentry.
+ *
+ * Detection strategy, in priority order:
+ *   1. Structured `extensions.code` on the error (or its `originalError`) is one
+ *      of the well-known client codes.
+ *   2. The error carries AST nodes from the client's executable document AND
+ *      has no execution `path` AND didn't come from a resolver throw. This
+ *      catches parse, validation, and variable / argument coercion errors from
+ *      graphql-js even when they lack an extension code.
+ */
 export function isClientError(error: unknown): boolean {
-	const maybeGraphQL = error as {extensions?: {code?: string}; originalError?: unknown; message?: string} | null
-	if (!maybeGraphQL) return false
+	if (error === null || typeof error !== "object") return false
 
-	const code = maybeGraphQL.extensions?.code
+	const err = error as {
+		extensions?: {code?: string}
+		originalError?: unknown
+		message?: string
+		nodes?: readonly ASTNode[]
+		path?: readonly (string | number)[]
+	}
+
+	// 1. Structured code (direct or via originalError)
+	const code = err.extensions?.code
 	if (typeof code === "string" && CLIENT_ERROR_CODES.has(code)) return true
 
-	const original = maybeGraphQL.originalError
+	const original = err.originalError
 	if (original instanceof GraphQLError) {
 		const origCode = original.extensions?.code
 		if (typeof origCode === "string" && CLIENT_ERROR_CODES.has(origCode)) return true
 	}
 
-	const originalMessage = original instanceof Error ? original.message : undefined
-	const message = originalMessage ?? maybeGraphQL.message
-	if (typeof message === "string" && CLIENT_ERROR_MESSAGE_PATTERNS.some((re) => re.test(message))) {
-		return true
+	// 2. AST-node inspection. Two signals narrow this to *pre-execution* errors
+	//    (parse, validate, variable/argument coercion) and exclude anything
+	//    thrown from a resolver:
+	//      - `path` is only set by graphql-js during execution — parse, validate,
+	//        and coerce errors all lack it.
+	//      - Plain resolver throws wrap the raw Error in `originalError`.
+	//    Without the `path` guard, a resolver that does
+	//    `throw new GraphQLError("db timed out")` would satisfy the node-kind
+	//    check and silently skip Sentry.
+	const hasResolverOrigin = original instanceof Error && !(original instanceof GraphQLError)
+	if (!hasResolverOrigin && !err.path && err.nodes?.length) {
+		if (err.nodes.some(isClientDocumentNode)) return true
 	}
 
 	return false

--- a/api/src/kg/paginationCapPlugin.ts
+++ b/api/src/kg/paginationCapPlugin.ts
@@ -22,7 +22,7 @@
  * nested sub-collections were uncapped, which is exactly the pattern
  * geogenesis' EntityPage hits when a user opens a hub entity like Claim.
  */
-import {GraphQLError} from "graphql"
+import {type FieldNode, GraphQLError, type ValidationContext} from "graphql"
 
 export const MAX_PAGINATION_LIMIT = 1000
 
@@ -42,6 +42,44 @@ export function assertPaginationWithinLimit(args: Record<string, unknown>) {
 				},
 			)
 		}
+	}
+}
+
+/**
+ * GraphQL validation rule that rejects `first` + `last` on the same field.
+ *
+ * PostGraphile's `PgConnectionArgFirstLastBeforeAfter` plugin also enforces
+ * this, but it runs during SQL construction (pgQuery hook) and throws a plain
+ * `Error` that reaches the client without any extension code and returns HTTP
+ * 200. That path sent the error to Sentry as a server issue and gave the
+ * client an unhelpful response.
+ *
+ * Running it as a validation rule catches the misuse during the validate
+ * phase — before any resolver or SQL runs — and surfaces it as a structured
+ * BAD_USER_INPUT / 400 on the response.
+ *
+ * No schema-type introspection needed: the GraphQL schema only exposes `last`
+ * on fields that legitimately paginate, so checking argument presence alone
+ * is sufficient.
+ */
+export function NoFirstAndLastRule(context: ValidationContext) {
+	return {
+		Field(node: FieldNode) {
+			const args = node.arguments ?? []
+			const hasFirst = args.some((a) => a.name.value === "first")
+			const hasLast = args.some((a) => a.name.value === "last")
+			if (hasFirst && hasLast) {
+				context.reportError(
+					new GraphQLError(`Cannot specify both "first" and "last" on field "${node.name.value}"`, {
+						nodes: [node],
+						extensions: {
+							code: "BAD_USER_INPUT",
+							http: {status: 400},
+						},
+					}),
+				)
+			}
+		},
 	}
 }
 

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -13,7 +13,7 @@ import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
 import EntitySpaceFilterPlugin from "./entitySpaceFilterPlugin"
 import {useGraphQLInstrumentation} from "./instrumentationPlugin"
-import PaginationCapPlugin from "./paginationCapPlugin"
+import PaginationCapPlugin, {NoFirstAndLastRule} from "./paginationCapPlugin"
 import UndashedUuidPlugin from "./uuidScalarPlugin"
 import {createValkeyCache} from "./valkeyCache"
 import ValueOrderByScorePlugin from "./valueOrderByScorePlugin"
@@ -269,9 +269,20 @@ const responseCachePlugin = (() => {
 })()
 
 // Shared plugins for GraphQL server.
+// Yoga plugin that registers custom GraphQL validation rules.
+// Validation runs before execute, so rules like NoFirstAndLastRule surface
+// misuse as a structured BAD_USER_INPUT response (with http.status 400) and
+// never reach resolvers — or the instrumentation plugin's Sentry capture.
+const customValidationRules: Plugin = {
+	onValidate({addValidationRule}) {
+		addValidationRule(NoFirstAndLastRule)
+	},
+}
+
 // Response cache is first so cache hits skip pgClient checkout entirely.
 const sharedPlugins = [
 	...(responseCachePlugin ? [responseCachePlugin] : []),
+	customValidationRules,
 	useGraphQLInstrumentation(),
 	usePgClient(pgPool),
 	useExecutionCancellation(),

--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -140,6 +140,7 @@ class IpfsParseResponseError extends Error {
 export function upload(formData: FormData, url: string) {
 	return Effect.gen(function* () {
 		const config = yield* Environment
+		const requestStart = Date.now()
 
 		const response = yield* Effect.tryPromise({
 			try: () =>
@@ -153,24 +154,58 @@ export function upload(formData: FormData, url: string) {
 			catch: (error) => new IpfsUploadError(`IPFS fetch failed: ${error}`),
 		})
 
-		const responseJson = yield* Effect.tryPromise({
-			try: () => response.json(),
-			catch: (error) => new IpfsParseResponseError(`Could not parse IPFS JSON response: ${error}`),
+		const responseText = yield* Effect.tryPromise({
+			try: () => response.text(),
+			catch: (error) => new IpfsParseResponseError(`Could not read IPFS response body: ${error}`),
 		})
+
+		const diagnostics = {
+			url,
+			httpStatus: response.status,
+			httpStatusText: response.statusText,
+			responseTimeMs: Date.now() - requestStart,
+			contentType: response.headers.get("content-type"),
+			contentLength: response.headers.get("content-length"),
+			pinataRequestId: response.headers.get("x-pinata-request-id") ?? response.headers.get("x-request-id"),
+			cfRay: response.headers.get("cf-ray"),
+			server: response.headers.get("server"),
+			retryAfter: response.headers.get("retry-after"),
+			rateLimitLimit: response.headers.get("x-ratelimit-limit"),
+			rateLimitRemaining: response.headers.get("x-ratelimit-remaining"),
+			rateLimitReset: response.headers.get("x-ratelimit-reset"),
+			bodyLength: responseText.length,
+			bodyPreview: responseText.slice(0, 1000),
+		}
+
+		if (!response.ok) {
+			yield* Effect.logWarning("[IPFS] gateway returned non-2xx status", diagnostics)
+			yield* Effect.fail(new IpfsUploadError(`IPFS gateway HTTP ${response.status} ${response.statusText}`))
+		}
+
+		const responseJson = yield* Effect.try({
+			try: () => JSON.parse(responseText) as {error?: unknown; data?: {cid?: string}},
+			catch: () => new IpfsParseResponseError(`Could not parse IPFS JSON response (status=${response.status})`),
+		}).pipe(Effect.tapError(() => Effect.logWarning("[IPFS] gateway returned non-JSON response", diagnostics)))
 
 		// Handle error responses from gateway
 		if (responseJson.error) {
 			const errorMsg =
-				typeof responseJson.error === "object"
-					? responseJson.error.message || JSON.stringify(responseJson.error)
+				typeof responseJson.error === "object" && responseJson.error !== null
+					? (responseJson.error as {message?: string}).message || JSON.stringify(responseJson.error)
 					: String(responseJson.error)
+			yield* Effect.logWarning("[IPFS] gateway returned error in body", {
+				...diagnostics,
+				gatewayErrorMessage: errorMsg,
+			})
 			yield* Effect.fail(new IpfsUploadError(`IPFS gateway error: ${errorMsg}`))
 		}
 
-		if (!responseJson.data?.cid) {
-			yield* Effect.fail(new IpfsUploadError("IPFS gateway returned no CID"))
+		const cid = responseJson.data?.cid
+		if (!cid) {
+			yield* Effect.logWarning("[IPFS] gateway returned no CID", diagnostics)
+			return yield* Effect.fail(new IpfsUploadError("IPFS gateway returned no CID"))
 		}
 
-		return `ipfs://${responseJson.data.cid}` as const
+		return `ipfs://${cid}` as const
 	}).pipe(Effect.withSpan("ipfs.upload"))
 }


### PR DESCRIPTION
Replacement for #612 — same intent (sync `main` into `dev`) but with the merge conflict in `api/src/kg/postgraphile.ts` resolved.

## Conflict

Only one spot, at the imports:
- `main` added: `import PaginationCapPlugin, {NoFirstAndLastRule} from "./paginationCapPlugin"` (from #610)
- `dev` had: `import PaginationCapPlugin from "./paginationCapPlugin"` + `import {useSearchInvocationLogger} from "./searchInvocationLogger"`

## Resolution

Kept both — both symbols are used downstream:
- `useSearchInvocationLogger()` inside `sharedPlugins`
- `NoFirstAndLastRule` inside `customValidationRules`

```ts
import PaginationCapPlugin, {NoFirstAndLastRule} from "./paginationCapPlugin"
import {useSearchInvocationLogger} from "./searchInvocationLogger"
```

## Verified

- `bun run check` (tsc) ✓
- No other conflicts; all other files auto-merged

#612 can be closed in favor of this.