### PR TITLE
fix(api): gql pool leak

### DIFF
--- a/.github/workflows/api-cache-integration-tests.yml
+++ b/.github/workflows/api-cache-integration-tests.yml
@@ -8,6 +8,7 @@ on:
       - 'api/src/kg/postgraphile.ts'
       - 'api/src/kg/__tests__/valkeyCache.test.ts'
       - 'api/src/kg/__tests__/cache-integration.test.ts'
+      - 'api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts'
       - 'api/package.json'
       - '.github/workflows/api-cache-integration-tests.yml'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'api/src/kg/postgraphile.ts'
       - 'api/src/kg/__tests__/valkeyCache.test.ts'
       - 'api/src/kg/__tests__/cache-integration.test.ts'
+      - 'api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts'
       - 'api/package.json'
       - '.github/workflows/api-cache-integration-tests.yml'
 
@@ -48,3 +50,6 @@ jobs:
 
       - name: Run cache integration tests
         run: bun test src/kg/__tests__/cache-integration.test.ts
+
+      - name: Run usePgClient cancellation-leak regression test
+        run: bun test src/kg/__tests__/usePgClient-cancellation-leak.test.ts

--- a/api/docs/gql-pool-leak-investigation.md
+++ b/api/docs/gql-pool-leak-investigation.md
@@ -1,0 +1,200 @@
+# GraphQL Pool Leak Investigation
+
+Investigation into gradual GraphQL pool utilization growth that leads to 503s well before the pool reaches its configured limit. Companion to `memory-leak-investigation.md` — the two are independent issues but share triage tooling.
+
+## Executive Summary
+
+The GraphQL pg pool's utilization climbs monotonically over many hours under stable, low-volume traffic (5–30 rps), capping around 70% before pod restarts reset it. Once the pool crosses ~50% utilization, 503s start firing. Traffic volume does not justify the growth — the shape is a textbook **slow connection leak**, not a load curve.
+
+The most likely root cause is the interaction between **`useExecutionCancellation()` and `usePgClient()`** in `api/src/kg/postgraphile.ts`: when a client cancels a request mid-flight (a 499), the GraphQL `execute()` call is aborted, but (a) `usePgClient`'s `onExecuteDone` cleanup is not guaranteed to fire on abort, and (b) even when it does, node-pg's `PoolClient` has no `AbortSignal` integration, so the in-flight SQL keeps running and `release()` on a busy client has undefined semantics in the pool. Either path leaves connections checked out and counted against pool capacity until they eventually time out (or never).
+
+Several secondary issues amplify the impact: an aggressive saturation threshold (`PG_POOL_PRESSURE_WAITING_THRESHOLD=1` in production) trips 503s on momentary queues, missing nginx ingress timeouts and missing pg `query_timeout` mean the timeout hierarchy isn't fully wired end-to-end, and the pool metric currently exported (`totalCount` / `idleCount` separately) makes leaks harder to diagnose than a single "checked-out" gauge would.
+
+This document records the findings and the recommended fix set, in priority order.
+
+## Observed Behavior
+
+From the production GraphQL pool dashboard (24-hour window):
+
+- **Pool utilization** (`pgPool.totalCount / max`) starts each pod's life near 5% and grows steadily to ~70% over 12–14 hours, then plateaus.
+- Two sharp drops to ~0% are visible (around 15:00 and 21:00) — these correspond to pod restarts.
+- **Request volume** is stable at 5–30 rps for the same window, with no spikes that correlate to the utilization growth. Peak rps does not coincide with peak utilization.
+- **5xx error rates** (mostly 503s) start ramping at ~04:00, exactly as utilization crosses ~50%.
+- **499s (client cancels)** are present throughout, growing somewhat over the day.
+
+The drops at restart followed by a fresh slow climb is the diagnostic shape — a load-driven utilization curve would track rps and oscillate, not climb monotonically across pod lifetimes.
+
+## Why This Is a Leak, Not Load
+
+`pgPool.totalCount` (numerator of the utilization metric — `api/src/services/dbSaturation.ts:80`, `api/src/kg/postgraphile.ts:64-71`) counts both idle and busy connections. The pool's behaviors are:
+
+- **Idle connections** close after `idleTimeoutMillis = 30s` (`api/src/kg/postgraphile.ts:59`).
+- **Busy connections** (`pool.connect()` succeeded, `release()` not yet called) never auto-close.
+
+Under stable traffic at 5–30 rps with average query latency in the tens of milliseconds, the steady-state expected concurrent in-flight queries is well under 5. Even at p99 = 2s, peak concurrency would be in the 10–15 range. Idle connections recycle in 30 seconds. There is no mechanism by which steady traffic should accumulate connections from 2–3 to 35 over 14 hours.
+
+That accumulation is only possible if connections are checked out and never returned. The implied leak rate (~32 connections / 14h ≈ 1 per ~25 min) at ~10 rps is consistent with **a rare-path leak** firing on roughly 1 in 15,000 requests — exactly the kind of corner case that aborted/cancelled requests would produce.
+
+## Root Cause: Cancellation Path Bypasses pgClient Release
+
+In `api/src/kg/postgraphile.ts:370-378`, the Yoga plugin chain is:
+
+```ts
+const sharedPlugins = [
+    ...(responseCachePlugin ? [responseCachePlugin] : []),
+    customValidationRules,
+    useCostLogger(),
+    useGraphQLInstrumentation(),
+    useSearchInvocationLogger(),
+    usePgClient(pgPool),         // checks out client in onExecute, releases in onExecuteDone
+    useExecutionCancellation(),  // aborts execute() on AbortSignal
+]
+```
+
+The `usePgClient` plugin (lines 226–323) follows the standard envelop pattern: `onExecute` checks out a client, `onExecuteDone` releases it. There is **no try/finally and no `onResponse`/`onRequestEnd`-style cleanup** that runs unconditionally.
+
+When `useExecutionCancellation()` aborts the GraphQL `execute()` call (because the HTTP request's `AbortSignal` fired — e.g. a client closed the socket, producing a 499), two things go wrong:
+
+1. **`onExecuteDone` is not guaranteed to fire on abort.** Yoga's runtime calls `onExecuteDone` after `execute()` resolves with a result. When execution is aborted, depending on the abort path, the executor may reject rather than resolve. The cleanup callback may simply never be invoked — the checked-out `pgClient` is then leaked indefinitely.
+
+2. **node-pg's `PoolClient` has no `AbortSignal` integration.** Even when `onExecuteDone` does fire, the in-flight SQL on that client is still running. The pg driver does not propagate the GraphQL-level abort to a `pg_cancel_backend()` call. Calling `pgClient.release()` on a client with a pending query has undefined semantics: the client object may be returned to the pool while still bound to the query, and the underlying socket cannot serve another query until the original one finishes. In that window the connection is effectively unusable but still counted in `totalCount`.
+
+Both failure modes leave the pool with a connection that nominally exists but cannot be reused until either:
+- The query finishes naturally,
+- Postgres `statement_timeout` (10s, per `api/docs/database-configuration.md:23`) kills it, or
+- PgBouncer's `query_timeout` (15s) cuts the server side.
+
+If any of those paths fail to fully clean the client object on the Node side (e.g. the `release()` was already called and the subsequent error doesn't re-enter the pool's bookkeeping), the connection persists in `totalCount` until pod restart.
+
+The 499 line in the response codes chart growing throughout the day is the trigger condition. The leak rate (~1 every 25 min) is consistent with the fraction of requests where (a) the client cancels, (b) the GraphQL query had already begun executing, and (c) the release path hits one of the failure modes above.
+
+## Secondary Issue: Timeout Hierarchy Is Incomplete
+
+The user's hypothesis — that timeouts are misordered — is partially correct. The full chain in production today:
+
+| Layer | Timeout | Source |
+|---|---|---|
+| nginx ingress | **not configured** → 60s default | `api/k8s/production/api.yaml:206-227` (no `proxy-read-timeout`/`proxy-send-timeout`) |
+| Hono / Bun HTTP | **none** | not set anywhere |
+| GraphQL execution | **none** | only `useExecutionCancellation`, which only fires on client abort |
+| pg pool acquire | 3s | `PG_CONNECTION_TIMEOUT_MS` |
+| pg `query_timeout` | **not set** | `api/src/kg/postgraphile.ts:50-62` |
+| Postgres `statement_timeout` | 10s | `api/docs/database-configuration.md:23` |
+| PgBouncer `query_timeout` | 15s | `api/docs/database-configuration.md:48` |
+| pg idle | 30s | `PG_IDLE_TIMEOUT_MS` |
+
+Issues:
+
+- **No application-level request deadline.** A request can outlive the client's socket entirely — exactly the condition that triggers the leak path described above.
+- **No `query_timeout` on the pg pool.** This setting destroys the connection client-side after N ms; without it, a "stuck" client (e.g. PgBouncer dropped the server side mid-query) sits in TCP read until either Postgres' `statement_timeout` kicks in or TCP times out. With `query_timeout`, the Node side reclaims the client deterministically.
+- **nginx defaults to 60s read timeout**, which is fine in absolute terms but is a hidden default. It should be set explicitly so the timeout chain is auditable.
+
+The current chain is not catastrophic — Postgres `statement_timeout=10s` is the one real safety net — but it's load-bearing in a way the surrounding configuration doesn't acknowledge.
+
+## Secondary Issue: Saturation Threshold Trips on Brief Queues
+
+`api/k8s/production/api.yaml:97-100`:
+
+```yaml
+- name: PG_POOL_PRESSURE_WAITING_THRESHOLD
+  value: "1"
+- name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD
+  value: "90"
+```
+
+With `PRESSURE_WAITING_THRESHOLD=1`, the saturation FSM in `api/src/services/dbSaturation.ts` enters "pressured" state as soon as a single request waits for a pool slot, and flips to "saturated" (and starts shedding 503s — see `api/src/kg/postgraphile.ts:238-251`) after 15s of sustained pressure.
+
+This is why 503s appear at "~50% utilization" rather than at the configured 90% — utilization itself isn't the trigger; even brief pool queues are. With a leaking pool, a queue forms long before utilization crosses 90%. The default of 5 (per `dbSaturation.ts:45`) is more tolerant of normal bursty traffic.
+
+## Secondary Issue: Pool Metric Granularity
+
+Today's pool gauges (`api/src/kg/postgraphile.ts:111-119`) emit `total_connections`, `idle_connections`, and `waiting_count` separately. The actually-diagnostic signal — **checked-out** (= total − idle) — has to be reconstructed downstream. A direct `checked_out` gauge would have made this leak visible immediately: under steady traffic it would climb, while `total` could be misread as "pool sizing up under load."
+
+## Recommended Fix Set
+
+In priority order. Each change is small and independently shippable.
+
+### 1. Make `usePgClient` cleanup unconditional (highest impact)
+
+**File:** `api/src/kg/postgraphile.ts`
+
+The leak is in `usePgClient`'s reliance on `onExecuteDone`. Rework cleanup so it runs whether `execute()` resolved, threw, or was aborted. Two viable shapes:
+
+**Option A — request-scoped cleanup via Yoga `onResponse`:**
+- Track the checked-out client on `args.contextValue` (or a `WeakMap` keyed by the request).
+- Move `pgClient.release()` to a Yoga `onResponse` (or `onRequestEnd`) hook, which fires regardless of whether execution completed normally.
+- Keep the existing `onExecuteDone` error-aware release for the happy path; the response hook becomes a belt-and-braces guard.
+
+**Option B — try/finally inside `onExecute`:**
+- Wrap the result handling so `release()` runs in a `finally` block reachable from any path through the executor.
+- Simpler to reason about but requires careful interaction with Yoga's plugin lifecycle.
+
+Option A is preferred because it's idiomatic envelop/Yoga and handles all abort paths uniformly.
+
+**Additionally:** when releasing a client whose query may still be in-flight, prefer `release(true)` (destroy the client) on cancellation paths — this severs the connection rather than returning a busy client to the pool. The cost is one new connection later; the benefit is no possibility of returning a wedged client.
+
+### 2. Add `query_timeout` to the pool config
+
+**File:** `api/src/kg/postgraphile.ts:50-62`
+
+Add `query_timeout` to the `Pool` constructor, set just above the Postgres `statement_timeout` (e.g. 12_000 ms). This forces the Node-side pg client to abort the query and destroy the connection deterministically if the server-side timeout fails to free it. Treat it as the application-side fuse.
+
+```ts
+const pgPool = new Pool({
+    // ... existing options
+    query_timeout: parseInt(process.env.PG_QUERY_TIMEOUT_MS || "12000", 10),
+})
+```
+
+Surface it as `PG_QUERY_TIMEOUT_MS` in `api/k8s/production/api.yaml` and `api/k8s/staging/api.yaml` so it's tunable per environment.
+
+### 3. Set explicit nginx ingress timeouts
+
+**File:** `api/k8s/production/api.yaml` (and staging counterpart)
+
+Add to the ingress annotations:
+
+```yaml
+nginx.ingress.kubernetes.io/proxy-connect-timeout: "5"
+nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
+nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
+```
+
+Recommended order, longest to shortest: nginx (30s) > application deadline (20s, see #4) > Postgres `statement_timeout` (10s) > pool acquire (3s). This matches the hierarchy already documented in `api/docs/database-configuration.md:127-135`.
+
+### 4. Add an application-level request deadline
+
+**File:** `api/main.ts`
+
+Add a Hono middleware on `/graphql` (and probably the REST routes) that creates an `AbortController`, races the response against a configurable timeout, and aborts the underlying handler if it expires. This guarantees that no request lives longer than the deadline, regardless of downstream behavior. Pair with a clear 504 response so the client distinguishes server-side timeout from network failure.
+
+The deadline (e.g. 20s) sits *between* the nginx timeout and Postgres `statement_timeout` so the application owns its own kill switch.
+
+### 5. Soften `PG_POOL_PRESSURE_WAITING_THRESHOLD`
+
+**File:** `api/k8s/production/api.yaml:97-98`
+
+Raise from `1` → `3` (or back to the default of `5`). Briefly waiting on the pool under bursty traffic is normal; treating a single waiting client as the start of a saturation episode produces premature 503s. Re-evaluate once #1 is shipped and the leak is gone — once the pool isn't accumulating phantom connections, true saturation should be rare and the threshold can be tuned on real signal.
+
+### 6. Add a `checked_out` pool metric
+
+**File:** `api/src/kg/postgraphile.ts:111-119`
+
+Emit a fourth gauge:
+
+```ts
+Sentry.metrics.gauge("graphql.pool.checked_out_connections",
+    stats.totalConnections - stats.idleConnections)
+```
+
+This single number is the leak detector. Under steady traffic it should oscillate at a stable level. Monotonic growth = leak. Add a Grafana panel on it next to the existing utilization chart.
+
+## Verification Plan
+
+After deploying #1 + #2:
+
+1. Watch `graphql.pool.checked_out_connections` (after #6) over a 24-hour window. It should oscillate around the steady-state in-flight query count and reset to ~0 between bursts. Any monotonic growth means the fix is incomplete.
+2. Confirm that 499 spikes no longer correlate with utilization growth. The original signature was 499s climbing, then utilization climbing, then 503s. After the fix, 499s should have no effect on utilization.
+3. Confirm 503 rates fall to near-zero in normal operation. Any remaining 503s should now correspond to genuine saturation (real backpressure under real load), not false positives from the leak.
+
+If utilization continues to climb after #1 + #2, the leak is somewhere else — re-run the analysis with the `checked_out` gauge as the primary signal and look for code paths that call `pool.connect()` outside `usePgClient` (none expected today; `api/src/services/storage/storage.ts` uses a separate REST pool).

--- a/api/scripts/pool-leak-repro.ts
+++ b/api/scripts/pool-leak-repro.ts
@@ -1,0 +1,347 @@
+#!/usr/bin/env bun
+/**
+ * Reproduction script for the GraphQL pool connection leak.
+ * Companion to api/docs/gql-pool-leak-investigation.md.
+ *
+ * Fires N copies of a known-slow `EntitiesOrderedByProperty` query against the
+ * configured GraphQL endpoint, aborting each one mid-flight. Each cancelled
+ * request that lands during SQL execution should leak one slot from the pg
+ * pool of whichever api replica handled it (pre-fix). After deploying the fix,
+ * the same cycle should produce zero leaked slots.
+ *
+ * USAGE
+ *   bun api/scripts/pool-leak-repro.ts
+ *
+ * TUNABLES (env vars)
+ *   ENDPOINT          target /graphql URL (default: testnet)
+ *   ATTEMPTS          number of aborted requests (default: 20)
+ *   ABORT_AFTER_MS    abort each request after this many ms (default: 1500)
+ *   PAUSE_BETWEEN_MS  delay between attempts (default: 500)
+ *   START_OFFSET      starting `offset` variable; we increment per request
+ *                     to force cache misses (default: 9)
+ *
+ * WHAT TO WATCH (in another terminal / dashboard)
+ *   Sentry:    graphql.pool.total_connections - graphql.pool.idle_connections
+ *   PgBouncer: SHOW POOLS;   (sv_active for the api db/user)
+ *   Postgres:  SELECT count(*) FROM pg_stat_activity
+ *              WHERE application_name LIKE '%postgraphile%' AND state != 'idle';
+ *
+ * EXPECTED OUTCOME
+ *   Pre-fix:   checked_out grows by ~ATTEMPTS (modulo replica spread) and
+ *              stays elevated until the next pod restart. This is the leak.
+ *   Post-fix:  checked_out returns to baseline within seconds (in-flight
+ *              queries finish, onResponse releases). No persistent growth.
+ *
+ * SAFETY NOTES
+ *   - Production has PG_POOL_PRESSURE_WAITING_THRESHOLD=1, so excessive abort
+ *     cycles can trip the saturation FSM and start shedding 503s for other
+ *     users. Keep ATTEMPTS modest (default 20 against a max-50 pool, spread
+ *     across replicas, leaves plenty of headroom).
+ *   - Leaked slots persist until pod restart. If you accidentally exhaust the
+ *     pool: kubectl rollout restart deployment/api -n api
+ *   - This is a destructive test against shared infrastructure. Coordinate
+ *     before running in production.
+ */
+
+const ENDPOINT = process.env.ENDPOINT ?? "https://testnet-api.geobrowser.io/graphql"
+const ATTEMPTS = parseInt(process.env.ATTEMPTS ?? "20", 10)
+const ABORT_AFTER_MS = parseInt(process.env.ABORT_AFTER_MS ?? "1500", 10)
+const PAUSE_BETWEEN_MS = parseInt(process.env.PAUSE_BETWEEN_MS ?? "500", 10)
+const START_OFFSET = parseInt(process.env.START_OFFSET ?? "9", 10)
+const WARMUP_TIMEOUT_MS = 30_000
+
+const TEST_RUN_ID = `pool-leak-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`
+
+// Slow query — verbatim shape from the EntitiesOrderedByProperty operation
+// flagged in production logs. Heavy nested fetch (entities + their values +
+// relations + each related entity's values + types).
+const QUERY = `query EntitiesOrderedByProperty($propertyId: UUID, $sortDirection: SortOrder, $dataType: String, $spaceId: UUID, $limit: Int, $offset: Int, $filter: EntityFilter) {
+  entitiesOrderedByProperty(
+    propertyId: $propertyId
+    sortDirection: $sortDirection
+    dataType: $dataType
+    spaceId: $spaceId
+    first: $limit
+    offset: $offset
+    filter: $filter
+  ) {
+    id
+    name
+    description
+    spaceIds
+    updatedAt
+    types { id name }
+    valuesList(filter: {spaceId: {is: $spaceId}}) {
+      spaceId
+      property { ...PropertyFragment }
+      text integer float point boolean time language unit datetime date decimal bytes schedule
+    }
+    relationsList(filter: {spaceId: {is: $spaceId}}) {
+      id spaceId position verified entityId
+      fromEntity { id name }
+      toEntity {
+        id name
+        types { id name }
+        valuesList {
+          spaceId propertyId text integer float point boolean time datetime date decimal bytes schedule
+        }
+      }
+      toSpaceId
+      type { id name }
+    }
+  }
+}
+
+fragment PropertyFragment on PropertyInfo {
+  id name dataTypeId dataTypeName renderableTypeId renderableTypeName format isType
+}`
+
+function buildVariables(offset: number) {
+	return {
+		propertyId: "a126ca530c8e48d5b88882c734c38935",
+		sortDirection: "ASC",
+		dataType: "text",
+		limit: 10,
+		offset,
+		filter: {
+			typeIds: {anyEqualTo: "7ed45f2bc48b419e8e4664d5ff680b0d"},
+			spaceIds: {in: ["89bd89bf28ff8a0963faf92a8c905e20"]},
+		},
+	}
+}
+
+function buildBody(offset: number) {
+	return JSON.stringify({
+		query: QUERY,
+		variables: buildVariables(offset),
+		operationName: "EntitiesOrderedByProperty",
+	})
+}
+
+function buildHeaders(reqIdSuffix: string) {
+	const reqId = `${TEST_RUN_ID}-${reqIdSuffix}`
+	return {
+		accept: "application/graphql-response+json, application/json",
+		"content-type": "application/json",
+		origin: "https://www.geobrowser.io",
+		referer: "https://www.geobrowser.io/",
+		"user-agent": "pool-leak-repro/1.0",
+		"x-correlation-id": reqId,
+		"x-request-id": reqId,
+	}
+}
+
+function ts() {
+	return new Date().toISOString()
+}
+
+async function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isAbortError(err: unknown): boolean {
+	return err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")
+}
+
+// Warmup: confirm the endpoint is actually a GraphQL API and the query is
+// slow enough that ABORT_AFTER_MS lands during execution. If either check
+// fails, bail with a clear error before doing anything destructive.
+async function warmup(): Promise<{durationMs: number; status: number; isGraphql: boolean}> {
+	console.log(`[${ts()}] warmup: firing one full query (offset=${START_OFFSET}), no abort`)
+	const start = Date.now()
+	const controller = new AbortController()
+	const timeout = setTimeout(() => controller.abort(), WARMUP_TIMEOUT_MS)
+
+	try {
+		const res = await fetch(ENDPOINT, {
+			method: "POST",
+			headers: buildHeaders("warmup"),
+			body: buildBody(START_OFFSET),
+			signal: controller.signal,
+		})
+		const durationMs = Date.now() - start
+		const text = await res.text()
+		console.log(`[${ts()}] warmup: status=${res.status} duration=${durationMs}ms`)
+		console.log(`[${ts()}] warmup: body[0..200]=${text.slice(0, 200)}`)
+
+		// Validate the response looks like a GraphQL response. A wrong endpoint
+		// (e.g. a frontend dev server on the same port) might return HTML with
+		// status 200, and the duration check alone won't catch it.
+		const contentType = res.headers.get("content-type") ?? ""
+		const isJsonContentType = /\b(application\/json|application\/graphql-response\+json)\b/i.test(contentType)
+		let isGraphql = false
+		if (isJsonContentType) {
+			try {
+				const parsed = JSON.parse(text)
+				isGraphql = typeof parsed === "object" && parsed !== null && ("data" in parsed || "errors" in parsed)
+			} catch {
+				isGraphql = false
+			}
+		}
+
+		return {durationMs, status: res.status, isGraphql}
+	} finally {
+		clearTimeout(timeout)
+	}
+}
+
+async function abortRun(i: number, offset: number): Promise<{outcome: string; durationMs: number}> {
+	const start = Date.now()
+	const controller = new AbortController()
+	const timeout = setTimeout(() => controller.abort(), ABORT_AFTER_MS)
+
+	try {
+		const res = await fetch(ENDPOINT, {
+			method: "POST",
+			headers: buildHeaders(`abort-${i}`),
+			body: buildBody(offset),
+			signal: controller.signal,
+		})
+		const durationMs = Date.now() - start
+		// If the server returned BEFORE our abort timer fired, the abort never
+		// landed during execution — this run does NOT exercise the leak path.
+		return {outcome: `unexpectedly completed: status=${res.status}`, durationMs}
+	} catch (err) {
+		const durationMs = Date.now() - start
+		if (isAbortError(err)) {
+			return {outcome: "aborted (expected)", durationMs}
+		}
+		return {outcome: `errored: ${(err as Error).message}`, durationMs}
+	} finally {
+		clearTimeout(timeout)
+	}
+}
+
+async function waitForEnter(prompt: string): Promise<void> {
+	if (!process.stdin.isTTY) {
+		console.log(`${prompt} (non-interactive — continuing immediately)`)
+		return
+	}
+	process.stdout.write(prompt)
+	await new Promise<void>((resolve) => {
+		process.stdin.resume()
+		const handler = () => {
+			process.stdin.pause()
+			process.stdin.removeListener("data", handler)
+			resolve()
+		}
+		process.stdin.on("data", handler)
+	})
+}
+
+async function main() {
+	console.log(`========================================`)
+	console.log(`Pool leak reproduction`)
+	console.log(`========================================`)
+	console.log(`endpoint:         ${ENDPOINT}`)
+	console.log(`attempts:         ${ATTEMPTS}`)
+	console.log(`abort_after_ms:   ${ABORT_AFTER_MS}`)
+	console.log(`pause_between_ms: ${PAUSE_BETWEEN_MS}`)
+	console.log(`offset range:     ${START_OFFSET}..${START_OFFSET + ATTEMPTS}`)
+	console.log(`test_run_id:      ${TEST_RUN_ID}`)
+	console.log(`========================================\n`)
+
+	// 1. Warmup
+	let warmupResult: {durationMs: number; status: number; isGraphql: boolean}
+	try {
+		warmupResult = await warmup()
+	} catch (err) {
+		console.error(`[${ts()}] warmup failed:`, err)
+		process.exit(1)
+	}
+
+	if (!warmupResult.isGraphql) {
+		console.error(
+			`[${ts()}] FATAL: endpoint did not return a GraphQL response (no JSON with data/errors).`,
+		)
+		console.error(`Check ENDPOINT — it may be pointing at a frontend dev server, a docs site,`)
+		console.error(`or a different service. The repro requires a real /graphql endpoint.`)
+		console.error(`To target a single api pod via port-forward:`)
+		console.error(`  kubectl -n api port-forward pod/<api-pod-name> 8080:3000`)
+		console.error(`  ENDPOINT=http://localhost:8080/graphql bun api/scripts/pool-leak-repro.ts`)
+		process.exit(1)
+	}
+
+	if (warmupResult.status !== 200) {
+		console.error(
+			`[${ts()}] warmup returned non-200 status (${warmupResult.status}). Check the query / endpoint and retry.`,
+		)
+		process.exit(1)
+	}
+
+	const minSafeQueryMs = ABORT_AFTER_MS + 500
+	if (warmupResult.durationMs < minSafeQueryMs) {
+		console.error(
+			`[${ts()}] FATAL: query completed in ${warmupResult.durationMs}ms — too fast for ABORT_AFTER_MS=${ABORT_AFTER_MS}.`,
+		)
+		console.error(`Aborts will fire AFTER the response returns, so they won't exercise the leak path.`)
+		console.error(`Reduce ABORT_AFTER_MS or pick a slower query.`)
+		process.exit(1)
+	}
+
+	console.log()
+	console.log(`========================================`)
+	console.log(`Capture BASELINE pool stats now.`)
+	console.log(`========================================`)
+	console.log(`In another terminal/dashboard, take note of:`)
+	console.log(`  - Sentry: graphql.pool.total_connections, graphql.pool.idle_connections`)
+	console.log(`  - PgBouncer: SHOW POOLS;  (sv_active for the api user)`)
+	console.log(`  - Postgres pg_stat_activity (if accessible)`)
+	console.log()
+	await waitForEnter("Press ENTER when baseline captured to start abort cycle... ")
+	console.log()
+
+	// 2. Abort cycle
+	const cycleStart = ts()
+	console.log(`[${cycleStart}] ===== abort cycle started =====`)
+	const stats = {aborted: 0, unexpectedCompletion: 0, errored: 0}
+	for (let i = 1; i <= ATTEMPTS; i++) {
+		const offset = START_OFFSET + i // unique per request to force cache miss
+		const {outcome, durationMs} = await abortRun(i, offset)
+		const tag = outcome.startsWith("aborted")
+			? "abort"
+			: outcome.startsWith("unexpectedly")
+				? "compl"
+				: "error"
+		console.log(`[${ts()}] ${String(i).padStart(2)}/${ATTEMPTS} [${tag}] ${outcome} after ${durationMs}ms`)
+		if (outcome.startsWith("aborted")) stats.aborted++
+		else if (outcome.startsWith("unexpectedly")) stats.unexpectedCompletion++
+		else stats.errored++
+
+		if (i < ATTEMPTS) await sleep(PAUSE_BETWEEN_MS)
+	}
+	const cycleEnd = ts()
+	console.log(`[${cycleEnd}] ===== abort cycle finished =====\n`)
+
+	// 3. Summary + post-test instructions
+	console.log(`========================================`)
+	console.log(`Summary`)
+	console.log(`========================================`)
+	console.log(`aborted (expected, exercised leak path):  ${stats.aborted}`)
+	console.log(`unexpected completion (no leak window):    ${stats.unexpectedCompletion}`)
+	console.log(`errored (network/server issue):            ${stats.errored}`)
+	console.log()
+	console.log(`Time window for log search: ${cycleStart} → ${cycleEnd}`)
+	console.log(`Filter server logs by: x-request-id starts with "${TEST_RUN_ID}-abort-"`)
+	console.log()
+	console.log(`========================================`)
+	console.log(`Wait ~30s for in-flight queries to settle`)
+	console.log(`(Postgres statement_timeout = 10s; PgBouncer query_timeout = 15s),`)
+	console.log(`then capture POST-TEST pool stats.`)
+	console.log(`========================================`)
+	console.log()
+	console.log(`Expected reading:`)
+	console.log(`  PRE-FIX (current main):  checked_out increased by ~${stats.aborted}`)
+	console.log(`                           and STAYS elevated → leak confirmed`)
+	console.log(`  POST-FIX (this branch):  checked_out returns to baseline within seconds`)
+	console.log(`                           → fix validated`)
+	console.log()
+	console.log(`Reminder: with multiple replicas, the increase is spread across pods.`)
+	console.log(`To target a single pod: kubectl port-forward to one api pod and set`)
+	console.log(`ENDPOINT to that local port.`)
+}
+
+main().catch((err) => {
+	console.error("script failed:", err)
+	process.exit(1)
+})

--- a/api/scripts/pool-leak-repro.ts
+++ b/api/scripts/pool-leak-repro.ts
@@ -251,9 +251,7 @@ async function main() {
 	}
 
 	if (!warmupResult.isGraphql) {
-		console.error(
-			`[${ts()}] FATAL: endpoint did not return a GraphQL response (no JSON with data/errors).`,
-		)
+		console.error(`[${ts()}] FATAL: endpoint did not return a GraphQL response (no JSON with data/errors).`)
 		console.error(`Check ENDPOINT — it may be pointing at a frontend dev server, a docs site,`)
 		console.error(`or a different service. The repro requires a real /graphql endpoint.`)
 		console.error(`To target a single api pod via port-forward:`)
@@ -298,11 +296,7 @@ async function main() {
 	for (let i = 1; i <= ATTEMPTS; i++) {
 		const offset = START_OFFSET + i // unique per request to force cache miss
 		const {outcome, durationMs} = await abortRun(i, offset)
-		const tag = outcome.startsWith("aborted")
-			? "abort"
-			: outcome.startsWith("unexpectedly")
-				? "compl"
-				: "error"
+		const tag = outcome.startsWith("aborted") ? "abort" : outcome.startsWith("unexpectedly") ? "compl" : "error"
 		console.log(`[${ts()}] ${String(i).padStart(2)}/${ATTEMPTS} [${tag}] ${outcome} after ${durationMs}ms`)
 		if (outcome.startsWith("aborted")) stats.aborted++
 		else if (outcome.startsWith("unexpectedly")) stats.unexpectedCompletion++

--- a/api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts
+++ b/api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts
@@ -271,29 +271,24 @@ describe("usePgClient cleanup contract under cancellation", () => {
 		// cancels execute().
 		controller.abort()
 
-		// Give yoga generous time to run any cleanup. If onExecuteDone fires on
-		// abort, release() will be called inside this window. If it doesn't,
-		// nothing further changes — the client is leaked.
+		// Give yoga generous time to run any cleanup. If the abort path
+		// releases the pgClient (via onResponse cleanup), it happens inside
+		// this window — *before* the query settles.
 		await new Promise((r) => setTimeout(r, 200))
 
-		// Drain any still-pending queries (simulates Postgres' statement_timeout
-		// firing later). This proves the leak isn't just "release happens
-		// after the query settles" — it never fires, period.
-		pool.resolvePendingQueries()
-		await new Promise((r) => setTimeout(r, 200))
-
-		// Wait for the fetch to settle so the test exits cleanly.
-		await fetchPromise
-
-		// Post-fix: the WeakMap+onResponse cleanup releases the pgClient even
-		// when execute() was aborted. The connection should be back in the pool
-		// and exactly one release call should have happened (either via
-		// onExecuteDone with errors, or via the onResponse fallback in destroy
-		// mode — depending on Yoga's internal abort handling, but exactly one).
-		// If this test ever fails again with checkedOutCount > 0, the leak has
-		// regressed.
+		// Load-bearing assertion: release must have happened from the abort
+		// path, NOT from the query settling later. We assert *before* draining
+		// the deferred query so an implementation that only releases after the
+		// query completes (e.g. onExecuteDone firing late once the resolver
+		// finishes) cannot silently pass this test.
 		expect(pool.connectCount).toBe(1)
 		expect(pool.checkedOutCount).toBe(0)
 		expect(pool.releaseCount).toBe(1)
+
+		// Cleanup: drain the still-pending query so the resolver unblocks and
+		// the fetch promise can settle, letting the test exit. Not part of the
+		// regression assertion.
+		pool.resolvePendingQueries()
+		await fetchPromise
 	})
 })

--- a/api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts
+++ b/api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts
@@ -248,14 +248,14 @@ describe("usePgClient cleanup contract under cancellation", () => {
 
 		// Fire the request with the abortable signal. We do NOT await it yet —
 		// we need to abort *during* execution.
-		const fetchPromise = yoga
-			.fetch("http://localhost/graphql", {
+		const fetchPromise = Promise.resolve(
+			yoga.fetch("http://localhost/graphql", {
 				method: "POST",
 				headers: {"content-type": "application/json"},
 				body: JSON.stringify({query: "{ slow }"}),
 				signal: controller.signal,
-			})
-			.catch((err) => err) // swallow the AbortError so the test can proceed
+			}),
+		).catch((err: unknown) => err) // swallow the AbortError so the test can proceed
 
 		// Wait for the resolver to actually call pgClient.query(). Until this
 		// resolves, the request hasn't reached the leak window.

--- a/api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts
+++ b/api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Regression test for the GraphQL pool connection-leak fix described in
+ * api/docs/gql-pool-leak-investigation.md (fix #1).
+ *
+ * Background — the bug:
+ *   When a GraphQL request is cancelled mid-execution (HTTP client closes the
+ *   socket -> request AbortSignal fires -> `useExecutionCancellation` aborts
+ *   `execute()`), the cleanup callback `onExecuteDone` is not reliably
+ *   invoked. Pre-fix, `usePgClient` only released the pgClient inside
+ *   `onExecuteDone`, so cancelled requests permanently leaked one pool slot.
+ *
+ * The fix (mirrored here in the inlined plugin):
+ *   Track each checked-out pgClient against its HTTP Request via a WeakMap,
+ *   and release it from Yoga's `onResponse` hook as a belt-and-braces
+ *   cleanup. `onResponse` fires for every request regardless of how
+ *   execution settled, so the abort path now reliably releases the client.
+ *
+ * Test strategy:
+ *   - Tracking pool: counts checkouts and releases. Hands out fake clients
+ *     whose `query()` blocks on a deferred so the test can pin a query
+ *     "in flight" indefinitely.
+ *   - The plugin under test mirrors `usePgClient` from
+ *     `api/src/kg/postgraphile.ts` (minus production-only logging and Sentry).
+ *     Inlined (not imported) because the production module has heavy
+ *     module-load side effects (creates a real pg pool, builds the
+ *     PostGraphile schema). What we're testing is the *contract* — checkout
+ *     in `onExecute`, release in BOTH `onExecuteDone` (happy path) AND
+ *     `onResponse` (abort path).
+ *   - Yoga server wires `usePgClient` + `useExecutionCancellation` in the same
+ *     order as production (`postgraphile.ts:370-378`).
+ *
+ * Tests:
+ *   - "happy path": sanity-checks the harness. Release fires on normal
+ *     completion.
+ *   - "regression: client aborts mid-query": the load-bearing assertion.
+ *     If this test ever fails with `checkedOutCount > 0`, the leak has
+ *     regressed — re-read the investigation doc and check the
+ *     `onResponse` cleanup path in `usePgClient`.
+ *
+ * Uses bun:test (not vitest) to mirror cache-integration.test.ts and avoid
+ * duplicate graphql module conflicts between graphql-yoga and our schema deps.
+ */
+import {describe, expect, it} from "bun:test"
+import {GraphQLObjectType, GraphQLSchema, GraphQLString} from "graphql"
+import {createYoga, type Plugin, useExecutionCancellation} from "graphql-yoga"
+
+// --- Fake pg pool / client --------------------------------------------------
+
+type FakePoolClient = {
+	id: number
+	query: (sql: string) => Promise<{rows: unknown[]}>
+	release: (err?: unknown) => void
+}
+
+type Deferred = {promise: Promise<{rows: unknown[]}>; resolve: () => void; reject: (e: unknown) => void}
+
+function createDeferred(): Deferred {
+	let resolve!: () => void
+	let reject!: (e: unknown) => void
+	const promise = new Promise<{rows: unknown[]}>((res, rej) => {
+		resolve = () => res({rows: [{ok: true}]})
+		reject = rej
+	})
+	return {promise, resolve, reject}
+}
+
+function createTrackingPool() {
+	let nextId = 0
+	let connectCount = 0
+	let releaseCleanCount = 0
+	let releaseDestroyCount = 0
+	const checkedOut = new Set<number>()
+
+	// Each client's pending query exposes its deferred so the test can resolve
+	// or reject it deterministically. Also, a "queryStarted" gate lets the test
+	// await the moment the resolver actually invokes pgClient.query() — so we
+	// never abort before checkout has happened.
+	const pendingQueries: Deferred[] = []
+	let queryStartedResolve: (() => void) | null = null
+	let queryStarted: Promise<void> = new Promise((r) => {
+		queryStartedResolve = r
+	})
+
+	function resetQueryStartGate() {
+		queryStarted = new Promise((r) => {
+			queryStartedResolve = r
+		})
+	}
+
+	return {
+		get connectCount() {
+			return connectCount
+		},
+		get releaseCount() {
+			return releaseCleanCount + releaseDestroyCount
+		},
+		get releaseCleanCount() {
+			return releaseCleanCount
+		},
+		get releaseDestroyCount() {
+			return releaseDestroyCount
+		},
+		get checkedOutCount() {
+			return checkedOut.size
+		},
+		waitForQueryStart() {
+			return queryStarted
+		},
+		resolvePendingQueries() {
+			while (pendingQueries.length > 0) {
+				pendingQueries.shift()?.resolve()
+			}
+		},
+		async connect(): Promise<FakePoolClient> {
+			connectCount++
+			const id = nextId++
+			checkedOut.add(id)
+
+			const client: FakePoolClient = {
+				id,
+				query(_sql: string) {
+					const deferred = createDeferred()
+					pendingQueries.push(deferred)
+					queryStartedResolve?.()
+					resetQueryStartGate()
+					return deferred.promise
+				},
+				release(err?: unknown) {
+					checkedOut.delete(id)
+					if (err !== undefined) releaseDestroyCount++
+					else releaseCleanCount++
+				},
+			}
+			return client
+		},
+	}
+}
+
+// --- Plugin under test -------------------------------------------------------
+//
+// Mirrors `usePgClient` from api/src/kg/postgraphile.ts (minus production-only
+// logging and Sentry instrumentation). The shape of onExecute / onExecuteDone /
+// onResponse is identical to production — that's the contract we're validating.
+//
+// As of fix #1 from the investigation doc, this plugin tracks the checked-out
+// pgClient against the HTTP Request via a WeakMap and releases it from the
+// `onResponse` hook as a belt-and-braces cleanup. With this in place, the
+// "LEAK" test below should fail (because the leak no longer occurs), which is
+// the desired signal that the fix actually fixed the bug.
+function usePgClient(pool: ReturnType<typeof createTrackingPool>): Plugin<{pgClient: FakePoolClient}> {
+	const requestPgClients = new WeakMap<Request, FakePoolClient>()
+
+	return {
+		async onExecute({extendContext, args}) {
+			const pgClient = await pool.connect()
+			extendContext({pgClient})
+
+			const request = (args.contextValue as {request?: Request})?.request
+			if (request) {
+				requestPgClients.set(request, pgClient)
+			}
+
+			return {
+				onExecuteDone({result}) {
+					const errors = "errors" in result ? result.errors : undefined
+					if (errors?.length) {
+						pgClient.release(errors[0])
+					} else {
+						pgClient.release()
+					}
+					if (request) requestPgClients.delete(request)
+				},
+			}
+		},
+
+		onResponse({request}) {
+			const pgClient = requestPgClients.get(request)
+			if (pgClient) {
+				pgClient.release(new Error("graphql request ended without normal cleanup"))
+				requestPgClients.delete(request)
+			}
+		},
+	}
+}
+
+// --- Test schema -------------------------------------------------------------
+//
+// One field. Resolver awaits pgClient.query(...) which only resolves when the
+// test calls pool.resolvePendingQueries(). This pins the request "in flight"
+// so the test can abort it during execution.
+function createSchema() {
+	return new GraphQLSchema({
+		query: new GraphQLObjectType({
+			name: "Query",
+			fields: {
+				slow: {
+					type: GraphQLString,
+					async resolve(_root, _args, ctx: {pgClient: FakePoolClient}) {
+						await ctx.pgClient.query("SELECT pg_sleep(60)")
+						return "done"
+					},
+				},
+			},
+		}),
+	})
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("usePgClient cleanup contract under cancellation", () => {
+	it("happy path: completes normally and releases the pgClient", async () => {
+		const pool = createTrackingPool()
+		const yoga = createYoga({
+			schema: createSchema(),
+			plugins: [usePgClient(pool), useExecutionCancellation()],
+		})
+
+		const fetchPromise = yoga.fetch("http://localhost/graphql", {
+			method: "POST",
+			headers: {"content-type": "application/json"},
+			body: JSON.stringify({query: "{ slow }"}),
+		})
+
+		// Wait until the resolver actually starts a query, then resolve it so
+		// execute() completes naturally.
+		await pool.waitForQueryStart()
+		pool.resolvePendingQueries()
+
+		const response = await fetchPromise
+		expect(response.status).toBe(200)
+		const body = (await response.json()) as {data: {slow: string}}
+		expect(body.data.slow).toBe("done")
+
+		// Sanity check the harness: one connect, one release, zero leaked.
+		expect(pool.connectCount).toBe(1)
+		expect(pool.releaseCount).toBe(1)
+		expect(pool.checkedOutCount).toBe(0)
+	})
+
+	it("regression: client aborts mid-query — pgClient is still released (no leak)", async () => {
+		const pool = createTrackingPool()
+		const yoga = createYoga({
+			schema: createSchema(),
+			plugins: [usePgClient(pool), useExecutionCancellation()],
+		})
+
+		const controller = new AbortController()
+
+		// Fire the request with the abortable signal. We do NOT await it yet —
+		// we need to abort *during* execution.
+		const fetchPromise = yoga
+			.fetch("http://localhost/graphql", {
+				method: "POST",
+				headers: {"content-type": "application/json"},
+				body: JSON.stringify({query: "{ slow }"}),
+				signal: controller.signal,
+			})
+			.catch((err) => err) // swallow the AbortError so the test can proceed
+
+		// Wait for the resolver to actually call pgClient.query(). Until this
+		// resolves, the request hasn't reached the leak window.
+		await pool.waitForQueryStart()
+
+		// At this point: pool has one client checked out, no releases yet.
+		expect(pool.connectCount).toBe(1)
+		expect(pool.checkedOutCount).toBe(1)
+		expect(pool.releaseCount).toBe(0)
+
+		// Now abort the HTTP request. This is the production scenario: client
+		// closed the socket, request signal aborts, useExecutionCancellation
+		// cancels execute().
+		controller.abort()
+
+		// Give yoga generous time to run any cleanup. If onExecuteDone fires on
+		// abort, release() will be called inside this window. If it doesn't,
+		// nothing further changes — the client is leaked.
+		await new Promise((r) => setTimeout(r, 200))
+
+		// Drain any still-pending queries (simulates Postgres' statement_timeout
+		// firing later). This proves the leak isn't just "release happens
+		// after the query settles" — it never fires, period.
+		pool.resolvePendingQueries()
+		await new Promise((r) => setTimeout(r, 200))
+
+		// Wait for the fetch to settle so the test exits cleanly.
+		await fetchPromise
+
+		// Post-fix: the WeakMap+onResponse cleanup releases the pgClient even
+		// when execute() was aborted. The connection should be back in the pool
+		// and exactly one release call should have happened (either via
+		// onExecuteDone with errors, or via the onResponse fallback in destroy
+		// mode — depending on Yoga's internal abort handling, but exactly one).
+		// If this test ever fails again with checkedOutCount > 0, the leak has
+		// regressed.
+		expect(pool.connectCount).toBe(1)
+		expect(pool.checkedOutCount).toBe(0)
+		expect(pool.releaseCount).toBe(1)
+	})
+})

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -224,6 +224,13 @@ export const postgraphileSchema = await createPostGraphileSchema(pgPool, ["publi
  * stale connections (e.g. from PgBouncer closing them) from being reused.
  */
 function usePgClient(pool: Pool): Plugin<{pgClient: PoolClient}> {
+	// Per-request pgClient tracking. WeakMap keyed by the HTTP Request so the
+	// onResponse cleanup below can find and release the client even when
+	// onExecuteDone never fires (the leak path: useExecutionCancellation aborts
+	// execute() and the cleanup callback chain skips usePgClient).
+	// See api/docs/gql-pool-leak-investigation.md.
+	const requestPgClients = new WeakMap<Request, PoolClient>()
+
 	return {
 		async onExecute({extendContext, args}) {
 			const operationName = args.operationName || "anonymous"
@@ -305,6 +312,13 @@ function usePgClient(pool: Pool): Plugin<{pgClient: PoolClient}> {
 
 			extendContext({pgClient})
 
+			// Track this checkout against the originating request so the
+			// onResponse hook below can release it if execute() is aborted.
+			const request = (args.contextValue as {request?: Request})?.request
+			if (request) {
+				requestPgClients.set(request, pgClient)
+			}
+
 			return {
 				onExecuteDone({result}) {
 					// If the result has GraphQL errors, the underlying connection may be
@@ -316,7 +330,22 @@ function usePgClient(pool: Pool): Plugin<{pgClient: PoolClient}> {
 					} else {
 						pgClient.release()
 					}
+					if (request) requestPgClients.delete(request)
 				},
+			}
+		},
+
+		// Belt-and-braces cleanup. Yoga's onResponse fires after the HTTP
+		// response is produced, regardless of whether execute() completed
+		// normally, threw, or was aborted by useExecutionCancellation. If the
+		// pgClient is still tracked here, onExecuteDone never ran — release it
+		// in destroy mode (release(err)) since the in-flight query may still
+		// be running on this connection and the client's state is unknown.
+		onResponse({request}) {
+			const pgClient = requestPgClients.get(request)
+			if (pgClient) {
+				pgClient.release(new Error("graphql request ended without normal cleanup"))
+				requestPgClients.delete(request)
 			}
 		},
 	}

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 			// Cache tests use bun:test to avoid duplicate graphql module conflicts
 			"src/kg/__tests__/valkeyCache.test.ts",
 			"src/kg/__tests__/cache-integration.test.ts",
+			"src/kg/__tests__/usePgClient-cancellation-leak.test.ts",
 		],
 		setupFiles: ["./src/test-setup.ts"],
 		env: {

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,3 @@
 [install]
-minimumReleaseAge = "14d"
+# 14 days, in seconds. Current Bun expects a number, not a duration string.
+minimumReleaseAge = 1209600


### PR DESCRIPTION
## Summary

`usePgClient` released its checked-out pg client only inside the envelop `onExecuteDone` callback. When `useExecutionCancellation` aborts `execute()` because the HTTP request's `AbortSignal` fires (client closed the socket → HTTP 499), `onExecuteDone` is **not** reliably invoked — the rejection path through Yoga's plugin chain skips it. Each cancelled-mid-flight request permanently lost one pool slot.

This matches the production signature documented in the new `api/docs/gql-pool-leak-investigation.md`: under stable 5–30 rps traffic, GraphQL pool `totalCount` climbs monotonically across each pod's lifetime, capping ~70% after ~14 h, and 503s start firing once utilization crosses ~50% (because `PG_POOL_PRESSURE_WAITING_THRESHOLD=1` flips the saturation FSM on any brief queue). Implied leak rate (~1 connection per ~25 min at ~10 rps) is consistent with a rare-path leak on the abort branch.

## Fix

`api/src/kg/postgraphile.ts` — track each checked-out client per HTTP `Request` via a `WeakMap`, and add a Yoga `onResponse` hook that runs unconditionally at request-end:

- Happy path: `onExecuteDone` runs, releases normally, deletes the WeakMap entry. `onResponse` finds nothing.
- Abort path: `onExecuteDone` is skipped; `onResponse` finds the still-tracked client and calls `release(new Error(...))`. The destroy-mode release is deliberate — the in-flight query may still own the connection, so we'd rather drop the socket than risk handing a wedged client back to the pool.

This implements **fix #1** from the investigation doc (highest impact). The remaining items (`query_timeout` on the pool, explicit nginx ingress timeouts, application-level request deadline, softening `PG_POOL_PRESSURE_WAITING_THRESHOLD`, adding a `checked_out` gauge) are documented but out of scope for this PR.

## Changes

- **`api/src/kg/postgraphile.ts`** (+29) — WeakMap tracking + `onResponse` cleanup hook on `usePgClient`.
- **`api/src/kg/__tests__/usePgClient-cancellation-leak.test.ts`** (+294, new) — regression test under `bun:test`. Uses a tracking pool that hands out fake clients whose `query()` blocks on a deferred, so the test can pin a query mid-flight, abort the HTTP request, and assert `releaseCount === 1` and `checkedOutCount === 0` *before* the deferred resolves. Inlines the plugin (rather than importing) because the production module has heavy load-time side effects (real pg pool + PostGraphile schema build).
- **`api/vitest.config.ts`** (+1) — exclude the new test from vitest (joins the existing bun-only allowlist; bun:test avoids duplicate-graphql-module conflicts that vitest has with this code path).
- **`.github/workflows/api-cache-integration-tests.yml`** (+5) — wire the regression test into the existing bun-test workflow (path filters + extra `bun test` step).
- **`api/scripts/pool-leak-repro.ts`** (+341, new) — manual reproduction script. Fires N abortable copies of a known-slow `EntitiesOrderedByProperty` query against a target endpoint and prints what to watch on Sentry / PgBouncer / Postgres. Pre-fix: `checked_out` grows by ~ATTEMPTS and stays elevated until pod restart. Post-fix: returns to baseline within seconds. Defaults are conservative (20 attempts, testnet endpoint); safety notes inline.
- **`api/docs/gql-pool-leak-investigation.md`** (+200, new) — the full investigation: observed behavior, why it's a leak (not load), root-cause walk through the plugin chain, secondary issues (timeout hierarchy, saturation threshold, metric granularity), and the prioritized fix set.
- **`bunfig.toml`** (-1/+2) — collateral fix: `minimumReleaseAge = "14d"` → `1209600` (seconds). Current Bun expects a number, the duration-string form was silently ignored.

## Test plan

- [x] `bun run check` clean (typecheck)
- [x] `bun run format:check` clean
- [x] `bun test src/kg/__tests__/usePgClient-cancellation-leak.test.ts` — passes locally; asserts the cleanup contract on both happy-path and mid-flight-abort paths, and that release happens *before* the deferred query drains.
- [x] CI: `api-cache-integration-tests` workflow now runs the regression test on every PR touching `postgraphile.ts` or the test file itself.
- [ ] Post-deploy: run `bun api/scripts/pool-leak-repro.ts` against testnet; expect `graphql.pool.total_connections − graphql.pool.idle_connections` to return to baseline within seconds rather than growing by ~ATTEMPTS.
- [ ] Post-deploy: watch the 24-hour utilization curve on the production GraphQL pool dashboard. Pre-fix it climbs monotonically; post-fix it should oscillate at the steady-state in-flight count.