### PR TITLE
feat(api): tag every Sentry alert with request origin, client IP, user-agent

### DIFF
--- a/api/src/kg/__tests__/searchInvocationLogger.test.ts
+++ b/api/src/kg/__tests__/searchInvocationLogger.test.ts
@@ -2,7 +2,7 @@ import {parse} from "graphql"
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
 import {log} from "../../services/telemetry"
 import {graphqlServer} from "../postgraphile"
-import {extractClientIp, findSearchInvocations} from "../searchInvocationLogger"
+import {findSearchInvocations} from "../searchInvocationLogger"
 
 async function executeGraphQL(query: string, variables?: Record<string, unknown>, headers?: Record<string, string>) {
 	const response = await graphqlServer.fetch(
@@ -20,49 +20,8 @@ async function executeGraphQL(query: string, variables?: Record<string, unknown>
 }
 
 // ---------------------------------------------------------------------------
-// Unit tests — pure AST walk + header parsing, no DB needed.
+// Unit tests — pure AST walk, no DB needed.
 // ---------------------------------------------------------------------------
-
-describe("extractClientIp", () => {
-	function h(entries: Record<string, string>): Headers {
-		return new Headers(entries)
-	}
-
-	it("prefers X-Real-IP", () => {
-		expect(extractClientIp(h({"x-real-ip": "203.0.113.5"}))).toBe("203.0.113.5")
-	})
-
-	it("returns rightmost X-Forwarded-For entry when X-Real-IP is absent", () => {
-		// nginx appends its observation to the right of any client-supplied XFF,
-		// so the rightmost entry is trusted and the leftmost is spoofable.
-		expect(extractClientIp(h({"x-forwarded-for": "1.2.3.4, 5.6.7.8, 203.0.113.5"}))).toBe("203.0.113.5")
-	})
-
-	it("ignores spoofed leftmost X-Forwarded-For entries when X-Real-IP is present", () => {
-		const headers = h({
-			"x-real-ip": "203.0.113.5",
-			"x-forwarded-for": "1.2.3.4, 203.0.113.5",
-		})
-		expect(extractClientIp(headers)).toBe("203.0.113.5")
-	})
-
-	it("returns null when neither header is present", () => {
-		expect(extractClientIp(h({}))).toBeNull()
-	})
-
-	it("returns null when X-Forwarded-For is empty / whitespace-only", () => {
-		expect(extractClientIp(h({"x-forwarded-for": ""}))).toBeNull()
-		expect(extractClientIp(h({"x-forwarded-for": ",  ,"}))).toBeNull()
-	})
-
-	it("trims whitespace around X-Real-IP", () => {
-		expect(extractClientIp(h({"x-real-ip": "  203.0.113.5  "}))).toBe("203.0.113.5")
-	})
-
-	it("handles single-entry X-Forwarded-For", () => {
-		expect(extractClientIp(h({"x-forwarded-for": "203.0.113.5"}))).toBe("203.0.113.5")
-	})
-})
 
 describe("findSearchInvocations", () => {
 	it("returns empty when no search field is present", () => {

--- a/api/src/kg/searchInvocationLogger.ts
+++ b/api/src/kg/searchInvocationLogger.ts
@@ -14,9 +14,15 @@
  * fragment spreads, and emits one `log.warn` per search-field selection.
  * Multiple `search` calls in a single document all get logged.
  *
- * Client IP extraction uses `extractClientIp` from `utils/clientIp`
- * (`X-Real-IP` preferred, rightmost `X-Forwarded-For` as fallback —
- * documented trust rules for our nginx topology live there).
+ * Client IP extraction (see `extractClientIp` in `utils/clientIp`) prefers
+ * `X-Real-IP` because it's the unspoofable value in this cluster's topology:
+ * DO LoadBalancer → ingress-nginx with `externalTrafficPolicy: Local`
+ * and L4 TCP passthrough preserves the real client source IP to nginx,
+ * and nginx sets `X-Real-IP = $remote_addr` (single-valued, overwrites
+ * any client-supplied header). `X-Forwarded-For` is a fallback: nginx
+ * appends its observed `$remote_addr` to the right of any client-supplied
+ * value, so the *rightmost* entry is trustworthy and leftmost entries are
+ * client-controlled / spoofable. Never reading leftmost XFF here.
  */
 import {
 	type DocumentNode,

--- a/api/src/kg/searchInvocationLogger.ts
+++ b/api/src/kg/searchInvocationLogger.ts
@@ -14,15 +14,9 @@
  * fragment spreads, and emits one `log.warn` per search-field selection.
  * Multiple `search` calls in a single document all get logged.
  *
- * Client IP extraction (see `extractClientIp`) prefers `X-Real-IP`
- * because it's the unspoofable value in this cluster's topology:
- * DO LoadBalancer → ingress-nginx with `externalTrafficPolicy: Local`
- * and L4 TCP passthrough preserves the real client source IP to nginx,
- * and nginx sets `X-Real-IP = $remote_addr` (single-valued, overwrites
- * any client-supplied header). `X-Forwarded-For` is a fallback: nginx
- * appends its observed `$remote_addr` to the right of any client-supplied
- * value, so the *rightmost* entry is trustworthy and leftmost entries are
- * client-controlled / spoofable. Never reading leftmost XFF here.
+ * Client IP extraction uses `extractClientIp` from `utils/clientIp`
+ * (`X-Real-IP` preferred, rightmost `X-Forwarded-For` as fallback —
+ * documented trust rules for our nginx topology live there).
  */
 import {
 	type DocumentNode,
@@ -35,6 +29,7 @@ import {
 } from "graphql"
 import type {Plugin} from "graphql-yoga"
 import {log} from "../services/telemetry"
+import {extractClientIp} from "../utils/clientIp"
 
 const SEARCH_FIELD_NAMES: ReadonlySet<string> = new Set(["search", "searchConnection"])
 
@@ -44,36 +39,6 @@ export type SearchInvocation = {
 	spaceId?: string
 	first?: number
 	similarityThreshold?: number
-}
-
-/**
- * Extract the real client IP from request headers.
- *
- * Priority:
- *   1. `X-Real-IP` — set by nginx to `$remote_addr`, single-valued,
- *      overwrites any client-supplied value. Unspoofable via HTTP in
- *      our cluster config.
- *   2. Rightmost entry of `X-Forwarded-For` — nginx appends its own
- *      `$remote_addr` to the end of the XFF chain via
- *      `$proxy_add_x_forwarded_for`. Leftmost entries are client-
- *      controlled and NOT trusted; we only read the rightmost.
- *
- * Returns `null` if neither header is present.
- */
-export function extractClientIp(headers: Headers): string | null {
-	const xRealIp = headers.get("x-real-ip")?.trim()
-	if (xRealIp) return xRealIp
-
-	const xff = headers.get("x-forwarded-for")
-	if (xff) {
-		const parts = xff
-			.split(",")
-			.map((s) => s.trim())
-			.filter(Boolean)
-		const rightmost = parts[parts.length - 1]
-		if (rightmost) return rightmost
-	}
-	return null
 }
 
 /**

--- a/api/src/middleware/requestLogging.ts
+++ b/api/src/middleware/requestLogging.ts
@@ -11,9 +11,9 @@
 import {SpanStatusCode, trace} from "@opentelemetry/api"
 import * as Sentry from "@sentry/node"
 import type {Context, Next} from "hono"
-import {extractClientIp} from "../utils/clientIp"
 import {detectDbFailureClass} from "../services/dbFailures"
 import {log} from "../services/telemetry"
+import {extractClientIp} from "../utils/clientIp"
 
 /**
  * Extract or generate a request ID.

--- a/api/src/middleware/requestLogging.ts
+++ b/api/src/middleware/requestLogging.ts
@@ -9,7 +9,9 @@
  */
 
 import {SpanStatusCode, trace} from "@opentelemetry/api"
+import * as Sentry from "@sentry/node"
 import type {Context, Next} from "hono"
+import {extractClientIp} from "../utils/clientIp"
 import {detectDbFailureClass} from "../services/dbFailures"
 import {log} from "../services/telemetry"
 
@@ -46,6 +48,13 @@ export function requestId() {
  * - END: status, duration, error (if any)
  *
  * Wraps request in OTEL span for HTTP context (flows through SentrySpanProcessor).
+ *
+ * Also opens a Sentry isolation scope around the request so that every
+ * `captureException` / `captureMessage` fired downstream (GraphQL errors,
+ * PostGraphile pool-connect failures, `log.error` calls, Effect `logError` /
+ * `logFatal`) inherits caller-identity tags — `origin`, `client_ip` — plus
+ * `user-agent` in the context. These are the signals you need to filter
+ * Sentry Issues by which frontend / IP / script is triggering them.
  */
 export function canonicalRequestLogging() {
 	return async (c: Context, next: Next) => {
@@ -54,82 +63,105 @@ export function canonicalRequestLogging() {
 		const path = c.req.path
 		const startTime = Date.now()
 
-		// Canonical START log
-		log.info(`${method} ${path} started`, {
-			requestId,
-			method,
-			path,
-			query: c.req.query(),
-		})
+		// Caller identity for Sentry alerts. `origin` + `user-agent` are
+		// client-settable but help distinguish frontends from ad-hoc scripts.
+		// `clientIp` uses the trust rules documented in searchInvocationLogger.
+		const headers = c.req.raw.headers
+		const origin = headers.get("origin")
+		const userAgent = headers.get("user-agent")
+		const clientIp = extractClientIp(headers)
 
-		// Get tracer lazily at request time (not module load) to ensure OTEL SDK is initialized
-		const tracer = trace.getTracer("gaia-api-http")
-		const origin = c.req.header("origin")
-		const span = tracer.startSpan(`${method} ${path}`, {
-			attributes: {
-				"http.method": method,
-				"http.route": path,
-				"http.request_id": requestId,
-				...(origin && {"http.request.header.origin": origin}),
-			},
-		})
-
-		// Store span context for GraphQL plugin (OTEL context doesn't propagate through graphql-yoga)
-		c.set("traceContext", {
-			traceId: span.spanContext().traceId,
-			spanId: span.spanContext().spanId,
-			traceFlags: span.spanContext().traceFlags,
-		})
-
-		try {
-			await next()
-
-			const status = c.res.status
-			const duration = Date.now() - startTime
-			const graphqlOperationName = c.get("graphqlOperationName") as string | undefined
-
-			span.setAttribute("http.status_code", status)
-			span.setAttribute("http.response_time_ms", duration)
-			if (graphqlOperationName) {
-				span.setAttribute("graphql.operation_name", graphqlOperationName)
-			}
-
-			if (status >= 400) {
-				span.setStatus({code: SpanStatusCode.ERROR, message: `HTTP ${status}`})
-			}
-
-			// Canonical END log
-			log.info(`${method} ${path} completed`, {
+		// withIsolationScope gives us a per-request Sentry scope so tags
+		// attach to every capture fired inside this handler without bleeding
+		// across concurrent requests.
+		return Sentry.withIsolationScope(async (scope) => {
+			if (origin) scope.setTag("origin", origin)
+			if (clientIp) scope.setTag("client_ip", clientIp)
+			scope.setContext("request", {
 				requestId,
 				method,
 				path,
-				status,
-				durationMs: duration,
-				...(graphqlOperationName ? {graphqlOperationName} : {}),
+				origin,
+				clientIp,
+				userAgent,
 			})
-		} catch (error) {
-			const duration = Date.now() - startTime
-			const failureClass = detectDbFailureClass(error)
 
-			span.setStatus({code: SpanStatusCode.ERROR, message: "error"})
-			span.setAttribute("http.response_time_ms", duration)
-			if (failureClass) {
-				span.setAttribute("db.failure_class", failureClass)
-			}
-
-			// Canonical ERROR log
-			log.error(`${method} ${path} failed`, {
+			// Canonical START log
+			log.info(`${method} ${path} started`, {
 				requestId,
 				method,
 				path,
-				durationMs: duration,
-				...(failureClass ? {failureClass} : {}),
-				error: error instanceof Error ? error.message : String(error),
+				query: c.req.query(),
 			})
 
-			throw error
-		} finally {
-			span.end()
-		}
+			// Get tracer lazily at request time (not module load) to ensure OTEL SDK is initialized
+			const tracer = trace.getTracer("gaia-api-http")
+			const span = tracer.startSpan(`${method} ${path}`, {
+				attributes: {
+					"http.method": method,
+					"http.route": path,
+					"http.request_id": requestId,
+					...(origin && {"http.request.header.origin": origin}),
+				},
+			})
+
+			// Store span context for GraphQL plugin (OTEL context doesn't propagate through graphql-yoga)
+			c.set("traceContext", {
+				traceId: span.spanContext().traceId,
+				spanId: span.spanContext().spanId,
+				traceFlags: span.spanContext().traceFlags,
+			})
+
+			try {
+				await next()
+
+				const status = c.res.status
+				const duration = Date.now() - startTime
+				const graphqlOperationName = c.get("graphqlOperationName") as string | undefined
+
+				span.setAttribute("http.status_code", status)
+				span.setAttribute("http.response_time_ms", duration)
+				if (graphqlOperationName) {
+					span.setAttribute("graphql.operation_name", graphqlOperationName)
+				}
+
+				if (status >= 400) {
+					span.setStatus({code: SpanStatusCode.ERROR, message: `HTTP ${status}`})
+				}
+
+				// Canonical END log
+				log.info(`${method} ${path} completed`, {
+					requestId,
+					method,
+					path,
+					status,
+					durationMs: duration,
+					...(graphqlOperationName ? {graphqlOperationName} : {}),
+				})
+			} catch (error) {
+				const duration = Date.now() - startTime
+				const failureClass = detectDbFailureClass(error)
+
+				span.setStatus({code: SpanStatusCode.ERROR, message: "error"})
+				span.setAttribute("http.response_time_ms", duration)
+				if (failureClass) {
+					span.setAttribute("db.failure_class", failureClass)
+				}
+
+				// Canonical ERROR log
+				log.error(`${method} ${path} failed`, {
+					requestId,
+					method,
+					path,
+					durationMs: duration,
+					...(failureClass ? {failureClass} : {}),
+					error: error instanceof Error ? error.message : String(error),
+				})
+
+				throw error
+			} finally {
+				span.end()
+			}
+		})
 	}
 }

--- a/api/src/utils/__tests__/clientIp.test.ts
+++ b/api/src/utils/__tests__/clientIp.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from "vitest"
+import {extractClientIp} from "../clientIp"
+
+describe("extractClientIp", () => {
+	function h(entries: Record<string, string>): Headers {
+		return new Headers(entries)
+	}
+
+	it("prefers X-Real-IP", () => {
+		expect(extractClientIp(h({"x-real-ip": "203.0.113.5"}))).toBe("203.0.113.5")
+	})
+
+	it("returns rightmost X-Forwarded-For entry when X-Real-IP is absent", () => {
+		// nginx appends its observation to the right of any client-supplied XFF,
+		// so the rightmost entry is trusted and the leftmost is spoofable.
+		expect(extractClientIp(h({"x-forwarded-for": "1.2.3.4, 5.6.7.8, 203.0.113.5"}))).toBe("203.0.113.5")
+	})
+
+	it("ignores spoofed leftmost X-Forwarded-For entries when X-Real-IP is present", () => {
+		const headers = h({
+			"x-real-ip": "203.0.113.5",
+			"x-forwarded-for": "1.2.3.4, 203.0.113.5",
+		})
+		expect(extractClientIp(headers)).toBe("203.0.113.5")
+	})
+
+	it("returns null when neither header is present", () => {
+		expect(extractClientIp(h({}))).toBeNull()
+	})
+
+	it("returns null when X-Forwarded-For is empty / whitespace-only", () => {
+		expect(extractClientIp(h({"x-forwarded-for": ""}))).toBeNull()
+		expect(extractClientIp(h({"x-forwarded-for": ",  ,"}))).toBeNull()
+	})
+
+	it("trims whitespace around X-Real-IP", () => {
+		expect(extractClientIp(h({"x-real-ip": "  203.0.113.5  "}))).toBe("203.0.113.5")
+	})
+
+	it("handles single-entry X-Forwarded-For", () => {
+		expect(extractClientIp(h({"x-forwarded-for": "203.0.113.5"}))).toBe("203.0.113.5")
+	})
+})

--- a/api/src/utils/clientIp.ts
+++ b/api/src/utils/clientIp.ts
@@ -1,0 +1,32 @@
+/**
+ * Extract the real client IP from request headers.
+ *
+ * Prefers `X-Real-IP` because it's the unspoofable value in this cluster's
+ * topology: DO LoadBalancer → ingress-nginx with `externalTrafficPolicy:
+ * Local` and L4 TCP passthrough preserves the real client source IP to
+ * nginx, and nginx sets `X-Real-IP = $remote_addr` — single-valued, and
+ * overwrites any client-supplied header so it can't be forged over HTTP.
+ *
+ * `X-Forwarded-For` is a fallback: nginx appends its own observed
+ * `$remote_addr` to the *right* of any client-supplied XFF via
+ * `$proxy_add_x_forwarded_for`, so the **rightmost** entry is trustworthy
+ * and everything to the left is client-controlled / spoofable. We never
+ * read the leftmost XFF entry here.
+ *
+ * Returns `null` if neither header is present.
+ */
+export function extractClientIp(headers: Headers): string | null {
+	const xRealIp = headers.get("x-real-ip")?.trim()
+	if (xRealIp) return xRealIp
+
+	const xff = headers.get("x-forwarded-for")
+	if (xff) {
+		const parts = xff
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean)
+		const rightmost = parts[parts.length - 1]
+		if (rightmost) return rightmost
+	}
+	return null
+}


### PR DESCRIPTION
## Summary
- Open a Sentry isolation scope around each HTTP request in `canonicalRequestLogging` so every `captureException` / `captureMessage` fired downstream inherits caller-identity tags automatically
- Adds searchable `origin` and `client_ip` **tags** to Sentry Issues, plus a `request` context entry with `user-agent`
- Reuses the existing `extractClientIp` helper (`x-real-ip` preferred, rightmost `x-forwarded-for` as fallback — documented trust rules for our nginx topology); moved from `kg/searchInvocationLogger` to `utils/clientIp` now that it has more than one consumer

## How this differs from #592
1. **Client IP + user-agent** — #592 doesn't touch either. Your original ask was "or using one of the x-portforwarded or x-ip-adddress header … or origin and ip address to sentry" — #592 only gave you origin. If you want IP for abuse investigations, #621 is the PR that delivers that.
2. **Direct filterability on the Issues tab** — with #592 alone, to see "which frontend errored", the flow is: open Issue → find trace_id → click to linked Transaction → read tag. With #621, it's: type `origin:"..."` in the Issues search bar. Big triage UX difference.
3. **Sampling independence** — if `SENTRY_TRACES_SAMPLE_RATE` ever drops below 1.0 (standard cost-control move), sampled-out transactions don't exist, so the click-through from #592 breaks. Issues always capture regardless, so tags on the issue itself always survive.

## Why
Sentry Issues today carry `operation_name` / `query_fingerprint` but no caller identity. When an error spike hits we can't tell which frontend is generating the traffic (production web app vs testnet vs localhost vs an ad-hoc script). #592 added `origin` to the transaction span, but span attributes don't attach to the error event — you'd have to click through to the linked transaction.

With this change, Sentry **Issues** search supports `origin:"https://geogenesis.vercel.app"` and `client_ip:"1.2.3.4"` directly, and every issue detail page shows the `request` context with the user-agent alongside.

## Why isolation scope vs per-site tags
The alternative was adding `origin` + `clientIp` + `userAgent` to every `Sentry.captureException` / `log.error` / `Effect.logError` call site — 19+ sites across the codebase. `Sentry.withIsolationScope` attaches the tags once per request; every downstream capture inherits them. Fewer lines, no per-site churn, and Effect-level errors (which don't have request context plumbed) also pick up the tags automatically.

Per-request scope prevents tag bleed between concurrent requests.

## Out of scope
- No changes to capture sites themselves — they keep their existing tags/extras and gain the new ones via scope inheritance
- No changes to the existing `http.request.header.origin` span attribute from #592 — that's still there for transactions

## Test plan
- [ ] With `SENTRY_DSN` + `SENTRY_TRACES_SAMPLE_RATE=1.0` set, hit `/graphql` with `-H 'Origin: https://example.com'` forcing an error (e.g. bad query past validation); confirm the resulting Sentry Issue shows `origin` and `client_ip` in the Tags panel
- [ ] Same request without an `Origin` header produces an issue without the `origin` tag (no empty tag) — verify tag cardinality stays clean
- [ ] Hit a non-GraphQL endpoint that throws (e.g. induced DB failure in a `/versioned/*` route) and confirm the `log.error` → Sentry issue also carries the tags
- [x] Type-check passes
- [x] Existing `canonicalRequestLogging` span behavior (method, route, status, request_id, origin span attr) unchanged