### PR TITLE
fix(kg-indexer): allow root space to publish system property schema

### DIFF
--- a/kg-indexer/docs/DECISIONS.md
+++ b/kg-indexer/docs/DECISIONS.md
@@ -49,4 +49,3 @@
 - Non-root spaces still have system-property relations dropped, preserving prior behavior
 - Onchain handler retains exclusive ownership of system-property values, so no row-level write races
 - If the root space is ever migrated, `sdk::core::ids::ROOT_SPACE_ID` must be updated alongside the indexer's gating check
-- Implementation lives in GEO-563/564; the SDK constant is GEO-562

--- a/kg-indexer/docs/DECISIONS.md
+++ b/kg-indexer/docs/DECISIONS.md
@@ -35,3 +35,18 @@
 - Kafka offsets only committed after full block is processed
 - If `is_last` never arrives, stale block detection warns after timeout
 - Messages without block metadata fall back to immediate processing
+
+## ADR-003: Root-space gating for system property relations
+
+**Status**: Accepted
+
+**Context**: The four onchain-derived system properties (`SpaceAddress`, `VotingMode`, `SpaceId`, `CreatedAtBlock`, enumerated in `sdk::core::ids::PROTECTED_PROPERTY_IDS`) need schema relations in the graph (e.g. `Types: Property`, `Data Type: Text/Integer`) so they look like first-class properties. Authoring those relations from arbitrary spaces would let any space redefine the schema of system properties. At the same time, their *values* are written directly by `handlers::system_entities::map_space_registered` from onchain events; permitting edit-pipeline writes for those values would create two writers racing for the same value rows.
+
+**Decision**: Edits from any space are blocked from authoring relations whose `from`/`to` is in `PROTECTED_PROPERTY_IDS`, with one exception: the root space (`sdk::core::ids::ROOT_SPACE_ID`) may author such relations to define the system-property schema. Values for those properties remain non-writable via edits — even from the root space — because the onchain handler is the sole writer.
+
+**Consequences**:
+- Schema for system properties is authored exactly once, by the root space
+- Non-root spaces still have system-property relations dropped, preserving prior behavior
+- Onchain handler retains exclusive ownership of system-property values, so no row-level write races
+- If the root space is ever migrated, `sdk::core::ids::ROOT_SPACE_ID` must be updated alongside the indexer's gating check
+- Implementation lives in GEO-563/564; the SDK constant is GEO-562

