### PR TITLE
chore(api): disable GraphQL response cache

### DIFF
--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -1,5 +1,4 @@
 import SimplifyInflectionPlugin from "@graphile-contrib/pg-simplify-inflector"
-import {useResponseCache} from "@graphql-yoga/plugin-response-cache"
 import * as Sentry from "@sentry/node"
 import {GraphQLError, print} from "graphql"
 import {createYoga, maskError, type Plugin, useExecutionCancellation} from "graphql-yoga"
@@ -25,7 +24,6 @@ import PaginationCapPlugin, {NoFirstAndLastRule} from "./paginationCapPlugin"
 import {useSearchInvocationLogger} from "./searchInvocationLogger"
 import {createShedEpisodeTracker} from "./shedEpisodeTracker"
 import UndashedUuidPlugin from "./uuidScalarPlugin"
-import {createValkeyCache} from "./valkeyCache"
 import ValueOrderByScorePlugin from "./valueOrderByScorePlugin"
 import ValueScalarsPlugin from "./valueScalarsPlugin"
 
@@ -323,35 +321,14 @@ function usePgClient(pool: Pool): Plugin<{pgClient: PoolClient}> {
 	}
 }
 
-// Response cache — shared across all API pods via Valkey (Redis-compatible).
-// Disabled gracefully if VALKEY_URL is not set (no cache, direct DB queries).
-// Valkey maxmemory + allkeys-lru eviction prevents unbounded memory growth.
-const DEFAULT_TTL_MS = 10_000
-// Longer TTL for expensive, rarely-changing queries identified in production logs.
-// These queries are identical across all users and produce large responses (2-15 MB).
-const LONG_TTL_MS = 60_000
-const responseCachePlugin = (() => {
-	const valkeyUrl = process.env.VALKEY_URL
-	if (!valkeyUrl) {
-		log.info("Response cache disabled (VALKEY_URL not set)")
-		return null
-	}
-	log.info("Response cache enabled", {valkeyUrl: valkeyUrl.replace(/\/\/.*@/, "//<redacted>@")})
-	return useResponseCache({
-		session: () => null,
-		ttl: DEFAULT_TTL_MS,
-		ttlPerSchemaCoordinate: {
-			// All DAO spaces list — 12 MB, called on 5+ pages, near-static
-			"Query.spaces": LONG_TTL_MS,
-			"Query.spacesConnection": LONG_TTL_MS,
-			// Bounties/entity lists — 2-15 MB, same result for all users
-			"Query.entities": LONG_TTL_MS,
-			"Query.entitiesConnection": LONG_TTL_MS,
-			"Query.entitiesOrderedByProperty": LONG_TTL_MS,
-		},
-		cache: createValkeyCache(valkeyUrl),
-	})
-})()
+// Response cache disabled — the 60s TTL on Query.spaces was serving stale
+// empty results to per-user filtered lookups (e.g. Spaces(filter:{address}))
+// while the user waited for the kg-indexer to write the row from a fresh
+// on-chain personal-space registration. Symptom: 60-second-stuck "Create
+// Personal Space" modal even though the chain + indexer were both fast.
+// Re-enable with a stricter cache key (filter-aware) before turning back on.
+log.info("Response cache disabled (hardcoded)")
+const responseCachePlugin = null
 
 // Shared plugins for GraphQL server.
 // Yoga plugin that registers custom GraphQL validation rules.


### PR DESCRIPTION
## Summary

Hardcode the response cache plugin to `null` so every GraphQL request hits the DB directly. The Valkey infrastructure stays intact for re-enable later.

## Why

A user reported the "Create Personal Space" modal staying stuck for ~60s. HAR + kubectl investigation showed:

- On-chain: tx landed in block 126800 at **16:23:16 UTC** (~1s after submit)
- kg-indexer: processed `SPACE_REGISTERED` and wrote the row in **9ms** (`batch_start` 16:23:16.199 → `batch_end` 16:23:16.208)
- Gaia GraphQL: returned `{spaces:[]}` for **another 43 seconds** (21 polls of `Spaces(filter:{address}, limit: 1)`)

Root cause: the page-load fetch at T+0.179s (before the user clicked anything) cached an empty result in Valkey under the LONG_TTL=60s policy for `Query.spaces`. Every poll for the next ~60s was a cache hit returning that stale empty.

The `LONG_TTL_MS = 60_000` was added to cache the static "all DAO spaces list" (12 MB, identical for every user). But the same TTL applied to **per-user filtered** lookups, where freshness matters when the user just performed a write.

## Fix

Simplest possible: set `responseCachePlugin = null`. All `Query.spaces` / `Query.entities*` calls go to the DB directly. The 12 MB DAO-list query loses its 60s cache hit, but at the cost of correctness for everything else.

A follow-up could re-enable with a filter-aware cache key (skip cache when `args.filter` is non-empty) — that's why the Valkey helper module is left untouched.

## Test plan

- [x] `bun run check` passes
- [ ] Smoke after deploy: create a personal space and confirm the modal completes in seconds, not 60s
- [ ] Watch `kubectl top pods -n api` for ~10 min — expect a step-up in CPU and DB pool utilization since the 12 MB `spaces` / `entities*` queries no longer cache. If pool pressure shedding kicks in (503s on `/graphql`), revert immediately.
- [ ] Track `gaia_api_graphql_response_size_bytes_*` metric for the response-size distribution shift