### PR TITLE
fix(api): use log.warn for over-threshold cost log so it reaches stdout

### DIFF
--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -242,9 +242,13 @@ function resolveValue(value: ValueNode, vars: Record<string, unknown>): unknown 
  * channels, no alerts:
  *   - Prometheus histogram `gaia_api_graphql_query_cost` — records every
  *     query's cost; charted in Grafana for distribution / outliers.
- *   - `log.info("High GraphQL query cost", ...)` when cost exceeds
- *     `COST_LOG_THRESHOLD` — structured stdout line, not a Sentry issue,
- *     so noisy shapes don't page anyone but are findable in log search.
+ *   - `log.warn("High GraphQL query cost", ...)` when cost exceeds
+ *     `COST_LOG_THRESHOLD`. `log.warn` in this codebase always writes to
+ *     stdout (visible in kubectl + Axiom) *and* drops a Sentry breadcrumb,
+ *     but does NOT create a Sentry issue — that's the captureMessage path
+ *     we deliberately don't use. `log.info`, by contrast, only writes a
+ *     breadcrumb in production (invisible to log search), which defeats the
+ *     point of the threshold log.
  *
  * Phase 1 is strictly observational. The outer try/catch is a shadow-mode
  * safety invariant: a failure inside the plugin must never break the
@@ -271,7 +275,7 @@ export function useCostLogger(): Plugin {
 
 				if (cost >= COST_LOG_THRESHOLD) {
 					const fullQuery = print(args.document)
-					log.info("High GraphQL query cost", {
+					log.warn("High GraphQL query cost", {
 						cost,
 						threshold: COST_LOG_THRESHOLD,
 						operationName: getOperationLabel(args),


### PR DESCRIPTION
## Summary

Follow-up to #615. `log.info` in this codebase only writes to Sentry breadcrumbs when `SENTRY_DSN` is set (staging/prod) — it **doesn't write to stdout**. That made the phase-1 over-threshold log effectively invisible: it only surfaces as context inside a Sentry issue that never happens.

Switches to `log.warn`, which in this codebase:

- ✅ Writes to stdout (visible via `kubectl logs` and Axiom)
- ✅ Drops a Sentry breadcrumb (context for any later errors)
- ❌ Does **not** create a Sentry issue — that was `captureMessage`, which we deliberately removed in #615 and isn't coming back

So the observability guarantee we wanted is restored without any of the alerting we wanted to avoid.

## Confirmed on staging

Before the fix, I sent 5 queries at cost levels spanning the 1M threshold. The Prometheus histogram captured all 5 exactly:

```
gaia_api_graphql_query_cost_count 5
gaia_api_graphql_query_cost_sum 1001503104
```

Sum matches `1 + 101 + 501_001 + 1_002_001 + 1_000_000_000` — the estimator is correct and the 1B cap fires correctly on the deeply-nested implicit-MAX query. But the two over-threshold queries (Q4 and Q5) never produced a stdout log line, which is what prompted this PR.

## Test plan

- [x] Unit tests pass (28/28) — no change in tested behavior, only log destination
- [x] Format + lint + tsc clean
- [ ] After deploy: confirm `kubectl logs -n api-staging -l app=api | grep "High GraphQL query cost"` surfaces the over-threshold entries