### PR TITLE
fix(api): return 400 for non-multipart IPFS upload bodies

### DIFF
--- a/api/src/ipfs/__tests__/router.test.ts
+++ b/api/src/ipfs/__tests__/router.test.ts
@@ -73,6 +73,33 @@ describe.each(ENDPOINTS)("POST %s", (endpoint) => {
 		expect(uploadFile).not.toHaveBeenCalled()
 	})
 
+	it("returns 400 with no Pinata call when the request body isn't multipart", async () => {
+		const {app, uploadEdit, uploadFile} = setupApp()
+
+		// Bare POST: no Content-Type, no body. c.req.formData() throws on this.
+		const res = await app.request(endpoint, {method: "POST"})
+
+		expect(res.status).toBe(400)
+		expect(await res.text()).toBe("Invalid multipart body")
+		expect(uploadEdit).not.toHaveBeenCalled()
+		expect(uploadFile).not.toHaveBeenCalled()
+	})
+
+	it("returns 400 with no Pinata call for a JSON body (wrong content-type)", async () => {
+		const {app, uploadEdit, uploadFile} = setupApp()
+
+		const res = await app.request(endpoint, {
+			method: "POST",
+			headers: {"content-type": "application/json"},
+			body: JSON.stringify({not: "multipart"}),
+		})
+
+		expect(res.status).toBe(400)
+		expect(await res.text()).toBe("Invalid multipart body")
+		expect(uploadEdit).not.toHaveBeenCalled()
+		expect(uploadFile).not.toHaveBeenCalled()
+	})
+
 	it("delegates to the upload service when a non-empty file is provided", async () => {
 		const {app, uploadEdit, uploadFile} = setupApp()
 

--- a/api/src/ipfs/index.ts
+++ b/api/src/ipfs/index.ts
@@ -25,6 +25,7 @@ type AppEnv = {
 
 const EMPTY_FILE_LOG_MESSAGE = "Empty file provided"
 const EMPTY_FILE_ERROR_MESSAGE = "File cannot be empty"
+const INVALID_MULTIPART_ERROR_MESSAGE = "Invalid multipart body"
 
 // OpenAPI response descriptions — kept as constants so the three routes stay
 // in lockstep without copy-paste drift.
@@ -42,9 +43,19 @@ function createUploadHandler(opts: {spanName: string; upload: UploadFn; runtime:
 	const {spanName, upload, runtime} = opts
 
 	return async (c: import("hono").Context<AppEnv>) => {
-		const formData = await c.req.formData()
-		const file = formData.get("file") as File | undefined
 		const requestId = c.get("requestId") ?? "unknown"
+
+		// Reject non-multipart bodies (bare POST, wrong content-type, malformed
+		// boundary, etc.) with 400 instead of letting the parse exception bubble
+		// up as 500. Scanners and ad-hoc curls hit this path; we don't want
+		// Sentry issues for malformed client input.
+		let formData: FormData
+		try {
+			formData = await c.req.formData()
+		} catch {
+			return new Response(INVALID_MULTIPART_ERROR_MESSAGE, {status: 400})
+		}
+		const file = formData.get("file") as File | undefined
 
 		const program = Effect.gen(function* () {
 			if (!file) {


### PR DESCRIPTION
## Summary

`c.req.formData()` throws when the request body isn't valid multipart (bare POST, JSON body, missing/malformed boundary). The throw happens **before** the Effect.gen validation block runs, so it bubbled up to Hono's default error handler as a 500 — generating spurious Sentry issues for what is malformed client input.

Found while smoke-testing the empty-file fix in prod (#649): a bare `curl -X POST` returned 500 because no real client sends a non-multipart body to these endpoints, but vulnerability scanners and crawlers do.

## Fix

Wrap the parse in try/catch and return 400 `Invalid multipart body`. Same shape as the empty-file fix; covers all 3 routes via the shared `createUploadHandler` factory in `api/src/ipfs/index.ts`.

## Test plan

- [x] `bun run check` passes
- [x] `bunx vitest run src/ipfs/__tests__/router.test.ts` — 15/15 (6 new: 2 cases × 3 endpoints)
- [ ] Smoke after deploy: `curl -X POST .../ipfs/upload-file` → 400 "Invalid multipart body" (was 500), no Sentry issue
- [ ] `curl -X POST -H "content-type: application/json" -d '{}' .../ipfs/upload-file` → 400 (was 500)