### PR TITLE
fix(search-indexer): set TOPOLOGY_STATE_PATH in nack-crash e2e test

### DIFF
--- a/search-indexer/tests/e2e-nack-crash/run-test.sh
+++ b/search-indexer/tests/e2e-nack-crash/run-test.sh
@@ -181,6 +181,9 @@ fi
 header "Phase 2: NACK → Crash"
 
 info "Starting search-indexer (run 1)"
+# Point topology persistence at our per-run work directory. The indexer
+# defaults to /data/topology_state.json, which isn't writable on CI runners
+# and isn't a sensible shared location between test runs anyway.
 ENVIRONMENT=staging \
 RUST_LOG="info,search_indexer=debug" \
 KAFKA_BROKER="$KAFKA_BROKER" \
@@ -192,6 +195,7 @@ OPENSEARCH_RETRY_INTERVAL_SECS=2 \
 KAFKA_GROUP_EDITS_ID="$KAFKA_GROUP_EDITS_ID" \
 KAFKA_GROUP_SCORES_ID="$KAFKA_GROUP_SCORES_ID" \
 KAFKA_GROUP_SPACE_TOPICS_ID="$KAFKA_GROUP_SPACE_TOPICS_ID" \
+TOPOLOGY_STATE_PATH="$WORK_DIR/topology_state.json" \
 "$INDEXER_BIN" > "$WORK_DIR/indexer-run1.log" 2>&1 &
 INDEXER_PID=$!
 
@@ -265,6 +269,9 @@ fi
 pass "Write block removed"
 
 info "Starting search-indexer (run 2)"
+# Reuse the same TOPOLOGY_STATE_PATH as run 1 so the second run actually
+# picks up the persisted state from the crashed run (that's the whole
+# point of the restart-replay test).
 ENVIRONMENT=staging \
 RUST_LOG="info,search_indexer=debug" \
 KAFKA_BROKER="$KAFKA_BROKER" \
@@ -276,6 +283,7 @@ OPENSEARCH_RETRY_INTERVAL_SECS=2 \
 KAFKA_GROUP_EDITS_ID="$KAFKA_GROUP_EDITS_ID" \
 KAFKA_GROUP_SCORES_ID="$KAFKA_GROUP_SCORES_ID" \
 KAFKA_GROUP_SPACE_TOPICS_ID="$KAFKA_GROUP_SPACE_TOPICS_ID" \
+TOPOLOGY_STATE_PATH="$WORK_DIR/topology_state.json" \
 "$INDEXER_BIN" > "$WORK_DIR/indexer-run2.log" 2>&1 &
 INDEXER_PID=$!
 


### PR DESCRIPTION
## Summary

Fixes the e2e failure on #617 (and any future PR that triggers the search-indexer e2e workflow). Root cause: the NACK-crash test's own indexer subprocesses were crashing on `/data/topology_state.json` before reaching the test's actual assertions.

## Why it was failing

The search-indexer defaults topology-state persistence to `/data/topology_state.json` ([`search-indexer/src/topology/persistence.rs:29`](https://github.com/geobrowser/gaia/blob/dev/search-indexer/src/topology/persistence.rs#L29)), overridable via `TOPOLOGY_STATE_PATH`. `/data` isn't writable on GitHub runners.

The workflow overrides this correctly for the two indexer invocations it launches directly (`Run search-indexer in background` line 242, `Start indexer for load test` line 353), and so does `tests/e2e-topology-restart/run-test.sh` (line 135). But `tests/e2e-nack-crash/run-test.sh` — which launches its own indexer for Phases 2 and 3 — didn't, so both runs got:

```
ERROR search_indexer::processor: Failed to save topology state, NACKing batch
  error=I/O error: Permission denied (os error 13)
```

Run 1 crashed on topology save → exited before anything reached OpenSearch. Run 2 hit the same error → Phase 3's "Polling OpenSearch for replayed documents" reported `0 hits` and failed.

## Fix

Add `TOPOLOGY_STATE_PATH="$WORK_DIR/topology_state.json"` to both `$INDEXER_BIN` invocations in `tests/e2e-nack-crash/run-test.sh` (run 1 and run 2). `$WORK_DIR` is already a per-run `mktemp -d` inside `/tmp`, so runs are isolated from each other. Runs 1 and 2 share the same path on purpose — that's how the restart-replay test observes persisted state from the crashed run.

## Test plan

- [x] `bash -n run-test.sh` — syntax check passes
- [ ] Re-running the e2e workflow after this merges should get past Phase 3 (documents indexed → test passes)
- [ ] No product code touched; nothing else can regress

## Scope

Only `search-indexer/tests/e2e-nack-crash/run-test.sh`. Test-infra-only change.