### PR TITLE
feat(monitoring): reduce cost-model output, log only cap-hitters

### DIFF
--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -197,23 +197,35 @@ describe("query cost histogram", () => {
 			})
 		}
 
-		// Cost 1001 → hits le=100_000, ..., le=+Inf (all buckets ≥ 1001)
+		// Cost 1001 — well below every numeric edge, so it lands in every
+		// bucket from the 100M floor up through 5P and +Inf.
 		runQuery(`{ entities { id } }`)
-		// Cost 100_001 (first:100_000 × id) is rejected by PaginationCapPlugin in
-		// the server path, but computeQueryCost is purely schema-free and happily
-		// evaluates AST-derived multipliers — pick a construction that produces
-		// a cost between 100k and 1M: entities(first:1000){id name} = 2001,
-		// that's still ≤ 100_000 so it only adds to the smaller bucket. Use a
-		// deliberately heavier query to straddle the 100k/1M edges.
-		runQuery(`{ entities(first: 500) { id name values(first: 5) { propertyId text } } }`) // 500*(1+1+5*(1+1)+1) + 1 = 500*13 + 1 = 6501
+		// A 6-nested first:1000 query clamps at the 9P cap. Since 9P > 5P
+		// (the top numeric edge), this observation is ONLY in +Inf.
+		runQuery(`
+			{
+				entities(first: 1000) {
+					a: entities(first: 1000) {
+						b: entities(first: 1000) {
+							c: entities(first: 1000) {
+								d: entities(first: 1000) {
+									e: entities(first: 1000) { id }
+								}
+							}
+						}
+					}
+				}
+			}
+		`)
 
 		const out = renderQueryCostHistogram()
 		expect(out).toContain("gaia_api_graphql_query_cost_count 2")
-		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${1001 + 6501}`)
-		// le=100000: both observations qualify (1001 and 6501 both ≤ 100_000)
-		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="100000"} 2$/m)
-		// le=1000000: still both
-		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="1000000"} 2$/m)
+		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${1001 + 9_000_000_000_000_000}`)
+		// le=100M (new floor): only the cheap query (cap-hitter is above 5P)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="100000000"} 1$/m)
+		// le=5P (top numeric edge): still only the cheap query
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="5000000000000000"} 1$/m)
+		// +Inf: both
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 2$/m)
 	})
 
