### PR TITLE
fix(api): drop Blob wrap in uploadEdit — align with Pinata SDK

### DIFF
--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -29,13 +29,7 @@ export function uploadEdit(file: File) {
 		const run = Effect.gen(function* () {
 			yield* Ref.update(attemptRef, (n) => n + 1)
 
-			// Pass the File directly rather than wrapping in `new Blob([file])`.
-			// The wrap is a Bun-era artifact from the original PR #15 that breaks
-			// under Node/undici — undici re-reads the wrapped Blob's stream during
-			// multipart serialization in a way that produces a chunked body
-			// without a proper terminating chunk, which Cloudflare's edge rejects
-			// with a fast 408 "client disconnected". Pinata's own SDK passes File
-			// directly for the same reason; `uploadFile` below has always done so.
+			// No Blob wrap — aligns with Pinata's SDK.
 			const formData = new FormData()
 			formData.append("network", "public")
 			formData.append("file", file, file.name || "edit.bin")

--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -29,10 +29,16 @@ export function uploadEdit(file: File) {
 		const run = Effect.gen(function* () {
 			yield* Ref.update(attemptRef, (n) => n + 1)
 
-			const blob = new Blob([file], {type: "application/octet-stream"})
+			// Pass the File directly rather than wrapping in `new Blob([file])`.
+			// The wrap is a Bun-era artifact from the original PR #15 that breaks
+			// under Node/undici — undici re-reads the wrapped Blob's stream during
+			// multipart serialization in a way that produces a chunked body
+			// without a proper terminating chunk, which Cloudflare's edge rejects
+			// with a fast 408 "client disconnected". Pinata's own SDK passes File
+			// directly for the same reason; `uploadFile` below has always done so.
 			const formData = new FormData()
 			formData.append("network", "public")
-			formData.append("file", blob, file.name || "edit.bin")
+			formData.append("file", file, file.name || "edit.bin")
 
 			const hash = yield* upload(formData, config.ipfsGatewayWrite)
 			yield* validateCid(hash)


### PR DESCRIPTION
## Summary

Removes `new Blob([file], {type: "application/octet-stream"})` from `uploadEdit` and passes the File directly to `FormData.append` — mirroring both Pinata's own SDK and our existing `uploadFile` path.

```diff
- const blob = new Blob([file], {type: "application/octet-stream"})
  const formData = new FormData()
  formData.append("network", "public")
- formData.append("file", blob, file.name || "edit.bin")
+ formData.append("file", file, file.name || "edit.bin")
```

## Why

Every prod `IPFS gateway HTTP 408 Request Timeout` event traced to date fires on `/ipfs/upload-edit`, never on `/ipfs/upload-file`. The only material difference between the two paths was this Blob wrap.

A sample event:
- `httpStatus: 408`, `bodyPreview: {"error":{"code":408,"message":"client disconnected"}}`
- `responseTimeMs: 80` (far too fast for a server-side read timeout)
- `fileSize: 12318` (tiny)
- `pinataRequestId: null`, `server: cloudflare`, `cfRay: 9f1690c92f8be8a6-EWR`

That combination — fast response, tiny body, CF origin (not Pinata backend), CF-canned `client disconnected` message — is what CF returns when it observes a premature TCP close mid-chunked-body. The Blob wrap forces undici to re-read the wrapped Blob's stream during multipart serialization in a way that can produce this on specific network paths.

## Investigation receipts

- **Pinata SDK reference:** [PinataCloud/pinata `src/core/functions/uploads/file.ts` line 245 (small-file branch)](https://github.com/PinataCloud/pinata/blob/main/src/core/functions/uploads/file.ts) passes File directly.
- **Our own known-good path:** `uploadFile` in this same file passes File directly and has never shown a 408 pattern.
- **Origin of the wrap:** introduced in commit `c04bcb5f` (PR #15, June 2025) with no comment, no PR description, no design doc. Most likely a Bun-era workaround for a FormData quirk that no longer applies under our current Node runtime.
- **Related fix:** PR #323 (`fix(api): ensure filename in FormData append for Bun compatibility`) fixed a related Bun FormData issue on `uploadFile` by supplying a filename — its description specifically cites Bun behavior.

## Local verification

Tested both shapes against live Pinata from Node v24.3.0 + undici.

### With the exact 408 payload (12,318-byte GRC-20 edit blob pulled from `ipfs_cache` id 40110, CID `bafkreibndfg5kxzlzg…pbrq`):

| | WITH wrap | WITHOUT wrap (fix) | Δ |
|---|---|---|---|
| Success | 3/3 | 3/3 | — |
| Elapsed (avg) | 1090 ms | 1014 ms | **-7%** |
| CPU total | 84.3 ms | 81.5 ms | -3% |
| RSS peak delta | 22.7 MiB | 17.5 MiB | -5.2 MiB |

### With a 50 MB random payload:

| | WITH wrap | WITHOUT wrap | Δ |
|---|---|---|---|
| Success | 2/2 | 2/2 | — |
| Elapsed (avg) | 7179 ms | 7099 ms | ~1% (network-bound) |
| CPU total | 329.7 ms | 294.1 ms | **-12% (~36 ms)** |
| RSS peak delta | 267.5 MiB | 267.3 MiB | same |

## Caveats

- **408 does not reproduce from local** (MacBook → CF SJC → Pinata). It needs prod path conditions (DO NYC2 → CF EWR → Pinata). Local testing proves the fix is safe + faster; only prod can confirm it resolves the 408s.
- Memory footprint is dominated by undici's internal multipart buffering (~5× payload size for 50 MB — noted as a separate concern for future). The wrap vs no-wrap delta is small on that axis.

## Rollback

One-line revert if 408s persist after deploy. Fallback path then:
1. Add `name` FormData field and `Source` header (full Pinata SDK alignment)
2. Pre-buffer the body with explicit `Content-Length` (eliminates chunked transfer as a variable)

## Test plan

- [x] `bun run format:check` / `lint` / `check` (tsc) clean
- [x] 108/108 unit tests pass
- [x] 6 live Pinata uploads with the exact 12 KB 408 payload — all 200 OK, CID matches `ipfs_cache`
- [x] 4 live Pinata uploads with 50 MB random payload — all 200 OK
- [ ] Post-deploy: watch Sentry for `IPFS gateway HTTP 408` on `/ipfs/upload-edit` — expect rate → 0
- [ ] Post-deploy: check Prometheus for any change in api pod CPU utilization during upload windows