### PR TITLE
feat(monitoring): chain lag metrics

### DIFF
--- a/chain-tip-exporter/src/main.rs
+++ b/chain-tip-exporter/src/main.rs
@@ -10,7 +10,7 @@
 //!
 //! - `RPC_URL` — EVM JSON-RPC endpoint (required)
 //! - `POLL_INTERVAL_SECS` — polling interval (default: 30)
-//! - `LATEST_BLOCK_BEHIND_THRESHOLD_SECS` — max latest-block age in seconds before emitting an error
+//! - `LATEST_BLOCK_BEHIND_THRESHOLD_SECS` — max latest-block age in seconds before emitting a warn
 //! - `METRICS_PORT` — port for the Prometheus listener (default: 9464)
 //! - `SENTRY_DSN`, `SENTRY_*`, `AXIOM_*` — telemetry (optional)
 
@@ -18,7 +18,7 @@ use std::env;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
-use hermes_instrumentation::{Backend, Config, error, info, warn};
+use hermes_instrumentation::{Backend, Config, info, warn};
 use serde::Deserialize;
 
 fn build_telemetry_config() -> Config {
@@ -133,7 +133,7 @@ fn alert_if_latest_block_is_stale(
     let block_age = latest_block_age_secs(now, block_timestamp);
     if block_age > threshold.as_secs() {
         let block_age_minutes = block_age / 60;
-        error!(
+        warn!(
             block_number,
             block_timestamp,
             latest_block_age_secs = block_age,

--- a/hermes-instrumentation/src/metrics.rs
+++ b/hermes-instrumentation/src/metrics.rs
@@ -68,9 +68,12 @@ pub fn install(service: &str, port: Option<u16>) -> Result<(), Error> {
 
 /// Update the `hermes_latest_processed_block` gauge.
 ///
-/// Call this each time a block has been fully processed end-to-end (e.g. block
-/// summary emitted to Kafka, or cursor durably persisted). The chain-tip
-/// distance against `chain_tip_block_number` is what drives the lag alerts.
+/// Call this each time a block has been fully processed end-to-end — block
+/// summary emitted to Kafka, cursor durably persisted, or the block was
+/// observed with no work to do (e.g. an empty IPFS-cache block). The
+/// chain-tip distance against `chain_tip_block_number` is what drives the
+/// lag alerts, so the gauge must advance on every block we successfully
+/// observed, otherwise quiet stretches will look like indexer lag.
 pub fn set_latest_processed_block(block: u64) {
     metrics::gauge!(LATEST_PROCESSED_BLOCK).set(block as f64);
 }

--- a/hermes-ipfs-cache/src/lib.rs
+++ b/hermes-ipfs-cache/src/lib.rs
@@ -206,8 +206,14 @@ impl Sink for IpfsCacheSink {
             info!(block = block_number, "Checkpoint");
         }
 
-        // Skip empty blocks entirely - no span created
+        // Skip empty blocks entirely - no span created.
+        // Still advance the lag gauges so HermesBehindChainTip doesn't false-fire
+        // during stretches of blocks that happen to contain no IPFS URIs.
         if edit_count == 0 {
+            hermes_instrumentation::metrics::set_latest_processed_block(block_number);
+            hermes_instrumentation::metrics::set_latest_processed_block_timestamp(
+                block_timestamp_seconds,
+            );
             return Ok(());
         }
 

--- a/monitoring/k8s/hermes-lag-alerts.yaml
+++ b/monitoring/k8s/hermes-lag-alerts.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hermes-lag-observability
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: hermes.lag
+      rules:
+        - alert: HermesBehindChainTip
+          expr: |
+            (
+              label_replace(
+                max by (gaia_namespace) (chain_tip_block_number),
+                "namespace", "$1", "gaia_namespace", "(.*)"
+              )
+              -
+              on(namespace) group_right
+              max by (namespace, service) (hermes_latest_processed_block)
+            ) > 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: hermes {{ $labels.service }} is behind chain tip
+            description: hermes {{ $labels.service }} in {{ $labels.namespace }} is {{ $value }} blocks behind chain tip for over 5 minutes.


### PR DESCRIPTION
## Summary

- **Add `HermesBehindChainTip` PrometheusRule** (`monitoring/k8s/hermes-lag-alerts.yaml`) — fires when either hermes-pipeline or hermes-ipfs-cache is more than 5 blocks behind the chain tip for 5m. `label_replace` aligns chain-tip-exporter's `gaia_namespace` target label with hermes services' `namespace`; `group_right` preserves the `service` label so the firing alert names the lagging side.
- **Advance gauges on empty hermes-ipfs-cache blocks** (`hermes-ipfs-cache/src/lib.rs`) — the early-return path for blocks with zero IPFS URIs no longer freezes \`hermes_latest_processed_block{,_timestamp}\`. Without this, the new alert would false-fire during quiet stretches. Cursor is intentionally not persisted on empty blocks (avoids one DB write per chain block; restart replays empty blocks as no-ops).
- **Demote chain-tip-exporter stale-RPC log from `error!` → `warn!`** (`chain-tip-exporter/src/main.rs`) — chains don't emit blocks on a strict period, so transient gaps shouldn't auto-create Sentry issues. The new PrometheusRule is the proper signal.
- Doc comment on `set_latest_processed_block` softened to reflect that the gauge advances on every observed block (Kafka emit, cursor persist, *or* no-work observation).

## Test plan

- [x] `cargo test -p hermes-ipfs-cache -p chain-tip-exporter -p hermes-instrumentation` — 20 tests pass
- [x] `cargo check -p hermes-ipfs-cache -p chain-tip-exporter -p hermes-instrumentation -p hermes-pipeline --all-targets` — clean
- [x] `promtool check rules` (run via `prom/prometheus` Docker image on the extracted `spec.groups`) — `SUCCESS: 1 rules found`
- [x] Post-deploy: confirm `HermesBehindChainTip` is not firing in either env, and the Sentry "RPC latest block is behind by N minutes" issue stops auto-creating new occurrences.