### PR TITLE
feat(api): phase 1 GraphQL query cost logger + Prometheus monitoring (shadow mode)

### DIFF
--- a/api/src/health.ts
+++ b/api/src/health.ts
@@ -1,5 +1,6 @@
 import {Hono} from "hono"
 import {describeRoute} from "hono-openapi"
+import {renderQueryCostHistogram} from "./kg/costLoggerPlugin"
 import {getGraphqlPoolPressure, getGraphqlPoolStats} from "./kg/postgraphile"
 import {db, getPoolStats} from "./services/storage/storage"
 import {log} from "./services/telemetry"
@@ -113,6 +114,9 @@ function renderPrometheusMetrics(): string {
 			"Recent GraphQL/PostGraphile pool acquire timeouts inside the configured moving window.",
 			graphqlPoolPressure.recentAcquireTimeouts,
 		),
+		// GraphQL query cost histogram (accumulated since process start;
+		// Prometheus derives time-windowed views via rate / histogram_quantile).
+		renderQueryCostHistogram(),
 	].join("\n")
 }
 

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -77,11 +77,11 @@ describe("computeQueryCost — pagination", () => {
 	})
 
 	it("catches implicit-default heavy queries that omit `first`", () => {
-		// Previously under-counted — now a nested un-paginated query correctly
-		// scales with the MAX default at each level.
-		// innermost: valuesList { propertyId text }  → MAX × 2 + 1 = 2001
-		// entity { id valuesList }                    → MAX × (1 + 2001) + 1 = 2_002_001
-		// entities { id entity { ... } }              → MAX × (1 + 2_002_001) + 1 = 2_002_002_001
+		// Previously under-counted — now a nested un-paginated query scales
+		// with the MAX default at each level. Math: innermost valuesList{2 scalars}
+		// would be MAX × 2 + 1 = 2001, then entity { id valuesList } → MAX × 2002 + 1,
+		// etc. Crosses the 1B cap at 3 levels of implicit defaults, so the walker
+		// clamps to MAX_COST_CALC_LIMIT rather than drifting toward Infinity.
 		const result = cost(`{
 			entities {
 				id
@@ -90,7 +90,7 @@ describe("computeQueryCost — pagination", () => {
 				}
 			}
 		}`)
-		expect(result).toBeGreaterThan(1_000_000_000) // billions — real SQL fan-out is huge
+		expect(result).toBe(1_000_000_000)
 	})
 })
 
@@ -224,5 +224,143 @@ describe("query cost histogram", () => {
 			},
 		})
 		expect(renderQueryCostHistogram()).toContain("gaia_api_graphql_query_cost_count 0")
