### PR TITLE
feat(monitoring): add Total Docs Indexed time-series to Gaia Overview

### DIFF
--- a/monitoring/k8s/gaia-overview-dashboard.yaml
+++ b/monitoring/k8s/gaia-overview-dashboard.yaml
@@ -3335,6 +3335,51 @@ data:
           }
         },
         {
+          "type": "timeseries",
+          "title": "Total Docs Indexed (over time)",
+          "description": "Primary-shard document count across user indices (excludes internal `.`-prefixed indices). Use to spot sudden drops (re-indexing, deletion, index recreation) or gradual growth.",
+          "id": 108,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 114
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "targets": [
+            {
+              "expr": "sum(elasticsearch_indices_docs{index!~\"\\\\..*\"})",
+              "legendFormat": "docs",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "smooth",
+                "spanNulls": true
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          }
+        },
+        {
           "type": "row",
           "id": 107,
           "title": "GraphQL Query Cost (shadow mode)",


### PR DESCRIPTION
## Summary

Adds a full-width time-series chart to the OpenSearch Health section of the Gaia Overview dashboard that graphs **primary-shard document count over time** across user indices.

Placement immediately below the Thread Pool Rejections / Circuit Breaker Trips panels and at the bottom of the OpenSearch Health section.

## Why

- The existing "Total Docs" stat (panel id 42) only shows current value. No way to spot:
  - Sudden drops from re-indexing, accidental deletion, or index recreation
  - Backfill progress during indexer catch-up runs
- A charted view of the same metric fills that gap without introducing any new PromQL metric.

## PromQL

Identical filter to the existing stat, to keep them in sync:

```promql
sum(elasticsearch_indices_docs{index!~"\\..*"})
```

Excludes internal indices prefixed with `.` (e.g. `.opendistro_security`, `.kibana_*`). Relies on the `elasticsearch_*` metrics from the OpenSearch exporter deployed in #623.

## Panel config

- `id: 108` (next available; no collisions with existing ids 1–107)
- `type: timeseries`, `unit: short`
- Smooth line with light fill, `spanNulls: true` so scrape gaps don't break the line
- List legend, single-series tooltip

## Test plan

- [x] YAML + inner JSON both parse cleanly (validated locally)
- [x] Panel count: 69 → 70, no gridPos collisions
- [ ] Post-apply: `kubectl apply -f monitoring/k8s/gaia-overview-dashboard.yaml`, hard-refresh Grafana, confirm the new chart renders with data from the exporter