### PR TITLE
feat(monitoring): subdivide cost histogram buckets between 100M and 1B

### DIFF
--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -49,8 +49,15 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 1_000
 // Upper bucket edges, spanning the realistic range of the conservative model
 // (trivial scalar ≈ 1 at the low end, nested no-pagination queries near the
 // 1B cap at the high end). `+Inf` is emitted via the total count at render.
+//
+// Granularity is intentionally asymmetric: powers of 10 up through 100M give
+// cheap coverage of the small-to-medium range where most queries land, while
+// the top end (100M–1B) is subdivided into 100M/200M/500M/800M/1B so the
+// heatmap can distinguish where the dominant high-cost mass actually sits
+// instead of collapsing everything above 100M into a single bucket.
 const COST_BUCKET_EDGES: readonly number[] = [
-	10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000,
+	10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000,
+	1_000_000_000,
 ]
 
 // noUncheckedIndexedAccess widens `number[]`'s index access to `number | undefined`,


### PR DESCRIPTION
## Summary

Expands `COST_BUCKET_EDGES` in `costLoggerPlugin.ts` from 9 edges to 12 by adding `200M`, `500M`, `800M` between the existing `100M` and `1B` edges. Lower-range edges (10 through 100M) unchanged.

## Why

Recent prod data from the shadow-mode cost logger:

| bucket (≤) | cumulative count | % of traffic |
|---|---|---|
| 100M | 1,778 | 47% |
| **1B** | **3,780** | **100%** |

~53% of all GraphQL queries pile into the single 100M→1B bucket, so the "GraphQL Query Cost Distribution (5m rate)" heatmap on the Gaia Overview dashboard can't resolve where in that band the mass actually sits. This change adds intermediate edges so the heatmap cells can distinguish, e.g., "most queries are 100M–200M" from "most queries are near the 1B cap."

## What changes

### Code (`api/src/kg/costLoggerPlugin.ts`)

```diff
 const COST_BUCKET_EDGES: readonly number[] = [
-	10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000,
+	10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000,
+	500_000_000, 800_000_000, 1_000_000_000,
 ]
```

The exporter will emit 3 new `le` labels: `2e+08`, `5e+08`, `8e+08`.

### Dashboard

**No changes needed.** The heatmap panel uses `sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m]))` which auto-adapts to whatever `le` values the metric carries. The `p50`/`p95`/`p99` timeseries is the same: purely `le`-driven.

### Tests

All 28 tests in `costLoggerPlugin.test.ts` still pass — they assert on edges `100`, `1000`, `10000`, which remain. Verified locally.

## Deploy-time behavior

The histogram is in-process and resets on pod restart (documented in the source). On rolling deploy:

- **Accumulated old-bucket-shape data is dropped.** Prometheus has a full time series under the new label set from the first post-deploy scrape.
- **Percentile panels will look jumpy** for ~5 min while `rate()` rebuilds over the new bucket count.
- **Heatmap cells in 100M–1B** populate gradually as scrapes land.

## Rollback

Revert is one line — delete the three new edges. No downstream schema that depends on bucket identity.

## Test plan

- [x] `bun run check` (tsc --noEmit) clean
- [x] `bun run format:check` + `bun run lint` clean (141 pre-existing warnings, unchanged)
- [x] 28/28 tests in `costLoggerPlugin.test.ts` pass
- [ ] After merge+deploy: confirm `gaia_api_graphql_query_cost_bucket{le="2e+08"}` / `5e+08` / `8e+08` appear in `/health/metrics` on any api pod
- [ ] After merge+deploy: confirm heatmap cells in the 100M–1B range are visibly finer on Grafana