### PR TITLE
feat(api): default pagination to 100, keep cap at 1000

### DIFF
--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -1,6 +1,11 @@
 import {Pool} from "pg"
 import {afterAll, beforeAll, describe, expect, it} from "vitest"
-import {applyDefaultFirstIfOmitted, assertPaginationWithinLimit, MAX_PAGINATION_LIMIT} from "../paginationCapPlugin"
+import {
+	applyDefaultFirstIfOmitted,
+	assertPaginationWithinLimit,
+	DEFAULT_PAGINATION_LIMIT,
+	MAX_PAGINATION_LIMIT,
+} from "../paginationCapPlugin"
 import {graphqlServer} from "../postgraphile"
 
 async function executeGraphQL(query: string, variables?: Record<string, unknown>) {
@@ -32,14 +37,14 @@ describe("assertPaginationWithinLimit", () => {
 
 describe("applyDefaultFirstIfOmitted", () => {
 	it("injects default first when neither first nor last is supplied", () => {
-		expect(applyDefaultFirstIfOmitted({})).toEqual({first: MAX_PAGINATION_LIMIT})
+		expect(applyDefaultFirstIfOmitted({})).toEqual({first: DEFAULT_PAGINATION_LIMIT})
 	})
 
 	it("preserves other args while injecting the default first", () => {
 		expect(applyDefaultFirstIfOmitted({offset: 10, filter: {name: "x"}})).toEqual({
 			offset: 10,
 			filter: {name: "x"},
-			first: MAX_PAGINATION_LIMIT,
+			first: DEFAULT_PAGINATION_LIMIT,
 		})
 	})
 
@@ -55,7 +60,7 @@ describe("applyDefaultFirstIfOmitted", () => {
 		// if `first` came through as anything non-numeric (shouldn't happen at runtime
 		// due to Int scalar validation) we still shouldn't silently override it
 		expect(applyDefaultFirstIfOmitted({first: null as unknown as number})).toEqual({
-			first: MAX_PAGINATION_LIMIT,
+			first: DEFAULT_PAGINATION_LIMIT,
 		})
 	})
 })
@@ -154,9 +159,9 @@ describe("PaginationCapPlugin", () => {
 
 	it("accepts queries with no pagination argument (cap enforced via injected default)", async () => {
 		// When `first` is omitted we still succeed, but the plugin injects a
-		// default `first = MAX_PAGINATION_LIMIT` so PostGraphile cannot resolve
-		// an unbounded collection. See the seeded integration block below for
-		// the length assertion.
+		// default `first = DEFAULT_PAGINATION_LIMIT` so PostGraphile cannot
+		// resolve an unbounded collection. See the seeded integration block
+		// below for the length assertion.
 		const result = await executeGraphQL(`
 			{
 				entities { id }
@@ -232,9 +237,12 @@ describe("PaginationCapPlugin", () => {
 /**
  * Integration test that seeds MAX_PAGINATION_LIMIT+N rows directly into the
  * entities table and verifies that a bare collection query resolves at most
- * MAX_PAGINATION_LIMIT rows — i.e. that applyDefaultFirstIfOmitted actually
- * propagates a LIMIT into the generated SQL. Runs against the test DB
- * configured in vitest.config.ts.
+ * DEFAULT_PAGINATION_LIMIT rows — i.e. that applyDefaultFirstIfOmitted
+ * actually propagates a LIMIT into the generated SQL. Runs against the test
+ * DB configured in vitest.config.ts.
+ *
+ * The seeded row count exceeds MAX (not just DEFAULT) so the same fixture can
+ * exercise the cap-rejection paths below.
  */
 describe("PaginationCapPlugin default-first injection (seeded)", () => {
 	const OVER_LIMIT = MAX_PAGINATION_LIMIT + 5
@@ -258,7 +266,7 @@ describe("PaginationCapPlugin default-first injection (seeded)", () => {
 		await pool.end()
 	})
 
-	it("returns at most MAX_PAGINATION_LIMIT rows when first is omitted", async () => {
+	it("returns at most DEFAULT_PAGINATION_LIMIT rows when first is omitted", async () => {
 		const result = await executeGraphQL(`
 			{
 				entities { id }
@@ -267,7 +275,7 @@ describe("PaginationCapPlugin default-first injection (seeded)", () => {
 		expect(result.status).toBe(200)
 		expect(result.body.errors).toBeUndefined()
 		const rows: Array<{id: string}> = result.body.data.entities
-		expect(rows.length).toBe(MAX_PAGINATION_LIMIT)
+		expect(rows.length).toBe(DEFAULT_PAGINATION_LIMIT)
 	})
 
 	it("returns exactly first rows when a first < cap is specified", async () => {
@@ -282,7 +290,7 @@ describe("PaginationCapPlugin default-first injection (seeded)", () => {
 		expect(rows.length).toBe(50)
 	})
 
-	it("returns at most MAX_PAGINATION_LIMIT rows via the connection form when first is omitted", async () => {
+	it("returns at most DEFAULT_PAGINATION_LIMIT rows via the connection form when first is omitted", async () => {
 		const result = await executeGraphQL(`
 			{
 				entitiesConnection {
@@ -293,7 +301,7 @@ describe("PaginationCapPlugin default-first injection (seeded)", () => {
 		expect(result.status).toBe(200)
 		expect(result.body.errors).toBeUndefined()
 		const nodes: Array<{id: string}> = result.body.data.entitiesConnection.nodes
-		expect(nodes.length).toBe(MAX_PAGINATION_LIMIT)
+		expect(nodes.length).toBe(DEFAULT_PAGINATION_LIMIT)
 	})
 
 	// --- Boundary tests: at-cap vs just-over-cap ---
@@ -478,7 +486,7 @@ describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
 		await pool.end()
 	})
 
-	it("caps nested relations at MAX when first is omitted on the nested field", async () => {
+	it("caps nested relations at DEFAULT when first is omitted on the nested field", async () => {
 		const result = await executeGraphQL(
 			`
 				query NestedDefault($id: UUID!) {
@@ -494,7 +502,7 @@ describe("PaginationCapPlugin nested default-first injection (seeded)", () => {
 		expect(result.status).toBe(200)
 		expect(result.body.errors).toBeUndefined()
 		const nested: Array<{id: string}> = result.body.data.entity.relationsList
-		expect(nested.length).toBe(MAX_PAGINATION_LIMIT)
+		expect(nested.length).toBe(DEFAULT_PAGINATION_LIMIT)
 	})
 
 	it("honors explicit first < cap on the nested field", async () => {

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -187,9 +187,12 @@ function sumSelections(
  *   - Pagination arg present but value unresolved / non-positive → fall back
  *     to MAX_PAGINATION_LIMIT (1000) — matches the effective cap at SQL build.
  *   - No pagination arg, has selections → `child × MAX_PAGINATION_LIMIT + 1`.
- *     PaginationCapPlugin injects `first: 1000` on every unpaginated
- *     collection field at SQL build, so modeling the default at 1000 matches
- *     the real fan-out ceiling. BigInt arithmetic means this doesn't overflow.
+ *     PaginationCapPlugin injects a default `first` on every unpaginated
+ *     collection field at SQL build (currently DEFAULT_PAGINATION_LIMIT=100),
+ *     but modeling at the cap keeps cost a conservative upper bound — a
+ *     query whose SHAPE could fan out to 1000 rows still gets flagged even
+ *     when the runtime default reduces actual rows. BigInt arithmetic means
+ *     this doesn't overflow.
  *   - No pagination arg, no selections → 1 (scalar leaf).
  */
 const DEFAULT_LIMIT = BigInt(MAX_PAGINATION_LIMIT)

--- a/api/src/kg/paginationCapPlugin.ts
+++ b/api/src/kg/paginationCapPlugin.ts
@@ -5,11 +5,16 @@
  * Does two things, uniformly across root and nested fields:
  * 1. Rejects oversized `first`/`last`/`offset` values (> MAX_PAGINATION_LIMIT)
  *    so abusive or buggy clients fail fast with BAD_USER_INPUT.
- * 2. Injects a default `first` when neither `first` nor `last` is supplied,
- *    so a bare `{ entity(id: ...) { relationsList { ... } } }` cannot resolve
- *    an unbounded sub-collection. Without this, PostGraphile 4 produces SQL
- *    without any LIMIT and returns every row — the Claim entity has 75K+
- *    inbound relations, which is the worst-case memory/CPU path.
+ * 2. Injects a default `first = DEFAULT_PAGINATION_LIMIT` when neither `first`
+ *    nor `last` is supplied, so a bare `{ entity(id: ...) { relationsList } }`
+ *    cannot resolve an unbounded sub-collection. Without this, PostGraphile 4
+ *    produces SQL without any LIMIT and returns every row — the Claim entity
+ *    has 75K+ inbound relations, which is the worst-case memory/CPU path.
+ *
+ * The default (100) is decoupled from the cap (1000): clients that genuinely
+ * need a large page can still opt in by passing an explicit `first` up to
+ * MAX_PAGINATION_LIMIT, but clients that omit pagination get a sensibly small
+ * page rather than 1000 rows of unrequested payload.
  *
  * Implementation: hooks `GraphQLObjectType:fields:field:args` and registers an
  * arg data generator on every connection / simple-collection field. The
@@ -25,6 +30,7 @@
 import {type FieldNode, GraphQLError, type ValidationContext} from "graphql"
 
 export const MAX_PAGINATION_LIMIT = 1000
+export const DEFAULT_PAGINATION_LIMIT = 100
 
 export function assertPaginationWithinLimit(args: Record<string, unknown>) {
 	for (const key of ["first", "last", "offset"] as const) {
@@ -85,8 +91,9 @@ export function NoFirstAndLastRule(context: ValidationContext) {
 
 /**
  * If the client supplied neither `first` nor `last`, inject `first` set to the
- * cap. Returns the original args object when either is set so we don't
- * silently override an explicit `last`-only pagination.
+ * default page size (DEFAULT_PAGINATION_LIMIT). Returns the original args
+ * object when either is set so we don't silently override an explicit
+ * `last`-only pagination.
  *
  * Kept as a pure helper so unit tests can exercise the policy without
  * standing up a full PostGraphile schema.
@@ -97,7 +104,7 @@ export function applyDefaultFirstIfOmitted(args: Record<string, unknown>): Recor
 	if (hasFirst || hasLast) {
 		return args
 	}
-	return {...args, first: MAX_PAGINATION_LIMIT}
+	return {...args, first: DEFAULT_PAGINATION_LIMIT}
 }
 
 const PaginationCapPlugin = (builder: any) => {
@@ -121,7 +128,7 @@ const PaginationCapPlugin = (builder: any) => {
 				const hasFirst = typeof fieldArgs.first === "number"
 				const hasLast = typeof fieldArgs.last === "number"
 				if (!hasFirst && !hasLast) {
-					queryBuilder.first(MAX_PAGINATION_LIMIT)
+					queryBuilder.first(DEFAULT_PAGINATION_LIMIT)
 				}
 			},
 		}))


### PR DESCRIPTION
## Summary

Splits the pagination default from the cap. `MAX_PAGINATION_LIMIT` stays at **1000** (the hard cap that rejects oversized requests). New `DEFAULT_PAGINATION_LIMIT = 100` is what gets injected when a client omits both `first` and `last`. Clients can still ask for up to 1000 explicitly.

Motivation: today the largest GraphQL responses in prod (15 MB \`entities\`, 13 MB \`Spaces\`) are driven by clients that pass \`first: 1000\` AND callers that don't paginate at all — both of which collapse the result set to "everything PostGraphile is willing to return." Most callers that omit pagination don't actually need 1000 rows; 100 is a saner default and cuts response size 10× for unpaginated queries.

## Test plan

- [ ] Unit: \`applyDefaultFirstIfOmitted({})\` returns \`{first: 100}\`
- [ ] Integration (seeded): bare \`{ entities { id } }\` returns exactly 100 rows
- [ ] Integration (seeded): \`entitiesConnection { nodes { id } }\` returns exactly 100 rows
- [ ] Integration (seeded): nested \`entity { relationsList }\` caps at 100
- [ ] Cap unchanged: \`first: 1000\` still succeeds; \`first: 1001\` still 400s
- [ ] Smoke (post-deploy): hit \`testnet-api.geobrowser.io\` with a bare query and confirm response size dropped

## Notes

- \`costLoggerPlugin\` continues to model fanout at MAX (1000), not the new default. This keeps cost a conservative upper bound — a query whose shape COULD fan out to 1000 rows still gets flagged even when the runtime default reduces actual rows. We can tighten the cost model in a follow-up if we want it to track actual SQL behavior.