--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -1483,62 +1483,37 @@ mod tests {
 
     #[test]
     fn seed_edit_smoke_root_space_passes_property_schema() {
-        // Regression test for the original bug: the seed edit defining the
-        // schema for the four protected property entities had its 8
-        // schema-defining relations silently filtered out.
-        //
-        // Construct 8 CreateRelation ops with the same shape as the seed
-        // edit — for each protected property entity, one
-        // `<property> -types-> Property` relation and one
-        // `<property> -DataType-> Text` relation — and assert all 8 survive
-        // when published from the root space, and that all 8 are dropped when
-        // published from any other space.
-        let space_address = Uuid::parse_str(sdk::core::ids::SPACE_ADDRESS_PROPERTY_ID).unwrap();
-        let voting_mode = Uuid::parse_str(sdk::core::ids::VOTING_MODE_PROPERTY_ID).unwrap();
-        let space_id_prop = Uuid::parse_str(sdk::core::ids::SPACE_ID_PROPERTY_ID).unwrap();
-        let created_at_block =
-            Uuid::parse_str(sdk::core::ids::CREATED_AT_BLOCK_PROPERTY_ID).unwrap();
-
-        // `type` relation type — exists in the SDK.
+        let property = Uuid::parse_str(sdk::core::ids::SPACE_ADDRESS_PROPERTY_ID).unwrap();
         let type_rel_type = Uuid::parse_str(sdk::core::ids::TYPE_RELATION_TYPE_ID).unwrap();
 
-        // The SDK does not export constants for these (sdk/src/core/ids.rs has
-        // no DATA_TYPE_RELATION_TYPE_ID, PROPERTY_TYPE_ID, or TEXT_TYPE_ID).
-        // Use deterministic placeholders — this test asserts the count and
-        // the gate, not specific endpoint UUIDs.
-        let property_type_placeholder = Uuid::from_bytes([0xAA; 16]); // stand-in for "Property" type entity
-        let data_type_rel_type_placeholder = Uuid::from_bytes([0xBB; 16]); // stand-in for `DataType` relation type
-        let text_type_placeholder = Uuid::from_bytes([0xCC; 16]); // stand-in for `Text` data type entity
+        // SDK doesn't export constants for these — use deterministic
+        // placeholders. Test asserts gating behavior, not endpoint UUIDs.
+        let property_type = Uuid::from_bytes([0xAA; 16]); // "Property" type entity
+        let data_type_rel = Uuid::from_bytes([0xBB; 16]); // `DataType` relation type
+        let text_type = Uuid::from_bytes([0xCC; 16]); // `Text` data type entity
 
-        let mut ops: Vec<RelationOp> = Vec::with_capacity(8);
-        for property in [space_address, voting_mode, space_id_prop, created_at_block] {
+        let ops = vec![
             // `<property> -types-> Property`
-            ops.push(RelationOp::Create(make_create_relation_with_ids(
+            RelationOp::Create(make_create_relation_with_ids(
                 type_rel_type,
                 property,
-                property_type_placeholder,
-            )));
+                property_type,
+            )),
             // `<property> -DataType-> Text`
-            ops.push(RelationOp::Create(make_create_relation_with_ids(
-                data_type_rel_type_placeholder,
+            RelationOp::Create(make_create_relation_with_ids(
+                data_type_rel,
                 property,
-                text_type_placeholder,
-            )));
-        }
+                text_type,
+            )),
+        ];
 
-        // From root: all 8 must survive.
         let from_root = filter_protected_relations(ops.clone(), &ROOT_SPACE_UUID);
-        assert_eq!(
-            from_root.len(),
-            8,
-            "root space should be allowed to author all 8 schema-defining seed relations",
-        );
+        assert_eq!(from_root.len(), 2, "root space must pass schema relations");
 
-        // From any other space: all 8 must be dropped (proves the gate works).
         let from_other = filter_protected_relations(ops, &NON_ROOT_SPACE_ID);
         assert!(
             from_other.is_empty(),
-            "non-root space must not author relations whose endpoints are protected property entities",
+            "non-root space must not author relations whose endpoints are protected",
         );
     }
 

--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -1420,7 +1420,7 @@ mod tests {
     }
 
     // ===================
-    // Root-space gating tests (GEO-563/564)
+    // Root-space gating tests
     // ===================
 
     #[test]

--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -138,15 +138,10 @@ fn filter_protected_relations(ops: Vec<RelationOp>, edit_space_id: &Uuid) -> Vec
     ops.into_iter()
         .filter(|op| match op {
             RelationOp::Create(rel) => {
-                if PROTECTED_RELATION_TYPES.contains(&rel.type_id) {
-                    return false;
-                }
-                if is_root {
-                    return true;
-                }
+                let type_protected = PROTECTED_RELATION_TYPES.contains(&rel.type_id);
                 let from_protected = PROTECTED_PROPERTIES.contains(&rel.from_id);
                 let to_protected = PROTECTED_PROPERTIES.contains(&rel.to_id);
-                !from_protected && !to_protected
+                !type_protected && (is_root || (!from_protected && !to_protected))
             }
             _ => true,
         })

--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -10,7 +10,7 @@ use grc_20::{
     UnsetRelationField, Value as Grc20Value,
 };
 use hermes_schema::pb::knowledge::HermesEdit;
-use sdk::core::ids::{PROTECTED_PROPERTY_IDS, PROTECTED_RELATION_TYPE_IDS};
+use sdk::core::ids::{PROTECTED_PROPERTY_IDS, PROTECTED_RELATION_TYPE_IDS, ROOT_SPACE_ID};
 use tracing::{debug_span, warn};
 use uuid::Uuid;
 
@@ -36,6 +36,9 @@ static PROTECTED_RELATION_TYPES: LazyLock<HashSet<Uuid>> = LazyLock::new(|| {
         .map(|id| Uuid::parse_str(id).expect("invalid protected relation type ID"))
         .collect()
 });
+
+static ROOT_SPACE_UUID: LazyLock<Uuid> =
+    LazyLock::new(|| Uuid::parse_str(ROOT_SPACE_ID).expect("invalid ROOT_SPACE_ID"));
 
 /// Result of processing an edit message
 pub struct EditResult {
@@ -110,21 +113,40 @@ fn extract_context(ctx: &Option<Context>) -> (Option<Uuid>, Option<Uuid>) {
 }
 
 /// Filter out value operations targeting protected property IDs.
+///
+/// Values for `SpaceAddress` / `VotingMode` / `SpaceId` / `CreatedAtBlock` are
+/// written directly by `handlers::system_entities::map_space_registered` from
+/// onchain events. Allowing edit-pipeline writes — even from the root space —
+/// would let two writers race for the same value rows. Always drop, regardless
+/// of `space_id`.
 fn filter_protected_values(ops: Vec<ValueOp>) -> Vec<ValueOp> {
     ops.into_iter()
         .filter(|op| !PROTECTED_PROPERTIES.contains(&op.property_id))
         .collect()
 }
 
-/// Filter out relation operations targeting protected relation types or property entities.
-fn filter_protected_relations(ops: Vec<RelationOp>) -> Vec<RelationOp> {
+/// Filter `Create` relation ops against system-protected state.
+///
+/// - `SYSTEM_TYPES_RELATION_TYPE_ID` is always dropped — owned by
+///   `map_space_registered`, never authored via edits (even from root).
+/// - Relations whose `from`/`to` is in `PROTECTED_PROPERTY_IDS` are dropped
+///   unless the publishing space is the root space, which authors the
+///   schema-defining seed edit (e.g. `SpaceAddress -types-> Property`).
+/// - `Update` / `Delete` / `Unset` pass through; tightened separately.
+fn filter_protected_relations(ops: Vec<RelationOp>, edit_space_id: &Uuid) -> Vec<RelationOp> {
+    let is_root = edit_space_id == &*ROOT_SPACE_UUID;
     ops.into_iter()
         .filter(|op| match op {
             RelationOp::Create(rel) => {
-                let type_protected = PROTECTED_RELATION_TYPES.contains(&rel.type_id);
+                if PROTECTED_RELATION_TYPES.contains(&rel.type_id) {
+                    return false;
+                }
+                if is_root {
+                    return true;
+                }
                 let from_protected = PROTECTED_PROPERTIES.contains(&rel.from_id);
                 let to_protected = PROTECTED_PROPERTIES.contains(&rel.to_id);
-                !type_protected && !from_protected && !to_protected
+                !from_protected && !to_protected
             }
             _ => true,
         })
@@ -156,7 +178,7 @@ pub fn handle_edit(edit: &HermesEdit) -> Result<EditResult, HandlerError> {
 
     // Filter out operations targeting system-protected properties and relation types
     let value_ops = filter_protected_values(value_ops);
-    let relation_ops = filter_protected_relations(relation_ops);
+    let relation_ops = filter_protected_relations(relation_ops, &space_id);
 
     // Squash operations within this edit to resolve conflicts
     let values = squash_values(&value_ops);
@@ -1336,6 +1358,11 @@ mod tests {
         assert_eq!(result[0].property_id, normal);
     }
 
+    /// Arbitrary non-root space ID for tests that exercise the
+    /// "publishing space is not root" branch of `filter_protected_relations`.
+    /// Must NOT collide with `ROOT_SPACE_UUID`.
+    const NON_ROOT_SPACE_ID: Uuid = Uuid::from_bytes([1; 16]);
+
     #[test]
     fn filter_relations_drops_protected_type() {
         let protected_type =
@@ -1345,7 +1372,7 @@ mod tests {
             Uuid::new_v4(),
             Uuid::new_v4(),
         ))];
-        let result = filter_protected_relations(ops);
+        let result = filter_protected_relations(ops, &NON_ROOT_SPACE_ID);
         assert!(result.is_empty());
     }
 
@@ -1357,7 +1384,7 @@ mod tests {
             protected_entity,
             Uuid::new_v4(),
         ))];
-        let result = filter_protected_relations(ops);
+        let result = filter_protected_relations(ops, &NON_ROOT_SPACE_ID);
         assert!(result.is_empty());
     }
 
