### PR TITLE
ci: bump digitalocean/action-doctl to v2.5.2, uses node24

### DIFF
--- a/.github/workflows/api-deploy-staging.yml
+++ b/.github/workflows/api-deploy-staging.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: api
 
@@ -25,7 +24,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: api
 
@@ -25,7 +24,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/atlas-deploy-staging.yml
+++ b/.github/workflows/atlas-deploy-staging.yml
@@ -21,7 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: atlas
 
@@ -33,7 +32,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/atlas-deploy.yml
+++ b/.github/workflows/atlas-deploy.yml
@@ -21,7 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: atlas
 
@@ -33,7 +32,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/delivery-worker-deploy-staging.yml
+++ b/.github/workflows/delivery-worker-deploy-staging.yml
@@ -15,7 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: delivery-worker
 
@@ -27,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@6374d029dfd5f449281f186d65663779c706c994 # v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/delivery-worker-deploy.yml
+++ b/.github/workflows/delivery-worker-deploy.yml
@@ -15,7 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: delivery-worker
 
@@ -27,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@6374d029dfd5f449281f186d65663779c706c994 # v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/hermes-ipfs-cache-deploy-staging.yml
+++ b/.github/workflows/hermes-ipfs-cache-deploy-staging.yml
@@ -19,7 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: hermes-ipfs-cache
 
@@ -31,7 +30,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/hermes-ipfs-cache-deploy.yml
+++ b/.github/workflows/hermes-ipfs-cache-deploy.yml
@@ -19,7 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: hermes-ipfs-cache
 
@@ -31,7 +30,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/hermes-pipeline-deploy-staging.yml
+++ b/.github/workflows/hermes-pipeline-deploy-staging.yml
@@ -21,7 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: hermes-pipeline
 
@@ -33,7 +32,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/hermes-pipeline-deploy.yml
+++ b/.github/workflows/hermes-pipeline-deploy.yml
@@ -21,7 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: hermes-pipeline
 
@@ -33,7 +32,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/kafka-ui-deploy-staging.yml
+++ b/.github/workflows/kafka-ui-deploy-staging.yml
@@ -14,9 +14,6 @@ concurrency:
   group: kafka-ui-staging
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,7 +22,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/kafka-ui-deploy.yml
+++ b/.github/workflows/kafka-ui-deploy.yml
@@ -14,9 +14,6 @@ concurrency:
   group: kafka-ui-production
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,7 +22,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/kg-indexer-deploy-staging.yml
+++ b/.github/workflows/kg-indexer-deploy-staging.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: kg-indexer
 
@@ -28,7 +27,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/kg-indexer-deploy.yml
+++ b/.github/workflows/kg-indexer-deploy.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: kg-indexer
 
@@ -28,7 +27,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/maintenance-deploy.yml
+++ b/.github/workflows/maintenance-deploy.yml
@@ -19,9 +19,6 @@ concurrency:
   group: maintenance-production
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -30,7 +27,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/notification-indexer-deploy-staging.yml
+++ b/.github/workflows/notification-indexer-deploy-staging.yml
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: notification-indexer
 
@@ -29,7 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@6374d029dfd5f449281f186d65663779c706c994 # v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/notification-indexer-deploy.yml
+++ b/.github/workflows/notification-indexer-deploy.yml
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: notification-indexer
 
@@ -29,7 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@6374d029dfd5f449281f186d65663779c706c994 # v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/proposal-executor-deploy-staging.yml
+++ b/.github/workflows/proposal-executor-deploy-staging.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: proposal-executor
 
@@ -25,7 +24,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.1
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/proposal-executor-deploy.yml
+++ b/.github/workflows/proposal-executor-deploy.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: proposal-executor
 
@@ -25,7 +24,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.1
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/scoring-cronjob-deploy-staging.yml
+++ b/.github/workflows/scoring-cronjob-deploy-staging.yml
@@ -14,7 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: scoring-service
 
@@ -26,7 +25,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.1
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/scoring-cronjob-deploy.yml
+++ b/.github/workflows/scoring-cronjob-deploy.yml
@@ -14,7 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: scoring-service
 
@@ -26,7 +25,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.1
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/scoring-topology-indexer-deploy-staging.yml
+++ b/.github/workflows/scoring-topology-indexer-deploy-staging.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: topology-indexer
 
@@ -28,7 +27,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.1
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/scoring-topology-indexer-deploy.yml
+++ b/.github/workflows/scoring-topology-indexer-deploy.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: topology-indexer
 
@@ -28,7 +27,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.1
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/scoring-vote-indexer-deploy-staging.yml
+++ b/.github/workflows/scoring-vote-indexer-deploy-staging.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: vote-indexer
 
@@ -28,7 +27,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/scoring-vote-indexer-deploy.yml
+++ b/.github/workflows/scoring-vote-indexer-deploy.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: vote-indexer
 
@@ -28,7 +27,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/search-admin-build.yml
+++ b/.github/workflows/search-admin-build.yml
@@ -13,7 +13,6 @@ on:
   workflow_dispatch:
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: search-admin
 
@@ -25,7 +24,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/search-indexer-deploy-staging.yml
+++ b/.github/workflows/search-indexer-deploy-staging.yml
@@ -20,7 +20,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: search-indexer
 
@@ -32,7 +31,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/search-indexer-deploy.yml
+++ b/.github/workflows/search-indexer-deploy.yml
@@ -20,7 +20,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: registry.digitalocean.com/geo
   IMAGE_NAME: search-indexer
 
@@ -32,7 +31,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 


### PR DESCRIPTION
## Summary
- SHA-pin every `digitalocean/action-doctl` reference in `.github/workflows/` to the `v2.5.2` release commit `3cb3953159719656269e044e0e24ca16dd2a690f` (with trailing `# v2.5.2` comment for readability)
- Drop the per-workflow `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` escape hatch — `v2.5.2` ships with Node 24 natively so it's no longer needed
- Clean up the now-empty `env:` blocks left behind in `kafka-ui-deploy.yml`, `kafka-ui-deploy-staging.yml`, and `maintenance-deploy.yml` (they only held the FORCE flag)

## Why
`digitalocean/action-doctl@v2` (and `@v2.5.1`) ship their JavaScript action with the Node 20 runtime. GitHub-hosted runners are deprecating Node 20 for JavaScript actions, which is why every deploy workflow carried `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a workaround. `v2.5.2` upgraded the action's runtime to Node 24, so the workaround is obsolete.

SHA pinning matches the supply-chain hardening pattern already used by the `notification-indexer-*` and `delivery-worker-*` workflows prior to this change — now extended uniformly across all 28 deploy workflows.

## Scope
28 workflow files changed. 1-to-1 mapping between files that used `action-doctl` and files that set the FORCE flag.

| Previous pin | Count |
|---|---|
| `@v2` (tag) | 18 |
| `@v2.5.1` (tag) | 6 |
| `@6374d02…` (SHA-pinned to old v2 commit) | 4 |

All 28 are now SHA-pinned to `3cb3953159719656269e044e0e24ca16dd2a690f` (v2.5.2).

## Test plan
- [ ] Trigger any one deploy workflow (e.g. push a no-op commit to `dev` touching a watched path) and confirm the `digitalocean/action-doctl@3cb39531…` step installs + authenticates without the Node 24 warning
- [ ] Confirm no workflow log contains the Node 20 deprecation notice that previously required the FORCE workaround
- [x] Diff review: 28 files, `+28/-62` — only the FORCE env line removed per file and the action reference SHA-pinned