### PR TITLE
feat(monitoring): BigInt cost walker + log10-compressed score

### DIFF
--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -2,46 +2,86 @@ import {parse} from "graphql"
 import {beforeEach, describe, expect, it} from "vitest"
 import {
 	__resetQueryCostHistogramForTests,
+	compressCost,
 	computeQueryCost,
+	computeQueryCostRaw,
 	renderQueryCostHistogram,
 	useCostLogger,
 } from "../costLoggerPlugin"
 import {MAX_PAGINATION_LIMIT} from "../paginationCapPlugin"
 
+/** Compressed-score helper (what gets recorded and logged). */
 const cost = (query: string, variables: Record<string, unknown> = {}) => computeQueryCost(parse(query), variables)
 
-describe("computeQueryCost — basic shapes", () => {
-	it("scalar-only operation → 1", () => {
-		expect(cost(`{ __typename }`)).toBe(1)
+/** Raw BigInt-cost helper — for tests that care about the exact multiplier math. */
+const rawCost = (query: string, variables: Record<string, unknown> = {}) => computeQueryCostRaw(parse(query), variables)
+
+// --------------------------------------------------------------------------
+// compressCost — log₁₀×10 compression primitive
+// --------------------------------------------------------------------------
+
+describe("compressCost", () => {
+	it("returns 0 for n ≤ 1 (trivial / empty)", () => {
+		expect(compressCost(0n)).toBe(0)
+		expect(compressCost(1n)).toBe(0)
 	})
 
-	it("structured field without first/last defaults to COST_MODEL_DEFAULT_LIMIT", () => {
-		// Single-entity lookups get over-counted — intentionally. We never know
-		// from the AST alone whether a field is a list or a single object; the
-		// SQL layer injects `first:` on every collection field anyway, so
-		// over-counting single-entity lookups is the price of never missing an
-		// unbounded collection.
-		// entity { id name } → 100 × (1 + 1) + 1 = 201 (COST_MODEL_DEFAULT_LIMIT)
-		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(201)
+	it("round(log₁₀(n) × 10) — each 10-point step = one order of magnitude", () => {
+		expect(compressCost(10n)).toBe(10) // log10(10) = 1.000
+		expect(compressCost(100n)).toBe(20) // log10(100) = 2.000
+		expect(compressCost(1_000n)).toBe(30)
+		expect(compressCost(1_000_000n)).toBe(60)
+		expect(compressCost(10n ** 15n)).toBe(150)
+		expect(compressCost(10n ** 25n)).toBe(250)
+	})
+
+	it("rounds correctly between decades", () => {
+		// log10(201) ≈ 2.303 → round(23.03) = 23
+		expect(compressCost(201n)).toBe(23)
+		// log10(51) ≈ 1.708 → round(17.08) = 17
+		expect(compressCost(51n)).toBe(17)
+	})
+
+	it("handles BigInts far past Number.MAX_SAFE_INTEGER without precision loss", () => {
+		// 27-digit number (past 2^53) — the kind of value cap-hitter
+		// entity queries produce with D=1000. log₁₀(1.4 × 10²⁶) ≈ 26.146.
+		const huge = 140_000_000_000_000_000_000_000_000n // 1.4 × 10²⁶
+		expect(compressCost(huge)).toBe(261)
+		// 300-digit number — adversarial-depth probe. log₁₀(10²⁹⁹) = 299.
+		const astronomical = 10n ** 299n
+		expect(compressCost(astronomical)).toBe(2990)
 	})
 })
 
-describe("computeQueryCost — pagination", () => {
-	it("first:50 selecting id → 51", () => {
-		expect(cost(`{ entities(first: 50) { id } }`)).toBe(51)
+// --------------------------------------------------------------------------
+// Compressed-cost scores for realistic shapes
+// --------------------------------------------------------------------------
+
+describe("computeQueryCost — compressed scores", () => {
+	it("scalar-only operation → 0", () => {
+		// raw = 1 → compressed = 0
+		expect(cost(`{ __typename }`)).toBe(0)
 	})
 
-	it("first:100 selecting id + name → 201", () => {
-		expect(cost(`{ entities(first: 100) { id name } }`)).toBe(201)
+	it("simple single-entity lookup → ~30", () => {
+		// raw = 1000 × 2 + 1 = 2001, log10 ≈ 3.301 → 33
+		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(33)
 	})
 
-	it("last on root collection honored", () => {
-		expect(cost(`{ entities(last: 25) { id } }`)).toBe(26)
+	it("first:50 single scalar → 17", () => {
+		// raw = 51, log10(51) ≈ 1.708 → 17
+		expect(cost(`{ entities(first: 50) { id } }`)).toBe(17)
 	})
 
-	it("nested list multiplies correctly", () => {
+	it("last:25 single scalar → 14", () => {
+		// raw = 26, log10 ≈ 1.415 → 14
+		expect(cost(`{ entities(last: 25) { id } }`)).toBe(14)
+	})
+
+	it("nested-list with explicit pagination → 24", () => {
 		// inner relations(first:10){id} = 11
 		// outer entities(first:20){id + inner} = 20 × (1 + 11) + 1 = 241
+		// log10(241) ≈ 2.382 → 24
 		expect(
 			cost(`{
 				entities(first: 20) {
@@ -49,301 +89,47 @@ describe("computeQueryCost — pagination", () => {
 					relations(first: 10) { id }
 				}
 			}`),
-		).toBe(241)
-	})
-
-	it("models the slow-query pattern that triggered prod statement_timeout", () => {
-		// The real shape we saw timing out, computed with the conservative model
-		// using COST_MODEL_DEFAULT_LIMIT = 100 for implicit fan-outs:
-		//   valuesList(first:1){propertyId}        = 1 × 1 + 1                  = 2
-		//   entity { valuesList }                  = 100 × 2 + 1                = 201
-		//   relations(first:50) { id, entity }     = 50 × (1 + 201) + 1         = 10_101
-		//   5 × 10_101 + 1 (id on entity)          = 50_506
-		//   entities(first:1000) { ... }           = 1000 × 50_506 + 1          = 50_506_001
-		const query = `
-			{
-				entities(first: 1000) {
-					id
-					a: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
-					b: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
-					c: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
-					d: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
-					e: relations(first: 50) { id entity { valuesList(first: 1) { propertyId } } }
-				}
-			}
-		`
-		const result = cost(query)
-		expect(result).toBe(50_506_001)
-		expect(result).toBeGreaterThan(10_000_000) // still trivially exceeds any threshold
-	})
-
-	it("catches implicit-default heavy queries that omit `first`", () => {
-		// Conservative model: each un-paginated structured field defaults to
-		// COST_MODEL_DEFAULT_LIMIT (100). The nested shape below multiplies out:
-		//   valuesList{2 scalars}             = 100 × 2 + 1         = 201
-		//   toEntity{valuesList}              = 100 × 201 + 1       = 20_101
-		//   relationsList{toEntity}           = 100 × 20_101 + 1    = 2_010_101
-		//   entities{id, relationsList}       = 100 × 2_010_102 + 1 = 201_010_201
-		// Under the 9P cap this is the exact cost — regression fixture for the
-		// multiplier math itself.
-		const result = cost(`{
-			entities {
-				id
-				relationsList {
-					toEntity { valuesList { propertyId text } }
-				}
-			}
-		}`)
-		expect(result).toBe(201_010_201)
+		).toBe(24)
 	})
 })
 
-describe("computeQueryCost — defensive handling of bogus inputs", () => {
-	it("first:0 uses MAX_PAGINATION_LIMIT (defensive)", () => {
-		// Otherwise an attacker could hide expensive nested work behind first:0
-		// (which at SQL time returns nothing, but is atypical in legit traffic).
-		expect(cost(`{ entities(first: 0) { id } }`)).toBe(MAX_PAGINATION_LIMIT * 1 + 1)
-	})
+// --------------------------------------------------------------------------
+// Exact-raw-cost regression tests (multiplier math)
+// --------------------------------------------------------------------------
 
-	it("negative first uses MAX_PAGINATION_LIMIT", () => {
-		expect(cost(`{ entities(first: -5) { id } }`)).toBe(MAX_PAGINATION_LIMIT + 1)
-	})
-
-	it("negative last uses MAX_PAGINATION_LIMIT", () => {
-		expect(cost(`{ entities(last: -100) { id } }`)).toBe(MAX_PAGINATION_LIMIT + 1)
-	})
-
-	it("negative outer first still charges for valid nested first", () => {
-		// Attack shape: user tries to hide expensive inner behind first:-5 outer.
-		// Inner relations(first:50){id} = 51.
-		// Outer entities(first:-5) → MAX × (1 + 51) + 1 = 52_001
+describe("computeQueryCostRaw — multiplier math", () => {
+	it("explicit-pagination nested: `entities(first:20) { id, relations(first:10){id} }` → 241n", () => {
 		expect(
-			cost(`{
-				entities(first: -5) {
+			rawCost(`{
+				entities(first: 20) {
 					id
-					relations(first: 50) { id }
+					relations(first: 10) { id }
 				}
 			}`),
-		).toBe(MAX_PAGINATION_LIMIT * 52 + 1)
-	})
-})
-
-describe("computeQueryCost — variables", () => {
-	it("resolves pagination args supplied via variables", () => {
-		expect(cost(`query Q($first: Int!) { entities(first: $first) { id } }`, {first: 100})).toBe(101)
+		).toBe(241n)
 	})
 
-	it("treats missing variable as no valid pagination → MAX", () => {
+	it("implicit-default heavy query: three unpaginated levels compound at 1000×", () => {
+		// valuesList { 2 scalars }             = 1000 × 2 + 1   = 2001
+		// toEntity { valuesList }              = 1000 × 2001 + 1 = 2_001_001
+		// relationsList { toEntity }           = 1000 × 2_001_001 + 1 = 2_001_001_001
+		// entities { id, relationsList }       = 1000 × 2_001_001_002 + 1 = 2_001_001_002_001
 		expect(
-			cost(
-				`query Q($first: Int) { entities(first: $first) { id } }`,
-				{}, // $first unresolved
-			),
-		).toBe(MAX_PAGINATION_LIMIT + 1)
-	})
-})
-
-describe("computeQueryCost — fragments", () => {
-	it("inline fragments contribute to parent's childComplexity", () => {
-		// entities(first:10) { ... on Entity { id name } }
-		// inline frag selections = 2 → outer = 10 × 2 + 1 = 21
-		expect(
-			cost(`{
-				entities(first: 10) {
-					... on Entity { id name }
+			rawCost(`{
+				entities {
+					id
+					relationsList {
+						toEntity { valuesList { propertyId text } }
+					}
 				}
 			}`),
-		).toBe(21)
+		).toBe(2_001_001_002_001n)
 	})
 
-	it("fragment spreads follow the definition", () => {
-		// fragment F on Entity { id name }
-		// entities(first:10) { ...F } → 10 × 2 + 1 = 21
-		expect(
-			cost(`
-				query { entities(first: 10) { ...F } }
-				fragment F on Entity { id name }
-			`),
-		).toBe(21)
-	})
-})
-
-describe("computeQueryCost — empty / edge", () => {
-	it("returns 0 for a document with no operation", () => {
-		expect(cost(`fragment Unused on Query { __typename }`)).toBe(0)
-	})
-})
-
-// --------------------------------------------------------------------------
-// Prometheus histogram exposed via /health/metrics
-// --------------------------------------------------------------------------
-
-describe("query cost histogram", () => {
-	beforeEach(() => {
-		__resetQueryCostHistogramForTests()
-	})
-
-	it("empty state emits zero-counts for all buckets", () => {
-		const out = renderQueryCostHistogram()
-		expect(out).toMatch(/# TYPE gaia_api_graphql_query_cost histogram/)
-		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 0/)
-		expect(out).toMatch(/gaia_api_graphql_query_cost_count 0/)
-		expect(out).toMatch(/gaia_api_graphql_query_cost_sum 0/)
-	})
-
-	it("each recorded query increments the right buckets cumulatively", async () => {
-		const plugin = useCostLogger()
-		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
-		const runQuery = (query: string, variables: Record<string, unknown> = {}) => {
-			onExecute({
-				args: {document: parse(query), variableValues: variables, operationName: null},
-			})
-		}
-
-		// Cost 101 — well below every numeric edge, so it lands in every
-		// bucket from the 100M floor up through 5P and +Inf.
-		runQuery(`{ entities { id } }`)
-		// A 6-nested first:1000 query clamps at the 9P cap. Since 9P > 5P
-		// (the top numeric edge), this observation is ONLY in +Inf.
-		runQuery(`
-			{
-				entities(first: 1000) {
-					a: entities(first: 1000) {
-						b: entities(first: 1000) {
-							c: entities(first: 1000) {
-								d: entities(first: 1000) {
-									e: entities(first: 1000) { id }
-								}
-							}
-						}
-					}
-				}
-			}
-		`)
-
-		const out = renderQueryCostHistogram()
-		expect(out).toContain("gaia_api_graphql_query_cost_count 2")
-		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${101 + 9_000_000_000_000_000}`)
-		// le=100M (new floor): only the cheap query (cap-hitter is above 5P)
-		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="100000000"} 1$/m)
-		// le=5P (top numeric edge): still only the cheap query
-		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="5000000000000000"} 1$/m)
-		// +Inf: both
-		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 2$/m)
-	})
-
-	it("skips introspection queries", async () => {
-		const plugin = useCostLogger()
-		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
-		onExecute({
-			args: {
-				document: parse(`{ __typename }`),
-				variableValues: {},
-				operationName: "IntrospectionQuery",
-			},
-		})
-		expect(renderQueryCostHistogram()).toContain("gaia_api_graphql_query_cost_count 0")
-	})
-})
-
-// --------------------------------------------------------------------------
-// Safety invariants — the plugin must never throw into yoga (shadow mode
-// must not break the request it was observing), and the cost math must
-// never produce Infinity / NaN regardless of input.
-// --------------------------------------------------------------------------
-
-const MAX_COST_CALC_LIMIT = Number.parseInt(process.env.GRAPHQL_COST_CALC_LIMIT ?? "9000000000000000", 10)
-
-describe("computeQueryCost — cap & overflow protection", () => {
-	it("MAX_COST_CALC_LIMIT stays within Number.MAX_SAFE_INTEGER", () => {
-		// Regression guard: the cap must be representable exactly as a JS
-		// Number. Above 2^53 - 1 (~9.007e15), integer arithmetic starts rounding,
-		// which would break the `Math.min(child * limit + 1, cap)` clamp and the
-		// `child >= cap` short-circuit — both rely on exact equality/comparison
-		// at the cap magnitude. If someone bumps the cap past this point they
-		// need BigInt, not just a bigger Number literal.
-		expect(MAX_COST_CALC_LIMIT).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER)
-		// And we still have unit precision at this magnitude (cap+1 > cap,
-		// cap-1 < cap). If we drift past MAX_SAFE_INTEGER these fail silently.
-		expect(MAX_COST_CALC_LIMIT + 1).toBeGreaterThan(MAX_COST_CALC_LIMIT)
-		expect(MAX_COST_CALC_LIMIT - 1).toBeLessThan(MAX_COST_CALC_LIMIT)
-	})
-
-	it("caps at MAX_COST_CALC_LIMIT (9P default) on an otherwise-astronomical query", () => {
-		// 6 nested levels of first:1000 would mathematically be 1000^6 = 1e18
-		// (way past Number.MAX_SAFE_INTEGER). With the 9P cap in place the
-		// walker bails as soon as the running total crosses it.
-		const query = `
-			{
-				entities(first: 1000) {
-					a: entities(first: 1000) {
-						b: entities(first: 1000) {
-							c: entities(first: 1000) {
-								d: entities(first: 1000) {
-									e: entities(first: 1000) { id }
-								}
-							}
-						}
-					}
-				}
-			}
-		`
-		expect(cost(query)).toBe(MAX_COST_CALC_LIMIT)
-	})
-
-	it("stops accumulating once a sibling pushes past the cap", () => {
-		// The first branch alone exceeds the cap; the second branch shouldn't
-		// be walked at all. Observable effect: result is exactly the cap.
-		// Needs 6 `first:1000` levels to clear the 500T cap: 1000^6 = 10^18 > 500T.
-		const query = `
-			{
-				first_branch: entities(first: 1000) {
-					a: entities(first: 1000) {
-						b: entities(first: 1000) {
-							c: entities(first: 1000) {
-								d: entities(first: 1000) {
-									e: entities(first: 1000) { id }
-								}
-							}
-						}
-					}
-				}
-				second_branch: entities(first: 1000) { id }
-			}
-		`
-		expect(cost(query)).toBe(MAX_COST_CALC_LIMIT)
-	})
-
-	it("never returns Infinity or NaN, even on pathologically deep inputs", () => {
-		// Build a synthetic query 50 levels deep, each with first:1000.
-		let q = "{ id }"
-		for (let i = 0; i < 50; i++) {
-			q = `{ entities(first: 1000) ${q} }`
-		}
-		const c = cost(q)
-		expect(Number.isFinite(c)).toBe(true)
-		expect(c).toBeLessThanOrEqual(MAX_COST_CALC_LIMIT)
-	})
-
-	it("handles a deeply-nested legit query without stack overflow", () => {
-		// 30-level nesting (realistic upper bound for client queries). Should
-		// return cleanly regardless of whether it hits the cap.
-		let q = "{ id }"
-		for (let i = 0; i < 30; i++) {
-			q = `{ entity(id: "x") ${q} }`
-		}
-		expect(() => cost(q)).not.toThrow()
-	})
-
-	it("caps on the production `entitiesConnection` query that produced a ~45 MB response", () => {
-		// Real query captured from prod stdout during the OOM investigation
-		// (fingerprint gql:1424e9e7). first:1000 at the root plus three levels
-		// of unbounded nested `{ nodes { ... } }` connections — the effective
-		// multiplier chain is ~1000^7 times leaf-scalar counts, so the
-		// unclamped cost is on the order of 10^22. The walker crosses the
-		// 9P cap almost immediately and short-circuits. Kept as a regression
-		// fixture so future changes to the cost model don't quietly start
-		// returning a finite value here.
+	it("real prod shape: `entitiesConnection` with 3-level nested relations", () => {
+		// Captured from prod logs (fingerprint gql:1424e9e7). Explicit
+		// first:1000 at the root + 3 levels of unbounded `{ nodes {...} }`
+		// nested connections produces a raw cost deep into 22-digit territory.
 		const query = `
 			query GetEntities($type: [UUID!], $first: Int!, $after: Cursor) {
 				entitiesConnection(
@@ -387,48 +173,241 @@ describe("computeQueryCost — cap & overflow protection", () => {
 				}
 			}
 		`
-		const result = cost(query, {
-			type: ["7ed45f2bc48b419e8e4664d5ff680b0d"],
-			first: 1000,
-			after: null,
-		})
-		expect(result).toBe(MAX_COST_CALC_LIMIT)
+		const raw = rawCost(query, {type: ["7ed45f2bc48b419e8e4664d5ff680b0d"], first: 1000, after: null})
+		// Raw is a 22-digit BigInt. Exact value is stable across runs since
+		// the walker is deterministic.
+		expect(raw.toString().length).toBeGreaterThanOrEqual(22)
+		expect(raw.toString().length).toBeLessThanOrEqual(23)
+		// Compressed score of the prod cap-hitter: ~220 (≈10²² raw cost).
+		expect(compressCost(raw)).toBeGreaterThanOrEqual(215)
+		expect(compressCost(raw)).toBeLessThanOrEqual(225)
 	})
 })
 
-describe("computeQueryCost — fragment cycles", () => {
-	it("returns cleanly on a fragment-spread cycle (A → B → A)", () => {
-		// NoFragmentCycles validation would normally reject this before
-		// execute, but we defend against an upstream plugin skipping validation.
+// --------------------------------------------------------------------------
+// Adversarial / pathological inputs — must not crash, must produce bounded
+// (if large) scores.
+// --------------------------------------------------------------------------
+
+describe("computeQueryCost — adversarial inputs", () => {
+	it("50-level deeply nested `entities(first:1000)` → score ~1500, no throw", () => {
+		// raw = 1000^50 ≈ 10^150 → compressed = 1500.
+		let q = "{ id }"
+		for (let i = 0; i < 50; i++) q = `{ entities(first: 1000) ${q} }`
+		const c = cost(q)
+		expect(Number.isFinite(c)).toBe(true)
+		expect(c).toBeGreaterThanOrEqual(1500)
+		expect(c).toBeLessThanOrEqual(1510)
+	})
+
+	it("100-level nesting — BigInt walker handles it, score scales linearly with depth", () => {
+		// raw = 1000^100 = 10^300 → compressed = 3000.
+		let q = "{ id }"
+		for (let i = 0; i < 100; i++) q = `{ entities(first: 1000) ${q} }`
+		const c = cost(q)
+		expect(c).toBeGreaterThanOrEqual(3000)
+		expect(c).toBeLessThanOrEqual(3010)
+	})
+
+	it("wide fan-out: 100 sibling aliased collections → modest score, linear in width", () => {
+		// Each sibling: entities(first:1000){id} = 1001 → 100 siblings sum = ~100_100.
+		// log10(100_100) ≈ 5.0 → compressed ≈ 50.
+		const aliases = Array.from({length: 100}, (_, i) => `a${i}: entities(first: 1000) { id }`).join(" ")
+		const c = cost(`{ ${aliases} }`)
+		expect(c).toBeGreaterThanOrEqual(45)
+		expect(c).toBeLessThanOrEqual(55)
+	})
+
+	it("attacker attempts `first: 0` to sneak nested work past the estimator", () => {
+		// first:0 is non-positive → fallback to MAX_PAGINATION_LIMIT. Nested
+		// relations(first:50){id} still charged.
+		// inner = 51, outer = 1000 × (1 + 51) + 1 = 52001 → compressed ~47.
+		const raw = rawCost(`{
+			entities(first: 0) {
+				id
+				relations(first: 50) { id }
+			}
+		}`)
+		expect(raw).toBe(BigInt(MAX_PAGINATION_LIMIT) * 52n + 1n)
+		expect(compressCost(raw)).toBe(47)
+	})
+
+	it("attacker attempts negative `first`", () => {
+		expect(rawCost(`{ entities(first: -100) { id } }`)).toBe(BigInt(MAX_PAGINATION_LIMIT) + 1n)
+	})
+
+	it("unresolved variable in `first:` falls back to MAX_PAGINATION_LIMIT", () => {
+		expect(rawCost(`query Q($first: Int) { entities(first: $first) { id } }`, {})).toBe(
+			BigInt(MAX_PAGINATION_LIMIT) + 1n,
+		)
+	})
+
+	it("fragment cycle terminates cleanly (defence-in-depth vs skipped validation)", () => {
 		const doc = `
 			query Q { ...A }
 			fragment A on Query { ...B }
 			fragment B on Query { ...A }
 		`
 		expect(() => cost(doc)).not.toThrow()
-		// Cost is 0 — the cycle is cut on second visit and neither fragment
-		// selects any concrete field. The important thing is that it terminates.
 		expect(cost(doc)).toBe(0)
 	})
 
-	it("allows a fragment to be used multiple times at sibling positions (not a cycle)", () => {
-		// Visited fragments are popped after each recursion, so the same
-		// fragment legitimately included twice as siblings does not get cut.
-		const doc = `
-			query Q { ...F ...F }
-			fragment F on Query { a: __typename b: __typename }
-		`
-		// two sibling spreads × (a + b = 2 scalars) = 4
-		expect(cost(doc)).toBe(4)
+	it("malformed input (null document) does not escape the plugin", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		expect(() =>
+			onExecute({
+				args: {
+					// biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
+					document: null as any,
+					variableValues: {},
+					operationName: null,
+				},
+			}),
+		).not.toThrow()
 	})
 })
 
-describe("useCostLogger — shadow-mode safety", () => {
-	it("does not throw when the cost walker throws", async () => {
+// --------------------------------------------------------------------------
+// Pagination arg resolution + variables
+// --------------------------------------------------------------------------
+
+describe("computeQueryCost — pagination + variables", () => {
+	it("resolves pagination args supplied via variables", () => {
+		expect(rawCost(`query Q($first: Int!) { entities(first: $first) { id } }`, {first: 100})).toBe(101n)
+	})
+
+	it("sibling with negative outer still charges for valid nested first", () => {
+		// Inner relations(first:50){id} = 51.
+		// Outer entities(first:-5) → MAX_PAGINATION_LIMIT × (1 + 51) + 1 = 52_001
+		expect(
+			rawCost(`{
+				entities(first: -5) {
+					id
+					relations(first: 50) { id }
+				}
+			}`),
+		).toBe(BigInt(MAX_PAGINATION_LIMIT) * 52n + 1n)
+	})
+})
+
+// --------------------------------------------------------------------------
+// Fragments
+// --------------------------------------------------------------------------
+
+describe("computeQueryCost — fragments", () => {
+	it("inline fragments contribute to parent's childComplexity", () => {
+		// entities(first:10) { ... on Entity { id name } }
+		// inline frag = 2 → 10 × 2 + 1 = 21
+		expect(rawCost(`{ entities(first: 10) { ... on Entity { id name } } }`)).toBe(21n)
+	})
+
+	it("fragment spreads follow the definition", () => {
+		expect(
+			rawCost(`
+				query { entities(first: 10) { ...F } }
+				fragment F on Entity { id name }
+			`),
+		).toBe(21n)
+	})
+
+	it("allows a fragment to be used multiple times at sibling positions (not a cycle)", () => {
+		// Visited fragments are popped after each recursion.
+		expect(
+			rawCost(`
+				query Q { ...F ...F }
+				fragment F on Query { a: __typename b: __typename }
+			`),
+		).toBe(4n)
+	})
+})
+
+// --------------------------------------------------------------------------
+// Empty / edge
+// --------------------------------------------------------------------------
+
+describe("computeQueryCost — empty / edge", () => {
+	it("returns 0 for a document with no operation", () => {
+		expect(cost(`fragment Unused on Query { __typename }`)).toBe(0)
+	})
+})
+
+// --------------------------------------------------------------------------
+// Prometheus histogram exposed via /health/metrics
+// --------------------------------------------------------------------------
+
+describe("query cost histogram", () => {
+	beforeEach(() => {
+		__resetQueryCostHistogramForTests()
+	})
+
+	it("empty state emits zero-counts for all buckets", () => {
+		const out = renderQueryCostHistogram()
+		expect(out).toMatch(/# TYPE gaia_api_graphql_query_cost histogram/)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 0/)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_count 0/)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_sum 0/)
+	})
+
+	it("records compressed scores into the right buckets", () => {
 		const plugin = useCostLogger()
 		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
-		// Hand the plugin a malformed document so computeQueryCost throws on
-		// the definitions.find lookup. The plugin should swallow, not rethrow.
+		const runQuery = (query: string, variables: Record<string, unknown> = {}) => {
+			onExecute({args: {document: parse(query), variableValues: variables, operationName: null}})
+		}
+
+		// Score 0 — trivial.
+		runQuery(`{ __typename }`)
+		// Score 33 — simple entity.
+		runQuery(`{ entity(id: "...") { id name } }`)
+
+		const out = renderQueryCostHistogram()
+		expect(out).toContain("gaia_api_graphql_query_cost_count 2")
+		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${0 + 33}`)
+		// le=30: only the trivial observation (33 > 30)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="30"} 1$/m)
+		// le=60: both
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="60"} 2$/m)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 2$/m)
+	})
+
+	it("adversarial pathological query records to the top bucket", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		let q = "{ id }"
+		for (let i = 0; i < 50; i++) q = `{ entities(first: 1000) ${q} }`
+		onExecute({args: {document: parse(q), variableValues: {}, operationName: null}})
+
+		const out = renderQueryCostHistogram()
+		// Score ~1500 lands in the 500 bucket? No — 1500 > 500 → +Inf.
+		// Goes into le=1000 and +Inf but not le=500.
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="500"} 0$/m)
+		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 1$/m)
+	})
+
+	it("skips introspection queries", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		onExecute({
+			args: {
+				document: parse(`{ __typename }`),
+				variableValues: {},
+				operationName: "IntrospectionQuery",
+			},
+		})
+		expect(renderQueryCostHistogram()).toContain("gaia_api_graphql_query_cost_count 0")
+	})
+})
+
+// --------------------------------------------------------------------------
+// Shadow-mode safety: the plugin must never throw into yoga, regardless of
+// walker output, log serialization failures, etc.
+// --------------------------------------------------------------------------
+
+describe("useCostLogger — shadow-mode safety", () => {
+	it("does not throw when the cost walker throws", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
 		expect(() =>
 			onExecute({
 				args: {
@@ -441,39 +420,33 @@ describe("useCostLogger — shadow-mode safety", () => {
 		).not.toThrow()
 	})
 
-	it("does not throw when the high-cost log path throws", async () => {
-		// Fake a variable that JSON.stringify can't serialize (circular ref).
-		// The log call inside the plugin's high-cost branch would normally
-		// blow up; the outer try/catch must keep the request flowing.
+	it("does not throw when the high-cost log path throws", () => {
+		// Circular variable defeats JSON.stringify inside log.warn. The plugin's
+		// outer try/catch must swallow it.
 		const circular: Record<string, unknown> = {}
 		circular.self = circular
 
 		const plugin = useCostLogger()
 		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
-		// A query guaranteed to cross the default log threshold (the cap itself).
-		// Six `first:1000` levels multiply out to 1000^6 = 1e18, well over 9P.
+		// 50-level deep query → compressed score ~1500, well above the 200 threshold,
+		// so the log path fires.
+		let q = "{ id }"
+		for (let i = 0; i < 50; i++) q = `{ entities(first: 1000) ${q} }`
 		expect(() =>
 			onExecute({
 				args: {
-					document: parse(`
-						{
-							entities(first: 1000) {
-								a: entities(first: 1000) {
-									b: entities(first: 1000) {
-										c: entities(first: 1000) {
-											d: entities(first: 1000) {
-												e: entities(first: 1000) { id }
-											}
-										}
-									}
-								}
-							}
-						}
-					`),
+					document: parse(q),
 					variableValues: {circular},
 					operationName: null,
 				},
 			}),
 		).not.toThrow()
+	})
+
+	it("handles a deeply-nested legit query without stack overflow", () => {
+		// 30-level nesting (realistic upper bound for client queries).
+		let q = "{ id }"
+		for (let i = 0; i < 30; i++) q = `{ entity(id: "x") ${q} }`
+		expect(() => cost(q)).not.toThrow()
 	})
 })

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -16,8 +16,8 @@ import {MAX_PAGINATION_LIMIT} from "./paginationCapPlugin"
 
 // Parse a positive-integer env var, falling back to `fallback` on anything
 // non-finite or non-positive. Guards against deploy-time misconfiguration
-// (e.g. `GRAPHQL_COST_CALC_LIMIT=abc` → parseInt = NaN) silently disabling
-// the walker's safety cap.
+// (e.g. `GRAPHQL_COST_LOG_THRESHOLD=abc` → parseInt = NaN) silently disabling
+// the threshold.
 function parsePositiveIntEnv(name: string, fallback: number): number {
 	const raw = process.env[name]
 	if (raw === undefined) return fallback
@@ -25,82 +25,57 @@ function parsePositiveIntEnv(name: string, fallback: number): number {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
-// Hard ceiling on the cost calculation itself. Once the walker's running
-// total reaches this value it short-circuits and returns the cap instead of
-// continuing to multiply. Caps memory (totalSum can't drift to Infinity),
-// caps CPU (adversarial or pathological queries don't walk forever), and
-// keeps the metric values in a sane range for Prometheus / Grafana.
+// ---------------------------------------------------------------------------
+// Compressed (log₁₀-scaled) cost
+// ---------------------------------------------------------------------------
+// The raw cost is a multiplicative estimate (`child × limit + 1` at every
+// nested level) and can produce 20+-digit BigInts for pathological queries —
+// well past Number.MAX_SAFE_INTEGER. Rather than cap the value and collapse
+// the tail into a single "too big" bin, we walk in BigInt and surface a
+// compressed score: `round(log₁₀(rawCost) × 10)`.
 //
-// Sits just below `Number.MAX_SAFE_INTEGER` (≈ 9.007 × 10¹⁵) — any higher
-// and intermediate arithmetic in the walker (child × limit) would lose
-// integer precision. This is the practical ceiling for the cost number
-// itself without reaching for BigInt.
-const MAX_COST_CALC_LIMIT = parsePositiveIntEnv("GRAPHQL_COST_CALC_LIMIT", 9_000_000_000_000_000)
-
-// Threshold above which we emit a warn-level log line with the full query +
-// variables. Set to the cap itself, so we only log queries that were
-// actually clamped — i.e. whose unclamped theoretical cost exceeds
-// MAX_COST_CALC_LIMIT. These are the truly pathological shapes worth
-// investigating; anything below the cap is fine to leave in the Prometheus
-// histogram without adding to stdout noise.
-const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", MAX_COST_CALC_LIMIT)
-
-// Per-level multiplier used when a collection field omits `first`/`last`.
-// Separate from MAX_PAGINATION_LIMIT (1000) — the paginationCap plugin still
-// injects `first: 1000` at SQL build time, but assuming the *full* SQL cap
-// at every implicit level compounds into unrealistically large numbers for
-// typical query shapes. 100 is a more realistic expected-fan-out for the
-// cost model and keeps the histogram distribution readable — cap-hitters
-// still clamp, deeply-nested structural issues still stand out, but the
-// per-query numbers stay closer to "scan rows" than "theoretical ceiling".
-const COST_MODEL_DEFAULT_LIMIT = 100
+// Properties:
+//   - 10-point step = 1 order of magnitude of raw cost. A score of 160 is
+//     10× more expensive than 150.
+//   - Fits Number. A 300-digit raw cost compresses to 3000 — still tiny.
+//   - Cheap to read. Triviality vs pathology is a two-digit diff, not an
+//     "is that 10¹⁷ or 10¹⁸ in scientific notation" squint.
+//
+// Approximate compressed landmarks, measured against real prod shapes:
+//   0           trivial scalar (`{ __typename }`)
+//   ~35         simple entity lookup (`entity(id) { id name }`)
+//   ~50         medium 1-level nested list
+//   ~160        non-nested heavy query (N=3 aliased relations, no nesting)
+//   ~250–270    cap-hitting prod shapes (N=3–10 aliased relations with
+//               nested `relations` inside `toEntity`) — these are the
+//               structurally-unbounded queries worth flagging.
+//   ~1500       50-level deeply nested adversarial probe.
+const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 200)
 
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
 // ---------------------------------------------------------------------------
-// Exposed via /health/metrics (see renderQueryCostHistogram). We accumulate
-// in-process monotonic counters (process start = 0), and Prometheus uses
-// rate()/histogram_quantile() over the scrape stream to derive time-windowed
-// distributions for the Grafana dashboard.
-
-// Upper bucket edges, spanning the realistic range of the conservative model
-// (trivial scalar ≈ 1 at the low end, nested no-pagination queries near the
-// 9 quadrillion cap at the high end). `+Inf` is emitted via the total count
-// at render and is the "clamped at cap" bin — queries whose unclamped cost
-// would exceed 9P land only in +Inf, since 9P > 5P (the last numeric edge).
+// Exposed via /health/metrics. In-process monotonic counters (reset on pod
+// restart) are converted by Prometheus over the scrape stream into rates +
+// quantiles for the Grafana dashboard.
 //
-// Granularity is intentionally asymmetric:
-//   - Everything below 100M collapses into a single bucket: cheap / trivial
-//     queries don't need fine resolution (prod sees almost no volume there).
-//   - 100M → 800M is subdivided (100M/200M/500M/800M) because that's where
-//     the dominant population sits in prod.
-//   - 800M → 50B jumps directly to 5B/50B (the 1B–5B range collapsed to a
-//     single 5B bucket since prod data didn't resolve anything useful there).
-//   - 50B → 9P covers the pathological tail on decade steps: 100B, 500B,
-//     5T, 50T, 500T, 5P — six resolution bins before +Inf / the cap.
-const COST_BUCKET_EDGES: readonly number[] = [
-	100_000_000, 200_000_000, 500_000_000, 800_000_000, 5_000_000_000, 50_000_000_000, 100_000_000_000, 500_000_000_000,
-	5_000_000_000_000, 50_000_000_000_000, 500_000_000_000_000, 5_000_000_000_000_000,
-]
+// Bucket edges now use the compressed (log₁₀×10) scale. Each 10-point step
+// is a 10× jump in raw cost, so one linear scale captures everything from
+// trivial scalars (score 0) to adversarial fractal nesting (score 1000+).
+const COST_BUCKET_EDGES: readonly number[] = [30, 60, 90, 120, 150, 180, 200, 220, 240, 260, 280, 300, 500, 1000]
 
-// noUncheckedIndexedAccess widens `number[]`'s index access to `number | undefined`,
-// so we go via a Map which has a crisper `get(k) | undefined` story and always
-// normalize via `?? 0`. A bit more allocation than a typed array but the map
-// is bounded to 9 entries and only written on the hot path; effect is nil.
 const bucketCounts = new Map<number, number>()
 let totalCount = 0
 let totalSum = 0
 
 function recordQueryCost(cost: number): void {
-	// Defensive: `computeQueryCost` already caps at MAX_COST_CALC_LIMIT and
-	// can't produce NaN / Infinity / negative, but a future caller mustn't be
-	// able to poison the metric. Non-finite / negative inputs are dropped.
+	// Defensive: `computeQueryCost` shouldn't produce NaN / Infinity /
+	// negative, but a future caller mustn't be able to poison the metric.
 	if (!Number.isFinite(cost) || cost < 0) return
-	const clamped = Math.min(cost, MAX_COST_CALC_LIMIT)
 	totalCount++
-	totalSum += clamped
+	totalSum += cost
 	for (const edge of COST_BUCKET_EDGES) {
-		if (clamped <= edge) bucketCounts.set(edge, (bucketCounts.get(edge) ?? 0) + 1)
+		if (cost <= edge) bucketCounts.set(edge, (bucketCounts.get(edge) ?? 0) + 1)
 	}
 }
 
@@ -110,7 +85,7 @@ function recordQueryCost(cost: number): void {
  */
 export function renderQueryCostHistogram(): string {
 	const lines = [
-		"# HELP gaia_api_graphql_query_cost GraphQL query complexity score distribution (conservative model, see costLoggerPlugin.ts).",
+		"# HELP gaia_api_graphql_query_cost GraphQL query complexity score (log10×10 compressed, see costLoggerPlugin.ts).",
 		"# TYPE gaia_api_graphql_query_cost histogram",
 	]
 	for (const edge of COST_BUCKET_EDGES) {
@@ -131,37 +106,46 @@ export function __resetQueryCostHistogramForTests(): void {
 	totalSum = 0
 }
 
+// ---------------------------------------------------------------------------
+// BigInt cost walker
+// ---------------------------------------------------------------------------
+// Walks the operation AST in BigInt so the multiplicative cost chain can grow
+// past Number.MAX_SAFE_INTEGER without losing precision or needing a cap.
+// Intentionally schema-free: works regardless of which `graphql` module
+// instance built the schema (PostGraphile v4 bundles its own copy).
+
 /**
- * Compute a query complexity score from the operation AST alone.
+ * Raw (uncompressed, BigInt) query cost — exported for tests. Production
+ * call sites should use `computeQueryCost` instead and work with the
+ * compressed Number score.
+ */
+export function computeQueryCostRaw(doc: DocumentNode, variables: Record<string, unknown> = {}): bigint {
+	const op = doc.definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
+	if (!op) return 0n
+	return sumSelections(op.selectionSet, variables, doc, new Set())
+}
+
+/**
+ * Compute a compressed query complexity score: `round(log₁₀(rawCost) × 10)`.
+ * See the constant block above for interpretive landmarks.
  *
- * Cost model, per field:
- *   - Explicit `first` / `last` arg → `child × limit + 1`. Limit clamps to
- *     MAX_PAGINATION_LIMIT when non-positive / non-finite / missing (from an
- *     unresolved variable), mirroring what PaginationCapPlugin actually
- *     applies at SQL-build time and closing the bogus-arg attack vector.
- *   - No pagination arg, has selections → `child × MAX_PAGINATION_LIMIT + 1`.
- *     Conservative: we treat any structured field without an explicit limit
- *     as if it were a list taking the 1000 default. Over-counts single-entity
- *     lookups, but we prefer over-counting to under-counting — PaginationCap
- *     injects the 1000 default on every collection field at SQL time, so the
- *     real work done under those queries scales that way whether or not we
- *     can see it in the AST.
- *   - No pagination arg, no selections → 1 (scalar leaf).
- *
- * Every recursive step checks a hard `MAX_COST_CALC_LIMIT` budget and short-
- * circuits once crossed — prevents Number overflow, unbounded walking on
- * adversarial inputs, and Infinity / NaN leaking into the Prometheus metric.
- *
- * Intentionally schema-free: walking only the document + variables means the
- * estimator works regardless of which `graphql` module instance built the
- * schema (PostGraphile v4 bundles its own copy). Schema-aware libraries like
- * graphql-query-complexity hit instanceof failures across the CJS/ESM module
- * boundary in that setup.
+ * Returns 0 for trivial queries; typical heavy prod queries land 150–250;
+ * structurally-unbounded shapes exceed 240.
  */
 export function computeQueryCost(doc: DocumentNode, variables: Record<string, unknown> = {}): number {
-	const op = doc.definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
-	if (!op) return 0
-	return sumSelections(op.selectionSet, variables, doc, new Set())
+	return compressCost(computeQueryCostRaw(doc, variables))
+}
+
+/** `round(log₁₀(n) × 10)` with BigInt-safe log10. Returns 0 for n ≤ 1. */
+export function compressCost(n: bigint): number {
+	if (n <= 1n) return 0
+	// Approximate log₁₀ via string length + leading digits. Stable to ~15
+	// significant digits regardless of how big n is.
+	const s = n.toString()
+	const leadDigits = Math.min(15, s.length)
+	const lead = Number(s.slice(0, leadDigits)) // fits in Number, leadDigits ≤ 15
+	const log10 = Math.log10(lead) + (s.length - leadDigits)
+	return Math.round(log10 * 10)
 }
 
 function sumSelections(
@@ -169,8 +153,8 @@ function sumSelections(
 	vars: Record<string, unknown>,
 	doc: DocumentNode,
 	visitedFragments: Set<string>,
-): number {
-	let total = 0
+): bigint {
+	let total = 0n
 	for (const sel of selectionSet.selections) {
 		if (sel.kind === Kind.FIELD) {
 			total += fieldCost(sel, vars, doc, visitedFragments)
@@ -179,9 +163,9 @@ function sumSelections(
 		} else if (sel.kind === Kind.FRAGMENT_SPREAD) {
 			// Fragment cycles (A spreads B spreads A) are normally blocked by
 			// the NoFragmentCycles validation rule, but if something in the
-			// pipeline ever skipped validation we'd recurse forever. Cheap
-			// insurance: track visited names on the way down, pop on the way
-			// back up so siblings can reuse the same fragment legitimately.
+			// pipeline ever skipped validation we'd recurse forever. Track
+			// visited names on the way down, pop on the way back up so
+			// siblings can reuse the same fragment legitimately.
 			const name = sel.name.value
 			if (visitedFragments.has(name)) continue
 			const frag = doc.definitions.find(
@@ -193,44 +177,47 @@ function sumSelections(
 				visitedFragments.delete(name)
 			}
 		}
-		if (total >= MAX_COST_CALC_LIMIT) return MAX_COST_CALC_LIMIT
 	}
 	return total
 }
+
+/**
+ * Cost model per field:
+ *   - Explicit `first` / `last` arg with a valid positive value → `child × limit + 1`.
+ *   - Pagination arg present but value unresolved / non-positive → fall back
+ *     to MAX_PAGINATION_LIMIT (1000) — matches the effective cap at SQL build.
+ *   - No pagination arg, has selections → `child × MAX_PAGINATION_LIMIT + 1`.
+ *     PaginationCapPlugin injects `first: 1000` on every unpaginated
+ *     collection field at SQL build, so modeling the default at 1000 matches
+ *     the real fan-out ceiling. BigInt arithmetic means this doesn't overflow.
+ *   - No pagination arg, no selections → 1 (scalar leaf).
+ */
+const DEFAULT_LIMIT = BigInt(MAX_PAGINATION_LIMIT)
 
 function fieldCost(
 	field: FieldNode,
 	vars: Record<string, unknown>,
 	doc: DocumentNode,
 	visitedFragments: Set<string>,
-): number {
-	// Check for the *syntactic* presence of first/last in the query, not the
-	// resolved value. `entities(first: $first)` with $first unresolved means
-	// the user intends pagination — we should still treat it as a list (and
-	// fall back to MAX because the effective limit is undefined).
+): bigint {
+	// Check for the *syntactic* presence of first/last. `entities(first: $n)`
+	// with `$n` unresolved still means the caller intended pagination — treat
+	// it as a list (and fall back to MAX_PAGINATION_LIMIT since the effective
+	// limit is undefined).
 	const argNames = new Set((field.arguments ?? []).map((a) => a.name.value))
 	const hasPagination = argNames.has("first") || argNames.has("last")
 
-	const child = field.selectionSet ? sumSelections(field.selectionSet, vars, doc, visitedFragments) : 0
-
-	// Propagate the cap so we never try to multiply a near-cap value and
-	// overflow. Math.min below also clamps the final result.
-	if (child >= MAX_COST_CALC_LIMIT) return MAX_COST_CALC_LIMIT
+	const child = field.selectionSet ? sumSelections(field.selectionSet, vars, doc, visitedFragments) : 0n
 
 	if (hasPagination) {
 		const args = resolveArgs(field.arguments, vars)
 		const raw = args.first ?? args.last
 		const validExplicit = typeof raw === "number" && Number.isFinite(raw) && raw > 0
-		const limit = validExplicit ? (raw as number) : MAX_PAGINATION_LIMIT
-		return Math.min(child * limit + 1, MAX_COST_CALC_LIMIT)
+		const limit = validExplicit ? BigInt(raw as number) : DEFAULT_LIMIT
+		return child * limit + 1n
 	}
 
-	// Structured field without an explicit limit: assume the cost-model
-	// default fan-out (COST_MODEL_DEFAULT_LIMIT, decoupled from the
-	// SQL-level MAX_PAGINATION_LIMIT). Leaf scalars (no selection set →
-	// child=0) collapse to `0 × N + 1 = 1` here, so we don't need a
-	// separate branch.
-	return Math.min(child * COST_MODEL_DEFAULT_LIMIT + 1, MAX_COST_CALC_LIMIT)
+	return child * DEFAULT_LIMIT + 1n
 }
 
 function resolveArgs(
@@ -272,14 +259,11 @@ function resolveValue(value: ValueNode, vars: Record<string, unknown>): unknown 
  * Yoga plugin that computes query cost on every request. Two observability
  * channels, no alerts:
  *   - Prometheus histogram `gaia_api_graphql_query_cost` — records every
- *     query's cost; charted in Grafana for distribution / outliers.
- *   - `log.warn("High GraphQL query cost", ...)` when cost exceeds
- *     `COST_LOG_THRESHOLD`. `log.warn` in this codebase always writes to
- *     stdout (visible in kubectl + Axiom) *and* drops a Sentry breadcrumb,
- *     but does NOT create a Sentry issue — that's the captureMessage path
- *     we deliberately don't use. `log.info`, by contrast, only writes a
- *     breadcrumb in production (invisible to log search), which defeats the
- *     point of the threshold log.
+ *     query's compressed score; charted in Grafana for distribution.
+ *   - `log.warn("High GraphQL query cost", ...)` when score ≥
+ *     `COST_LOG_THRESHOLD`. `log.warn` always writes to stdout (visible in
+ *     kubectl + Axiom) *and* drops a Sentry breadcrumb, but does NOT create
+ *     a Sentry issue.
  *
  * Phase 1 is strictly observational. The outer try/catch is a shadow-mode
  * safety invariant: a failure inside the plugin must never break the
@@ -316,11 +300,7 @@ export function useCostLogger(): Plugin {
 					})
 				}
 			} catch (error) {
-				// Shadow-mode guarantee: never break the request. If anything at
-				// all throws — log stringification bombing on a circular variable,
-				// print() choking on an unusual AST, anything else — swallow it.
-				// The nested try around the diagnostic log itself protects against
-				// a log writer that's itself broken.
+				// Shadow-mode guarantee: never break the request.
 				try {
 					log.warn("[cost] plugin onExecute threw", {
 						error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary
- **BigInt walker**: cost calc runs in `bigint`, no overflow, no cap. Computes the true raw cost regardless of magnitude.
- **log₁₀×10 compressed score**: `round(log₁₀(raw) × 10)` — a small Number that preserves order of magnitude. 10 points = one decade.
- **New log threshold**: `200` (compressed). Catches queries whose true cost exceeds 10²⁰, i.e. the genuinely pathological shapes. Previously the threshold sat at the 9P cap, which was hit by ~14/min prod queries.
- **New bucket edges** on the compressed scale: `[30, 60, 90, 120, 150, 180, 200, 220, 240, 260, 280, 300, 500, 1000]`. One linear scale captures trivial (0) through adversarial-nesting (~1500).

## Why
The Number walker capped raw cost at 9×10¹⁵ (just under `Number.MAX_SAFE_INTEGER`). Every query above that — currently 26 of 375 requests per pod — collapsed to the same cap value and landed in a single `+Inf` bucket. Real costs there range from ~10¹⁸ to ~10²⁶; the metric couldn't distinguish "very heavy" from "truly adversarial".

BigInt lets the walker carry the full 20+-digit multiplicative chain; log₁₀ compresses it back to a bounded Number for the metric. Result: every query, from `{ __typename }` (score 0) to a 100-level nested probe (score 3000), lives on one readable linear scale.

## Compressed score landmarks

| Shape | Compressed |
|---|---|
| `{ __typename }` | 0 |
| `entity(id) { id name }` | 33 |
| `entities(first: 50) { id }` | 17 |
| Medium 1-level nested list | ~50 |
| Heavy un-nested (N=3 aliased relations) | ~160 |
| **Current cap-hitter** (entity with nested `toEntity.relations`) | **~220–260** |
| 50-level deeply-nested adversarial | ~1500 |

## Perf cost (measured, 100k-iter bench on dev machine)

| Shape | Number walker (old) | BigInt walker (new) | Delta |
|---|---|---|---|
| Trivial scalar | 0.06 µs | 0.09 µs | +30 ns |
| Simple entity | 0.13 µs | 0.16 µs | +30 ns |
| Medium 1-level nested | 0.23 µs | 0.32 µs | +90 ns |
| Cap-hitter (N=3, M=1) | 0.65 µs | 3.2 µs | +2.5 µs |
| 100-level adversarial | — | ~15 µs | — |

Per-request overhead at current prod traffic (~800 RPS): ~0.25% of one CPU. Negligible vs SQL time on a cap-hitter request (100ms+).

**Memory**: BigInt intermediates are short-lived and GC'd per-call. No steady-state growth.

## Test plan
- [x] `compressCost` precision tests (27-digit and 300-digit BigInts past `MAX_SAFE_INTEGER`)
- [x] Compressed-score fixtures for trivial / simple / medium / heavy shapes
- [x] Raw-cost regression tests preserve the multiplier math
- [x] Adversarial suite: 50-level, 100-level, wide fan-out, `first:0`, negative `first`, unresolved variable, fragment cycle, malformed document — none throw
- [x] Real prod entity cap-hitter shape included as a fixture
- [x] Histogram test covers new bucket assignment with compressed scores
- [x] Shadow-mode safety preserved (plugin never escapes into Yoga)
- [ ] After deploy: Grafana distribution should now show a long tail instead of a piled `+Inf` bin; log.warn volume should drop to only true outliers

## Dashboard
`gaia-overview-dashboard.yaml` uses `histogram_quantile` over `le`; new bucket edges flow through automatically. No panel change.

## Follow-ups
- The p50/p95/p99 quantile panels will now be meaningful (previously collapsed against the 9P cap). Worth checking after deploy.