@@ -435,11 +447,26 @@ describe("useCostLogger — shadow-mode safety", () => {
 
 		const plugin = useCostLogger()
 		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
-		// A query guaranteed to cross the default 1M log threshold.
+		// A query guaranteed to cross the default log threshold (the cap itself).
+		// Six `first:1000` levels multiply out to 1000^6 = 1e18, well over 9P.
 		expect(() =>
 			onExecute({
 				args: {
-					document: parse(`{ entities(first: 1000) { relationsList { id } } }`),
+					document: parse(`
+						{
+							entities(first: 1000) {
+								a: entities(first: 1000) {
+									b: entities(first: 1000) {
+										c: entities(first: 1000) {
+											d: entities(first: 1000) {
+												e: entities(first: 1000) { id }
+											}
+										}
+									}
+								}
+							}
+						}
+					`),
 					variableValues: {circular},
 					operationName: null,
 				},

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -15,14 +15,14 @@ describe("computeQueryCost — basic shapes", () => {
 		expect(cost(`{ __typename }`)).toBe(1)
 	})
 
-	it("structured field without first/last defaults to MAX (conservative)", () => {
+	it("structured field without first/last defaults to COST_MODEL_DEFAULT_LIMIT", () => {
 		// Single-entity lookups get over-counted — intentionally. We never know
 		// from the AST alone whether a field is a list or a single object; the
-		// SQL layer injects first=MAX on every collection field anyway, so
+		// SQL layer injects `first:` on every collection field anyway, so
 		// over-counting single-entity lookups is the price of never missing an
 		// unbounded collection.
-		// entity { id name } → MAX × (1 + 1) + 1 = 2001
-		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(MAX_PAGINATION_LIMIT * 2 + 1)
+		// entity { id name } → 100 × (1 + 1) + 1 = 201 (COST_MODEL_DEFAULT_LIMIT)
+		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(201)
 	})
 })
 
@@ -53,12 +53,13 @@ describe("computeQueryCost — pagination", () => {
 	})
 
 	it("models the slow-query pattern that triggered prod statement_timeout", () => {
-		// The real shape we saw timing out, computed with the conservative model:
+		// The real shape we saw timing out, computed with the conservative model
+		// using COST_MODEL_DEFAULT_LIMIT = 100 for implicit fan-outs:
 		//   valuesList(first:1){propertyId}        = 1 × 1 + 1                  = 2
-		//   entity { valuesList }                  = MAX × 2 + 1                = 2001
-		//   relations(first:50) { id, entity }     = 50 × (1 + 2001) + 1        = 100_101
-		//   5 × 100_101 + 1 (id on entity)         = 500_506
-		//   entities(first:1000) { ... }           = 1000 × 500_506 + 1         = 500_506_001
+		//   entity { valuesList }                  = 100 × 2 + 1                = 201
+		//   relations(first:50) { id, entity }     = 50 × (1 + 201) + 1         = 10_101
+		//   5 × 10_101 + 1 (id on entity)          = 50_506
+		//   entities(first:1000) { ... }           = 1000 × 50_506 + 1          = 50_506_001
 		const query = `
 			{
 				entities(first: 1000) {
@@ -72,17 +73,19 @@ describe("computeQueryCost — pagination", () => {
 			}
 		`
 		const result = cost(query)
-		expect(result).toBe(500_506_001)
-		expect(result).toBeGreaterThan(100_000_000) // trivially exceeds any threshold
+		expect(result).toBe(50_506_001)
+		expect(result).toBeGreaterThan(10_000_000) // still trivially exceeds any threshold
 	})
 
 	it("catches implicit-default heavy queries that omit `first`", () => {
 		// Conservative model: each un-paginated structured field defaults to
-		// MAX_PAGINATION_LIMIT (1000). The nested shape below multiplies out to
-		// valuesList{2 scalars} = 2001, toEntity{valuesList} = 2_001_001,
-		// relationsList{toEntity} = 2_001_001_001, entities{id, relationsList} =
-		// 2_001_001_002_001 (~2T). Under the 500T cap this is the exact cost —
-		// useful as a regression fixture for the multiplier math itself.
+		// COST_MODEL_DEFAULT_LIMIT (100). The nested shape below multiplies out:
+		//   valuesList{2 scalars}             = 100 × 2 + 1         = 201
+		//   toEntity{valuesList}              = 100 × 201 + 1       = 20_101
+		//   relationsList{toEntity}           = 100 × 20_101 + 1    = 2_010_101
+		//   entities{id, relationsList}       = 100 × 2_010_102 + 1 = 201_010_201
+		// Under the 9P cap this is the exact cost — regression fixture for the
+		// multiplier math itself.
 		const result = cost(`{
 			entities {
 				id
@@ -91,7 +94,7 @@ describe("computeQueryCost — pagination", () => {
 				}
 			}
 		}`)
-		expect(result).toBe(2_001_001_002_001)
+		expect(result).toBe(201_010_201)
 	})
 })
 
@@ -197,7 +200,7 @@ describe("query cost histogram", () => {
 			})
 		}
 
-		// Cost 1001 — well below every numeric edge, so it lands in every
+		// Cost 101 — well below every numeric edge, so it lands in every
 		// bucket from the 100M floor up through 5P and +Inf.
 		runQuery(`{ entities { id } }`)
 		// A 6-nested first:1000 query clamps at the 9P cap. Since 9P > 5P
@@ -220,7 +223,7 @@ describe("query cost histogram", () => {
 
 		const out = renderQueryCostHistogram()
 		expect(out).toContain("gaia_api_graphql_query_cost_count 2")
-		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${1001 + 9_000_000_000_000_000}`)
+		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${101 + 9_000_000_000_000_000}`)
 		// le=100M (new floor): only the cheap query (cap-hitter is above 5P)
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="100000000"} 1$/m)
 		// le=5P (top numeric edge): still only the cheap query

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -45,6 +45,16 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 9_000
 // histogram without adding to stdout noise.
 const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", MAX_COST_CALC_LIMIT)
 
+// Per-level multiplier used when a collection field omits `first`/`last`.
+// Separate from MAX_PAGINATION_LIMIT (1000) — the paginationCap plugin still
+// injects `first: 1000` at SQL build time, but assuming the *full* SQL cap
+// at every implicit level compounds into unrealistically large numbers for
+// typical query shapes. 100 is a more realistic expected-fan-out for the
+// cost model and keeps the histogram distribution readable — cap-hitters
+// still clamp, deeply-nested structural issues still stand out, but the
+// per-query numbers stay closer to "scan rows" than "theoretical ceiling".
+const COST_MODEL_DEFAULT_LIMIT = 100
+
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
 // ---------------------------------------------------------------------------
@@ -215,11 +225,12 @@ function fieldCost(
 		return Math.min(child * limit + 1, MAX_COST_CALC_LIMIT)
 	}
 
-	// Structured field without an explicit limit: conservatively assume the
-	// SQL-injected default of MAX_PAGINATION_LIMIT applies. Leaf scalars
-	// (no selection set → child=0) collapse to `0 × N + 1 = 1` here, so we
-	// don't need a separate branch.
-	return Math.min(child * MAX_PAGINATION_LIMIT + 1, MAX_COST_CALC_LIMIT)
+	// Structured field without an explicit limit: assume the cost-model
+	// default fan-out (COST_MODEL_DEFAULT_LIMIT, decoupled from the
+	// SQL-level MAX_PAGINATION_LIMIT). Leaf scalars (no selection set →
+	// child=0) collapse to `0 × N + 1 = 1` here, so we don't need a
+	// separate branch.
+	return Math.min(child * COST_MODEL_DEFAULT_LIMIT + 1, MAX_COST_CALC_LIMIT)
 }
 
 function resolveArgs(

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -25,12 +25,6 @@ function parsePositiveIntEnv(name: string, fallback: number): number {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
-// Threshold above which we emit an info-level log line with the full query +
-// variables. Not an alert — just "this one is worth finding in logs if we
-// need to investigate a slow response later". Kept separate from the
-// histogram metric (which records every query regardless of size).
-const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 1_000_000)
-
 // Hard ceiling on the cost calculation itself. Once the walker's running
 // total reaches this value it short-circuits and returns the cap instead of
 // continuing to multiply. Caps memory (totalSum can't drift to Infinity),
@@ -42,6 +36,14 @@ const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 1_0
 // integer precision. This is the practical ceiling for the cost number
 // itself without reaching for BigInt.
 const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 9_000_000_000_000_000)
