### PR TITLE
feat(api): log 5xx responses at error level

### DIFF
--- a/api/src/middleware/requestLogging.ts
+++ b/api/src/middleware/requestLogging.ts
@@ -129,15 +129,23 @@ export function canonicalRequestLogging() {
 					span.setStatus({code: SpanStatusCode.ERROR, message: `HTTP ${status}`})
 				}
 
-				// Canonical END log
-				log.info(`${method} ${path} completed`, {
+				// Canonical END log — promote to error level for 5xx responses
+				// so handlers that return a 5xx without throwing (e.g. c.text("…", 500),
+				// GraphQL errors surfaced by graphql-yoga) still produce a Sentry
+				// issue. The catch branch below handles the throwing path.
+				const endLogFields = {
 					requestId,
 					method,
 					path,
 					status,
 					durationMs: duration,
 					...(graphqlOperationName ? {graphqlOperationName} : {}),
-				})
+				}
+				if (status >= 500) {
+					log.error(`${method} ${path} returned ${status}`, endLogFields)
+				} else {
+					log.info(`${method} ${path} completed`, endLogFields)
+				}
 			} catch (error) {
 				const duration = Date.now() - startTime
 				const failureClass = detectDbFailureClass(error)


### PR DESCRIPTION
## Summary

Promote the canonical END log in `canonicalRequestLogging` to `log.error` when a request returns status ≥ 500. Today the middleware only emits `log.error` when a handler *throws*; handlers that *return* a 5xx response (e.g. `c.text("…", 500)`, GraphQL errors surfaced by graphql-yoga, any upstream-call failure caught internally) flow through the success path and only emit `log.info`, so they never hit Sentry.

Context: on testnet prod in the last 30 min we observed a 504 on `/graphql` that had no matching app-level error log — this fixes that blind spot.

## Test plan

- [ ] Unit: confirm a handler returning `c.text("boom", 500)` produces a `log.error` END event (`method path returned 500`) with the same fields as the info path
- [ ] Unit: 4xx / 2xx / 3xx still go to `log.info`
- [ ] Smoke: deploy to testnet, hit any endpoint that returns 5xx, verify the event shows up in Sentry tagged with `requestId`, `method`, `path`, `status`, `durationMs`