+	})
+})
+
+// --------------------------------------------------------------------------
+// Safety invariants — the plugin must never throw into yoga (shadow mode
+// must not break the request it was observing), and the cost math must
+// never produce Infinity / NaN regardless of input.
+// --------------------------------------------------------------------------
+
+const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "1000000000", 10)
+
+describe("computeQueryCost — cap & overflow protection", () => {
+	it("caps at MAX_COST_CALC_LIMIT (1B default) on an otherwise-astronomical query", () => {
+		// 6 nested levels of first:1000 would mathematically be 1000^6 = 1e18
+		// (way past Number.MAX_SAFE_INTEGER). With the cap in place the walker
+		// bails as soon as the running total crosses 1B.
+		const query = `
+			{
+				entities(first: 1000) {
+					a: entities(first: 1000) {
+						b: entities(first: 1000) {
+							c: entities(first: 1000) {
+								d: entities(first: 1000) {
+									e: entities(first: 1000) { id }
+								}
+							}
+						}
+					}
+				}
+			}
+		`
+		expect(cost(query)).toBe(MAX_COST_CALC_LIMIT)
+	})
+
+	it("stops accumulating once a sibling pushes past the cap", () => {
+		// The first branch alone exceeds the cap; the second branch shouldn't
+		// be walked at all. Observable effect: result is exactly the cap.
+		const query = `
+			{
+				first_branch: entities(first: 1000) {
+					a: entities(first: 1000) {
+						b: entities(first: 1000) {
+							c: entities(first: 1000) { id }
+						}
+					}
+				}
+				second_branch: entities(first: 1000) { id }
+			}
+		`
+		expect(cost(query)).toBe(MAX_COST_CALC_LIMIT)
+	})
+
+	it("never returns Infinity or NaN, even on pathologically deep inputs", () => {
+		// Build a synthetic query 50 levels deep, each with first:1000.
+		let q = "{ id }"
+		for (let i = 0; i < 50; i++) {
+			q = `{ entities(first: 1000) ${q} }`
+		}
+		const c = cost(q)
+		expect(Number.isFinite(c)).toBe(true)
+		expect(c).toBeLessThanOrEqual(MAX_COST_CALC_LIMIT)
+	})
+
+	it("handles a deeply-nested legit query without stack overflow", () => {
+		// 30-level nesting (realistic upper bound for client queries). Should
+		// return cleanly regardless of whether it hits the cap.
+		let q = "{ id }"
+		for (let i = 0; i < 30; i++) {
+			q = `{ entity(id: "x") ${q} }`
+		}
+		expect(() => cost(q)).not.toThrow()
+	})
+})
+
+describe("computeQueryCost — fragment cycles", () => {
+	it("returns cleanly on a fragment-spread cycle (A → B → A)", () => {
+		// NoFragmentCycles validation would normally reject this before
+		// execute, but we defend against an upstream plugin skipping validation.
+		const doc = `
+			query Q { ...A }
+			fragment A on Query { ...B }
+			fragment B on Query { ...A }
+		`
+		expect(() => cost(doc)).not.toThrow()
+		// Cost is 0 — the cycle is cut on second visit and neither fragment
+		// selects any concrete field. The important thing is that it terminates.
+		expect(cost(doc)).toBe(0)
+	})
+
+	it("allows a fragment to be used multiple times at sibling positions (not a cycle)", () => {
+		// Visited fragments are popped after each recursion, so the same
+		// fragment legitimately included twice as siblings does not get cut.
+		const doc = `
+			query Q { ...F ...F }
+			fragment F on Query { a: __typename b: __typename }
+		`
+		// two sibling spreads × (a + b = 2 scalars) = 4
+		expect(cost(doc)).toBe(4)
+	})
+})
+
+describe("useCostLogger — shadow-mode safety", () => {
+	it("does not throw when the cost walker throws", async () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		// Hand the plugin a malformed document so computeQueryCost throws on
+		// the definitions.find lookup. The plugin should swallow, not rethrow.
+		expect(() =>
+			onExecute({
+				args: {
+					// biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
+					document: null as any,
+					variableValues: {},
+					operationName: null,
+				},
+			}),
+		).not.toThrow()
+	})
+
+	it("does not throw when the high-cost log path throws", async () => {
+		// Fake a variable that JSON.stringify can't serialize (circular ref).
+		// The log call inside the plugin's high-cost branch would normally
+		// blow up; the outer try/catch must keep the request flowing.
+		const circular: Record<string, unknown> = {}
+		circular.self = circular
+
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		// A query guaranteed to cross the default 1M log threshold.
+		expect(() =>
+			onExecute({
+				args: {
+					document: parse(`{ entities(first: 1000) { relationsList { id } } }`),
+					variableValues: {circular},
+					operationName: null,
+				},
+			}),
+		).not.toThrow()
 	})
 })

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -1,0 +1,146 @@
+import {parse} from "graphql"
+import {describe, expect, it} from "vitest"
+import {computeQueryCost} from "../costLoggerPlugin"
+import {MAX_PAGINATION_LIMIT} from "../paginationCapPlugin"
+
+const cost = (query: string, variables: Record<string, unknown> = {}) => computeQueryCost(parse(query), variables)
+
+describe("computeQueryCost — basic shapes", () => {
+	it("scalar-only operation → 1", () => {
+		expect(cost(`{ __typename }`)).toBe(1)
+	})
+
+	it("object field with no pagination args → sum of children + 1", () => {
+		// Single-entity lookup (no first/last): not multiplied.
+		// entity { id name } → (1 + 1) + 1 = 3
+		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(3)
+	})
+})
+
+describe("computeQueryCost — pagination", () => {
+	it("first:50 selecting id → 51", () => {
+		expect(cost(`{ entities(first: 50) { id } }`)).toBe(51)
+	})
+
+	it("first:100 selecting id + name → 201", () => {
+		expect(cost(`{ entities(first: 100) { id name } }`)).toBe(201)
+	})
+
+	it("last on root collection honored", () => {
+		expect(cost(`{ entities(last: 25) { id } }`)).toBe(26)
+	})
+
+	it("nested list multiplies correctly", () => {
+		// inner relations(first:10){id} = 11
+		// outer entities(first:20){id + inner} = 20 × (1 + 11) + 1 = 241
+		expect(
+			cost(`{
+				entities(first: 20) {
+					id
+					relations(first: 10) { id }
+				}
+			}`),
+		).toBe(241)
+	})
+
+	it("models the slow-query pattern that triggered prod statement_timeout", () => {
+		// 1000-entity outer × 5 relation sub-collections × 50 each × 2 nested entity fields
+		// matches the real shape we saw timing out.
+		// inner per-sub-collection: 50 × (1 + (1 + 1)) + 1 ... we'll just compute raw:
+		// { id, entity { valuesList(first:1){propertyId} } } = 1 + (1*1+1 + 1) = 4
+		// sub-collection(first:50){...} = 50 × 4 + 1 = 201
+		// 5 of those + id = 5 × 201 + 1 = 1006 per outer entity
+		// entities(first:1000){...} = 1000 × 1006 + 1 = 1_006_001
+		const query = `
+			{
+				entities(first: 1000) {
+					id
+					a: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
+					b: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
+					c: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
+					d: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
+					e: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
+				}
+			}
+		`
+		const result = cost(query)
+		expect(result).toBe(1_006_001)
+		expect(result).toBeGreaterThan(100_000) // would trivially exceed any sane threshold
+	})
+})
+
+describe("computeQueryCost — defensive handling of bogus inputs", () => {
+	it("first:0 uses MAX_PAGINATION_LIMIT (defensive)", () => {
+		// Otherwise an attacker could hide expensive nested work behind first:0
+		// (which at SQL time returns nothing, but is atypical in legit traffic).
+		expect(cost(`{ entities(first: 0) { id } }`)).toBe(MAX_PAGINATION_LIMIT * 1 + 1)
+	})
+
+	it("negative first uses MAX_PAGINATION_LIMIT", () => {
+		expect(cost(`{ entities(first: -5) { id } }`)).toBe(MAX_PAGINATION_LIMIT + 1)
+	})
+
+	it("negative last uses MAX_PAGINATION_LIMIT", () => {
+		expect(cost(`{ entities(last: -100) { id } }`)).toBe(MAX_PAGINATION_LIMIT + 1)
+	})
+
+	it("negative outer first still charges for valid nested first", () => {
+		// Attack shape: user tries to hide expensive inner behind first:-5 outer.
+		// Inner relations(first:50){id} = 51.
+		// Outer entities(first:-5) → MAX × (1 + 51) + 1 = 52_001
+		expect(
+			cost(`{
+				entities(first: -5) {
+					id
+					relations(first: 50) { id }
+				}
+			}`),
+		).toBe(MAX_PAGINATION_LIMIT * 52 + 1)
+	})
+})
+
+describe("computeQueryCost — variables", () => {
+	it("resolves pagination args supplied via variables", () => {
+		expect(cost(`query Q($first: Int!) { entities(first: $first) { id } }`, {first: 100})).toBe(101)
+	})
+
+	it("treats missing variable as no valid pagination → MAX", () => {
+		expect(
+			cost(
+				`query Q($first: Int) { entities(first: $first) { id } }`,
+				{}, // $first unresolved
+			),
+		).toBe(MAX_PAGINATION_LIMIT + 1)
+	})
+})
+
+describe("computeQueryCost — fragments", () => {
+	it("inline fragments contribute to parent's childComplexity", () => {
+		// entities(first:10) { ... on Entity { id name } }
+		// inline frag selections = 2 → outer = 10 × 2 + 1 = 21
+		expect(
+			cost(`{
+				entities(first: 10) {
+					... on Entity { id name }
+				}
+			}`),
+		).toBe(21)
+	})
+
+	it("fragment spreads follow the definition", () => {
+		// fragment F on Entity { id name }
+		// entities(first:10) { ...F } → 10 × 2 + 1 = 21
+		expect(
+			cost(`
+				query { entities(first: 10) { ...F } }
+				fragment F on Entity { id name }
+			`),
+		).toBe(21)
+	})
+})
+
+describe("computeQueryCost — empty / edge", () => {
+	it("returns 0 for a document with no operation", () => {
+		expect(cost(`fragment Unused on Query { __typename }`)).toBe(0)
+	})
+})

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -1,6 +1,11 @@
 import {parse} from "graphql"
-import {describe, expect, it} from "vitest"
-import {computeQueryCost} from "../costLoggerPlugin"
+import {beforeEach, describe, expect, it} from "vitest"
+import {
+	__resetQueryCostHistogramForTests,
+	computeQueryCost,
+	renderQueryCostHistogram,
+	useCostLogger,
+} from "../costLoggerPlugin"
 import {MAX_PAGINATION_LIMIT} from "../paginationCapPlugin"
 
 const cost = (query: string, variables: Record<string, unknown> = {}) => computeQueryCost(parse(query), variables)
