### PR TITLE
feat(hermes-ipfs-cache): log cursor on every persist for recovery

### DIFF
--- a/hermes-ipfs-cache/README.md
+++ b/hermes-ipfs-cache/README.md
@@ -151,6 +151,28 @@ The cache tracks pending fetches per block and only persists the cursor when:
 
 This ensures that on restart, processing resumes from the oldest incomplete block, even if later blocks completed first. Duplicate fetches are handled efficiently by the upsert - already-cached content is simply skipped.
 
+### Recovery
+
+If the `meta.cursor` row for `id = 'hermes_ipfs_cache'` is corrupted or lost, the most recent safe cursor can be reconstructed from logs without reprocessing history from a much earlier checkpoint. Every persist emits an `info!` line with `event = "ipfs_cache.batch_end"` carrying `indexer_id`, `block_number`, and `cursor` — and that line fires *before* the database write, so it reaches stdout / Sentry / Axiom even when the persist itself fails (the failure surfaces separately as `event = "ipfs_cache.persist_cursor_failed"` with the same fields).
+
+To recover:
+
+1. In Axiom (or Sentry / your log store), filter for `event = "ipfs_cache.batch_end"` and `indexer_id = "hermes_ipfs_cache"`, sorted by time descending. Take the most recent entry.
+2. Note its `cursor` and `block_number`.
+3. Restore the `meta` row, e.g.:
+
+   ```sql
+   INSERT INTO meta (id, cursor, block_number)
+   VALUES ('hermes_ipfs_cache', '<cursor from log>', '<block_number from log>')
+   ON CONFLICT (id) DO UPDATE
+     SET cursor = EXCLUDED.cursor,
+         block_number = EXCLUDED.block_number;
+   ```
+
+4. Restart the service. It will log `Resuming from persisted cursor` and continue from there.
+
+The recovered cursor lags real progress by however many in-flight blocks were behind the minimum at crash time — restart will reprocess those blocks, but the `ON CONFLICT DO NOTHING` upsert on `ipfs_cache` makes the replay cheap.
+
 ## Cache Miss Behavior
 
 Downstream consumers (like `hermes-pipeline`) should retry on cache miss. Since this service runs ahead, misses indicate the cache is catching up. The retry should eventually succeed once the content is fetched and stored.

--- a/hermes-ipfs-cache/src/lib.rs
+++ b/hermes-ipfs-cache/src/lib.rs
@@ -308,7 +308,9 @@ impl Sink for IpfsCacheSink {
                         );
                         info!(
                             event = "ipfs_cache.batch_end",
+                            indexer_id = INDEXER_ID,
                             block_number = persist_block,
+                            cursor = %persist_cursor,
                             edit_count = total,
                             duration_ms = duration.as_millis(),
                             "Batch end"
@@ -319,7 +321,14 @@ impl Sink for IpfsCacheSink {
                             .persist_cursor(INDEXER_ID, &persist_cursor, persist_block)
                             .await
                         {
-                            error!(error = %e, "Failed to persist cursor");
+                            error!(
+                                event = "ipfs_cache.persist_cursor_failed",
+                                indexer_id = INDEXER_ID,
+                                block_number = persist_block,
+                                cursor = %persist_cursor,
+                                error = %e,
+                                "Failed to persist cursor"
+                            );
                         } else {
                             // Cursor durably persisted — update lag gauges.
                             hermes_instrumentation::metrics::set_latest_processed_block(


### PR DESCRIPTION
## Summary

Logs the substreams cursor on every persist in `hermes-ipfs-cache` so an operator can recover a corrupted `meta.cursor` row from log history (Axiom / Sentry / stdout) instead of having to reprocess history from a much earlier checkpoint.

Closes [GEO-551](https://linear.app/defi-wonderland/issue/GEO-551/log-ipfs-cache-cursor-for-recovery).

## Why this is safe

The `PendingFetches` strategy already only emits a cursor from `complete_one()` when a block has fully completed *and* is the minimum pending block — every cursor that reaches the persist path is by definition a safe restart point. These new log fields just surface those values.

## Changes

- **`ipfs_cache.batch_end` log** (`hermes-ipfs-cache/src/lib.rs`) — adds `indexer_id` and `cursor` fields. The line fires *before* `cache.persist_cursor()`, so the cursor reaches stdout / Sentry / Axiom even when the DB write itself fails.
- **persist-failure error log** — replaces the bare `"Failed to persist cursor"` with a structured `event = "ipfs_cache.persist_cursor_failed"` carrying `indexer_id`, `block_number`, `cursor`, and the underlying error, so failures are filterable and actionable.
- **`hermes-ipfs-cache/README.md`** — new "Recovery" subsection under "Cursor Persistence" describing the log-grep → SQL-restore → restart procedure.

## Out of scope

- Logging cursor on the every-100-blocks `Checkpoint` log — that fires on the receive path, where the current block's cursor isn't a safe restart point yet.
- A separate `ipfs_cache.cursor_persisted` event — would duplicate `batch_end`, which already fires exactly once per persist.
- A `cursor_history` DB table — Axiom retains 100% of traces, so DB-side history would be redundant.
- Test additions — these are pure log-field additions; the existing 13 tests cover the underlying `PendingFetches` correctness and are unaffected.

## Test plan

- [x] `cargo build -p hermes-ipfs-cache`
- [x] `cargo test -p hermes-ipfs-cache --lib` — 13/13 passing
- [ ] In staging, verify an `ipfs_cache.batch_end` log line carries `indexer_id`, `block_number`, and `cursor`
- [ ] Walk the README recovery procedure end-to-end: corrupt the `meta.cursor` row, restore from a recent log line, restart, confirm processing resumes correctly