### PR TITLE
feat(monitoring): unify Environment dropdown across api/knowledge/search/scoring + ingress filters

### DIFF
--- a/monitoring/k8s/api-capacity-alerts.yaml
+++ b/monitoring/k8s/api-capacity-alerts.yaml
@@ -29,7 +29,7 @@ spec:
             kube_horizontalpodautoscaler_status_current_replicas{namespace="api", horizontalpodautoscaler="api"}
             >=
             kube_horizontalpodautoscaler_spec_max_replicas{namespace="api", horizontalpodautoscaler="api"}
-            and api:ingress_p99_latency_seconds:5m > 2
+            and api:ingress_p99_latency_seconds:5m{exported_namespace="api",ingress="api",exported_service="api"} > 2
           for: 10m
           labels:
             severity: critical
@@ -39,7 +39,7 @@ spec:
             description: API is at max replicas with sustained p99 latency above 2s.
 
         - alert: Api5xxRateHigh
-          expr: api:ingress_5xx_ratio:rate5m > 0.02
+          expr: api:ingress_5xx_ratio:rate5m{exported_namespace="api",ingress="api",exported_service="api"} > 0.02
           for: 10m
           labels:
             severity: warning

--- a/monitoring/k8s/api-ingress-dashboard.yaml
+++ b/monitoring/k8s/api-ingress-dashboard.yaml
@@ -31,6 +31,30 @@ data:
               "text": "Prometheus",
               "value": "Prometheus"
             }
+          },
+          {
+            "name": "env",
+            "label": "Environment",
+            "description": "Suffix appended to the ingress host. Empty for production, '-staging' for staging.",
+            "type": "custom",
+            "query": "Production : (?:),Staging : -staging",
+            "current": {
+              "selected": true,
+              "text": "Production",
+              "value": "(?:)"
+            },
+            "options": [
+              {
+                "selected": true,
+                "text": "Production",
+                "value": "(?:)"
+              },
+              {
+                "selected": false,
+                "text": "Staging",
+                "value": "-staging"
+              }
+            ]
           }
         ]
       },
@@ -52,12 +76,12 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "api:ingress_requests_per_second:rate5m",
+              "expr": "api:ingress_requests_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "total"
             },
             {
               "refId": "B",
-              "expr": "api:ingress_5xx_per_second:rate5m",
+              "expr": "api:ingress_5xx_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "5xx"
             }
           ],
@@ -95,7 +119,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "api:ingress_5xx_ratio:rate5m",
+              "expr": "api:ingress_5xx_ratio:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "5xx ratio"
             }
           ],
@@ -135,22 +159,22 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "api:ingress_p50_latency_seconds:5m",
+              "expr": "api:ingress_p50_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p50"
             },
             {
               "refId": "B",
-              "expr": "api:ingress_p75_latency_seconds:5m",
+              "expr": "api:ingress_p75_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p75"
             },
             {
               "refId": "C",
-              "expr": "api:ingress_p95_latency_seconds:5m",
+              "expr": "api:ingress_p95_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p95"
             },
             {
               "refId": "D",
-              "expr": "api:ingress_p99_latency_seconds:5m",
+              "expr": "api:ingress_p99_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p99"
             }
           ],
@@ -188,7 +212,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "api:ingress_method_p99_latency_seconds:5m",
+              "expr": "api:ingress_method_p99_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "{{method}}"
             }
           ],
@@ -226,7 +250,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "api:ingress_method_requests_per_second:rate5m",
+              "expr": "api:ingress_method_requests_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "{{method}}"
             }
           ],
@@ -264,7 +288,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "api:ingress_status_requests_per_second:rate5m",
+              "expr": "api:ingress_status_requests_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "{{status}}"
             }
           ],
@@ -302,7 +326,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "sum by (status) (increase(nginx_ingress_controller_requests{host=\"testnet-api.geobrowser.io\"}[24h]))",
+              "expr": "sum by (status) (increase(nginx_ingress_controller_requests{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}[24h]))",
               "format": "table",
               "instant": true,
               "legendFormat": "{{status}}"
@@ -357,17 +381,17 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "api:ingress_499_per_second:rate5m",
+              "expr": "api:ingress_499_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "499"
             },
             {
               "refId": "B",
-              "expr": "api:ingress_500_per_second:rate5m",
+              "expr": "api:ingress_500_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "500"
             },
             {
               "refId": "C",
-              "expr": "api:ingress_503_per_second:rate5m",
+              "expr": "api:ingress_503_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "503"
             }
           ],
@@ -405,7 +429,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "api:ingress_error_status_requests_per_second:rate5m",
+              "expr": "api:ingress_error_status_requests_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "{{status}}"
             }
           ],

--- a/monitoring/k8s/api-ingress-rules.yaml
+++ b/monitoring/k8s/api-ingress-rules.yaml
@@ -9,13 +9,18 @@ spec:
   groups:
     - name: api.ingress
       rules:
+        # Recording rules preserve the `exported_namespace` label so dashboards
+        # can filter per environment (api / api-staging). The `ingress` and
+        # `exported_service` filters narrow to just the api Ingress and reject
+        # other namespaces' ingresses (e.g. monitoring/grafana). Use `sum(...)`
+        # in callers to aggregate across environments when needed.
         - record: api:ingress_requests_per_second:rate5m
           expr: |