@@ -162,5 +167,62 @@ describe("computeQueryCost — fragments", () => {
 describe("computeQueryCost — empty / edge", () => {
 	it("returns 0 for a document with no operation", () => {
 		expect(cost(`fragment Unused on Query { __typename }`)).toBe(0)
+	})
+})
+
+// --------------------------------------------------------------------------
+// Prometheus histogram exposed via /health/metrics
+// --------------------------------------------------------------------------
+
+describe("query cost histogram", () => {
+	beforeEach(() => {
+		__resetQueryCostHistogramForTests()
+	})
+
+	it("empty state emits zero-counts for all buckets", () => {
+		const out = renderQueryCostHistogram()
+		expect(out).toMatch(/# TYPE gaia_api_graphql_query_cost histogram/)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 0/)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_count 0/)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_sum 0/)
+	})
+
+	it("each recorded query increments the right buckets cumulatively", async () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		const runQuery = (query: string, variables: Record<string, unknown> = {}) => {
+			onExecute({
+				args: {document: parse(query), variableValues: variables, operationName: null},
+			})
+		}
+
+		// Cost 51 → should hit le=100, le=1000, ..., le=+Inf (all ≥ 51)
+		runQuery(`{ entities(first: 50) { id } }`)
+		// Cost 1001 → hits le=10_000, le=100_000, ..., le=+Inf (buckets ≥ 1001)
+		runQuery(`{ entities { id } }`)
+
+		const out = renderQueryCostHistogram()
+		expect(out).toContain("gaia_api_graphql_query_cost_count 2")
+		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${51 + 1001}`)
+		// le=100: only the cost=51 observation qualifies
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="100"} 1$/m)
+		// le=1000: still only cost=51 (1001 > 1000)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="1000"} 1$/m)
+		// le=10000: both observations
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="10000"} 2$/m)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 2$/m)
+	})
+
+	it("skips introspection queries", async () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		onExecute({
+			args: {
+				document: parse(`{ __typename }`),
+				variableValues: {},
+				operationName: "IntrospectionQuery",
+			},
+		})
+		expect(renderQueryCostHistogram()).toContain("gaia_api_graphql_query_cost_count 0")
 	})
 })

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -10,10 +10,14 @@ describe("computeQueryCost — basic shapes", () => {
 		expect(cost(`{ __typename }`)).toBe(1)
 	})
 
-	it("object field with no pagination args → sum of children + 1", () => {
-		// Single-entity lookup (no first/last): not multiplied.
-		// entity { id name } → (1 + 1) + 1 = 3
-		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(3)
+	it("structured field without first/last defaults to MAX (conservative)", () => {
+		// Single-entity lookups get over-counted — intentionally. We never know
+		// from the AST alone whether a field is a list or a single object; the
+		// SQL layer injects first=MAX on every collection field anyway, so
+		// over-counting single-entity lookups is the price of never missing an
+		// unbounded collection.
+		// entity { id name } → MAX × (1 + 1) + 1 = 2001
+		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(MAX_PAGINATION_LIMIT * 2 + 1)
 	})
 })
 
@@ -44,13 +48,12 @@ describe("computeQueryCost — pagination", () => {
 	})
 
 	it("models the slow-query pattern that triggered prod statement_timeout", () => {
-		// 1000-entity outer × 5 relation sub-collections × 50 each × 2 nested entity fields
-		// matches the real shape we saw timing out.
-		// inner per-sub-collection: 50 × (1 + (1 + 1)) + 1 ... we'll just compute raw:
-		// { id, entity { valuesList(first:1){propertyId} } } = 1 + (1*1+1 + 1) = 4
-		// sub-collection(first:50){...} = 50 × 4 + 1 = 201
-		// 5 of those + id = 5 × 201 + 1 = 1006 per outer entity
-		// entities(first:1000){...} = 1000 × 1006 + 1 = 1_006_001
+		// The real shape we saw timing out, computed with the conservative model:
+		//   valuesList(first:1){propertyId}        = 1 × 1 + 1                  = 2
+		//   entity { valuesList }                  = MAX × 2 + 1                = 2001
+		//   relations(first:50) { id, entity }     = 50 × (1 + 2001) + 1        = 100_101
+		//   5 × 100_101 + 1 (id on entity)         = 500_506
+		//   entities(first:1000) { ... }           = 1000 × 500_506 + 1         = 500_506_001
 		const query = `
 			{
 				entities(first: 1000) {
@@ -64,8 +67,25 @@ describe("computeQueryCost — pagination", () => {
 			}
 		`
 		const result = cost(query)
-		expect(result).toBe(1_006_001)
-		expect(result).toBeGreaterThan(100_000) // would trivially exceed any sane threshold
+		expect(result).toBe(500_506_001)
+		expect(result).toBeGreaterThan(100_000_000) // trivially exceeds any threshold
+	})
+
+	it("catches implicit-default heavy queries that omit `first`", () => {
+		// Previously under-counted — now a nested un-paginated query correctly
+		// scales with the MAX default at each level.
+		// innermost: valuesList { propertyId text }  → MAX × 2 + 1 = 2001
+		// entity { id valuesList }                    → MAX × (1 + 2001) + 1 = 2_002_001
+		// entities { id entity { ... } }              → MAX × (1 + 2_002_001) + 1 = 2_002_002_001
+		const result = cost(`{
+			entities {
+				id
+				relationsList {
+					toEntity { valuesList { propertyId text } }
+				}
+			}
+		}`)
+		expect(result).toBeGreaterThan(1_000_000_000) // billions — real SQL fan-out is huge
 	})
 })
 

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -1,0 +1,198 @@
+import * as Sentry from "@sentry/node"
+import {
+	type ArgumentNode,
+	type DocumentNode,
+	type FieldNode,
+	type FragmentDefinitionNode,
+	Kind,
+	type OperationDefinitionNode,
+	print,
+	type SelectionSetNode,
+	type ValueNode,
+} from "graphql"
+import type {Plugin} from "graphql-yoga"
+import {graphqlQueryFingerprint} from "../services/queryFingerprint"
+import {log} from "../services/telemetry"
+import {MAX_PAGINATION_LIMIT} from "./paginationCapPlugin"
+
+// Threshold above which we warn (log + Sentry issue). Phase 1 tuning knob —
+// start conservative, then re-tune from observed distribution.
+const COST_WARN_THRESHOLD = Number.parseInt(process.env.GRAPHQL_COST_WARN_THRESHOLD ?? "10000", 10)
+
+/**
+ * Compute a query complexity score from the operation AST alone.
+ *
+ * Cost model, per field:
+ *   - with an explicit first/last arg → `child × limit + 1` (limit clamped to
+ *     MAX_PAGINATION_LIMIT if non-positive / non-finite, matching what
+ *     PaginationCapPlugin injects at SQL-build time and closing the bogus-arg
+ *     attack vector).
+ *   - no pagination arg, has selections → `child + 1` (treated as an object).
+ *   - no pagination arg, no selections → 1 (scalar).
+ *
+ * Intentionally schema-free: walking only the document + variables means this
+ * works regardless of which `graphql` module instance built the schema
+ * (PostGraphile v4 bundles its own copy). That's the only way to use
+ * graphql-js type introspection here without hitting instanceof failures
+ * across CJS/ESM module boundaries.
+ *
+ * Known limitation: simple-collection fields called without explicit `first`
+ * will be under-counted (the SQL layer still applies MAX_PAGINATION_LIMIT
+ * via PaginationCapPlugin, but we can't see that from the AST). Phase 1's
+ * job is to catch queries with explicit high limits — those are the real
+ * attack surface — not to model the implicit default perfectly.
+ */
+export function computeQueryCost(doc: DocumentNode, variables: Record<string, unknown> = {}): number {
+	const op = doc.definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
+	if (!op) return 0
+	return sumSelections(op.selectionSet, variables, doc)
+}
+
+function sumSelections(selectionSet: SelectionSetNode, vars: Record<string, unknown>, doc: DocumentNode): number {
+	let total = 0
+	for (const sel of selectionSet.selections) {
+		if (sel.kind === Kind.FIELD) {
+			total += fieldCost(sel, vars, doc)
+		} else if (sel.kind === Kind.INLINE_FRAGMENT) {
+			total += sumSelections(sel.selectionSet, vars, doc)
+		} else if (sel.kind === Kind.FRAGMENT_SPREAD) {
+			const frag = doc.definitions.find(
+				(d): d is FragmentDefinitionNode =>
+					d.kind === Kind.FRAGMENT_DEFINITION && d.name.value === sel.name.value,
+			)
+			if (frag) total += sumSelections(frag.selectionSet, vars, doc)
+		}
+	}
+	return total
+}
+
+function fieldCost(field: FieldNode, vars: Record<string, unknown>, doc: DocumentNode): number {
+	// Check for the *syntactic* presence of first/last in the query, not the
+	// resolved value. `entities(first: $first)` with $first unresolved means
+	// the user intends pagination — we should still treat it as a list (and
+	// fall back to MAX because the effective limit is undefined).
+	const argNames = new Set((field.arguments ?? []).map((a) => a.name.value))
+	const hasPagination = argNames.has("first") || argNames.has("last")
+
+	const child = field.selectionSet ? sumSelections(field.selectionSet, vars, doc) : 0
+
+	if (hasPagination) {
+		const args = resolveArgs(field.arguments, vars)
+		const raw = args.first ?? args.last
+		const validExplicit = typeof raw === "number" && Number.isFinite(raw) && raw > 0
+		const limit = validExplicit ? (raw as number) : MAX_PAGINATION_LIMIT
+		return child * limit + 1
+	}
+
+	// No pagination args — object (has selections) or scalar.
+	return child + 1
+}
+
+function resolveArgs(
+	args: readonly ArgumentNode[] | undefined,
+	vars: Record<string, unknown>,
+): Record<string, unknown> {
+	const out: Record<string, unknown> = {}
+	for (const a of args ?? []) {
+		out[a.name.value] = resolveValue(a.value, vars)
+	}
+	return out
+}
+
+function resolveValue(value: ValueNode, vars: Record<string, unknown>): unknown {
+	switch (value.kind) {
+		case Kind.INT:
+			return Number.parseInt(value.value, 10)
+		case Kind.FLOAT:
+			return Number.parseFloat(value.value)
+		case Kind.STRING:
+		case Kind.ENUM:
+			return value.value
+		case Kind.BOOLEAN:
+			return value.value
+		case Kind.NULL:
+			return null
+		case Kind.VARIABLE:
+			return vars[value.name.value]
+		case Kind.LIST:
+			return value.values.map((v) => resolveValue(v, vars))
+		case Kind.OBJECT:
+			return Object.fromEntries(value.fields.map((f) => [f.name.value, resolveValue(f.value, vars)]))
+		default:
+			return undefined
+	}
+}
+
+/**
+ * Yoga plugin that computes query cost and logs / Sentry-alerts when it
+ * exceeds `COST_WARN_THRESHOLD`. Phase 1 is strictly observational — the
+ * plugin never rejects a query. Phase 2 will add a hard ceiling by comparing
+ * the same computed cost against a configured limit.
+ */
+export function useCostLogger(): Plugin {
+	return {
+		onExecute({args}) {
+			if (args.operationName === "IntrospectionQuery") return
+
+			let cost: number
+			try {
+				cost = computeQueryCost(args.document, args.variableValues ?? {})
+			} catch (error) {
+				log.warn("[cost] complexity calculation failed", {
+					error: error instanceof Error ? error.message : String(error),
+					operationName: args.operationName ?? undefined,
+				})
+				return
+			}
+
+			const operationLabel = getOperationLabel(args)
+			const fullQuery = print(args.document)
+			const queryFingerprint = graphqlQueryFingerprint(fullQuery)
+
+			Sentry.addBreadcrumb({
+				category: "graphql.cost",
+				message: "Computed GraphQL query cost",
+				data: {cost, operationName: operationLabel, queryFingerprint},
+				level: "info",
+			})
+
+			if (cost >= COST_WARN_THRESHOLD) {
+				log.warn("High GraphQL query cost", {
+					cost,
+					threshold: COST_WARN_THRESHOLD,
+					operationName: operationLabel,
+					queryFingerprint,
+					query: fullQuery.slice(0, 2000),
+					variables: args.variableValues,
+				})
+
+				Sentry.captureMessage("High GraphQL query cost", {
+					level: "warning",
+					tags: {
+						"graphql.operation_name": operationLabel,
+						"graphql.query_fingerprint": queryFingerprint,
+					},
+					extra: {
+						cost,
+						threshold: COST_WARN_THRESHOLD,
+						query: fullQuery.slice(0, 2000),
+						variables: args.variableValues,
+					},
+				})
+			}
+		},
+	}
+}
+
+function getOperationLabel(args: {operationName?: string | null; document: {definitions: readonly unknown[]}}): string {
+	if (args.operationName) return args.operationName
+
+	const operationDef = args.document.definitions.find(
+		(def): def is OperationDefinitionNode =>
+			typeof def === "object" && def !== null && "kind" in def && def.kind === Kind.OPERATION_DEFINITION,
+	)
+	if (!operationDef) return "anonymous"
+
+	const firstField = operationDef.selectionSet.selections.find((sel): sel is FieldNode => sel.kind === Kind.FIELD)
+	return firstField ? `${operationDef.operation} ${firstField.name.value}` : operationDef.operation
+}

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -20,6 +20,13 @@ import {MAX_PAGINATION_LIMIT} from "./paginationCapPlugin"
 // histogram metric (which records every query regardless of size).
 const COST_LOG_THRESHOLD = Number.parseInt(process.env.GRAPHQL_COST_LOG_THRESHOLD ?? "1000000", 10)
 
+// Hard ceiling on the cost calculation itself. Once the walker's running
+// total reaches this value it short-circuits and returns the cap instead of
+// continuing to multiply. Caps memory (totalSum can't drift to Infinity),
+// caps CPU (adversarial or pathological queries don't walk forever), and
+// keeps the metric values in a sane range for Prometheus / Grafana.
+const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "1000000000", 10)
+
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
 // ---------------------------------------------------------------------------
@@ -29,9 +36,8 @@ const COST_LOG_THRESHOLD = Number.parseInt(process.env.GRAPHQL_COST_LOG_THRESHOL
 // distributions for the Grafana dashboard.
 
 // Upper bucket edges, spanning the realistic range of the conservative model
-// (trivial scalar ≈ 1 at the low end, deeply-nested no-pagination queries in
-// the billions at the high end). `+Inf` is emitted implicitly via the total
-// count at render time.
+// (trivial scalar ≈ 1 at the low end, nested no-pagination queries near the
+// 1B cap at the high end). `+Inf` is emitted via the total count at render.
 const COST_BUCKET_EDGES: readonly number[] = [
 	10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000,
 ]
@@ -45,16 +51,20 @@ let totalCount = 0
 let totalSum = 0
 
 function recordQueryCost(cost: number): void {
+	// Defensive: `computeQueryCost` already caps at MAX_COST_CALC_LIMIT and
+	// can't produce NaN / Infinity / negative, but a future caller mustn't be
+	// able to poison the metric. Non-finite / negative inputs are dropped.
+	if (!Number.isFinite(cost) || cost < 0) return
+	const clamped = Math.min(cost, MAX_COST_CALC_LIMIT)
 	totalCount++
-	totalSum += cost
+	totalSum += clamped
 	for (const edge of COST_BUCKET_EDGES) {
-		if (cost <= edge) bucketCounts.set(edge, (bucketCounts.get(edge) ?? 0) + 1)
+		if (clamped <= edge) bucketCounts.set(edge, (bucketCounts.get(edge) ?? 0) + 1)
 	}
 }
 
 /**
- * Render the cost histogram in Prometheus text format. Called by
- * `/health/metrics` alongside the existing pool gauges. Emits the `le`
+ * Render the cost histogram in Prometheus text format. Emits the `le`
  * buckets, `+Inf` total, `_sum`, and `_count` lines.
  */
 export function renderQueryCostHistogram(): string {
@@ -97,6 +107,10 @@ export function __resetQueryCostHistogramForTests(): void {
  *     can see it in the AST.
  *   - No pagination arg, no selections → 1 (scalar leaf).
  *
+ * Every recursive step checks a hard `MAX_COST_CALC_LIMIT` budget and short-
+ * circuits once crossed — prevents Number overflow, unbounded walking on
+ * adversarial inputs, and Infinity / NaN leaking into the Prometheus metric.
+ *
  * Intentionally schema-free: walking only the document + variables means the
  * estimator works regardless of which `graphql` module instance built the
  * schema (PostGraphile v4 bundles its own copy). Schema-aware libraries like
@@ -106,28 +120,49 @@ export function __resetQueryCostHistogramForTests(): void {
 export function computeQueryCost(doc: DocumentNode, variables: Record<string, unknown> = {}): number {
 	const op = doc.definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
 	if (!op) return 0
-	return sumSelections(op.selectionSet, variables, doc)
+	return sumSelections(op.selectionSet, variables, doc, new Set())
 }
 
-function sumSelections(selectionSet: SelectionSetNode, vars: Record<string, unknown>, doc: DocumentNode): number {
+function sumSelections(
+	selectionSet: SelectionSetNode,
+	vars: Record<string, unknown>,
+	doc: DocumentNode,
+	visitedFragments: Set<string>,
+): number {
 	let total = 0
 	for (const sel of selectionSet.selections) {
 		if (sel.kind === Kind.FIELD) {
-			total += fieldCost(sel, vars, doc)
+			total += fieldCost(sel, vars, doc, visitedFragments)
 		} else if (sel.kind === Kind.INLINE_FRAGMENT) {
-			total += sumSelections(sel.selectionSet, vars, doc)
+			total += sumSelections(sel.selectionSet, vars, doc, visitedFragments)
 		} else if (sel.kind === Kind.FRAGMENT_SPREAD) {
+			// Fragment cycles (A spreads B spreads A) are normally blocked by
+			// the NoFragmentCycles validation rule, but if something in the
+			// pipeline ever skipped validation we'd recurse forever. Cheap
+			// insurance: track visited names on the way down, pop on the way
+			// back up so siblings can reuse the same fragment legitimately.
+			const name = sel.name.value
+			if (visitedFragments.has(name)) continue
 			const frag = doc.definitions.find(
-				(d): d is FragmentDefinitionNode =>
-					d.kind === Kind.FRAGMENT_DEFINITION && d.name.value === sel.name.value,
+				(d): d is FragmentDefinitionNode => d.kind === Kind.FRAGMENT_DEFINITION && d.name.value === name,
 			)
-			if (frag) total += sumSelections(frag.selectionSet, vars, doc)
+			if (frag) {
+				visitedFragments.add(name)
+				total += sumSelections(frag.selectionSet, vars, doc, visitedFragments)
+				visitedFragments.delete(name)
+			}
 		}
+		if (total >= MAX_COST_CALC_LIMIT) return MAX_COST_CALC_LIMIT
 	}
 	return total
 }
 
-function fieldCost(field: FieldNode, vars: Record<string, unknown>, doc: DocumentNode): number {
+function fieldCost(
+	field: FieldNode,
+	vars: Record<string, unknown>,
+	doc: DocumentNode,
+	visitedFragments: Set<string>,
+): number {
 	// Check for the *syntactic* presence of first/last in the query, not the
 	// resolved value. `entities(first: $first)` with $first unresolved means
 	// the user intends pagination — we should still treat it as a list (and
@@ -135,22 +170,25 @@ function fieldCost(field: FieldNode, vars: Record<string, unknown>, doc: Documen
 	const argNames = new Set((field.arguments ?? []).map((a) => a.name.value))
 	const hasPagination = argNames.has("first") || argNames.has("last")
 
-	const child = field.selectionSet ? sumSelections(field.selectionSet, vars, doc) : 0
+	const child = field.selectionSet ? sumSelections(field.selectionSet, vars, doc, visitedFragments) : 0
+
+	// Propagate the cap so we never try to multiply a near-cap value and
+	// overflow. Math.min below also clamps the final result.
+	if (child >= MAX_COST_CALC_LIMIT) return MAX_COST_CALC_LIMIT
 
 	if (hasPagination) {
 		const args = resolveArgs(field.arguments, vars)
 		const raw = args.first ?? args.last
 		const validExplicit = typeof raw === "number" && Number.isFinite(raw) && raw > 0
 		const limit = validExplicit ? (raw as number) : MAX_PAGINATION_LIMIT
-		return child * limit + 1
+		return Math.min(child * limit + 1, MAX_COST_CALC_LIMIT)
 	}
 
 	// Structured field without an explicit limit: conservatively assume the
-	// SQL-injected default of MAX_PAGINATION_LIMIT applies. Without this we'd
-	// miss every `{ entities { ... } }`-style query that leans on the implicit
-	// cap. Leaf scalars (no selection set → child=0) collapse to `0 × N + 1 = 1`
-	// here, so we don't need a separate branch.
-	return child * MAX_PAGINATION_LIMIT + 1
+	// SQL-injected default of MAX_PAGINATION_LIMIT applies. Leaf scalars
+	// (no selection set → child=0) collapse to `0 × N + 1 = 1` here, so we
+	// don't need a separate branch.
+	return Math.min(child * MAX_PAGINATION_LIMIT + 1, MAX_COST_CALC_LIMIT)
 }
 
 function resolveArgs(
@@ -197,37 +235,54 @@ function resolveValue(value: ValueNode, vars: Record<string, unknown>): unknown 
  *     `COST_LOG_THRESHOLD` — structured stdout line, not a Sentry issue,
  *     so noisy shapes don't page anyone but are findable in log search.
  *
- * Phase 1 is strictly observational. Phase 2 will add a hard ceiling by
- * comparing the same computed cost against a configured limit.
+ * Phase 1 is strictly observational. The outer try/catch is a shadow-mode
+ * safety invariant: a failure inside the plugin must never break the
+ * request it was observing.
  */
 export function useCostLogger(): Plugin {
 	return {
 		onExecute({args}) {
-			if (args.operationName === "IntrospectionQuery") return
-
-			let cost: number
 			try {
-				cost = computeQueryCost(args.document, args.variableValues ?? {})
+				if (args.operationName === "IntrospectionQuery") return
+
+				let cost: number
+				try {
+					cost = computeQueryCost(args.document, args.variableValues ?? {})
+				} catch (error) {
+					log.warn("[cost] complexity calculation failed", {
+						error: error instanceof Error ? error.message : String(error),
+						operationName: args.operationName ?? undefined,
+					})
+					return
+				}
+
+				recordQueryCost(cost)
+
+				if (cost >= COST_LOG_THRESHOLD) {
+					const fullQuery = print(args.document)
+					log.info("High GraphQL query cost", {
+						cost,
+						threshold: COST_LOG_THRESHOLD,
+						operationName: getOperationLabel(args),
+						queryFingerprint: graphqlQueryFingerprint(fullQuery),
+						query: fullQuery.slice(0, 2000),
+						variables: args.variableValues,
+					})
+				}
 			} catch (error) {
-				log.warn("[cost] complexity calculation failed", {
-					error: error instanceof Error ? error.message : String(error),
-					operationName: args.operationName ?? undefined,
-				})
-				return
-			}
-
-			recordQueryCost(cost)
-
-			if (cost >= COST_LOG_THRESHOLD) {
-				const fullQuery = print(args.document)
-				log.info("High GraphQL query cost", {
-					cost,
-					threshold: COST_LOG_THRESHOLD,
-					operationName: getOperationLabel(args),
-					queryFingerprint: graphqlQueryFingerprint(fullQuery),
-					query: fullQuery.slice(0, 2000),
-					variables: args.variableValues,
-				})
+				// Shadow-mode guarantee: never break the request. If anything at
+				// all throws — log stringification bombing on a circular variable,
+				// print() choking on an unusual AST, anything else — swallow it.
+				// The nested try around the diagnostic log itself protects against
+				// a log writer that's itself broken.
+				try {
+					log.warn("[cost] plugin onExecute threw", {
+						error: error instanceof Error ? error.message : String(error),
+						operationName: args.operationName ?? undefined,
+					})
+				} catch {
+					// Nothing we can do; keep the request flowing.
+				}
 			}
 		},
 	}

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -16,31 +16,34 @@ import {log} from "../services/telemetry"
 import {MAX_PAGINATION_LIMIT} from "./paginationCapPlugin"
 
 // Threshold above which we warn (log + Sentry issue). Phase 1 tuning knob —
-// start conservative, then re-tune from observed distribution.
-const COST_WARN_THRESHOLD = Number.parseInt(process.env.GRAPHQL_COST_WARN_THRESHOLD ?? "10000", 10)
+// start from a ceiling that accommodates the conservative model (fields
+// without explicit first/last are scored as if they returned MAX items,
+// so nested structured responses score in the millions), then re-tune from
+// observed distribution.
+const COST_WARN_THRESHOLD = Number.parseInt(process.env.GRAPHQL_COST_WARN_THRESHOLD ?? "1000000", 10)
 
 /**
  * Compute a query complexity score from the operation AST alone.
  *
  * Cost model, per field:
- *   - with an explicit first/last arg → `child × limit + 1` (limit clamped to
- *     MAX_PAGINATION_LIMIT if non-positive / non-finite, matching what
- *     PaginationCapPlugin injects at SQL-build time and closing the bogus-arg
- *     attack vector).
- *   - no pagination arg, has selections → `child + 1` (treated as an object).
- *   - no pagination arg, no selections → 1 (scalar).
+ *   - Explicit `first` / `last` arg → `child × limit + 1`. Limit clamps to
+ *     MAX_PAGINATION_LIMIT when non-positive / non-finite / missing (from an
+ *     unresolved variable), mirroring what PaginationCapPlugin actually
+ *     applies at SQL-build time and closing the bogus-arg attack vector.
+ *   - No pagination arg, has selections → `child × MAX_PAGINATION_LIMIT + 1`.
+ *     Conservative: we treat any structured field without an explicit limit
+ *     as if it were a list taking the 1000 default. Over-counts single-entity
+ *     lookups, but we prefer over-counting to under-counting — PaginationCap
+ *     injects the 1000 default on every collection field at SQL time, so the
+ *     real work done under those queries scales that way whether or not we
+ *     can see it in the AST.
+ *   - No pagination arg, no selections → 1 (scalar leaf).
  *
- * Intentionally schema-free: walking only the document + variables means this
- * works regardless of which `graphql` module instance built the schema
- * (PostGraphile v4 bundles its own copy). That's the only way to use
- * graphql-js type introspection here without hitting instanceof failures
- * across CJS/ESM module boundaries.
- *
- * Known limitation: simple-collection fields called without explicit `first`
- * will be under-counted (the SQL layer still applies MAX_PAGINATION_LIMIT
- * via PaginationCapPlugin, but we can't see that from the AST). Phase 1's
- * job is to catch queries with explicit high limits — those are the real
- * attack surface — not to model the implicit default perfectly.
+ * Intentionally schema-free: walking only the document + variables means the
+ * estimator works regardless of which `graphql` module instance built the
+ * schema (PostGraphile v4 bundles its own copy). Schema-aware libraries like
+ * graphql-query-complexity hit instanceof failures across the CJS/ESM module
+ * boundary in that setup.
  */
 export function computeQueryCost(doc: DocumentNode, variables: Record<string, unknown> = {}): number {
 	const op = doc.definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
@@ -84,8 +87,12 @@ function fieldCost(field: FieldNode, vars: Record<string, unknown>, doc: Documen
 		return child * limit + 1
 	}
 
-	// No pagination args — object (has selections) or scalar.
-	return child + 1
+	// Structured field without an explicit limit: conservatively assume the
+	// SQL-injected default of MAX_PAGINATION_LIMIT applies. Without this we'd
+	// miss every `{ entities { ... } }`-style query that leans on the implicit
+	// cap. Leaf scalars (no selection set → child=0) collapse to `0 × N + 1 = 1`
+	// here, so we don't need a separate branch.
+	return child * MAX_PAGINATION_LIMIT + 1
 }
 
 function resolveArgs(

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -14,18 +14,29 @@ import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
 import {MAX_PAGINATION_LIMIT} from "./paginationCapPlugin"
 
+// Parse a positive-integer env var, falling back to `fallback` on anything
+// non-finite or non-positive. Guards against deploy-time misconfiguration
+// (e.g. `GRAPHQL_COST_CALC_LIMIT=abc` → parseInt = NaN) silently disabling
+// the walker's safety cap.
+function parsePositiveIntEnv(name: string, fallback: number): number {
+	const raw = process.env[name]
+	if (raw === undefined) return fallback
+	const parsed = Number.parseInt(raw, 10)
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
 // Threshold above which we emit an info-level log line with the full query +
 // variables. Not an alert — just "this one is worth finding in logs if we
 // need to investigate a slow response later". Kept separate from the
 // histogram metric (which records every query regardless of size).
-const COST_LOG_THRESHOLD = Number.parseInt(process.env.GRAPHQL_COST_LOG_THRESHOLD ?? "1000000", 10)
+const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 1_000_000)
 
 // Hard ceiling on the cost calculation itself. Once the walker's running
 // total reaches this value it short-circuits and returns the cap instead of
 // continuing to multiply. Caps memory (totalSum can't drift to Infinity),
 // caps CPU (adversarial or pathological queries don't walk forever), and
 // keeps the metric values in a sane range for Prometheus / Grafana.
-const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "1000000000", 10)
+const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 1_000_000_000)
 
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node"
 import {
 	type ArgumentNode,
 	type DocumentNode,
@@ -15,12 +14,71 @@ import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
 import {MAX_PAGINATION_LIMIT} from "./paginationCapPlugin"
 
-// Threshold above which we warn (log + Sentry issue). Phase 1 tuning knob —
-// start from a ceiling that accommodates the conservative model (fields
-// without explicit first/last are scored as if they returned MAX items,
-// so nested structured responses score in the millions), then re-tune from
-// observed distribution.
-const COST_WARN_THRESHOLD = Number.parseInt(process.env.GRAPHQL_COST_WARN_THRESHOLD ?? "1000000", 10)
+// Threshold above which we emit an info-level log line with the full query +
+// variables. Not an alert — just "this one is worth finding in logs if we
+// need to investigate a slow response later". Kept separate from the
+// histogram metric (which records every query regardless of size).
+const COST_LOG_THRESHOLD = Number.parseInt(process.env.GRAPHQL_COST_LOG_THRESHOLD ?? "1000000", 10)
+
+// ---------------------------------------------------------------------------
+// Prometheus histogram metric — gaia_api_graphql_query_cost
+// ---------------------------------------------------------------------------
+// Exposed via /health/metrics (see renderQueryCostHistogram). We accumulate
+// in-process monotonic counters (process start = 0), and Prometheus uses
+// rate()/histogram_quantile() over the scrape stream to derive time-windowed
+// distributions for the Grafana dashboard.
+
+// Upper bucket edges, spanning the realistic range of the conservative model
+// (trivial scalar ≈ 1 at the low end, deeply-nested no-pagination queries in
+// the billions at the high end). `+Inf` is emitted implicitly via the total
+// count at render time.
+const COST_BUCKET_EDGES: readonly number[] = [
+	10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000,
+]
+
+// noUncheckedIndexedAccess widens `number[]`'s index access to `number | undefined`,
+// so we go via a Map which has a crisper `get(k) | undefined` story and always
+// normalize via `?? 0`. A bit more allocation than a typed array but the map
+// is bounded to 9 entries and only written on the hot path; effect is nil.
+const bucketCounts = new Map<number, number>()
+let totalCount = 0
+let totalSum = 0
+
+function recordQueryCost(cost: number): void {
+	totalCount++
+	totalSum += cost
+	for (const edge of COST_BUCKET_EDGES) {
+		if (cost <= edge) bucketCounts.set(edge, (bucketCounts.get(edge) ?? 0) + 1)
+	}
+}
+
+/**
+ * Render the cost histogram in Prometheus text format. Called by
+ * `/health/metrics` alongside the existing pool gauges. Emits the `le`
+ * buckets, `+Inf` total, `_sum`, and `_count` lines.
+ */
+export function renderQueryCostHistogram(): string {
+	const lines = [
+		"# HELP gaia_api_graphql_query_cost GraphQL query complexity score distribution (conservative model, see costLoggerPlugin.ts).",
+		"# TYPE gaia_api_graphql_query_cost histogram",
+	]
+	for (const edge of COST_BUCKET_EDGES) {
+		lines.push(`gaia_api_graphql_query_cost_bucket{le="${edge}"} ${bucketCounts.get(edge) ?? 0}`)
+	}
+	lines.push(`gaia_api_graphql_query_cost_bucket{le="+Inf"} ${totalCount}`)
+	lines.push(`gaia_api_graphql_query_cost_sum ${totalSum}`)
+	lines.push(`gaia_api_graphql_query_cost_count ${totalCount}`)
+	return `${lines.join("\n")}\n`
+}
+
+/**
+ * Reset accumulated histogram state. Tests only — not used in runtime.
+ */
+export function __resetQueryCostHistogramForTests(): void {
+	bucketCounts.clear()
+	totalCount = 0
+	totalSum = 0
+}
 
 /**
  * Compute a query complexity score from the operation AST alone.
@@ -131,10 +189,16 @@ function resolveValue(value: ValueNode, vars: Record<string, unknown>): unknown 
 }
 
 /**
- * Yoga plugin that computes query cost and logs / Sentry-alerts when it
- * exceeds `COST_WARN_THRESHOLD`. Phase 1 is strictly observational — the
- * plugin never rejects a query. Phase 2 will add a hard ceiling by comparing
- * the same computed cost against a configured limit.
+ * Yoga plugin that computes query cost on every request. Two observability
+ * channels, no alerts:
+ *   - Prometheus histogram `gaia_api_graphql_query_cost` — records every
+ *     query's cost; charted in Grafana for distribution / outliers.
+ *   - `log.info("High GraphQL query cost", ...)` when cost exceeds
+ *     `COST_LOG_THRESHOLD` — structured stdout line, not a Sentry issue,
+ *     so noisy shapes don't page anyone but are findable in log search.
+ *
+ * Phase 1 is strictly observational. Phase 2 will add a hard ceiling by
+ * comparing the same computed cost against a configured limit.
  */
 export function useCostLogger(): Plugin {
 	return {
@@ -152,39 +216,17 @@ export function useCostLogger(): Plugin {
 				return
 			}
 
-			const operationLabel = getOperationLabel(args)
-			const fullQuery = print(args.document)
-			const queryFingerprint = graphqlQueryFingerprint(fullQuery)
+			recordQueryCost(cost)
 
-			Sentry.addBreadcrumb({
-				category: "graphql.cost",
-				message: "Computed GraphQL query cost",
-				data: {cost, operationName: operationLabel, queryFingerprint},
-				level: "info",
-			})
-
-			if (cost >= COST_WARN_THRESHOLD) {
-				log.warn("High GraphQL query cost", {
+			if (cost >= COST_LOG_THRESHOLD) {
+				const fullQuery = print(args.document)
+				log.info("High GraphQL query cost", {
 					cost,
-					threshold: COST_WARN_THRESHOLD,
-					operationName: operationLabel,
-					queryFingerprint,
+					threshold: COST_LOG_THRESHOLD,
+					operationName: getOperationLabel(args),
+					queryFingerprint: graphqlQueryFingerprint(fullQuery),
 					query: fullQuery.slice(0, 2000),
 					variables: args.variableValues,
-				})
-
-				Sentry.captureMessage("High GraphQL query cost", {
-					level: "warning",
-					tags: {
-						"graphql.operation_name": operationLabel,
-						"graphql.query_fingerprint": queryFingerprint,
-					},
-					extra: {
-						cost,
-						threshold: COST_WARN_THRESHOLD,
-						query: fullQuery.slice(0, 2000),
-						variables: args.variableValues,
-					},
 				})
 			}
 		},

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -11,6 +11,7 @@ import {classifyDbFailure} from "../services/dbFailures"
 import {getGraphqlPressureSnapshot, recordGraphqlAcquireTimeout, shouldShedPoolTraffic} from "../services/dbSaturation"
 import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
+import {useCostLogger} from "./costLoggerPlugin"
 import EntitySpaceFilterPlugin from "./entitySpaceFilterPlugin"
 import {useGraphQLInstrumentation} from "./instrumentationPlugin"
 import PaginationCapPlugin, {NoFirstAndLastRule} from "./paginationCapPlugin"
@@ -159,8 +160,11 @@ const postgraphileOptions = {
 	},
 }
 
-// Create PostGraphile schemas
-const postgraphileSchema = await createPostGraphileSchema(pgPool, ["public"], postgraphileOptions)
+// Create PostGraphile schemas. Exported so cost-estimator / query-shape tests
+// can run complexity calculations against the real schema instead of a fake
+// minimal one — catches schema-level surprises (NonNull wrapping, Connection
+// naming, auto-generated field shapes) that mocks don't.
+export const postgraphileSchema = await createPostGraphileSchema(pgPool, ["public"], postgraphileOptions)
 
 /**
  * Yoga plugin that manages the pgClient lifecycle for PostGraphile resolvers.
@@ -314,6 +318,7 @@ const customValidationRules: Plugin = {
 const sharedPlugins = [
 	...(responseCachePlugin ? [responseCachePlugin] : []),
 	customValidationRules,
+	useCostLogger(),
 	useGraphQLInstrumentation(),
 	useSearchInvocationLogger(),
 	usePgClient(pgPool),

--- a/monitoring/k8s/gaia-overview-dashboard.yaml
+++ b/monitoring/k8s/gaia-overview-dashboard.yaml
@@ -12,7 +12,7 @@ data:
       ],
       "timezone": "browser",
       "schemaVersion": 39,
-      "version": 3,
+      "version": 4,
       "refresh": "30s",
       "time": {
         "from": "now-6h",
@@ -3388,6 +3388,120 @@ data:
               "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          }
+        },
+        {
+          "type": "row",
+          "id": 107,
+          "title": "GraphQL Query Cost (shadow mode)",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 105
+          },
+          "panels": []
+        },
+        {
+          "id": 14,
+          "type": "heatmap",
+          "title": "GraphQL Query Cost Distribution (5m rate)",
+          "description": "Histogram of GraphQL query cost over the last 5 minutes. Dark cells = many queries in that cost bucket.",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 106
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m]))",
+              "format": "heatmap",
+              "legendFormat": "{{le}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "calculate": false,
+            "yAxis": {
+              "axisLabel": "cost bucket",
+              "unit": "short"
+            },
+            "cellGap": 1,
+            "color": {
+              "mode": "scheme",
+              "scheme": "Spectral",
+              "steps": 64,
+              "exponent": 0.5
+            }
+          }
+        },
+        {
+          "id": 15,
+          "type": "timeseries",
+          "title": "GraphQL Query Cost p50 / p95 / p99 (5m)",
+          "description": "Percentiles of GraphQL query cost over the rolling 5-minute window. Spikes indicate callers sending more expensive queries.",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 106
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m])))",
+              "legendFormat": "p50"
+            },
+            {
+              "refId": "B",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m])))",
+              "legendFormat": "p95"
+            },
+            {
+              "refId": "C",
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m])))",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": [
+                "mean",
+                "max"
+              ]
             },
             "tooltip": {
               "mode": "multi"


### PR DESCRIPTION
## Summary

Shadow-mode observation of GraphQL query cost, surfacing in Grafana. No rejection, no Sentry alerting — phase 2 will add a hard ceiling using the same `computeQueryCost` once real-traffic data is collected to tune the limit.

Shadow-mode invariant: **the cost code can never block, fail, or affect the API call it's observing.** Three layers of try/catch + hard computation cap + env-var validation ensure this.

## What ships

### Cost model (pure AST walker, schema-free)

- **Explicit `first`/`last`**: `child × limit + 1`. Limit clamps to `MAX_PAGINATION_LIMIT` (1000) for non-positive / non-finite / missing-variable values — mirrors what `PaginationCapPlugin` injects at SQL time and closes the `first: -5` bogus-arg attack.
- **Structured field without explicit `first`/`last`**: `child × MAX_PAGINATION_LIMIT + 1`. Conservative: every collection field gets the 1000 default at SQL time, so we assume that applies anywhere we can't see a limit. Over-counts single-entity lookups, which we accept.
- **Scalar leaf**: `1`.
- **Hard cap**: `MAX_COST_CALC_LIMIT` (1B, env-tunable). Walker short-circuits at every recursive step once the running total crosses this. Caps memory, CPU, and prevents `Number` overflow drifting to `Infinity` / `NaN`.

### Observability

- **Prometheus histogram** `gaia_api_graphql_query_cost` exposed via `/health/metrics` (already scraped by `kube-prometheus-stack` via the `api-metrics` ServiceMonitor). Buckets: 10 / 100 / 1k / 10k / 100k / 1M / 10M / 100M / 1B.
- **Grafana dashboard** panels added to `gaia-overview-dashboard.yaml` (new "GraphQL Query Cost (shadow mode)" section):
  - Cost distribution heatmap (5m rate)
  - p50 / p95 / p99 time series
- **Structured `log.info` line** when a query's cost exceeds `GRAPHQL_COST_LOG_THRESHOLD` (default `1_000_000`) — findable in Axiom for investigation; not an alert, not a Sentry issue.

### Safety invariants (cannot break the request)

1. **Outer `try/catch`** around the entire `onExecute` body — swallows any synchronous exception from `print()`, `log.info`, or anywhere else in the plugin.
2. **Nested `try/catch`** around the fallback `log.warn` itself, so a broken log writer can't propagate either.
3. **Inner `try/catch`** specifically around `computeQueryCost` — any walker exception falls through to a warning-log + early-return with no recording.
4. **Early-termination budget** (`MAX_COST_CALC_LIMIT`) at every `sumSelections` and `fieldCost` return — a pathological 50-level query terminates in finite steps rather than multiplying forever.
5. **Fragment-cycle guard** via visited-fragment `Set` threaded through recursion — defends against a future plugin skipping `NoFragmentCycles` validation.
6. **Env-var validation** (`parsePositiveIntEnv`) — a misconfigured `GRAPHQL_COST_CALC_LIMIT=abc` can't silently disable the cap by resolving to `NaN`.
7. **Defensive recording** — `recordQueryCost` rejects non-finite / negative inputs so the Prometheus `_sum` can never be poisoned.

## Why a hand-rolled AST walker

We first tried [`graphql-query-complexity`](https://www.npmjs.com/package/graphql-query-complexity). Its schema traversal uses `instanceof` checks that fail across `graphql` module instances — PostGraphile v4 bundles `graphql@15`, separate from our `graphql@16`, separated further by the CJS/ESM module boundary. Workarounds (`overrides`, CJS subpath imports) either broke PostGraphile's error handling or didn't reliably dedupe across Bun's module resolver. Walking only the document + variables makes us immune to which `graphql` instance built the schema.

## Benchmark

100k iterations, per-call timing (Node v24.3, local):

| Query shape | Mean | p99 |
|---|---|---|
| Scalar `{ __typename }` | 0.19µs | 1.75µs |
| Single entity | 0.26µs | 1.62µs |
| Small list `first:50` | 0.28µs | 0.67µs |
| Realistic geogenesis Entity | 3.10µs | 5.33µs |
| Slow-query prod pattern | 4.89µs | 8.13µs |

Effectively zero overhead against a typical 50–500ms GraphQL request.

## Tests — 28 cases, all passing

- Cost model: scalars, `first`/`last`, defaults, nested lists, variables, fragments, inline fragments, bogus inputs (`0` / `-5` / `NaN` / unresolved variable), slow-query pattern
- Histogram: empty-state emission, cumulative bucket counts, introspection skip
- **Safety**: malformed-AST throw, circular-variable log throw, 6-level pathological query caps cleanly, sibling-branch short-circuit after cap, 50-level nesting never produces Infinity/NaN, 30-level legit query no stack overflow, fragment-cycle handled, sibling fragment reuse still counted

Full kg suite passes (199 tests). Cache tests (21 via bun test). Format + lint + tsc all clean.

## Config

| Var | Default | Purpose |
|---|---|---|
| `GRAPHQL_COST_LOG_THRESHOLD` | `1_000_000` | Cost above which we emit a structured log line (env-tunable; fallback on bad values) |
| `GRAPHQL_COST_CALC_LIMIT` | `1_000_000_000` | Hard ceiling on computation; walker short-circuits once crossed (env-tunable; fallback on bad values) |
| (phase 2) `GRAPHQL_COST_HARD_LIMIT` | — | To be added when we flip from observe to reject |

## Calibration plan

1. Merge to `dev`, deploy to staging.
2. Watch the new Grafana panels — distribution, percentiles, outliers.
3. Deploy to prod in shadow mode for ~3–7 days.
4. Pick a phase-2 hard limit from the observed p99 + headroom.

## Out of scope

- Query rejection (phase 2)
- Per-operation label on the histogram (cardinality concern — add later if useful)
- Depth / alias / token limits
- Moving the `/health/metrics` histogram call out of `health.ts` via a metrics registry (small follow-up PR to keep this one focused)