### PR TITLE
feat(monitoring): OpenSearch exporter + dashboard cleanup

### DIFF
--- a/monitoring/k8s/gaia-overview-dashboard.yaml
+++ b/monitoring/k8s/gaia-overview-dashboard.yaml
@@ -2687,66 +2687,6 @@ data:
           }
         },
         {
-          "type": "timeseries",
-          "title": "Atlas CPU Throttling Ratio",
-          "id": 34,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 68
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "targets": [
-            {
-              "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{namespace=\"knowledge\",pod=~\"atlas-.*\",container=\"atlas\"}[5m])) / sum(rate(container_cpu_cfs_periods_total{namespace=\"knowledge\",pod=~\"atlas-.*\",container=\"atlas\"}[5m]))",
-              "legendFormat": "atlas throttling",
-              "refId": "A"
-            }
-          ],
-          "fieldConfig": {
-            "defaults": {
-              "unit": "percentunit",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 0.15
-                  },
-                  {
-                    "color": "red",
-                    "value": 0.25
-                  }
-                ]
-              },
-              "custom": {
-                "thresholdsStyle": {
-                  "mode": "line"
-                }
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi"
-            }
-          }
-        },
-        {
           "type": "stat",
           "title": "Atlas Available Replicas",
           "id": 35,
@@ -2834,7 +2774,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 76
+            "y": 85
           },
           "collapsed": false,
           "panels": []
@@ -2847,7 +2787,7 @@ data:
             "h": 4,
             "w": 4,
             "x": 0,
-            "y": 77
+            "y": 86
           },
           "datasource": {
             "type": "prometheus",
@@ -2893,7 +2833,7 @@ data:
             "h": 4,
             "w": 4,
             "x": 4,
-            "y": 77
+            "y": 86
           },
           "datasource": {
             "type": "prometheus",
@@ -2947,7 +2887,7 @@ data:
             "h": 4,
             "w": 4,
             "x": 8,
-            "y": 77
+            "y": 86
           },
           "datasource": {
             "type": "prometheus",
@@ -2984,7 +2924,7 @@ data:
             "h": 4,
             "w": 4,
             "x": 12,
-            "y": 77
+            "y": 86
           },
           "datasource": {
             "type": "prometheus",
@@ -3047,7 +2987,7 @@ data:
             "h": 4,
             "w": 4,
             "x": 16,
-            "y": 77
+            "y": 86
           },
           "datasource": {
             "type": "prometheus",
@@ -3095,7 +3035,7 @@ data:
             "h": 4,
             "w": 4,
             "x": 20,
-            "y": 77
+            "y": 86
           },
           "datasource": {
             "type": "prometheus",
@@ -3149,7 +3089,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 90
           },
           "datasource": {
             "type": "prometheus",
@@ -3187,7 +3127,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 90
           },
           "datasource": {
             "type": "prometheus",
@@ -3244,7 +3184,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 98
           },
           "datasource": {
             "type": "prometheus",
@@ -3287,7 +3227,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 98
           },
           "datasource": {
             "type": "prometheus",
@@ -3330,7 +3270,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 97
+            "y": 106
           },
           "datasource": {
             "type": "prometheus",
@@ -3366,7 +3306,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 106
           },
           "datasource": {
             "type": "prometheus",
@@ -3403,7 +3343,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 105
+            "y": 76
           },
           "panels": []
         },