-            sum(rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io"}[5m]))
+            sum by (exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[5m]))
 
         - record: api:ingress_5xx_per_second:rate5m
           expr: |
-            sum(rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io",status=~"5.."}[5m]))
+            sum by (exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api",status=~"5.."}[5m]))
 
         - record: api:ingress_5xx_ratio:rate5m
           expr: |
@@ -25,22 +30,22 @@ spec:
 
         - record: api:ingress_status_requests_per_second:rate5m
           expr: |
-            sum by (status) (
-              rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io"}[5m])
+            sum by (exported_namespace, status) (
+              rate(nginx_ingress_controller_requests{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[5m])
             )
 
         - record: api:ingress_method_requests_per_second:rate5m
           expr: |
-            sum by (method) (
-              rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io"}[5m])
+            sum by (exported_namespace, method) (
+              rate(nginx_ingress_controller_requests{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[5m])
             )
 
         - record: api:ingress_method_p99_latency_seconds:5m
           expr: |
             histogram_quantile(
               0.99,
-              sum by (le, method) (
-                rate(nginx_ingress_controller_request_duration_seconds_bucket{host="testnet-api.geobrowser.io"}[5m])
+              sum by (exported_namespace, le, method) (
+                rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[5m])
               )
             )
 
@@ -48,8 +53,8 @@ spec:
           expr: |
             histogram_quantile(
               0.95,
-              sum by (le) (
-                rate(nginx_ingress_controller_request_duration_seconds_bucket{host="testnet-api.geobrowser.io"}[2m])
+              sum by (exported_namespace, le) (
+                rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[2m])
               )
             )
 
@@ -57,28 +62,28 @@ spec:
           expr: |
             histogram_quantile(
               0.99,
-              sum by (le) (
-                rate(nginx_ingress_controller_request_duration_seconds_bucket{host="testnet-api.geobrowser.io"}[2m])
+              sum by (exported_namespace, le) (
+                rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[2m])
               )
             )
 
         - record: api:ingress_error_status_requests_per_second:rate5m
           expr: |
-            sum by (status) (
-              rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io",status=~"4..|5.."}[5m])
+            sum by (exported_namespace, status) (
+              rate(nginx_ingress_controller_requests{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api",status=~"4..|5.."}[5m])
             )
 
         - record: api:ingress_499_per_second:rate5m
           expr: |
-            sum(rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io",status="499"}[5m]))
+            sum by (exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api",status="499"}[5m]))
 
         - record: api:ingress_500_per_second:rate5m
           expr: |
-            sum(rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io",status="500"}[5m]))
+            sum by (exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api",status="500"}[5m]))
 
         - record: api:ingress_503_per_second:rate5m
           expr: |
-            sum(rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io",status="503"}[5m]))
+            sum by (exported_namespace) (rate(nginx_ingress_controller_requests{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api",status="503"}[5m]))
 
         - record: api:ingress_499_ratio:rate5m
           expr: |
@@ -96,8 +101,8 @@ spec:
           expr: |
             histogram_quantile(
               0.95,
-              sum by (le) (
-                rate(nginx_ingress_controller_request_duration_seconds_bucket{host="testnet-api.geobrowser.io"}[5m])
+              sum by (exported_namespace, le) (
+                rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[5m])
               )
             )
 
@@ -105,8 +110,8 @@ spec:
           expr: |
             histogram_quantile(
               0.50,
-              sum by (le) (
-                rate(nginx_ingress_controller_request_duration_seconds_bucket{host="testnet-api.geobrowser.io"}[5m])
+              sum by (exported_namespace, le) (
+                rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[5m])
               )
             )
 
@@ -114,8 +119,8 @@ spec:
           expr: |
             histogram_quantile(
               0.75,
-              sum by (le) (
-                rate(nginx_ingress_controller_request_duration_seconds_bucket{host="testnet-api.geobrowser.io"}[5m])
+              sum by (exported_namespace, le) (
+                rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[5m])
               )
             )
 
@@ -123,7 +128,7 @@ spec:
           expr: |
             histogram_quantile(
               0.99,
-              sum by (le) (
-                rate(nginx_ingress_controller_request_duration_seconds_bucket{host="testnet-api.geobrowser.io"}[5m])
+              sum by (exported_namespace, le) (
+                rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"}[5m])
               )
             )

--- a/monitoring/k8s/gaia-overview-dashboard.yaml
+++ b/monitoring/k8s/gaia-overview-dashboard.yaml
@@ -31,25 +31,26 @@ data:
             }
           },
           {
-            "name": "namespace",
-            "label": "Namespace",
+            "name": "env",
+            "label": "Environment",
+            "description": "Suffix appended to namespaces (api, knowledge, search, scoring) and the ingress host. Empty for production, '-staging' for staging.",
             "type": "custom",
-            "query": "knowledge,knowledge-staging",
+            "query": "Production : (?:),Staging : -staging",
             "current": {
               "selected": true,
-              "text": "knowledge",
-              "value": "knowledge"
+              "text": "Production",
+              "value": "(?:)"
             },
             "options": [
               {
                 "selected": true,
-                "text": "knowledge",
-                "value": "knowledge"
+                "text": "Production",
+                "value": "(?:)"
               },
               {
                 "selected": false,
-                "text": "knowledge-staging",
-                "value": "knowledge-staging"
+                "text": "Staging",
+                "value": "-staging"
               }
             ]
           }
@@ -85,7 +86,7 @@ data:
           },
           "targets": [
             {
-              "expr": "api:ingress_requests_per_second:rate5m",
+              "expr": "api:ingress_requests_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "rps",
               "refId": "A"
             }
@@ -137,7 +138,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "sum(increase(nginx_ingress_controller_requests{host=\"testnet-api.geobrowser.io\",status=~\"5..\"}[$__range]))",
+              "expr": "sum(increase(nginx_ingress_controller_requests{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\",status=~\"5..\"}[$__range]))",
               "instant": true
             }
           ],
@@ -194,7 +195,7 @@ data:
           },
           "targets": [
             {
-              "expr": "api:ingress_p99_latency_seconds:5m",
+              "expr": "api:ingress_p99_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p99",
               "refId": "A"
             }
@@ -248,7 +249,7 @@ data:
           },
           "targets": [
             {
-              "expr": "api:ingress_5xx_ratio:rate5m",
+              "expr": "api:ingress_5xx_ratio:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "5xx",
               "refId": "A"
             }
@@ -303,12 +304,12 @@ data:
           },
           "targets": [
             {
-              "expr": "kube_horizontalpodautoscaler_status_current_replicas{namespace=\"api\", horizontalpodautoscaler=\"api\"}",
+              "expr": "kube_horizontalpodautoscaler_status_current_replicas{namespace=~\"^api${env:raw}$\", horizontalpodautoscaler=\"api\"}",
               "legendFormat": "current",
               "refId": "A"
             },
             {
-              "expr": "kube_horizontalpodautoscaler_spec_max_replicas{namespace=\"api\", horizontalpodautoscaler=\"api\"}",
+              "expr": "kube_horizontalpodautoscaler_spec_max_replicas{namespace=~\"^api${env:raw}$\", horizontalpodautoscaler=\"api\"}",
               "legendFormat": "max",
               "refId": "B"
             }
@@ -354,7 +355,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max(gaia_api_graphql_pool_saturated)",
+              "expr": "max(gaia_api_graphql_pool_saturated{namespace=~\"^api${env:raw}$\"})",
               "legendFormat": "saturated",
               "refId": "A"
             }
@@ -430,12 +431,12 @@ data:
           },
           "targets": [
             {
-              "expr": "api:ingress_requests_per_second:rate5m",
+              "expr": "api:ingress_requests_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "total",
               "refId": "A"
             },
             {
-              "expr": "api:ingress_5xx_per_second:rate5m",
+              "expr": "api:ingress_5xx_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "5xx",
               "refId": "B"
             }
@@ -489,22 +490,22 @@ data:
           },
           "targets": [
             {
-              "expr": "api:ingress_p50_latency_seconds:5m",
+              "expr": "api:ingress_p50_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "api:ingress_p75_latency_seconds:5m",
+              "expr": "api:ingress_p75_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p75",
               "refId": "B"
             },
             {
-              "expr": "api:ingress_p95_latency_seconds:5m",
+              "expr": "api:ingress_p95_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p95",
               "refId": "C"
             },
             {
-              "expr": "api:ingress_p99_latency_seconds:5m",
+              "expr": "api:ingress_p99_latency_seconds:5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "p99",
               "refId": "D"
             }
@@ -542,17 +543,17 @@ data:
           },
           "targets": [
             {
-              "expr": "api:ingress_499_per_second:rate5m",
+              "expr": "api:ingress_499_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "499 (client cancel)",
               "refId": "A"
             },
             {
-              "expr": "api:ingress_500_per_second:rate5m",
+              "expr": "api:ingress_500_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "500 (server error)",
               "refId": "B"
             },
             {
-              "expr": "api:ingress_503_per_second:rate5m",
+              "expr": "api:ingress_503_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "503 (unavailable)",
               "refId": "C"
             }
@@ -621,7 +622,7 @@ data:
           },
           "targets": [
             {
-              "expr": "api:ingress_status_requests_per_second:rate5m",
+              "expr": "api:ingress_status_requests_per_second:rate5m{exported_namespace=~\"^api${env:raw}$\",ingress=\"api\",exported_service=\"api\"}",
               "legendFormat": "{{status}}",
               "refId": "A"
             }
@@ -672,7 +673,7 @@ data:
           },
           "targets": [
             {
-              "expr": "avg(gaia_api_db_pool_utilization_ratio)",
+              "expr": "avg(gaia_api_db_pool_utilization_ratio{namespace=~\"^api${env:raw}$\"})",
               "legendFormat": "utilization",
               "refId": "A"
             }
@@ -734,7 +735,7 @@ data:
           },
           "targets": [
             {
-              "expr": "avg(gaia_api_graphql_pool_utilization_ratio)",
+              "expr": "avg(gaia_api_graphql_pool_utilization_ratio{namespace=~\"^api${env:raw}$\"})",
               "legendFormat": "utilization",
               "refId": "A"
             }
@@ -796,17 +797,17 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(gaia_api_db_pool_waiting_count)",
+              "expr": "sum(gaia_api_db_pool_waiting_count{namespace=~\"^api${env:raw}$\"})",
               "legendFormat": "REST waiting",
               "refId": "A"
             },
             {
-              "expr": "sum(gaia_api_graphql_pool_waiting_count)",
+              "expr": "sum(gaia_api_graphql_pool_waiting_count{namespace=~\"^api${env:raw}$\"})",
               "legendFormat": "GQL waiting",
               "refId": "B"
             },
             {
-              "expr": "sum(gaia_api_graphql_pool_recent_acquire_timeouts)",
+              "expr": "sum(gaia_api_graphql_pool_recent_acquire_timeouts{namespace=~\"^api${env:raw}$\"})",
               "legendFormat": "GQL acquire timeouts",
               "refId": "C"
             }
@@ -855,7 +856,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"api\",container=\"api\"}) / sum(kube_pod_container_resource_limits{namespace=\"api\",container=\"api\",resource=\"memory\"})",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"^api${env:raw}$\",container=\"api\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^api${env:raw}$\",container=\"api\",resource=\"memory\"})",
               "refId": "A"
             }
           ],
@@ -885,7 +886,7 @@ data:
               "links": [
                 {
                   "title": "Explore memory history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D%5C%22api%5C%22,container%3D%5C%22api%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D~%5C%22%5Eapi%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22api%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -918,7 +919,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container=\"atlas\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"atlas\",resource=\"memory\"})",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"^knowledge${env:raw}$\",container=\"atlas\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"atlas\",resource=\"memory\"})",
               "refId": "A"
             }
           ],
@@ -948,7 +949,7 @@ data:
               "links": [
                 {
                   "title": "Explore memory history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D%5C%22%24namespace%5C%22,container%3D%5C%22atlas%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D~%5C%22%5Eknowledge%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22atlas%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -981,7 +982,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container=\"hermes-pipeline\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"hermes-pipeline\",resource=\"memory\"})",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-pipeline\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-pipeline\",resource=\"memory\"})",
               "refId": "A"
             }
           ],
@@ -1011,7 +1012,7 @@ data:
               "links": [
                 {
                   "title": "Explore memory history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D%5C%22%24namespace%5C%22,container%3D%5C%22hermes-pipeline%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D~%5C%22%5Eknowledge%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22hermes-pipeline%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1044,7 +1045,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container=\"kg-indexer\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"kg-indexer\",resource=\"memory\"})",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"^knowledge${env:raw}$\",container=\"kg-indexer\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"kg-indexer\",resource=\"memory\"})",
               "refId": "A"
             }
           ],
@@ -1074,7 +1075,7 @@ data:
               "links": [
                 {
                   "title": "Explore memory history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D%5C%22%24namespace%5C%22,container%3D%5C%22kg-indexer%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D~%5C%22%5Eknowledge%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22kg-indexer%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1107,7 +1108,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"search\",container=\"search-indexer\"}) / sum(kube_pod_container_resource_limits{namespace=\"search\",container=\"search-indexer\",resource=\"memory\"})",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"^search${env:raw}$\",container=\"search-indexer\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^search${env:raw}$\",container=\"search-indexer\",resource=\"memory\"})",
               "refId": "A"
             }
           ],
@@ -1137,7 +1138,7 @@ data:
               "links": [
                 {
                   "title": "Explore memory history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D%5C%22search%5C%22,container%3D%5C%22search-indexer%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D~%5C%22%5Esearch%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22search-indexer%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1170,7 +1171,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container=\"hermes-ipfs-cache\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"hermes-ipfs-cache\",resource=\"memory\"})",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-ipfs-cache\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-ipfs-cache\",resource=\"memory\"})",
               "refId": "A"
             }
           ],
@@ -1200,7 +1201,7 @@ data:
               "links": [
                 {
                   "title": "Explore memory history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D%5C%22%24namespace%5C%22,container%3D%5C%22hermes-ipfs-cache%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D~%5C%22%5Eknowledge%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22hermes-ipfs-cache%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1233,7 +1234,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"scoring\",container=\"scoring-service\"}) / sum(kube_pod_container_resource_limits{namespace=\"scoring\",container=\"scoring-service\",resource=\"memory\"})",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"^scoring${env:raw}$\",container=\"scoring-service\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^scoring${env:raw}$\",container=\"scoring-service\",resource=\"memory\"})",
               "refId": "A"
             }
           ],
@@ -1263,7 +1264,7 @@ data:
               "links": [
                 {
                   "title": "Explore memory history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D%5C%22scoring%5C%22,container%3D%5C%22scoring-service%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(container_memory_working_set_bytes%7Bnamespace%3D~%5C%22%5Escoring%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22scoring-service%5C%22%7D)%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1296,7 +1297,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"api\",container=\"api\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"api\",container=\"api\",resource=\"cpu\"})",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"^api${env:raw}$\",container=\"api\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^api${env:raw}$\",container=\"api\",resource=\"cpu\"})",
               "refId": "A"
             }
           ],
@@ -1326,7 +1327,7 @@ data:
               "links": [
                 {
                   "title": "Explore CPU history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D%5C%22api%5C%22,container%3D%5C%22api%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D~%5C%22%5Eapi%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22api%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1359,7 +1360,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container=\"atlas\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"atlas\",resource=\"cpu\"})",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"^knowledge${env:raw}$\",container=\"atlas\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"atlas\",resource=\"cpu\"})",
               "refId": "A"
             }
           ],
@@ -1389,7 +1390,7 @@ data:
               "links": [
                 {
                   "title": "Explore CPU history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D%5C%22%24namespace%5C%22,container%3D%5C%22atlas%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D~%5C%22%5Eknowledge%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22atlas%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1422,7 +1423,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container=\"hermes-pipeline\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"hermes-pipeline\",resource=\"cpu\"})",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-pipeline\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-pipeline\",resource=\"cpu\"})",
               "refId": "A"
             }
           ],
@@ -1452,7 +1453,7 @@ data:
               "links": [
                 {
                   "title": "Explore CPU history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D%5C%22%24namespace%5C%22,container%3D%5C%22hermes-pipeline%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D~%5C%22%5Eknowledge%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22hermes-pipeline%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1485,7 +1486,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container=\"kg-indexer\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"kg-indexer\",resource=\"cpu\"})",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"^knowledge${env:raw}$\",container=\"kg-indexer\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"kg-indexer\",resource=\"cpu\"})",
               "refId": "A"
             }
           ],
@@ -1515,7 +1516,7 @@ data:
               "links": [
                 {
                   "title": "Explore CPU history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D%5C%22%24namespace%5C%22,container%3D%5C%22kg-indexer%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D~%5C%22%5Eknowledge%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22kg-indexer%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1548,7 +1549,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"search\",container=\"search-indexer\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"search\",container=\"search-indexer\",resource=\"cpu\"})",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"^search${env:raw}$\",container=\"search-indexer\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^search${env:raw}$\",container=\"search-indexer\",resource=\"cpu\"})",
               "refId": "A"
             }
           ],
@@ -1578,7 +1579,7 @@ data:
               "links": [
                 {
                   "title": "Explore CPU history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D%5C%22search%5C%22,container%3D%5C%22search-indexer%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D~%5C%22%5Esearch%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22search-indexer%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1611,7 +1612,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container=\"hermes-ipfs-cache\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"hermes-ipfs-cache\",resource=\"cpu\"})",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-ipfs-cache\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-ipfs-cache\",resource=\"cpu\"})",
               "refId": "A"
             }
           ],
@@ -1641,7 +1642,7 @@ data:
               "links": [
                 {
                   "title": "Explore CPU history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D%5C%22%24namespace%5C%22,container%3D%5C%22hermes-ipfs-cache%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D~%5C%22%5Eknowledge%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22hermes-ipfs-cache%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1674,7 +1675,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"scoring\",container=\"scoring-service\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"scoring\",container=\"scoring-service\",resource=\"cpu\"})",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"^scoring${env:raw}$\",container=\"scoring-service\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^scoring${env:raw}$\",container=\"scoring-service\",resource=\"cpu\"})",
               "refId": "A"
             }
           ],
@@ -1704,7 +1705,7 @@ data:
               "links": [
                 {
                   "title": "Explore CPU history",
-                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D%5C%22scoring%5C%22,container%3D%5C%22scoring-service%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
+                  "url": "/explore?orgId=1&left=%7B%22queries%22:%5B%7B%22expr%22:%22sum(rate(container_cpu_usage_seconds_total%7Bnamespace%3D~%5C%22%5Escoring%24%7Benv%3Araw%7D%24%5C%22,container%3D%5C%22scoring-service%5C%22%7D%5B5m%5D))%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D",
                   "targetBlank": true
                 }
               ]
@@ -1752,7 +1753,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=\"api\",container=\"api\"}) / sum(kube_pod_container_resource_limits{namespace=\"api\",container=\"api\",resource=\"memory\"}))[48h:])",
+              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=~\"^api${env:raw}$\",container=\"api\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^api${env:raw}$\",container=\"api\",resource=\"memory\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -1808,7 +1809,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=\"$namespace\",container=\"atlas\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"atlas\",resource=\"memory\"}))[48h:])",
+              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=~\"^knowledge${env:raw}$\",container=\"atlas\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"atlas\",resource=\"memory\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -1864,7 +1865,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=\"$namespace\",container=\"hermes-pipeline\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"hermes-pipeline\",resource=\"memory\"}))[48h:])",
+              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-pipeline\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-pipeline\",resource=\"memory\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -1920,7 +1921,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=\"$namespace\",container=\"kg-indexer\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"kg-indexer\",resource=\"memory\"}))[48h:])",
+              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=~\"^knowledge${env:raw}$\",container=\"kg-indexer\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"kg-indexer\",resource=\"memory\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -1976,7 +1977,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=\"search\",container=\"search-indexer\"}) / sum(kube_pod_container_resource_limits{namespace=\"search\",container=\"search-indexer\",resource=\"memory\"}))[48h:])",
+              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=~\"^search${env:raw}$\",container=\"search-indexer\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^search${env:raw}$\",container=\"search-indexer\",resource=\"memory\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2032,7 +2033,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=\"$namespace\",container=\"hermes-ipfs-cache\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"hermes-ipfs-cache\",resource=\"memory\"}))[48h:])",
+              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-ipfs-cache\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-ipfs-cache\",resource=\"memory\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2088,7 +2089,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=\"scoring\",container=\"scoring-service\"}) / sum(kube_pod_container_resource_limits{namespace=\"scoring\",container=\"scoring-service\",resource=\"memory\"}))[48h:])",
+              "expr": "max_over_time((sum(container_memory_working_set_bytes{namespace=~\"^scoring${env:raw}$\",container=\"scoring-service\"}) / sum(kube_pod_container_resource_limits{namespace=~\"^scoring${env:raw}$\",container=\"scoring-service\",resource=\"memory\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2144,7 +2145,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=\"api\",container=\"api\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"api\",container=\"api\",resource=\"cpu\"}))[48h:])",
+              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=~\"^api${env:raw}$\",container=\"api\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^api${env:raw}$\",container=\"api\",resource=\"cpu\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2200,7 +2201,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container=\"atlas\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"atlas\",resource=\"cpu\"}))[48h:])",
+              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=~\"^knowledge${env:raw}$\",container=\"atlas\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"atlas\",resource=\"cpu\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2256,7 +2257,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container=\"hermes-pipeline\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"hermes-pipeline\",resource=\"cpu\"}))[48h:])",
+              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-pipeline\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-pipeline\",resource=\"cpu\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2312,7 +2313,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container=\"kg-indexer\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"kg-indexer\",resource=\"cpu\"}))[48h:])",
+              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=~\"^knowledge${env:raw}$\",container=\"kg-indexer\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"kg-indexer\",resource=\"cpu\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2368,7 +2369,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=\"search\",container=\"search-indexer\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"search\",container=\"search-indexer\",resource=\"cpu\"}))[48h:])",
+              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=~\"^search${env:raw}$\",container=\"search-indexer\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^search${env:raw}$\",container=\"search-indexer\",resource=\"cpu\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2424,7 +2425,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container=\"hermes-ipfs-cache\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",container=\"hermes-ipfs-cache\",resource=\"cpu\"}))[48h:])",
+              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-ipfs-cache\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^knowledge${env:raw}$\",container=\"hermes-ipfs-cache\",resource=\"cpu\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2480,7 +2481,7 @@ data:
           },
           "targets": [
             {
-              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=\"scoring\",container=\"scoring-service\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=\"scoring\",container=\"scoring-service\",resource=\"cpu\"}))[48h:])",
+              "expr": "max_over_time((sum(rate(container_cpu_usage_seconds_total{namespace=~\"^scoring${env:raw}$\",container=\"scoring-service\"}[5m])) / sum(kube_pod_container_resource_limits{namespace=~\"^scoring${env:raw}$\",container=\"scoring-service\",resource=\"cpu\"}))[48h:])",
               "refId": "A"
             }
           ],
@@ -2550,7 +2551,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=~\"api|knowledge|search|scoring\", container=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"}[5m]))",
+              "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=~\"^(api|knowledge|search|scoring)${env:raw}$\", container=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"}[5m]))",
               "legendFormat": "{{container}}",
               "refId": "A"
             }
@@ -2587,13 +2588,13 @@ data:
           },
           "targets": [
             {
-              "expr": "kube_deployment_status_replicas_available{namespace=~\"api|knowledge|search|scoring\", deployment=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"}",
+              "expr": "kube_deployment_status_replicas_available{namespace=~\"^(api|knowledge|search|scoring)${env:raw}$\", deployment=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"}",
               "format": "table",
               "instant": true,
               "refId": "A"
             },
             {
-              "expr": "kube_deployment_spec_replicas{namespace=~\"api|knowledge|search|scoring\", deployment=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"}",
+              "expr": "kube_deployment_spec_replicas{namespace=~\"^(api|knowledge|search|scoring)${env:raw}$\", deployment=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"}",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -2649,7 +2650,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=~\"api|knowledge|search|scoring\", container=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"}[5m]))",
+              "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=~\"^(api|knowledge|search|scoring)${env:raw}$\", container=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"}[5m]))",
               "legendFormat": "{{container}}",
               "refId": "A"
             }
