### PR TITLE
fix(scoring): filter entities to only those with existing values

### DIFF
--- a/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
+++ b/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
@@ -91,8 +91,9 @@ class ScoringDataProvider:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT id, created_at
-                FROM entities
+                SELECT e.id, e.created_at
+                FROM entities e
+                WHERE EXISTS (SELECT 1 FROM "values" v WHERE v.entity_id = e.id)
                 """
             )
             rows = cur.fetchall()


### PR DESCRIPTION
## Summary

- Filter `_fetch_entities` with `WHERE EXISTS (SELECT 1 FROM "values" v WHERE v.entity_id = e.id)` — drops entities with no perspectives at the SQL layer.
- Collapses the input set from ~8M entities → ≤520k, fixing the OOM crash during data-load (cronjob currently in `CrashLoopBackoff`, scores not updating in prod).