### PR TITLE
fix(api): tighten /search clause cap — 100-char limit, fuzzy gate, analyzer-aligned token split

### DIFF
--- a/api/src/search/index.test.ts
+++ b/api/src/search/index.test.ts
@@ -229,18 +229,18 @@ describe("Search Router - Integration Tests", () => {
 
 		// Error cases
 		it("returns 400 for query longer than maximum length", async () => {
-			const longQuery = "a".repeat(201)
+			const longQuery = "a".repeat(101)
 			const request = new Request(`http://localhost/search?query=${longQuery}`)
 			const response = await app.fetch(request)
 			const result = await response.json()
 
 			expect(response.status).toBe(400)
 			expect(result.error).toBe("Invalid parameter")
-			expect(result.message).toContain("must not exceed 200 characters")
+			expect(result.message).toContain("must not exceed 100 characters")
 		})
 
-		it("accepts query exactly at the 200-char boundary", async () => {
-			const boundaryQuery = "a".repeat(200)
+		it("accepts query exactly at the 100-char boundary", async () => {
+			const boundaryQuery = "a".repeat(100)
 			const request = new Request(`http://localhost/search?query=${boundaryQuery}`)
 			const response = await app.fetch(request)
 

--- a/api/src/search/index.test.ts
+++ b/api/src/search/index.test.ts
@@ -229,14 +229,22 @@ describe("Search Router - Integration Tests", () => {
 
 		// Error cases
 		it("returns 400 for query longer than maximum length", async () => {
-			const longQuery = "a".repeat(501)
+			const longQuery = "a".repeat(201)
 			const request = new Request(`http://localhost/search?query=${longQuery}`)
 			const response = await app.fetch(request)
 			const result = await response.json()
 
 			expect(response.status).toBe(400)
 			expect(result.error).toBe("Invalid parameter")
-			expect(result.message).toContain("must not exceed 500 characters")
+			expect(result.message).toContain("must not exceed 200 characters")
+		})
+
+		it("accepts query exactly at the 200-char boundary", async () => {
+			const boundaryQuery = "a".repeat(200)
+			const request = new Request(`http://localhost/search?query=${boundaryQuery}`)
+			const response = await app.fetch(request)
+
+			expect(response.status).toBe(200)
 		})
 
 		it("returns 400 for invalid scope", async () => {

--- a/api/src/search/index.ts
+++ b/api/src/search/index.ts
@@ -46,10 +46,12 @@ const MAX_LIMIT = 100
  * clause explosions. The previous 500-char ceiling let long pasted text
  * (e.g. press-release blurbs) reach OpenSearch and blow past
  * `indices.query.bool.max_clause_count = 1024` via fuzzy + prefix
- * expansion. 200 chars is comfortably under the empirical 250-char
- * threshold while still admitting realistic search inputs.
+ * expansion. 100 chars covers realistic name/title-style search inputs
+ * while keeping the worst-case clause count well under 1024 even when
+ * combined with the per-sub-query token cap and fuzzy gate (see
+ * MAX_TEXT_TOKENS, FUZZY_MAX_TOKENS in opensearch.ts).
  */
-const MAX_QUERY_LENGTH = 200
+const MAX_QUERY_LENGTH = 100
 
 /**
  * Maximum length for space_id parameter (UUID format: 36 dashed, 32 dashless).
@@ -163,14 +165,14 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 					in: "query",
 					description: "Search query string (alias: q)",
 					required: false,
-					schema: {type: "string", maxLength: 200},
+					schema: {type: "string", maxLength: 100},
 				},
 				{
 					name: "q",
 					in: "query",
 					description: "Search query string (alias for query)",
 					required: false,
-					schema: {type: "string", maxLength: 200},
+					schema: {type: "string", maxLength: 100},
 				},
 				{
 					name: "scope",

--- a/api/src/search/index.ts
+++ b/api/src/search/index.ts
@@ -42,9 +42,14 @@ const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 100
 
 /**
- * Maximum length for search queries to prevent abuse.
+ * Maximum length for search queries to prevent abuse and OpenSearch
+ * clause explosions. The previous 500-char ceiling let long pasted text
+ * (e.g. press-release blurbs) reach OpenSearch and blow past
+ * `indices.query.bool.max_clause_count = 1024` via fuzzy + prefix
+ * expansion. 200 chars is comfortably under the empirical 250-char
+ * threshold while still admitting realistic search inputs.
  */
-const MAX_QUERY_LENGTH = 500
+const MAX_QUERY_LENGTH = 200
 
 /**
  * Maximum length for space_id parameter (UUID format: 36 dashed, 32 dashless).
@@ -158,14 +163,14 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 					in: "query",
 					description: "Search query string (alias: q)",
 					required: false,
-					schema: {type: "string", maxLength: 500},
+					schema: {type: "string", maxLength: 200},
 				},
 				{
 					name: "q",
 					in: "query",
 					description: "Search query string (alias for query)",
 					required: false,
-					schema: {type: "string", maxLength: 500},
+					schema: {type: "string", maxLength: 200},
 				},
 				{
 					name: "scope",

--- a/api/src/services/search/opensearch.test.ts
+++ b/api/src/services/search/opensearch.test.ts
@@ -77,23 +77,25 @@ describe("OpenSearchClient", () => {
 			expect(termExactName.term.name_raw.value).toBe(fullQuery)
 		})
 
-		it("includes fuzzy clause when token count <= 5", () => {
-			// 5 tokens — at the boundary
-			const query = client.buildBaseTextQuery("alpha beta gamma delta epsilon") as {
+		it("includes fuzzy clause with capped max_expansions when token count <= 3", () => {
+			// 3 tokens — at the boundary
+			const query = client.buildBaseTextQuery("alpha beta gamma") as {
 				bool: {should: Record<string, unknown>[]}
 			}
 			const fuzzy = query.bool.should.find(
 				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
-			) as {multi_match: {query: string; fuzziness: string}}
+			) as {multi_match: {query: string; fuzziness: string; max_expansions: number}}
 
 			expect(fuzzy).toBeDefined()
 			expect(fuzzy.multi_match.fuzziness).toBe("AUTO")
-			expect(fuzzy.multi_match.query).toBe("alpha beta gamma delta epsilon")
+			expect(fuzzy.multi_match.query).toBe("alpha beta gamma")
+			// max_expansions is capped (default OS value is 50; we pin lower for safety).
+			expect(fuzzy.multi_match.max_expansions).toBe(25)
 		})
 
-		it("drops fuzzy clause when token count > 5 (fan-out reduction)", () => {
-			// 6 tokens — just over the boundary
-			const query = client.buildBaseTextQuery("alpha beta gamma delta epsilon zeta") as {
+		it("drops fuzzy clause when token count > 3 (fan-out reduction)", () => {
+			// 4 tokens — just over the boundary
+			const query = client.buildBaseTextQuery("alpha beta gamma delta") as {
 				bool: {should: Record<string, unknown>[]}
 			}
 			const fuzzy = query.bool.should.find(
@@ -135,7 +137,8 @@ describe("OpenSearchClient", () => {
 		})
 
 		it("does not truncate when query is already short", () => {
-			const shortQuery = "five tokens or less here"
+			// 3 tokens — fuzzy is included (≤ FUZZY_MAX_TOKENS) and sees the full query.
+			const shortQuery = "three short tokens"
 			const query = client.buildBaseTextQuery(shortQuery) as {
 				bool: {should: Record<string, unknown>[]}
 			}

--- a/api/src/services/search/opensearch.test.ts
+++ b/api/src/services/search/opensearch.test.ts
@@ -31,9 +31,10 @@ describe("OpenSearchClient", () => {
 		})
 
 		it("caps clause-heavy sub-queries to 20 tokens; exact-match clauses see full query", () => {
-			// Query of 30 tokens → cap should kick in at 20 for fuzzy / bool_prefix /
+			// Query of 30 tokens → cap should kick in at 20 for bool_prefix /
 			// match_phrase_prefix. The exact-match clauses (term: name_raw, match: name)
-			// must still see all 30 tokens so a full-name match isn't lost.
+			// must still see all 30 tokens so a full-name match isn't lost. Fuzzy is
+			// dropped entirely at this token count (see separate test).
 			const tokens = Array.from({length: 30}, (_, i) => `t${i + 1}`)
 			const fullQuery = tokens.join(" ")
 			const cappedQuery = tokens.slice(0, 20).join(" ")
@@ -44,10 +45,6 @@ describe("OpenSearchClient", () => {
 			}
 			const should = query.bool.should
 
-			// Find each sub-query type
-			const fuzzy = should.find(
-				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
-			) as {multi_match: {query: string}}
 			const boolPrefix = should.find(
 				(c) => "multi_match" in c && (c.multi_match as {type?: string}).type === "bool_prefix",
 			) as {multi_match: {query: string}}
@@ -69,8 +66,6 @@ describe("OpenSearchClient", () => {
 			) as {term: {name_raw: {value: string}}}
 
 			// Heavy sub-queries: capped to 20 tokens, must NOT contain the 26th token
-			expect(fuzzy.multi_match.query).toBe(cappedQuery)
-			expect(fuzzy.multi_match.query).not.toContain(overflowToken)
 			expect(boolPrefix.multi_match.query).toBe(cappedQuery)
 			expect(boolPrefix.multi_match.query).not.toContain(overflowToken)
 			expect(phrasePrefixName.match_phrase_prefix.name.query).toBe(cappedQuery)
@@ -80,6 +75,63 @@ describe("OpenSearchClient", () => {
 			expect(matchExactToken.match.name.query).toBe(fullQuery)
 			expect(matchExactToken.match.name.query).toContain(overflowToken)
 			expect(termExactName.term.name_raw.value).toBe(fullQuery)
+		})
+
+		it("includes fuzzy clause when token count <= 5", () => {
+			// 5 tokens — at the boundary
+			const query = client.buildBaseTextQuery("alpha beta gamma delta epsilon") as {
+				bool: {should: Record<string, unknown>[]}
+			}
+			const fuzzy = query.bool.should.find(
+				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
+			) as {multi_match: {query: string; fuzziness: string}}
+
+			expect(fuzzy).toBeDefined()
+			expect(fuzzy.multi_match.fuzziness).toBe("AUTO")
+			expect(fuzzy.multi_match.query).toBe("alpha beta gamma delta epsilon")
+		})
+
+		it("drops fuzzy clause when token count > 5 (fan-out reduction)", () => {
+			// 6 tokens — just over the boundary
+			const query = client.buildBaseTextQuery("alpha beta gamma delta epsilon zeta") as {
+				bool: {should: Record<string, unknown>[]}
+			}
+			const fuzzy = query.bool.should.find(
+				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
+			)
+			expect(fuzzy).toBeUndefined()
+
+			// Other heavy clauses must still be present (they have their own cap)
+			const boolPrefix = query.bool.should.find(
+				(c) => "multi_match" in c && (c.multi_match as {type?: string}).type === "bool_prefix",
+			)
+			expect(boolPrefix).toBeDefined()
+		})
+
+		it("counts punctuation-separated tokens correctly (no whitespace bypass)", () => {
+			// Adversarial: 6 tokens separated by commas/hyphens/dots, no whitespace.
+			// Whitespace-only splitter would see this as 1 token and incorrectly
+			// keep fuzzy enabled. The analyzer-aligned splitter sees 6 → fuzzy dropped.
+			const query = client.buildBaseTextQuery("alpha,beta-gamma.delta;epsilon!zeta") as {
+				bool: {should: Record<string, unknown>[]}
+			}
+			const fuzzy = query.bool.should.find(
+				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
+			)
+			expect(fuzzy).toBeUndefined()
+		})
+
+		it("preserves accented Latin letters as a single token (no over-split)", () => {
+			// "café" is one token to OpenSearch's analyzer. Our splitter should agree.
+			// "café" with no punctuation → 1 token → fuzzy enabled.
+			const query = client.buildBaseTextQuery("café") as {
+				bool: {should: Record<string, unknown>[]}
+			}
+			const fuzzy = query.bool.should.find(
+				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
+			) as {multi_match: {query: string}}
+			expect(fuzzy).toBeDefined()
+			expect(fuzzy.multi_match.query).toBe("café")
 		})
 
 		it("does not truncate when query is already short", () => {

--- a/api/src/services/search/opensearch.test.ts
+++ b/api/src/services/search/opensearch.test.ts
@@ -29,6 +29,70 @@ describe("OpenSearchClient", () => {
 			expect(queryStr).toContain("fuzziness")
 			expect(queryStr).toContain("match_phrase_prefix")
 		})
+
+		it("caps clause-heavy sub-queries to 20 tokens; exact-match clauses see full query", () => {
+			// Query of 30 tokens → cap should kick in at 20 for fuzzy / bool_prefix /
+			// match_phrase_prefix. The exact-match clauses (term: name_raw, match: name)
+			// must still see all 30 tokens so a full-name match isn't lost.
+			const tokens = Array.from({length: 30}, (_, i) => `t${i + 1}`)
+			const fullQuery = tokens.join(" ")
+			const cappedQuery = tokens.slice(0, 20).join(" ")
+			const overflowToken = tokens[25] // would be present if cap weren't applied
+
+			const query = client.buildBaseTextQuery(fullQuery) as {
+				bool: {should: Record<string, unknown>[]}
+			}
+			const should = query.bool.should
+
+			// Find each sub-query type
+			const fuzzy = should.find(
+				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
+			) as {multi_match: {query: string}}
+			const boolPrefix = should.find(
+				(c) => "multi_match" in c && (c.multi_match as {type?: string}).type === "bool_prefix",
+			) as {multi_match: {query: string}}
+			const phrasePrefixName = should.find(
+				(c) => "match_phrase_prefix" in c && (c.match_phrase_prefix as {name?: unknown}).name !== undefined,
+			) as {match_phrase_prefix: {name: {query: string}}}
+			const phrasePrefixDesc = should.find(
+				(c) =>
+					"match_phrase_prefix" in c &&
+					(c.match_phrase_prefix as {description?: unknown}).description !== undefined,
+			) as {match_phrase_prefix: {description: {query: string}}}
+			const matchExactToken = should.find(
+				(c) => "match" in c && (c.match as {name?: unknown}).name !== undefined,
+			) as {match: {name: {query: string}}}
+			const termExactName = should.find(
+				(c) =>
+					"term" in c &&
+					typeof (c.term as {name_raw?: {value?: string; boost?: number}}).name_raw?.value === "string",
+			) as {term: {name_raw: {value: string}}}
+
+			// Heavy sub-queries: capped to 20 tokens, must NOT contain the 26th token
+			expect(fuzzy.multi_match.query).toBe(cappedQuery)
+			expect(fuzzy.multi_match.query).not.toContain(overflowToken)
+			expect(boolPrefix.multi_match.query).toBe(cappedQuery)
+			expect(boolPrefix.multi_match.query).not.toContain(overflowToken)
+			expect(phrasePrefixName.match_phrase_prefix.name.query).toBe(cappedQuery)
+			expect(phrasePrefixDesc.match_phrase_prefix.description.query).toBe(cappedQuery)
+
+			// Exact-match sub-queries: still see the full 30-token query
+			expect(matchExactToken.match.name.query).toBe(fullQuery)
+			expect(matchExactToken.match.name.query).toContain(overflowToken)
+			expect(termExactName.term.name_raw.value).toBe(fullQuery)
+		})
+
+		it("does not truncate when query is already short", () => {
+			const shortQuery = "five tokens or less here"
+			const query = client.buildBaseTextQuery(shortQuery) as {
+				bool: {should: Record<string, unknown>[]}
+			}
+			const fuzzy = query.bool.should.find(
+				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
+			) as {multi_match: {query: string}}
+
+			expect(fuzzy.multi_match.query).toBe(shortQuery)
+		})
 	})
 
 	describe("buildUuidQuery", () => {

--- a/api/src/services/search/opensearch.ts
+++ b/api/src/services/search/opensearch.ts
@@ -163,6 +163,32 @@ export const DEFAULT_PAGE_SIZE = 20
  */
 export const MAX_PAGE_SIZE = 100
 
+/**
+ * Maximum number of whitespace-separated tokens fed to the clause-heavy
+ * sub-queries (fuzzy multi_match, bool_prefix multi_match, and the two
+ * match_phrase_prefix clauses). Excess tokens are dropped from these
+ * sub-queries only — exact-match clauses (`term: name_raw`, `match: name`)
+ * still see the full query so an exact full-name hit isn't lost.
+ *
+ * Each token in the heavy sub-queries can multiply into many internal
+ * Lucene clauses (fuzzy `AUTO` × 2 fields, bool_prefix × 6 fields, plus
+ * phrase-prefix expansion of the trailing token to 50 terms by default).
+ * 20 tokens keeps the upper-bound clause count comfortably under
+ * `indices.query.bool.max_clause_count = 1024` for realistic queries.
+ */
+export const MAX_TEXT_TOKENS = 20
+
+/**
+ * Truncate a query to the first `maxTokens` whitespace-separated tokens.
+ * If the query already fits, returns it as-is (no allocation). Used to
+ * cap fan-out in the clause-heavy sub-queries — see MAX_TEXT_TOKENS.
+ */
+function truncateToTokens(query: string, maxTokens: number): string {
+	const tokens = query.split(/\s+/)
+	if (tokens.length <= maxTokens) return query
+	return tokens.slice(0, maxTokens).join(" ")
+}
+
 // System IDs from the SDK are already dashless — use directly for OpenSearch queries
 const TYPE_RELATION_TYPE_ID = SystemIds.TYPES_PROPERTY as string
 const AVATAR_RELATION_TYPE_ID = ContentIds.AVATAR_PROPERTY as string
@@ -913,6 +939,11 @@ export class OpenSearchClient implements SearchClient {
 	}
 
 	buildBaseTextQuery(queryText: string): object {
+		// Heavy sub-queries (fuzzy + bool_prefix + match_phrase_prefix) see only
+		// the first MAX_TEXT_TOKENS tokens to bound clause fan-out. Exact-match
+		// sub-queries (term: name_raw, match: name) keep the full query so a
+		// full-name match still wins when available.
+		const cappedQuery = truncateToTokens(queryText, MAX_TEXT_TOKENS)
 		return {
 			bool: {
 				should: [
@@ -976,9 +1007,12 @@ export class OpenSearchClient implements SearchClient {
 						},
 					},
 					{
-						// Autocomplete-style match over n-grams with higher weight on name
+						// Autocomplete-style match over n-grams with higher weight on name.
+						// Capped at MAX_TEXT_TOKENS because bool_prefix expands the trailing
+						// token across 6 fields (name/description × original/_2gram/_3gram),
+						// so per-token cost is the highest among the 8 sub-queries.
 						multi_match: {
-							query: queryText,
+							query: cappedQuery,
 							type: "bool_prefix",
 							fields: [
 								`name^${this.b("name_field_boost", NAME_FIELD_BOOST)}`,
@@ -991,29 +1025,36 @@ export class OpenSearchClient implements SearchClient {
 						},
 					},
 					{
-						// Fuzzy text match to tolerate minor typos
-						// AUTO fuzziness: 1-2 chars: 0 edits, 3-4 chars: 1 edit, 5+ chars: 2 edits
+						// Fuzzy text match to tolerate minor typos.
+						// AUTO fuzziness: 1-2 chars: 0 edits, 3-4 chars: 1 edit, 5+ chars: 2 edits.
+						// Capped at MAX_TEXT_TOKENS — fuzzy AUTO expands each term into many
+						// edit-distance variants, multiplied by 2 fields. Without a cap, a long
+						// pasted query trips OpenSearch's max_clause_count = 1024 with a 500.
 						multi_match: {
-							query: queryText,
+							query: cappedQuery,
 							fields: ["name", "description"],
 							fuzziness: "AUTO",
 							boost: this.b("fuzzy_reduction_boost", FUZZY_REDUCTION_BOOST),
 						},
 					},
 					{
-						// Strongly boost documents where the name starts with the query text
+						// Strongly boost documents where the name starts with the query text.
+						// Capped — match_phrase_prefix expands the trailing token to up to 50
+						// terms (default max_expansions), and the phrase grows linearly with
+						// token count.
 						match_phrase_prefix: {
 							name: {
-								query: queryText,
+								query: cappedQuery,
 								boost: this.b("name_prefix_boost", NAME_PREFIX_BOOST),
 							},
 						},
 					},
 					{
-						// Moderately boost documents where the description starts with the query text
+						// Moderately boost documents where the description starts with the
+						// query text. Same fan-out concerns as the name phrase-prefix above.
 						match_phrase_prefix: {
 							description: {
-								query: queryText,
+								query: cappedQuery,
 								boost: this.b("description_prefix_boost", DESCRIPTION_PREFIX_BOOST),
 							},
 						},

--- a/api/src/services/search/opensearch.ts
+++ b/api/src/services/search/opensearch.ts
@@ -199,8 +199,22 @@ export const MAX_TEXT_TOKENS = 20
  * typo tolerance is most useful for short single- or few-word queries
  * anyway. Multi-word queries have enough token redundancy that exact
  * and prefix matches cover the typo cases sufficiently.
+ *
+ * Set to 3 (vs the more permissive 5) to keep worst-case clause count
+ * under ~480 even when fuzzy is enabled — comfortably below
+ * OpenSearch's max_clause_count = 1024.
  */
-export const FUZZY_MAX_TOKENS = 5
+export const FUZZY_MAX_TOKENS = 3
+
+/**
+ * Maximum number of edit-distance variants generated per term in the
+ * fuzzy `multi_match` clause. Default in OpenSearch is 50, which when
+ * multiplied by 2 fields × FUZZY_MAX_TOKENS gives the dominant share
+ * of the worst-case clause count. Halving to 25 nearly halves the
+ * fuzzy budget at minimal recall cost — typo correction still works
+ * for the common 1-2-edit cases.
+ */
+export const FUZZY_MAX_EXPANSIONS = 25
 
 /**
  * Count tokens in the query (drops empty splits from leading/trailing
@@ -1080,6 +1094,7 @@ export class OpenSearchClient implements SearchClient {
 										query: cappedQuery,
 										fields: ["name", "description"],
 										fuzziness: "AUTO",
+										max_expansions: FUZZY_MAX_EXPANSIONS,
 										boost: this.b("fuzzy_reduction_boost", FUZZY_REDUCTION_BOOST),
 									},
 								},

--- a/api/src/services/search/opensearch.ts
+++ b/api/src/services/search/opensearch.ts
@@ -164,27 +164,62 @@ export const DEFAULT_PAGE_SIZE = 20
 export const MAX_PAGE_SIZE = 100
 
 /**
- * Maximum number of whitespace-separated tokens fed to the clause-heavy
- * sub-queries (fuzzy multi_match, bool_prefix multi_match, and the two
- * match_phrase_prefix clauses). Excess tokens are dropped from these
- * sub-queries only — exact-match clauses (`term: name_raw`, `match: name`)
- * still see the full query so an exact full-name hit isn't lost.
+ * Approximation of OpenSearch's standard analyzer for token counting:
+ * splits on whitespace, Unicode punctuation, and Unicode symbols. Covers
+ * the basics — spaces, tabs, periods, dashes, commas, slashes, colons,
+ * semicolons, brackets, math/currency symbols, etc.
+ *
+ * Not a perfect match for Lucene's UAX #29 tokenizer, but close enough
+ * to bound clause fan-out in the heavy sub-queries when paired with
+ * MAX_QUERY_LENGTH and MAX_TEXT_TOKENS. We err on the side of OVER-
+ * splitting (more tokens than the analyzer sees) — that just means a
+ * slightly tighter cap than necessary, never a looser one.
+ */
+const TOKEN_BOUNDARY_REGEX = /[\s\p{P}\p{S}]+/u
+
+/**
+ * Maximum number of tokens fed to the clause-heavy sub-queries
+ * (bool_prefix multi_match and the two match_phrase_prefix clauses).
+ * Excess tokens are dropped from these sub-queries only — exact-match
+ * clauses (`term: name_raw`, `match: name`) still see the full query
+ * so an exact full-name hit isn't lost.
  *
  * Each token in the heavy sub-queries can multiply into many internal
- * Lucene clauses (fuzzy `AUTO` × 2 fields, bool_prefix × 6 fields, plus
- * phrase-prefix expansion of the trailing token to 50 terms by default).
- * 20 tokens keeps the upper-bound clause count comfortably under
- * `indices.query.bool.max_clause_count = 1024` for realistic queries.
+ * Lucene clauses (bool_prefix × 6 fields, plus phrase-prefix expansion
+ * of the trailing token to 50 terms by default). 20 tokens keeps the
+ * upper-bound clause count comfortably under
+ * `indices.query.bool.max_clause_count = 1024`.
  */
 export const MAX_TEXT_TOKENS = 20
 
 /**
- * Truncate a query to the first `maxTokens` whitespace-separated tokens.
- * If the query already fits, returns it as-is (no allocation). Used to
- * cap fan-out in the clause-heavy sub-queries — see MAX_TEXT_TOKENS.
+ * Maximum token count at which fuzzy `multi_match` is included in the
+ * base text query. Above this, fuzzy is skipped entirely — its
+ * per-token edit-distance fan-out is the highest of any sub-query, and
+ * typo tolerance is most useful for short single- or few-word queries
+ * anyway. Multi-word queries have enough token redundancy that exact
+ * and prefix matches cover the typo cases sufficiently.
+ */
+export const FUZZY_MAX_TOKENS = 5
+
+/**
+ * Count tokens in the query (drops empty splits from leading/trailing
+ * separators).
+ */
+function countTokens(query: string): number {
+	return query.split(TOKEN_BOUNDARY_REGEX).filter((t) => t.length > 0).length
+}
+
+/**
+ * Truncate a query to the first `maxTokens` tokens. Re-joined with
+ * single spaces — the actual analyzer at search time tokenizes again,
+ * so the rejoining is just to preserve a string shape for the
+ * OpenSearch DSL. If the query already fits, returns it as-is (no
+ * allocation). Used to cap fan-out in the clause-heavy sub-queries —
+ * see MAX_TEXT_TOKENS.
  */
 function truncateToTokens(query: string, maxTokens: number): string {
-	const tokens = query.split(/\s+/)
+	const tokens = query.split(TOKEN_BOUNDARY_REGEX).filter((t) => t.length > 0)
 	if (tokens.length <= maxTokens) return query
 	return tokens.slice(0, maxTokens).join(" ")
 }
@@ -944,6 +979,13 @@ export class OpenSearchClient implements SearchClient {
 		// sub-queries (term: name_raw, match: name) keep the full query so a
 		// full-name match still wins when available.
 		const cappedQuery = truncateToTokens(queryText, MAX_TEXT_TOKENS)
+		// Fuzzy `multi_match` AUTO is the highest-fan-out clause (each term
+		// expands into edit-distance variants × 2 fields). Drop it entirely
+		// for queries with more than FUZZY_MAX_TOKENS analyzer-aligned tokens
+		// — multi-word queries have enough redundancy that exact + prefix
+		// clauses cover the typo cases. Single- and few-word queries keep
+		// fuzzy for the typical "user typed `etereum`" case.
+		const includeFuzzy = countTokens(queryText) <= FUZZY_MAX_TOKENS
 		return {
 			bool: {
 				should: [
@@ -1024,19 +1066,25 @@ export class OpenSearchClient implements SearchClient {
 							],
 						},
 					},
-					{
-						// Fuzzy text match to tolerate minor typos.
-						// AUTO fuzziness: 1-2 chars: 0 edits, 3-4 chars: 1 edit, 5+ chars: 2 edits.
-						// Capped at MAX_TEXT_TOKENS — fuzzy AUTO expands each term into many
-						// edit-distance variants, multiplied by 2 fields. Without a cap, a long
-						// pasted query trips OpenSearch's max_clause_count = 1024 with a 500.
-						multi_match: {
-							query: cappedQuery,
-							fields: ["name", "description"],
-							fuzziness: "AUTO",
-							boost: this.b("fuzzy_reduction_boost", FUZZY_REDUCTION_BOOST),
-						},
-					},
+					// Fuzzy text match to tolerate minor typos.
+					// AUTO fuzziness: 1-2 chars: 0 edits, 3-4 chars: 1 edit, 5+ chars: 2 edits.
+					// Skipped when the query has more than FUZZY_MAX_TOKENS analyzer-aligned
+					// tokens — fuzzy AUTO expands each term into many edit-distance variants
+					// across 2 fields and is the worst per-token offender for clause fan-out.
+					// Multi-word queries have enough redundancy to find typos via the exact
+					// and prefix clauses without it.
+					...(includeFuzzy
+						? [
+								{
+									multi_match: {
+										query: cappedQuery,
+										fields: ["name", "description"],
+										fuzziness: "AUTO",
+										boost: this.b("fuzzy_reduction_boost", FUZZY_REDUCTION_BOOST),
+									},
+								},
+							]
+						: []),
 					{
 						// Strongly boost documents where the name starts with the query text.
 						// Capped — match_phrase_prefix expands the trailing token to up to 50


### PR DESCRIPTION
## What

Stops OpenSearch from returning `500 too_many_nested_clauses (max=1024)` on long-form queries. Multiple layers of bounds; worst case now sits at ~576 clauses (~56% of the 1024 limit) — over 2× safety margin.

1. **`MAX_QUERY_LENGTH` 500 → 100 chars** (router). Realistic name/title-style queries fit; long pasted text doesn't reach OpenSearch.
2. **Token splitter** changed from `/\s+/` to **`/[\s\p{P}\p{S}]+/u`**. Whitespace-only split was leaky — a user passing `term1,term2,...,term50` without spaces looked like 1 token to the cap but exploded to ~50 tokens inside OpenSearch's analyzer. The new regex covers the basics: whitespace, all Unicode punctuation, all Unicode symbols (commas, hyphens, dots, slashes, brackets, math/currency, etc.).
3. **`MAX_TEXT_TOKENS = 20`** retained — caps `bool_prefix` and `match_phrase_prefix` clauses; exact-match clauses still see the full query so a full-name match isn't lost.
4. **`FUZZY_MAX_TOKENS = 3`** (new). Fuzzy `multi_match` AUTO is the highest-fan-out clause (per-token edit-distance × 2 fields). Skip fuzzy entirely when token count > 3; multi-word queries have enough redundancy that the exact + prefix clauses cover typos sufficiently. Single-word and 2-3-word queries (the typical typo case) keep fuzzy.
5. **`FUZZY_MAX_EXPANSIONS = 25`** (new). Pinned via `max_expansions: 25` on the fuzzy `multi_match`; OpenSearch's default is 50. Halves the per-term fan-out for fuzzy with negligible recall impact (1-2-edit typos still match).

## Reported issue

Sentry caught a 500 in prod for a 306-char query (press-release blurb pasted into the search box). Verified live:

```
HTTP 500  size=175b  time=1.36s
{"error":"Search failed","message":"search_phase_execution_exception:
 [too_many_nested_clauses] Reason: Query contains too many nested clauses;
 maxClauseCount is set to 1024"}
```

## Worst-case clause math

### Adversarial 100-char punctuation-heavy input (~30-50 OS tokens, fuzzy off at >3 tokens)

| Sub-query | Clauses |
|---|---|
| `term: name_raw` × 3 | 3 |
| `match: name` (full query, ~50 tokens) | ~50 |
| `bool_prefix multi_match` × 6 fields (capped at 20 tokens) | 6×19 + 300 = ~414 |
| Fuzzy `multi_match` (skipped) | 0 |
| `match_phrase_prefix: name` (capped at 20 tokens) | ~70 |
| `match_phrase_prefix: description` (capped at 20 tokens) | ~70 |
| **Total** | **~607** |

### Worst case at exactly the fuzzy boundary (3 tokens, fuzzy enabled)

| Sub-query | Clauses |
|---|---|
| `term: name_raw` × 3 | 3 |
| `match: name` | 3 |
| `bool_prefix multi_match` × 6 fields | 6×2 + 300 = ~312 |
| Fuzzy `multi_match` (3 tokens × 2 fields × 25 max_expansions) | up to 150 |
| `match_phrase_prefix: name` | ~53 |
| `match_phrase_prefix: description` | ~53 |
| **Total** | **~574** |

Both well under 1024 with comfortable margin.

## Tests

- **143/143 unit tests pass** (5 new in `opensearch.test.ts`, 1 new in `index.test.ts`).
- New cases:
  - 30-token query → bool_prefix + phrase_prefix capped to 20; exact-match clauses see all 30; fuzzy dropped
  - 3-token query → fuzzy included with `max_expansions: 25` (boundary acceptance + asserts the cap)
  - 4-token query → fuzzy dropped (boundary rejection)
  - Punctuation-bypass: `alpha,beta-gamma.delta;epsilon!zeta` correctly counts 6 tokens, fuzzy dropped (whitespace-only splitter would have wrongly counted 1)
  - Accented Latin: `café` stays as one token (not over-split)
  - 100-char query → 200 OK at boundary; 101-char → 400

## Test plan

- [x] Unit tests pass locally
- [ ] Reproduce the original 306-char Sentry query against staging → expect 400 (router rejects), no 500
- [ ] Reproduce a 99-char punctuation-heavy adversarial input → expect 200 with bounded clause count, no 500
- [ ] CI green