@@ -3416,7 +3356,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 106
+            "y": 77
           },
           "datasource": {
             "type": "prometheus",
@@ -3460,7 +3400,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 106
+            "y": 77
           },
           "datasource": {
             "type": "prometheus",

--- a/monitoring/k8s/opensearch-exporter.yaml
+++ b/monitoring/k8s/opensearch-exporter.yaml
@@ -11,15 +11,16 @@
 #
 # Hand-rendered from the upstream helm chart to match the pattern established
 # by prometheus-stack.yaml and api-metrics-servicemonitor.yaml: one committed
-# YAML, applied via `kubectl apply`. Equivalent chart values:
+# YAML, applied via `kubectl apply`. Equivalent chart values (note: v1.7.0
+# renamed some toggles into the `collector.*` namespace):
 #   serviceMonitor.enabled=true
 #   serviceMonitor.labels.release=kube-prometheus-stack
 #   extraEnvSecrets.ES_URI={secret: es-exporter-creds, key: ES_URI}
 #   es.all=true
 #   es.indices=true
-#   es.cluster_settings=true
 #   es.shards=true
-#   es.snapshots=true
+#   collector.snapshots=true
+#   collector.clustersettings=true
 #
 # ─── Prerequisite: credentials Secret (NOT committed) ────────────────────────
 #
@@ -76,11 +77,15 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             # Collector toggles — mirror the chart values documented above.
+            # Note: v1.7.0 moved some flags to the `--collector.*` namespace
+            # (dropping underscores). `--es.snapshots` and `--es.cluster_settings`
+            # from older docs are now `--collector.snapshots` and
+            # `--collector.clustersettings`.
             - --es.all
             - --es.indices
-            - --es.cluster_settings
             - --es.shards
-            - --es.snapshots
+            - --collector.snapshots
+            - --collector.clustersettings
             - --es.timeout=30s
           env:
             # ES_URI is the standard env var the exporter reads; takes

--- a/monitoring/k8s/opensearch-exporter.yaml
+++ b/monitoring/k8s/opensearch-exporter.yaml
@@ -76,6 +76,12 @@ spec:
           image: quay.io/prometheuscommunity/elasticsearch-exporter:v1.7.0
           imagePullPolicy: IfNotPresent
           args:
+            # v1.7.0 of the exporter does NOT read ES_URI from the environment —
+            # it always uses --es.uri (default http://localhost:9200) unless
+            # explicitly overridden. k8s `$(VAR)` syntax substitutes the env
+            # var at container runtime, so the secret value never appears in
+            # the committed YAML or in the Deployment spec itself.
+            - --es.uri=$(ES_URI)
             # Collector toggles — mirror the chart values documented above.
             # Note: v1.7.0 moved some flags to the `--collector.*` namespace
             # (dropping underscores). `--es.snapshots` and `--es.cluster_settings`
@@ -88,9 +94,8 @@ spec:
             - --collector.clustersettings
             - --es.timeout=30s
           env:
-            # ES_URI is the standard env var the exporter reads; takes
-            # precedence over the --es.uri flag. URL includes auth creds, so
-            # it stays in the Secret and never in the checked-in YAML.
+            # URL includes auth creds, so it stays in the Secret and never in
+            # the checked-in YAML. Substituted into --es.uri above via $(VAR).
             - name: ES_URI
               valueFrom:
                 secretKeyRef:

--- a/monitoring/k8s/opensearch-exporter.yaml
+++ b/monitoring/k8s/opensearch-exporter.yaml
@@ -1,0 +1,167 @@
+# Prometheus exporter for the DigitalOcean managed OpenSearch cluster.
+#
+# Translates the OpenSearch REST API (`/_cluster/health`, `/_nodes/stats`,
+# `/_cat/indices`, `/_snapshot/_all`, ...) into the `elasticsearch_*` metric
+# names that monitoring/k8s/gaia-overview-dashboard.yaml references. The
+# "OpenSearch Health" section of that dashboard stays empty until this
+# exporter is running and being scraped.
+#
+# OpenSearch is wire-compatible with Elasticsearch, so the upstream
+# prometheus-community/elasticsearch_exporter works against it unmodified.
+#
+# Hand-rendered from the upstream helm chart to match the pattern established
+# by prometheus-stack.yaml and api-metrics-servicemonitor.yaml: one committed
+# YAML, applied via `kubectl apply`. Equivalent chart values:
+#   serviceMonitor.enabled=true
+#   serviceMonitor.labels.release=kube-prometheus-stack
+#   extraEnvSecrets.ES_URI={secret: es-exporter-creds, key: ES_URI}
+#   es.all=true
+#   es.indices=true
+#   es.cluster_settings=true
+#   es.shards=true
+#   es.snapshots=true
+#
+# ─── Prerequisite: credentials Secret (NOT committed) ────────────────────────
+#
+# Copy the OpenSearch URL already in api-secrets into a Secret in the
+# monitoring namespace that this Deployment reads from:
+#
+#   kubectl create secret generic es-exporter-creds -n monitoring \
+#     --from-literal=ES_URI="$(kubectl get secret -n api api-secrets \
+#         -o jsonpath='{.data.OPENSEARCH_URL}' | base64 -d)"
+#
+# ─── Apply ───────────────────────────────────────────────────────────────────
+#
+#   kubectl apply -f monitoring/k8s/opensearch-exporter.yaml
+#
+# Verify metrics are flowing:
+#   kubectl -n monitoring port-forward svc/opensearch-exporter 9114:9114 &
+#   curl -s localhost:9114/metrics | grep -E '^elasticsearch_(cluster_health|indices_search_query_total|jvm_memory)'
+#
+# In Prometheus UI (port-forward 9090):
+#   sum(elasticsearch_indices_search_query_total)  should return a value.
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opensearch-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: opensearch-exporter
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opensearch-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: opensearch-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opensearch-exporter
+    spec:
+      serviceAccountName: opensearch-exporter
+      restartPolicy: Always
+      containers:
+        - name: exporter
+          image: quay.io/prometheuscommunity/elasticsearch-exporter:v1.7.0
+          imagePullPolicy: IfNotPresent
+          args:
+            # Collector toggles — mirror the chart values documented above.
+            - --es.all
+            - --es.indices
+            - --es.cluster_settings
+            - --es.shards
+            - --es.snapshots
+            - --es.timeout=30s
+          env:
+            # ES_URI is the standard env var the exporter reads; takes
+            # precedence over the --es.uri flag. URL includes auth creds, so
+            # it stays in the Secret and never in the checked-in YAML.
+            - name: ES_URI
+              valueFrom:
+                secretKeyRef:
+                  name: es-exporter-creds
+                  key: ES_URI
+          ports:
+            - name: http
+              containerPort: 9114
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opensearch-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: opensearch-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9114
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: opensearch-exporter
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opensearch-exporter
+  namespace: monitoring
+  labels:
+    # The kube-prometheus-stack Prometheus CR selects ServiceMonitors with
+    # this label, matching the pattern used by api-metrics-servicemonitor.yaml
+    # and ingress-nginx-metrics.yaml.
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch-exporter
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/monitoring/k8s/opensearch-exporter.yaml
+++ b/monitoring/k8s/opensearch-exporter.yaml
@@ -73,7 +73,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: exporter
-          image: quay.io/prometheuscommunity/elasticsearch-exporter:v1.7.0
+          image: quay.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
           imagePullPolicy: IfNotPresent
           args:
             # v1.7.0 of the exporter does NOT read ES_URI from the environment —

--- a/monitoring/k8s/opensearch-exporter.yaml
+++ b/monitoring/k8s/opensearch-exporter.yaml
@@ -11,8 +11,7 @@
 #
 # Hand-rendered from the upstream helm chart to match the pattern established
 # by prometheus-stack.yaml and api-metrics-servicemonitor.yaml: one committed
-# YAML, applied via `kubectl apply`. Equivalent chart values (note: v1.7.0
-# renamed some toggles into the `collector.*` namespace):
+# YAML, applied via `kubectl apply`. Equivalent chart values:
 #   serviceMonitor.enabled=true
 #   serviceMonitor.labels.release=kube-prometheus-stack
 #   extraEnvSecrets.ES_URI={secret: es-exporter-creds, key: ES_URI}
@@ -76,17 +75,11 @@ spec:
           image: quay.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
           imagePullPolicy: IfNotPresent
           args:
-            # v1.7.0 of the exporter does NOT read ES_URI from the environment —
-            # it always uses --es.uri (default http://localhost:9200) unless
-            # explicitly overridden. k8s `$(VAR)` syntax substitutes the env
-            # var at container runtime, so the secret value never appears in
-            # the committed YAML or in the Deployment spec itself.
+            # The exporter does not auto-read ES_URI from the environment —
+            # the flag has to be passed explicitly. k8s `$(VAR)` syntax
+            # substitutes the env var at container runtime, so the secret
+            # value never appears in the committed YAML or Deployment spec.
             - --es.uri=$(ES_URI)
-            # Collector toggles — mirror the chart values documented above.
-            # Note: v1.7.0 moved some flags to the `--collector.*` namespace
-            # (dropping underscores). `--es.snapshots` and `--es.cluster_settings`
-            # from older docs are now `--collector.snapshots` and
-            # `--collector.clustersettings`.
             - --es.all
             - --es.indices
             - --es.shards


### PR DESCRIPTION
Enables the empty OpenSearch Health section on the Gaia Overview dashboard, and tightens panel ordering / removes a dead panel.

## Summary

- **Add the Prometheus exporter for DO-managed OpenSearch** — the dashboard's `elasticsearch_*` PromQL queries returned no data because no exporter was running. This adds one: hand-rendered from `prometheus-community/elasticsearch_exporter` (helm chart) to match the existing "render + commit + apply" pattern used by `prometheus-stack.yaml` and `api-metrics-servicemonitor.yaml`.
- **Move GraphQL Query Cost panels above OpenSearch Health** so the shadow-mode cost panels (from #615) are visible above-the-fold rather than below ~13 rows of OpenSearch / JVM / thread-pool widgets.
- **Remove the Atlas CPU Throttling Ratio panel** — was rendering "No data" (the `container_cpu_cfs_throttled_seconds_total` metric doesn't populate for the `knowledge` namespace in this cluster).

## Apply order post-merge

One prerequisite Secret (NOT committed — contains OpenSearch creds copied from `api/api-secrets.OPENSEARCH_URL`):

```
kubectl create secret generic es-exporter-creds -n monitoring \
  --from-literal=ES_URI="$(kubectl get secret -n api api-secrets \
      -o jsonpath='{.data.OPENSEARCH_URL}' | base64 -d)"
```

Then:

```
kubectl apply -f monitoring/k8s/opensearch-exporter.yaml
kubectl apply -f monitoring/k8s/gaia-overview-dashboard.yaml
```

Grafana's dashboard sidecar auto-reloads the ConfigMap within ~60s.

## Verification (already performed in staging/prod cluster while developing)

- `kubectl exec` into exporter pod → `/metrics` returns `elasticsearch_cluster_health_active_primary_shards` = 15, 33 active shards, 3 nodes reporting (`nyc2-09228-4/5/6`), all circuit breakers at 0
- Prometheus: `job=opensearch-exporter` target UP, `sum(elasticsearch_indices_search_query_total)` returns ~196M lifetime searches
- All dashboard panel PromQL expressions (`elasticsearch_cluster_health_status`, `elasticsearch_indices_search_query_total`, `elasticsearch_jvm_memory_used_bytes`, etc.) return data

## Files

| File | Change |
|---|---|
| `monitoring/k8s/opensearch-exporter.yaml` | **new** — SA + Deployment + Service + ServiceMonitor |
| `monitoring/k8s/gaia-overview-dashboard.yaml` | panel re-order + Atlas CPU Throttling removal |

## Notable tradeoffs

- `ES_URI` is passed via k8s `$(VAR)` arg substitution because v1.7.0 of the exporter doesn't bind the env var automatically through kingpin — verified empirically (pod came up but hit `localhost:9200` until `--es.uri=$(ES_URI)` was added).
- Flag names for v1.7.0: some collectors moved to `--collector.*` namespace (`--collector.snapshots`, `--collector.clustersettings`). Older `--es.snapshots` / `--es.cluster_settings` are gone.
- Atlas CPU Throttling removal is intentional — the metric doesn't populate in this cluster. If the underlying scrape is fixed later, re-add as a new panel rather than restoring this one.

## Rollback

- Exporter: `kubectl delete -f monitoring/k8s/opensearch-exporter.yaml` + `kubectl delete secret es-exporter-creds -n monitoring`
- Dashboard: revert `monitoring/k8s/gaia-overview-dashboard.yaml` and re-apply