### PR TITLE
feat(monitoring): raise cost cap to 500T and extend histogram buckets

### DIFF
--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -90,7 +90,7 @@ describe("computeQueryCost — pagination", () => {
 				}
 			}
 		}`)
-		expect(result).toBe(100_000_000_000)
+		expect(result).toBe(500_000_000_000)
 	})
 })
 
@@ -231,13 +231,13 @@ describe("query cost histogram", () => {
 // never produce Infinity / NaN regardless of input.
 // --------------------------------------------------------------------------
 
-const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "100000000000", 10)
+const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "500000000000", 10)
 
 describe("computeQueryCost — cap & overflow protection", () => {
-	it("caps at MAX_COST_CALC_LIMIT (100B default) on an otherwise-astronomical query", () => {
+	it("caps at MAX_COST_CALC_LIMIT (500B default) on an otherwise-astronomical query", () => {
 		// 6 nested levels of first:1000 would mathematically be 1000^6 = 1e18
 		// (way past Number.MAX_SAFE_INTEGER). With the cap in place the walker
-		// bails as soon as the running total crosses 100B.
+		// bails as soon as the running total crosses 500B.
 		const query = `
 			{
 				entities(first: 1000) {
@@ -293,6 +293,66 @@ describe("computeQueryCost — cap & overflow protection", () => {
 			q = `{ entity(id: "x") ${q} }`
 		}
 		expect(() => cost(q)).not.toThrow()
+	})
+
+	it("caps on the production `entitiesConnection` query that produced a ~45 MB response", () => {
+		// Real query captured from prod stdout during the OOM investigation
+		// (fingerprint gql:1424e9e7). first:1000 at the root plus three levels
+		// of unbounded nested `{ nodes { ... } }` connections — the effective
+		// multiplier chain is ~1000^7 times leaf-scalar counts, so the
+		// unclamped cost is on the order of 10^22. The walker crosses the
+		// 500B cap almost immediately and short-circuits. Kept as a regression
+		// fixture so future changes to the cost model don't quietly start
+		// returning a finite value here.
+		const query = `
+			query GetEntities($type: [UUID!], $first: Int!, $after: Cursor) {
+				entitiesConnection(
+					first: $first
+					after: $after
+					filter: {relations: {some: {typeId: {is: "8f151ba4de204e3c9cb499ddf96f48f1"}, toEntityId: {in: $type}}}}
+				) {
+					pageInfo { hasNextPage endCursor }
+					nodes {
+						id
+						name
+						values {
+							nodes {
+								spaceId propertyId text language date datetime time
+								integer float decimal unit boolean point
+							}
+						}
+						relations {
+							nodes {
+								id spaceId fromEntityId toEntityId typeId verified
+								position toSpaceId entityId
+								entity {
+									id
+									name
+									values {
+										nodes {
+											spaceId propertyId text language date datetime time
+											integer float decimal unit boolean point
+										}
+									}
+									relations {
+										nodes {
+											id spaceId fromEntityId toEntityId typeId
+											position toSpaceId entityId
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`
+		const result = cost(query, {
+			type: ["7ed45f2bc48b419e8e4664d5ff680b0d"],
+			first: 1000,
+			after: null,
+		})
+		expect(result).toBe(MAX_COST_CALC_LIMIT)
 	})
 })
 

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -77,11 +77,12 @@ describe("computeQueryCost — pagination", () => {
 	})
 
 	it("catches implicit-default heavy queries that omit `first`", () => {
-		// Previously under-counted — now a nested un-paginated query scales
-		// with the MAX default at each level. Math: innermost valuesList{2 scalars}
-		// would be MAX × 2 + 1 = 2001, then entity { id valuesList } → MAX × 2002 + 1,
-		// etc. Crosses the 1B cap at 3 levels of implicit defaults, so the walker
-		// clamps to MAX_COST_CALC_LIMIT rather than drifting toward Infinity.
+		// Conservative model: each un-paginated structured field defaults to
+		// MAX_PAGINATION_LIMIT (1000). The nested shape below multiplies out to
+		// valuesList{2 scalars} = 2001, toEntity{valuesList} = 2_001_001,
+		// relationsList{toEntity} = 2_001_001_001, entities{id, relationsList} =
+		// 2_001_001_002_001 (~2T). Under the 500T cap this is the exact cost —
+		// useful as a regression fixture for the multiplier math itself.
 		const result = cost(`{
 			entities {
 				id
@@ -90,7 +91,7 @@ describe("computeQueryCost — pagination", () => {
 				}
 			}
 		}`)
-		expect(result).toBe(500_000_000_000)
+		expect(result).toBe(2_001_001_002_001)
 	})
 })
 
