### PR TITLE
feat(monitoring): raise cost cap to 5B and reshape histogram buckets

### DIFF
--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -90,7 +90,7 @@ describe("computeQueryCost — pagination", () => {
 				}
 			}
 		}`)
-		expect(result).toBe(1_000_000_000)
+		expect(result).toBe(5_000_000_000)
 	})
 })
 
@@ -196,7 +196,7 @@ describe("query cost histogram", () => {
 			})
 		}
 
-		// Cost 51 → should hit le=100, le=1000, ..., le=+Inf (all ≥ 51)
+		// Cost 51 → should hit le=1000, le=10_000, ..., le=+Inf (all ≥ 51)
 		runQuery(`{ entities(first: 50) { id } }`)
 		// Cost 1001 → hits le=10_000, le=100_000, ..., le=+Inf (buckets ≥ 1001)
 		runQuery(`{ entities { id } }`)
@@ -204,9 +204,7 @@ describe("query cost histogram", () => {
 		const out = renderQueryCostHistogram()
 		expect(out).toContain("gaia_api_graphql_query_cost_count 2")
 		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${51 + 1001}`)
-		// le=100: only the cost=51 observation qualifies
-		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="100"} 1$/m)
-		// le=1000: still only cost=51 (1001 > 1000)
+		// le=1000: only the cost=51 observation qualifies (1001 > 1000)
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="1000"} 1$/m)
 		// le=10000: both observations
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="10000"} 2$/m)
@@ -233,13 +231,13 @@ describe("query cost histogram", () => {
 // never produce Infinity / NaN regardless of input.
 // --------------------------------------------------------------------------
 
-const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "1000000000", 10)
+const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "5000000000", 10)
 
 describe("computeQueryCost — cap & overflow protection", () => {
-	it("caps at MAX_COST_CALC_LIMIT (1B default) on an otherwise-astronomical query", () => {
+	it("caps at MAX_COST_CALC_LIMIT (5B default) on an otherwise-astronomical query", () => {
 		// 6 nested levels of first:1000 would mathematically be 1000^6 = 1e18
 		// (way past Number.MAX_SAFE_INTEGER). With the cap in place the walker
-		// bails as soon as the running total crosses 1B.
+		// bails as soon as the running total crosses 5B.
 		const query = `
 			{
 				entities(first: 1000) {

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -36,7 +36,7 @@ const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 1_0
 // continuing to multiply. Caps memory (totalSum can't drift to Infinity),
 // caps CPU (adversarial or pathological queries don't walk forever), and
 // keeps the metric values in a sane range for Prometheus / Grafana.
-const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 1_000_000_000)
+const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 5_000_000_000)
 
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
@@ -48,16 +48,19 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 1_000
 
 // Upper bucket edges, spanning the realistic range of the conservative model
 // (trivial scalar ≈ 1 at the low end, nested no-pagination queries near the
-// 1B cap at the high end). `+Inf` is emitted via the total count at render.
+// 5B cap at the high end). `+Inf` is emitted via the total count at render.
 //
-// Granularity is intentionally asymmetric: powers of 10 up through 100M give
-// cheap coverage of the small-to-medium range where most queries land, while
-// the top end (100M–1B) is subdivided into 100M/200M/500M/800M/1B so the
-// heatmap can distinguish where the dominant high-cost mass actually sits
-// instead of collapsing everything above 100M into a single bucket.
+// Granularity is intentionally asymmetric:
+//   - Everything below 1000 collapses into a single bucket: trivial queries
+//     (scalar/introspection-shape) don't need fine resolution.
+//   - 1k → 100M covers the small-to-medium range on powers of 10.
+//   - 100M → 1B is subdivided (100M/200M/500M/800M/1B) because that's where
+//     the dominant population sits in prod.
+//   - 1B → 5B adds 2B/3B/5B so the new top range (after the cap bump) can
+//     show which queries are truly pathological vs just "very expensive".
 const COST_BUCKET_EDGES: readonly number[] = [
-	10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000,
-	1_000_000_000,
+	1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000, 1_000_000_000,
+	2_000_000_000, 3_000_000_000, 5_000_000_000,
 ]
 
 // noUncheckedIndexedAccess widens `number[]`'s index access to `number | undefined`,


### PR DESCRIPTION
## Summary

Two related changes to the GraphQL query cost logger:

1. **`MAX_COST_CALC_LIMIT`: 1B → 5B.** Gives the walker room to distinguish "very expensive" (1B–5B) from "truly pathological" (>5B, clamped). Still caps to bound Number/CPU — just at a higher ceiling.
2. **`COST_BUCKET_EDGES` reshaped:**
   - **Dropped** `le=10`, `le=100` — the bottom three buckets collapsed into one (`le=1000`). Trivial-cost queries don't need fine resolution.
   - **Added** `le=2B`, `le=3B`, `le=5B` — the new top range unlocked by the cap bump.

Net: 12 edges → 13. Small increase in scraped series per pod, negligible memory impact.

## Why

Prior PR #625 subdivided the 100M→1B range because that was where ~53% of prod traffic sat. With the cap at 1B, everything above 1B was silently clamped to 1B — we couldn't see whether a query was computed at exactly 1B or would naturally go to 10B.

Raising to 5B means the walker keeps computing further up (up to the new cap), and the new `le=2B/3B/5B` buckets give the heatmap the resolution to show where in that new range queries land.

Collapsing the bottom three edges is cleanup — nothing useful came out of distinguishing `le=10`, `le=100`, `le=1000` on the heatmap in practice; those were all "trivial" queries and a single bucket suffices.

## What changes

### Code (`api/src/kg/costLoggerPlugin.ts`)

```diff
-const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 1_000_000_000)
+const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 5_000_000_000)

 const COST_BUCKET_EDGES: readonly number[] = [
-	10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000,
-	1_000_000_000,
+	1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000, 1_000_000_000,
+	2_000_000_000, 3_000_000_000, 5_000_000_000,
 ]
```

Comment above the edges updated to explain the asymmetric granularity.

### Dashboard

**No changes needed.** The heatmap panel uses `sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m]))`; the p50/p95/p99 panel uses `histogram_quantile(...)`. Both auto-pick up whatever `le` labels the exporter emits. Once this deploys and pods are re-scraped, the new top-range cells render and the bottom cells collapse automatically.

### Tests (`api/src/kg/__tests__/costLoggerPlugin.test.ts`)

- Cumulative-bucket test: removed the `le=100` assertion (edge no longer exists). `le=1000` / `le=10000` / `le=+Inf` assertions stay; expected counts unchanged (cost 51 still in `le=1000`, cost 1001 still above it).
- Cap test: asserts `5_000_000_000` instead of `1_000_000_000`; description updated to "5B default".
- Test-side default env mirror: `"1000000000"` → `"5000000000"`.

## Deploy-time behavior

Same as #625: histogram is in-process, resets on pod restart. Post rolling deploy:

- Old bucket-shape series drop; new series appear.
- Percentile panels will look jumpy for ~5 min while `rate()` rebuilds.
- Heatmap cells in the 1B–5B range populate gradually; bottom three cells fuse into one.

## Rollback

Two-line reversion: flip the cap back to 1B and restore the old edges. No downstream schema bound to bucket identity.

## Test plan

- [x] `bun run check` (tsc --noEmit) clean
- [x] `bun run format:check` clean (after auto-format)
- [x] `bun run lint` clean (141 pre-existing warnings, unchanged)
- [x] `bun run test src/kg/__tests__/costLoggerPlugin.test.ts` → 28/28 pass
- [x] `bun run test --exclude "**/__tests__/**"` → 108/108 pass
- [ ] After merge+deploy: `/health/metrics` exposes `le="2e+09"`, `3e+09`, `5e+09` (or `2000000000.0`, etc.) lines
- [ ] After merge+deploy: Grafana heatmap shows finer cells in the 1B–5B band