+
+// Threshold above which we emit a warn-level log line with the full query +
+// variables. Set to the cap itself, so we only log queries that were
+// actually clamped — i.e. whose unclamped theoretical cost exceeds
+// MAX_COST_CALC_LIMIT. These are the truly pathological shapes worth
+// investigating; anything below the cap is fine to leave in the Prometheus
+// histogram without adding to stdout noise.
+const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", MAX_COST_CALC_LIMIT)
 
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
@@ -58,9 +60,8 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 9_000
 // would exceed 9P land only in +Inf, since 9P > 5P (the last numeric edge).
 //
 // Granularity is intentionally asymmetric:
-//   - Everything below 100k collapses into a single bucket: trivial queries
-//     (scalar/introspection-shape) don't need fine resolution.
-//   - 100k → 100M covers the small-to-medium range on powers of 10.
+//   - Everything below 100M collapses into a single bucket: cheap / trivial
+//     queries don't need fine resolution (prod sees almost no volume there).
 //   - 100M → 800M is subdivided (100M/200M/500M/800M) because that's where
 //     the dominant population sits in prod.
 //   - 800M → 50B jumps directly to 5B/50B (the 1B–5B range collapsed to a
@@ -68,8 +69,8 @@ const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 9_000
 //   - 50B → 9P covers the pathological tail on decade steps: 100B, 500B,
 //     5T, 50T, 500T, 5P — six resolution bins before +Inf / the cap.
 const COST_BUCKET_EDGES: readonly number[] = [
-	100_000, 1_000_000, 10_000_000, 100_000_000, 200_000_000, 500_000_000, 800_000_000, 5_000_000_000, 50_000_000_000,
-	100_000_000_000, 500_000_000_000, 5_000_000_000_000, 50_000_000_000_000, 500_000_000_000_000, 5_000_000_000_000_000,
+	100_000_000, 200_000_000, 500_000_000, 800_000_000, 5_000_000_000, 50_000_000_000, 100_000_000_000, 500_000_000_000,
+	5_000_000_000_000, 50_000_000_000_000, 500_000_000_000_000, 5_000_000_000_000_000,
 ]
 
 // noUncheckedIndexedAccess widens `number[]`'s index access to `number | undefined`,