@@ -231,13 +232,13 @@ describe("query cost histogram", () => {
 // never produce Infinity / NaN regardless of input.
 // --------------------------------------------------------------------------
 
-const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "500000000000", 10)
+const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "500000000000000", 10)
 
 describe("computeQueryCost — cap & overflow protection", () => {
-	it("caps at MAX_COST_CALC_LIMIT (500B default) on an otherwise-astronomical query", () => {
+	it("caps at MAX_COST_CALC_LIMIT (500T default) on an otherwise-astronomical query", () => {
 		// 6 nested levels of first:1000 would mathematically be 1000^6 = 1e18
 		// (way past Number.MAX_SAFE_INTEGER). With the cap in place the walker
-		// bails as soon as the running total crosses 500B.
+		// bails as soon as the running total crosses 500T.
 		const query = `
 			{
 				entities(first: 1000) {
@@ -259,12 +260,17 @@ describe("computeQueryCost — cap & overflow protection", () => {
 	it("stops accumulating once a sibling pushes past the cap", () => {
 		// The first branch alone exceeds the cap; the second branch shouldn't
 		// be walked at all. Observable effect: result is exactly the cap.
+		// Needs 6 `first:1000` levels to clear the 500T cap: 1000^6 = 10^18 > 500T.
 		const query = `
 			{
 				first_branch: entities(first: 1000) {
 					a: entities(first: 1000) {
 						b: entities(first: 1000) {
-							c: entities(first: 1000) { id }
+							c: entities(first: 1000) {
+								d: entities(first: 1000) {
+									e: entities(first: 1000) { id }
+								}
+							}
 						}
 					}
 				}
@@ -301,7 +307,7 @@ describe("computeQueryCost — cap & overflow protection", () => {
 		// of unbounded nested `{ nodes { ... } }` connections — the effective
 		// multiplier chain is ~1000^7 times leaf-scalar counts, so the
 		// unclamped cost is on the order of 10^22. The walker crosses the
-		// 500B cap almost immediately and short-circuits. Kept as a regression
+		// 500T cap almost immediately and short-circuits. Kept as a regression
 		// fixture so future changes to the cost model don't quietly start
 		// returning a finite value here.
 		const query = `

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -90,7 +90,7 @@ describe("computeQueryCost — pagination", () => {
 				}
 			}
 		}`)
-		expect(result).toBe(5_000_000_000)
+		expect(result).toBe(100_000_000_000)
 	})
 })
 
@@ -231,13 +231,13 @@ describe("query cost histogram", () => {
 // never produce Infinity / NaN regardless of input.
 // --------------------------------------------------------------------------
 
-const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "5000000000", 10)
+const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "100000000000", 10)
 
 describe("computeQueryCost — cap & overflow protection", () => {
-	it("caps at MAX_COST_CALC_LIMIT (5B default) on an otherwise-astronomical query", () => {
+	it("caps at MAX_COST_CALC_LIMIT (100B default) on an otherwise-astronomical query", () => {
 		// 6 nested levels of first:1000 would mathematically be 1000^6 = 1e18
 		// (way past Number.MAX_SAFE_INTEGER). With the cap in place the walker
-		// bails as soon as the running total crosses 5B.
+		// bails as soon as the running total crosses 100B.
 		const query = `
 			{
 				entities(first: 1000) {

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -36,7 +36,7 @@ const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 1_0
 // continuing to multiply. Caps memory (totalSum can't drift to Infinity),
 // caps CPU (adversarial or pathological queries don't walk forever), and
 // keeps the metric values in a sane range for Prometheus / Grafana.
-const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 500_000_000_000)
+const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 500_000_000_000_000)
 
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
@@ -48,9 +48,9 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 500_0
 
 // Upper bucket edges, spanning the realistic range of the conservative model
 // (trivial scalar ≈ 1 at the low end, nested no-pagination queries near the
-// 500B cap at the high end). `+Inf` is emitted via the total count at render
-// and is the "above 500B" bucket — with the cap in place it equals the 500B
-// bucket, but remains present so a future cap bump still gets captured.
+// 500T cap at the high end). `+Inf` is emitted via the total count at render
+// and is now the "clamped at cap" bin — queries whose unclamped cost would
+// exceed 500T land only in +Inf, since 500T > 50T (the last numeric edge).
 //
 // Granularity is intentionally asymmetric:
 //   - Everything below 1000 collapses into a single bucket: trivial queries
@@ -59,11 +59,14 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 500_0
 //   - 100M → 1B is subdivided (100M/200M/500M/800M/1B) because that's where
 //     the dominant population sits in prod.
 //   - 1B → 5B adds 2B/3B/5B for the prior top range.
-//   - 5B → 500B adds 50B/100B/500B so the new 500B cap surfaces which queries
-//     are truly pathological vs just "very expensive".
+//   - 5B → 500B adds 50B/100B/500B.
+//   - 500B → 500T adds 5T/50T so the tail of genuinely pathological queries
+//     (3-level unbounded nested connections, 1000^7 theoretical) gets two
+//     resolution bins before landing in +Inf as "at the cap".
 const COST_BUCKET_EDGES: readonly number[] = [
 	1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000, 1_000_000_000,
-	2_000_000_000, 3_000_000_000, 5_000_000_000, 50_000_000_000, 100_000_000_000, 500_000_000_000,
+	2_000_000_000, 3_000_000_000, 5_000_000_000, 50_000_000_000, 100_000_000_000, 500_000_000_000, 5_000_000_000_000,
+	50_000_000_000_000,
 ]
 
 // noUncheckedIndexedAccess widens `number[]`'s index access to `number | undefined`,

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -36,7 +36,7 @@ const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 1_0
 // continuing to multiply. Caps memory (totalSum can't drift to Infinity),
 // caps CPU (adversarial or pathological queries don't walk forever), and
 // keeps the metric values in a sane range for Prometheus / Grafana.
-const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 100_000_000_000)
+const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 500_000_000_000)
 
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
@@ -48,7 +48,9 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 100_0
 
 // Upper bucket edges, spanning the realistic range of the conservative model
 // (trivial scalar ≈ 1 at the low end, nested no-pagination queries near the
-// 100B cap at the high end). `+Inf` is emitted via the total count at render.
+// 500B cap at the high end). `+Inf` is emitted via the total count at render
+// and is the "above 500B" bucket — with the cap in place it equals the 500B
+// bucket, but remains present so a future cap bump still gets captured.
 //
 // Granularity is intentionally asymmetric:
 //   - Everything below 1000 collapses into a single bucket: trivial queries
@@ -57,9 +59,8 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 100_0
 //   - 100M → 1B is subdivided (100M/200M/500M/800M/1B) because that's where
 //     the dominant population sits in prod.
 //   - 1B → 5B adds 2B/3B/5B for the prior top range.
-//   - 5B → 500B adds 50B/100B/500B so the new 100B cap surfaces which queries
-//     are truly pathological vs just "very expensive"; the 500B edge is
-//     forward-looking and will only fill if the cap is raised further.
+//   - 5B → 500B adds 50B/100B/500B so the new 500B cap surfaces which queries
+//     are truly pathological vs just "very expensive".
 const COST_BUCKET_EDGES: readonly number[] = [
 	1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000, 1_000_000_000,
 	2_000_000_000, 3_000_000_000, 5_000_000_000, 50_000_000_000, 100_000_000_000, 500_000_000_000,

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -36,7 +36,7 @@ const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 1_0
 // continuing to multiply. Caps memory (totalSum can't drift to Infinity),
 // caps CPU (adversarial or pathological queries don't walk forever), and
 // keeps the metric values in a sane range for Prometheus / Grafana.
-const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 5_000_000_000)
+const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 100_000_000_000)
 
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
@@ -48,7 +48,7 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 5_000
 
 // Upper bucket edges, spanning the realistic range of the conservative model
 // (trivial scalar ≈ 1 at the low end, nested no-pagination queries near the
-// 5B cap at the high end). `+Inf` is emitted via the total count at render.
+// 100B cap at the high end). `+Inf` is emitted via the total count at render.
 //
 // Granularity is intentionally asymmetric:
 //   - Everything below 1000 collapses into a single bucket: trivial queries
@@ -56,11 +56,13 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 5_000
 //   - 1k → 100M covers the small-to-medium range on powers of 10.
 //   - 100M → 1B is subdivided (100M/200M/500M/800M/1B) because that's where
 //     the dominant population sits in prod.
-//   - 1B → 5B adds 2B/3B/5B so the new top range (after the cap bump) can
-//     show which queries are truly pathological vs just "very expensive".
+//   - 1B → 5B adds 2B/3B/5B for the prior top range.
+//   - 5B → 500B adds 50B/100B/500B so the new 100B cap surfaces which queries
+//     are truly pathological vs just "very expensive"; the 500B edge is
+//     forward-looking and will only fill if the cap is raised further.
 const COST_BUCKET_EDGES: readonly number[] = [
 	1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000, 1_000_000_000,
-	2_000_000_000, 3_000_000_000, 5_000_000_000,
+	2_000_000_000, 3_000_000_000, 5_000_000_000, 50_000_000_000, 100_000_000_000, 500_000_000_000,
 ]
 
 // noUncheckedIndexedAccess widens `number[]`'s index access to `number | undefined`,


### PR DESCRIPTION
## Summary
- Bump `MAX_COST_CALC_LIMIT` from 5B → **500T** (env-overridable via `GRAPHQL_COST_CALC_LIMIT`)
- Add histogram bucket edges at **50B, 100B, 500B, 5T, 50T** to `gaia_api_graphql_query_cost_bucket`
- No dashboard change — `gaia-overview-dashboard.yaml` uses `histogram_quantile`, new edges flow through automatically

## Why
The recent 5xx investigation surfaced queries with theoretical cost ~10²² (3 levels of unbounded nested `{ nodes { ... } }` → multiplier 1000⁷). They all clamped at the 5B cap, collapsing the tail — can't distinguish "very expensive" from "truly pathological" in Grafana. 500T gives ~6 orders of magnitude of headroom, and the new buckets provide resolution in that range. `+Inf` is now the honest "at the cap" bin.

## Walker perf (measured locally, 100k-iter bench)
Trivial query 0.18 µs · typical 0.43 µs · prod bomb hitting cap 2.6 µs · 50-level pathological 3.2 µs · 200-field wide 8.3 µs. Walker time is driven by AST size, not cost; raising the cap adds a handful of µs at most to cap-hitters.

## Out of scope
No changes to `paginationCapPlugin` or `COST_LOG_THRESHOLD`. Walker stays warn-only — this is pure observability.

## Test plan
- [x] lint / tsc / `vitest run src/kg/__tests__/costLoggerPlugin.test.ts` pass (29 tests)
- [x] New regression test asserts the prod-shape `entitiesConnection` bomb clamps at the cap
- [ ] After deploy, confirm the new bucket labels show up on Grafana heatmap and p95/p99 panels