@@ -1369,7 +1396,7 @@ mod tests {
             Uuid::new_v4(),
             protected_entity,
         ))];
-        let result = filter_protected_relations(ops);
+        let result = filter_protected_relations(ops, &NON_ROOT_SPACE_ID);
         assert!(result.is_empty());
     }
 
@@ -1380,7 +1407,7 @@ mod tests {
             Uuid::new_v4(),
             Uuid::new_v4(),
         ))];
-        let result = filter_protected_relations(ops);
+        let result = filter_protected_relations(ops, &NON_ROOT_SPACE_ID);
         assert_eq!(result.len(), 1);
     }
 
@@ -1393,8 +1420,131 @@ mod tests {
             RelationOp::Delete(make_delete_relation(id, space_id)),
             RelationOp::Unset(make_unset_relation(id, space_id)),
         ];
-        let result = filter_protected_relations(ops);
+        let result = filter_protected_relations(ops, &NON_ROOT_SPACE_ID);
         assert_eq!(result.len(), 3);
+    }
+
+    // ===================
+    // Root-space gating tests (GEO-563/564)
+    // ===================
+
+    #[test]
+    fn root_space_can_create_relation_with_protected_from() {
+        // Seed-edit shape: `SpaceAddress -types-> <Property>` from root.
+        // `from` is protected, but `type` is not in PROTECTED_RELATION_TYPES
+        // and we are publishing from the root space, so the relation is kept.
+        let protected_from = Uuid::parse_str(sdk::core::ids::SPACE_ADDRESS_PROPERTY_ID).unwrap();
+        let unprotected_type = Uuid::parse_str(sdk::core::ids::TYPE_RELATION_TYPE_ID).unwrap();
+        let ops = vec![RelationOp::Create(make_create_relation_with_ids(
+            unprotected_type,
+            protected_from,
+            Uuid::new_v4(),
+        ))];
+        let result = filter_protected_relations(ops, &ROOT_SPACE_UUID);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn root_space_can_create_relation_with_protected_to() {
+        // Symmetric: `<something> -<unprotected>-> VotingMode` from root.
+        let protected_to = Uuid::parse_str(sdk::core::ids::VOTING_MODE_PROPERTY_ID).unwrap();
+        let unprotected_type = Uuid::parse_str(sdk::core::ids::TYPE_RELATION_TYPE_ID).unwrap();
+        let ops = vec![RelationOp::Create(make_create_relation_with_ids(
+            unprotected_type,
+            Uuid::new_v4(),
+            protected_to,
+        ))];
+        let result = filter_protected_relations(ops, &ROOT_SPACE_UUID);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn root_space_still_blocked_from_system_types_relation() {
+        // Type-level protection is unconditional. Even root cannot author
+        // SYSTEM_TYPES via the edit pipeline — that relation type is owned
+        // by `map_space_registered`.
+        let protected_type =
+            Uuid::parse_str(sdk::core::ids::SYSTEM_TYPES_RELATION_TYPE_ID).unwrap();
+        let ops = vec![RelationOp::Create(make_create_relation_with_ids(
+            protected_type,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        ))];
+        let result = filter_protected_relations(ops, &ROOT_SPACE_UUID);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn root_space_still_blocked_from_protected_value() {
+        // `filter_protected_values` is space-agnostic — values for protected
+        // properties are managed by `map_space_registered`, not the edit
+        // pipeline. Confirm the value filter did NOT get relaxed alongside
+        // the relation change.
+        let protected = Uuid::parse_str(sdk::core::ids::SPACE_ADDRESS_PROPERTY_ID).unwrap();
+        let ops = vec![make_value_op_with_property(protected)];
+        let result = filter_protected_values(ops);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn seed_edit_smoke_root_space_passes_property_schema() {
+        // Regression test for the original bug: the seed edit defining the
+        // schema for the four protected property entities had its 8
+        // schema-defining relations silently filtered out.
+        //
+        // Construct 8 CreateRelation ops with the same shape as the seed
+        // edit — for each protected property entity, one
+        // `<property> -types-> Property` relation and one
+        // `<property> -DataType-> Text` relation — and assert all 8 survive
+        // when published from the root space, and that all 8 are dropped when
+        // published from any other space.
+        let space_address = Uuid::parse_str(sdk::core::ids::SPACE_ADDRESS_PROPERTY_ID).unwrap();
+        let voting_mode = Uuid::parse_str(sdk::core::ids::VOTING_MODE_PROPERTY_ID).unwrap();
+        let space_id_prop = Uuid::parse_str(sdk::core::ids::SPACE_ID_PROPERTY_ID).unwrap();
+        let created_at_block =
+            Uuid::parse_str(sdk::core::ids::CREATED_AT_BLOCK_PROPERTY_ID).unwrap();
+
+        // `type` relation type — exists in the SDK.
+        let type_rel_type = Uuid::parse_str(sdk::core::ids::TYPE_RELATION_TYPE_ID).unwrap();
+
+        // The SDK does not export constants for these (sdk/src/core/ids.rs has
+        // no DATA_TYPE_RELATION_TYPE_ID, PROPERTY_TYPE_ID, or TEXT_TYPE_ID).
+        // Use deterministic placeholders — this test asserts the count and
+        // the gate, not specific endpoint UUIDs.
+        let property_type_placeholder = Uuid::from_bytes([0xAA; 16]); // stand-in for "Property" type entity
+        let data_type_rel_type_placeholder = Uuid::from_bytes([0xBB; 16]); // stand-in for `DataType` relation type
+        let text_type_placeholder = Uuid::from_bytes([0xCC; 16]); // stand-in for `Text` data type entity
+
+        let mut ops: Vec<RelationOp> = Vec::with_capacity(8);
+        for property in [space_address, voting_mode, space_id_prop, created_at_block] {
+            // `<property> -types-> Property`
+            ops.push(RelationOp::Create(make_create_relation_with_ids(
+                type_rel_type,
+                property,
+                property_type_placeholder,
+            )));
+            // `<property> -DataType-> Text`
+            ops.push(RelationOp::Create(make_create_relation_with_ids(
+                data_type_rel_type_placeholder,
+                property,
+                text_type_placeholder,
+            )));
+        }
+
+        // From root: all 8 must survive.
+        let from_root = filter_protected_relations(ops.clone(), &ROOT_SPACE_UUID);
+        assert_eq!(
+            from_root.len(),
+            8,
+            "root space should be allowed to author all 8 schema-defining seed relations",
+        );
+
+        // From any other space: all 8 must be dropped (proves the gate works).
+        let from_other = filter_protected_relations(ops, &NON_ROOT_SPACE_ID);
+        assert!(
+            from_other.is_empty(),
+            "non-root space must not author relations whose endpoints are protected property entities",
+        );
     }
 
     #[test]

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -38,6 +38,18 @@ pub const VOTING_MODE_PROPERTY_ID: &str = "af26ed41-de0f-5b4f-a093-e9d3f683db07"
 pub const SPACE_ID_PROPERTY_ID: &str = "712adc1f-e950-5d14-bbd8-bf2166fe59c1";
 pub const CREATED_AT_BLOCK_PROPERTY_ID: &str = "da2952fb-17d6-53f3-b521-52e254106e0b";
 
+/// Onchain-derived ID of the "root" space whose editors are authorized to
+/// publish edits that mutate the system property-definition entities — i.e.
+/// relations whose `from` or `to` is in `PROTECTED_PROPERTY_IDS`. Edits from
+/// any other space targeting those entities as relation endpoints are
+/// silently dropped by the kg-indexer.
+///
+/// NOTE: Space IDs are per-deployment (`keccak('grc20.space', account, nonce,
+/// chainId)`), so this constant pins the SDK to a single chain/env. Update
+/// it if the root space is migrated, or fork the SDK if you ever run
+/// multiple envs from one binary.
+pub const ROOT_SPACE_ID: &str = "a19c345a-b986-6679-b001-d7d2138d88a1";
+
 // Protected relation type IDs
 pub const SYSTEM_TYPES_RELATION_TYPE_ID: &str = "88b3d6ad-288c-529c-a212-0e1c24819185";
 


### PR DESCRIPTION
## Summary

`filter_protected_relations` was dropping every edit op whose `from`/`to` is one of the four onchain-derived system property entities (`SpaceAddress`, `VotingMode`, `SpaceId`, `CreatedAtBlock`). That over-broadly drops the legitimate seed edit defining those entities' schema (e.g. `SpaceAddress -types-> Property`, `SpaceAddress -DataType-> Text`), so the system properties never get their type/data-type relations in the graph.

This PR adds a `ROOT_SPACE_ID` constant in the SDK and gates the `from`/`to` check on the publishing space — edits from root pass through, all others still drop. The relation-type filter (`SYSTEM_TYPES_RELATION_TYPE_ID`) and the value filter remain unconditional even from root: those are owned by `map_space_registered` from onchain events, and allowing edit-pipeline writes would race two writers on the same rows.

`space_id` cannot be spoofed — `SpaceRegistry.enter()` enforces it via `msg.sender` lookup or signature verification, so gating on it is sound defense.

A new ADR-003 in `kg-indexer/docs/DECISIONS.md` records the protection model.

## Test plan

- [x] `cargo build -p kg-indexer` clean
- [x] `SQLX_OFFLINE=true cargo test -p kg-indexer --bins handlers::edits` — 36/36 pass, including 5 new tests covering root-passes, root-still-blocked-from-system-types, root-still-blocked-from-protected-value, and a seed-edit smoke test
- [ ] Post-deploy: confirm the queued root-space relation lands the missing schema relations on the four system property entities