### PR DESCRIPTION
## Summary
Three changes to the GraphQL cost observability, all low-risk tuning — no runtime behavior changes, only how costs are computed and reported.

- **Scale down cost output ~5 orders of magnitude.** New `COST_MODEL_DEFAULT_LIMIT = 100` (decoupled from `MAX_PAGINATION_LIMIT = 1000`) is the implicit per-level multiplier for collection fields without `first`/`last`. SQL-level enforcement unchanged; this only tunes what the cost model *assumes* about fan-out.
- **Log threshold → cap (`9P`).** Previously `1M`, which emitted ~150 warn lines per 30s in prod (mostly noise from routine 2–4M-cost queries). Now only queries whose unclamped cost exceeds `MAX_COST_CALC_LIMIT` get logged — i.e. the actually-pathological ones. Derived from `MAX_COST_CALC_LIMIT` so the two can't drift.
- **Collapse bottom 4 histogram bucket edges.** Drop `100k`, `1M`, `10M` (1k/10k were already removed in the prior PR). Live `/health/metrics` from prod showed zero observations in that range over 12 min. New floor is `100M`.

## Why
Grafana was unreadable: the heatmap's live range spanned ~15 orders of magnitude (trivial scalars at 1 through cap-hitters at 9P), most observations piled into the tail, and stdout was drowning in cost warnings that weren't actionable. Rescaling the mid-range down and tightening the log threshold lets the histogram show the *distribution* clearly while stdout now only flags the queries that truly need attention.

## Concrete before/after
| Query shape | Before | After |
|---|---|---|
| Single entity lookup | 2,001 | 201 |
| "slow-query statement_timeout" | 500,506,001 | 50,506,001 |
| Implicit-default heavy | 2,001,001,002,001 | 201,010,201 |
| Cap-hitting pathological (1000⁷) | 9P | 9P (unchanged) |

Log volume reduction in prod (extrapolating from the 30s sample that showed ~150 warn lines at the 1M threshold and ~14 cap-hitters): expected ~90% reduction in stdout noise, focused on actionable queries.

## Dashboard
No change needed — `gaia-overview-dashboard.yaml` uses `histogram_quantile` over `le`, so removed edges and rescaled values both propagate automatically on the next scrape.

## Test plan
- [x] lint / tsc / vitest (30 tests) pass
- [x] Bucket-assignment test reshaped — cumulativity demonstrated with a cap-hitter landing in `+Inf` only
- [x] High-cost log-path safety test uses a shape that still clears the new 9P threshold
- [x] Known-shape tests updated to the new 100-multiplier expected values
- [ ] After deploy: confirm stdout `High GraphQL query cost` volume drops, Grafana heatmap renders with the tighter bucket range, and the quantile panels land in a meaningful position rather than all at cap