@@ -2687,7 +2688,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum by (container) (container_memory_working_set_bytes{namespace=~\"api|knowledge|search|scoring\", container=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"})",
+              "expr": "sum by (container) (container_memory_working_set_bytes{namespace=~\"^(api|knowledge|search|scoring)${env:raw}$\", container=~\"api|atlas|hermes-pipeline|kg-indexer|search-indexer|hermes-ipfs-cache|scoring-service\"})",
               "legendFormat": "{{container}}",
               "refId": "A"
             }
@@ -2725,7 +2726,7 @@ data:
           },
           "targets": [
             {
-              "expr": "kube_deployment_status_replicas_available{namespace=\"$namespace\",deployment=\"atlas\"}",
+              "expr": "kube_deployment_status_replicas_available{namespace=~\"^knowledge${env:raw}$\",deployment=\"atlas\"}",
               "refId": "A"
             }
           ],
@@ -2772,7 +2773,7 @@ data:
           },
           "targets": [
             {
-              "expr": "kube_deployment_spec_replicas{namespace=\"$namespace\",deployment=\"atlas\"}",
+              "expr": "kube_deployment_spec_replicas{namespace=~\"^knowledge${env:raw}$\",deployment=\"atlas\"}",
               "refId": "A"
             }
           ],
@@ -3433,7 +3434,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m]))",
+              "expr": "sum by (le) (rate(gaia_api_graphql_query_cost_bucket{namespace=~\"^api${env:raw}$\"}[5m]))",
               "format": "heatmap",
               "legendFormat": "{{le}}"
             }
