### PR TITLE
Revert "chore(scoring): increase scoring cronjob memory"

### DIFF
--- a/scoring-service/deployment/production/cronjob.yaml
+++ b/scoring-service/deployment/production/cronjob.yaml
@@ -87,8 +87,8 @@ spec:
                       optional: true
               resources:
                 requests:
-                  memory: "4096Mi"
+                  memory: "2048Mi"
                   cpu: "1000m"
                 limits:
-                  memory: "8192Mi"
+                  memory: "4096Mi"
                   cpu: "2000m"

--- a/scoring-service/deployment/staging/cronjob.yaml
+++ b/scoring-service/deployment/staging/cronjob.yaml
@@ -62,8 +62,8 @@ spec:
                   value: "z_score_sigmoid"
               resources:
                 requests:
-                  memory: "4096Mi"
+                  memory: "2048Mi"
                   cpu: "1000m"
                 limits:
-                  memory: "8192Mi"
+                  memory: "4096Mi"
                   cpu: "2000m"


### PR DESCRIPTION
Reverts geobrowser/gaia#608 given that each node has 8 GB of RAM at most and the cluster is having problems allocating the requested RAM to it as there are several other things also running and consuming RAM at the same time.