@@ -3477,17 +3478,17 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "histogram_quantile(0.50, sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m])))",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(gaia_api_graphql_query_cost_bucket{namespace=~\"^api${env:raw}$\"}[5m])))",
               "legendFormat": "p50"
             },
             {
               "refId": "B",
-              "expr": "histogram_quantile(0.95, sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m])))",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(gaia_api_graphql_query_cost_bucket{namespace=~\"^api${env:raw}$\"}[5m])))",
               "legendFormat": "p95"
             },
             {
               "refId": "C",
-              "expr": "histogram_quantile(0.99, sum by (le) (rate(gaia_api_graphql_query_cost_bucket[5m])))",
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(gaia_api_graphql_query_cost_bucket{namespace=~\"^api${env:raw}$\"}[5m])))",
               "legendFormat": "p99"
             }
           ],
@@ -3547,7 +3548,7 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "sum by (le) (rate(gaia_api_graphql_response_size_bytes_bucket[5m]))",
+              "expr": "sum by (le) (rate(gaia_api_graphql_response_size_bytes_bucket{namespace=~\"^api${env:raw}$\"}[5m]))",
               "format": "heatmap",
               "legendFormat": "{{le}}"
             }
@@ -3591,17 +3592,17 @@ data:
           "targets": [
             {
               "refId": "A",
-              "expr": "histogram_quantile(0.50, sum by (le) (rate(gaia_api_graphql_response_size_bytes_bucket[5m])))",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(gaia_api_graphql_response_size_bytes_bucket{namespace=~\"^api${env:raw}$\"}[5m])))",
               "legendFormat": "p50"
             },
             {
               "refId": "B",
-              "expr": "histogram_quantile(0.95, sum by (le) (rate(gaia_api_graphql_response_size_bytes_bucket[5m])))",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(gaia_api_graphql_response_size_bytes_bucket{namespace=~\"^api${env:raw}$\"}[5m])))",
               "legendFormat": "p95"
             },
             {
               "refId": "C",
-              "expr": "histogram_quantile(0.99, sum by (le) (rate(gaia_api_graphql_response_size_bytes_bucket[5m])))",
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(gaia_api_graphql_response_size_bytes_bucket{namespace=~\"^api${env:raw}$\"}[5m])))",
               "legendFormat": "p99"
             }
           ],

--- a/monitoring/k8s/prometheus-adapter-config.yaml
+++ b/monitoring/k8s/prometheus-adapter-config.yaml
@@ -67,27 +67,27 @@ data:
       window: 5m
 
     externalRules:
-      - seriesQuery: '{__name__="nginx_ingress_controller_requests",host="testnet-api.geobrowser.io"}'
+      - seriesQuery: '{__name__="nginx_ingress_controller_requests",exported_namespace="api",ingress="api",exported_service="api"}'
         name:
           as: api_ingress_503_ratio_rate5m
         metricsQuery: |
-          (sum(rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io",status="503"}[5m])) or vector(0))
+          (sum(rate(nginx_ingress_controller_requests{exported_namespace="api",ingress="api",exported_service="api",status="503"}[5m])) or vector(0))
           /
-          clamp_min(sum(rate(nginx_ingress_controller_requests{host="testnet-api.geobrowser.io"}[5m])), 1)
+          clamp_min(sum(rate(nginx_ingress_controller_requests{exported_namespace="api",ingress="api",exported_service="api"}[5m])), 1)
         resources:
           namespaced: false
-      - seriesQuery: '{__name__="api:ingress_p95_latency_seconds:2m"}'
+      - seriesQuery: '{__name__="api:ingress_p95_latency_seconds:2m",exported_namespace="api",ingress="api",exported_service="api"}'
         name:
           as: api_ingress_p95_latency_seconds_2m
         metricsQuery: |
-          api:ingress_p95_latency_seconds:2m
+          api:ingress_p95_latency_seconds:2m{exported_namespace="api",ingress="api",exported_service="api"}
         resources:
           namespaced: false
-      - seriesQuery: '{__name__="api:ingress_p99_latency_seconds:2m"}'
+      - seriesQuery: '{__name__="api:ingress_p99_latency_seconds:2m",exported_namespace="api",ingress="api",exported_service="api"}'
         name:
           as: api_ingress_p99_latency_seconds_2m
         metricsQuery: |
-          api:ingress_p99_latency_seconds:2m
+          api:ingress_p99_latency_seconds:2m{exported_namespace="api",ingress="api",exported_service="api"}
         resources:
           namespaced: false
       - seriesQuery: '{__name__="kube_deployment_status_replicas_available",namespace="api",deployment="api"}'


### PR DESCRIPTION
Replaces the existing `$namespace` template variable on the Gaia Overview dashboard with a single `$env` suffix variable that drives every env-discriminating filter: namespace filters across all four service namespaces, the api-ingress filter, and the per-env values exposed to HPA via prometheus-adapter. Picking "Staging" in the dropdown switches api 5xx counts, RPS, GraphQL pool utilization, GraphQL histograms, HPA replicas, and per-service mem/cpu panels in one go.

## Files changed (5)

### `api-ingress-rules.yaml` — recording rules

Was: `host="testnet-api.geobrowser.io"` hardcoded; `host` label aggregated away.

Now: `exported_namespace=~"api(-staging)?",ingress="api",exported_service="api"` with `sum by (exported_namespace, ...)` to preserve the env discriminator. Namespace-based filters survive DNS migrations; the `ingress`/`exported_service` triple rejects unrelated ingresses (e.g. monitoring/grafana). Cluster-wide aggregates still possible via `sum(...)` wrapping.

### `gaia-overview-dashboard.yaml` — main dashboard

- `$env` template variable (custom, label "Environment", text="Production" value="(?:)" / text="Staging" value="-staging"). The `(?:)` value works around Grafana's empty-value substitution bug — it's a regex-empty group that's a non-empty string, so Grafana substitutes it cleanly and the regex engine treats it as nothing.
- All 18 PromQL `expr` strings + 14 URL-encoded data-link drill-ins rewritten to use `${env:raw}` (the `:raw` formatter bypasses Grafana's regex auto-escape so `(?:)` reaches the regex engine intact).
- All filters now anchored regex matches: `namespace=~"^api${env:raw}$"`, `exported_namespace=~"^api${env:raw}$"`, etc. Anchors prevent substring matches between `api` and `api-staging`.
- `gaia_api_*` panels (GQL Pool Saturated, REST/GraphQL Pool Utilization, Pool Waiting & Acquire Timeouts, GraphQL Query Cost histograms, GraphQL Response Size histograms) now filter by `namespace=~"^api${env:raw}$"` — picking Staging routes them to `api-staging`.
- Multi-namespace regex panels (Pod Restarts, Deployment Availability, CPU/Memory by Service): `namespace=~"^(api|knowledge|search|scoring)${env:raw}$"`.

### `api-ingress-dashboard.yaml` — ingress dashboard

- Same `$env` variable added.
- All 14 recording-rule references and the one direct `nginx_ingress_controller_requests` query rewritten to filter by `exported_namespace=~"^api${env:raw}$",ingress="api",exported_service="api"`.

### `api-capacity-alerts.yaml` — PrometheusRule alerts

- `Api5xxRateHigh` and `ApiHpaMaxedWithHighP99` exprs pinned to the prod env via `exported_namespace="api",ingress="api",exported_service="api"` to preserve pre-existing prod-only alert behavior. Without this, the recording-rule label change would cause per-host alerts and break the vector matching on the HPA `and`.

### `prometheus-adapter-config.yaml` — HPA external metrics

- `api_ingress_p95_latency_seconds_2m` and `api_ingress_p99_latency_seconds_2m` external metrics pinned to prod env via the same triple. The 503 ratio rule and the raw `nginx_ingress_controller_requests` `seriesQuery` were also updated to use namespace-based filtering for consistency.

After applying, the prometheus-adapter pods need a restart to pick up the new ConfigMap (the adapter only reads its config at startup):

```bash
kubectl -n monitoring rollout restart deployment prometheus-adapter
```

## What stays cluster-wide (intentional)

OpenSearch panels (Search QPS, JVM Heap, Cluster Health, etc) — single shared OpenSearch cluster, so per-env doesn't apply.

## Verification

- `kubectl apply --dry-run=client` clean on all 5 files.
- All hardcoded `host="testnet-api.geobrowser.io"` references removed from the repo.
- Dashboard JSON parses; templating + panel counts intact (65 + 9).
- Probed live cluster: `exported_namespace` label values present (`api`, `api-staging`); ingress filter matches both; recording rule emits 2 series (one per env); prod p99 = 0.44s, staging = 0 (no traffic).

## Deploying

```bash
kubectl apply -f monitoring/k8s/api-ingress-rules.yaml \
              -f monitoring/k8s/api-ingress-dashboard.yaml \
              -f monitoring/k8s/gaia-overview-dashboard.yaml \
              -f monitoring/k8s/api-capacity-alerts.yaml \
              -f monitoring/k8s/prometheus-adapter-config.yaml
kubectl -n monitoring rollout restart deployment prometheus-adapter
```

Grafana sidecar reloads the dashboard ConfigMaps within ~10s. Recording rules and alerts apply immediately. The adapter rollout takes ~10s.