### PR TITLE
feat(monitoring): add Kafka consumer lag exporter

### DIFF
--- a/monitoring/k8s/kafka-consumer-lag-alerts.yaml
+++ b/monitoring/k8s/kafka-consumer-lag-alerts.yaml
@@ -1,0 +1,81 @@
+# Alert rules for Kafka consumer-group lag.
+#
+# Sourced from kafka_exporter (see monitoring/k8s/kafka-exporter.yaml). Lag
+# observability is centralised in the exporter so these rules fire even when
+# the consumer pod itself is dead — exactly when in-process gauges go silent.
+#
+# Thresholds: aggressive defaults — tune after observing staging for a week.
+#
+# Apply:
+#   kubectl apply -f monitoring/k8s/kafka-consumer-lag-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kafka-consumer-lag
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: kafka.consumer.lag
+      rules:
+        - alert: KafkaConsumerLagHigh
+          expr: kafka_consumergroup_lag > 1000
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: Kafka consumer group {{ $labels.consumergroup }} is lagging
+            description: |
+              Consumer group {{ $labels.consumergroup }} has lag {{ $value }}
+              messages on topic {{ $labels.topic }} partition {{ $labels.partition }}
+              for over 2 minutes.
+
+        - alert: KafkaConsumerLagCritical
+          expr: kafka_consumergroup_lag > 10000
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Kafka consumer group {{ $labels.consumergroup }} is severely lagging
+            description: |
+              Consumer group {{ $labels.consumergroup }} has lag {{ $value }}
+              messages on topic {{ $labels.topic }} partition {{ $labels.partition }}
+              for over 5 minutes — consumer is falling behind faster than it can
+              catch up.
+
+        # Stuck = committed offset has not advanced while there are unprocessed
+        # messages. Catches a hung consumer that's still holding its group
+        # membership but not making progress (deadlock, long-running query,
+        # external dependency outage).
+        - alert: KafkaConsumerStuck
+          expr: |
+            (
+              increase(kafka_consumergroup_current_offset[5m]) == 0
+              and
+              kafka_consumergroup_lag > 0
+            )
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Kafka consumer group {{ $labels.consumergroup }} is stuck
+            description: |
+              Consumer group {{ $labels.consumergroup }} has not advanced its
+              committed offset for topic {{ $labels.topic }} partition
+              {{ $labels.partition }} in 5 minutes, but {{ $value }} messages
+              are unprocessed.
+
+        # Group is registered with the broker but has no active members. Means
+        # all consumers crashed or were scaled to 0 — distinct from "stuck"
+        # because there's no heartbeat at all.
+        - alert: KafkaConsumerGroupEmpty
+          expr: kafka_consumergroup_members == 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: Kafka consumer group {{ $labels.consumergroup }} has no members
+            description: |
+              Consumer group {{ $labels.consumergroup }} has zero active members
+              for over 2 minutes. Consumer pods are likely down or scaled to 0.

--- a/monitoring/k8s/kafka-consumer-lag-alerts.yaml
+++ b/monitoring/k8s/kafka-consumer-lag-alerts.yaml
@@ -20,7 +20,7 @@ spec:
     - name: kafka.consumer.lag
       rules:
         - alert: KafkaConsumerLagHigh
-          expr: kafka_consumergroup_lag > 1000
+          expr: max by (consumergroup, topic) (kafka_consumergroup_lag) > 1000
           for: 2m
           labels:
             severity: warning
@@ -28,11 +28,10 @@ spec:
             summary: Kafka consumer group {{ $labels.consumergroup }} is lagging
             description: |
               Consumer group {{ $labels.consumergroup }} has lag {{ $value }}
-              messages on topic {{ $labels.topic }} partition {{ $labels.partition }}
-              for over 2 minutes.
+              messages on topic {{ $labels.topic }} for over 2 minutes.
 
         - alert: KafkaConsumerLagCritical
-          expr: kafka_consumergroup_lag > 10000
+          expr: max by (consumergroup, topic) (kafka_consumergroup_lag) > 10000
           for: 5m
           labels:
             severity: critical
@@ -40,9 +39,8 @@ spec:
             summary: Kafka consumer group {{ $labels.consumergroup }} is severely lagging
             description: |
               Consumer group {{ $labels.consumergroup }} has lag {{ $value }}
-              messages on topic {{ $labels.topic }} partition {{ $labels.partition }}
-              for over 5 minutes — consumer is falling behind faster than it can
-              catch up.
+              messages on topic {{ $labels.topic }} for over 5 minutes —
+              consumer is falling behind faster than it can catch up.
 
         # Stuck = committed offset has not advanced while there are unprocessed
         # messages. Catches a hung consumer that's still holding its group

--- a/monitoring/k8s/kafka-consumer-lag-alerts.yaml
+++ b/monitoring/k8s/kafka-consumer-lag-alerts.yaml
@@ -51,9 +51,9 @@ spec:
         - alert: KafkaConsumerStuck
           expr: |
             (
-              increase(kafka_consumergroup_current_offset[5m]) == 0
-              and
               kafka_consumergroup_lag > 0
+              and on(consumergroup, topic, partition)
+              (changes(kafka_consumergroup_current_offset[1m]) == 0)
             )
           for: 5m
           labels:

--- a/monitoring/k8s/kafka-consumer-lag-dashboard.yaml
+++ b/monitoring/k8s/kafka-consumer-lag-dashboard.yaml
@@ -1,0 +1,415 @@
+apiVersion: v1
+data:
+  kafka-consumer-lag.json: |-
+    {
+      "id": null,
+      "uid": "kafka-consumer-lag",
+      "title": "Kafka Consumer Lag",
+      "tags": [
+        "kafka",
+        "lag",
+        "observability"
+      ],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "datasource",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {
+              "selected": true,
+              "text": "Prometheus",
+              "value": "Prometheus"
+            }
+          },
+          {
+            "name": "consumergroup",
+            "label": "Consumer Group",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "$datasource" },
+            "query": "label_values(kafka_consumergroup_lag, consumergroup)",
+            "includeAll": true,
+            "multi": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" }
+          },
+          {
+            "name": "topic",
+            "label": "Topic",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "$datasource" },
+            "query": "label_values(kafka_consumergroup_lag{consumergroup=~\"$consumergroup\"}, topic)",
+            "includeAll": true,
+            "multi": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "title": "Current State",
+          "id": 100,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+          "collapsed": false,
+          "panels": []
+        },
+        {
+          "type": "stat",
+          "title": "Active Consumer Groups",
+          "id": 1,
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "count(count by (consumergroup) (kafka_consumergroup_lag))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "blue", "value": null }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "stat",
+          "title": "Max Lag (single partition)",
+          "id": 2,
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "max(kafka_consumergroup_lag{consumergroup=~\"$consumergroup\",topic=~\"$topic\"})",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1000 },
+                  { "color": "red", "value": 10000 }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "stat",
+          "title": "Total Lag (all partitions)",
+          "id": 3,
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "sum(kafka_consumergroup_lag{consumergroup=~\"$consumergroup\",topic=~\"$topic\"})",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 5000 },
+                  { "color": "red", "value": 50000 }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "stat",
+          "title": "Empty Groups (no members)",
+          "id": 4,
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "count(kafka_consumergroup_members == 0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              },
+              "noValue": "0"
+            }
+          }
+        },
+        {
+          "type": "row",
+          "title": "Lag",
+          "id": 101,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+          "collapsed": false,
+          "panels": []
+        },
+        {
+          "type": "timeseries",
+          "title": "Lag by Group + Topic (sum across partitions)",
+          "id": 5,
+          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 6 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "sum by (consumergroup, topic) (kafka_consumergroup_lag{consumergroup=~\"$consumergroup\",topic=~\"$topic\"})",
+              "legendFormat": "{{consumergroup}} / {{topic}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "spanNulls": true
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max", "lastNotNull"] },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "type": "row",
+          "title": "Throughput",
+          "id": 102,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+          "collapsed": false,
+          "panels": []
+        },
+        {
+          "type": "timeseries",
+          "title": "Consumption Rate (committed offset / sec)",
+          "id": 6,
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "sum by (consumergroup, topic) (rate(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}[5m]))",
+              "legendFormat": "{{consumergroup}} / {{topic}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "decimals": 1,
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 0,
+                "spanNulls": true
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"] },
+            "tooltip": { "mode": "multi" }
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "Production Rate (high watermark / sec)",
+          "id": 7,
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "sum by (topic) (rate(kafka_topic_partition_current_offset{topic=~\"$topic\"}[5m]))",
+              "legendFormat": "{{topic}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "decimals": 1,
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 0,
+                "spanNulls": true
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"] },
+            "tooltip": { "mode": "multi" }
+          }
+        },
+        {
+          "type": "row",
+          "title": "Detail",
+          "id": 103,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+          "collapsed": false,
+          "panels": []
+        },
+        {
+          "type": "table",
+          "title": "Top Lagging Partitions",
+          "id": 8,
+          "gridPos": { "h": 9, "w": 12, "x": 0, "y": 25 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "topk(20, kafka_consumergroup_lag{consumergroup=~\"$consumergroup\",topic=~\"$topic\"} > 0)",
+              "instant": true,
+              "format": "table",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true, "__name__": true, "job": true, "instance": true, "endpoint": true, "service": true, "container": true, "namespace": true, "pod": true },
+                "renameByName": { "Value": "lag", "consumergroup": "group", "topic": "topic", "partition": "partition" },
+                "indexByName": { "consumergroup": 0, "topic": 1, "partition": 2, "Value": 3 }
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0
+            }
+          },
+          "options": {
+            "showHeader": true,
+            "sortBy": [{ "displayName": "lag", "desc": true }]
+          }
+        },
+        {
+          "type": "table",
+          "title": "Consumer Group Members",
+          "id": 9,
+          "gridPos": { "h": 9, "w": 12, "x": 12, "y": 25 },
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "kafka_consumergroup_members{consumergroup=~\"$consumergroup\"}",
+              "instant": true,
+              "format": "table",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true, "__name__": true, "job": true, "instance": true, "endpoint": true, "service": true, "container": true, "namespace": true, "pod": true },
+                "renameByName": { "Value": "members", "consumergroup": "group" },
+                "indexByName": { "consumergroup": 0, "Value": 1 }
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "green", "value": 1 }
+                ]
+              },
+              "custom": {
+                "cellOptions": { "type": "color-text" }
+              }
+            }
+          },
+          "options": {
+            "showHeader": true,
+            "sortBy": [{ "displayName": "members", "desc": false }]
+          }
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: kube-prometheus-stack-grafana
+    grafana_dashboard: "1"
+    release: kube-prometheus-stack
+  name: kafka-consumer-lag-dashboard
+  namespace: monitoring

--- a/monitoring/k8s/kafka-exporter.yaml
+++ b/monitoring/k8s/kafka-exporter.yaml
@@ -1,0 +1,193 @@
+# Prometheus exporter for Kafka consumer-group lag.
+#
+# Deploys danielqsj/kafka_exporter as an admin client against the managed
+# Kafka cluster. It auto-discovers all consumer groups and exposes:
+#
+#   kafka_consumergroup_current_offset{consumergroup,topic,partition}
+#   kafka_consumergroup_lag{consumergroup,topic,partition}
+#   kafka_topic_partition_current_offset{topic,partition}
+#   kafka_topic_partition_oldest_offset{topic,partition}
+#   kafka_consumergroup_members{consumergroup}
+#
+# Replaces the per-service in-process LagMonitor approach: lag visibility no
+# longer depends on consumer pods being healthy, which is exactly when the
+# signal matters most.
+#
+# ─── Prerequisite: credentials Secret (NOT committed) ────────────────────────
+#
+# Copy the Kafka credentials already in <service>-secrets into a Secret in the
+# monitoring namespace that this Deployment reads from. The kg-indexer secret
+# has all four keys we need:
+#
+#   # Production
+#   kubectl create secret generic kafka-exporter-creds -n monitoring \
+#     --from-literal=KAFKA_BROKER="$(kubectl get secret -n knowledge kg-indexer-secrets \
+#         -o jsonpath='{.data.KAFKA_BROKER}' | base64 -d)" \
+#     --from-literal=KAFKA_USERNAME="$(kubectl get secret -n knowledge kg-indexer-secrets \
+#         -o jsonpath='{.data.KAFKA_USERNAME}' | base64 -d)" \
+#     --from-literal=KAFKA_PASSWORD="$(kubectl get secret -n knowledge kg-indexer-secrets \
+#         -o jsonpath='{.data.KAFKA_PASSWORD}' | base64 -d)" \
+#     --from-literal=KAFKA_SSL_CA_PEM="$(kubectl get secret -n knowledge kg-indexer-secrets \
+#         -o jsonpath='{.data.KAFKA_SSL_CA_PEM}' | base64 -d)"
+#
+#   # Staging — substitute `knowledge-staging` for `knowledge`.
+#
+# ─── Apply ───────────────────────────────────────────────────────────────────
+#
+#   kubectl apply -f monitoring/k8s/kafka-exporter.yaml
+#
+# Verify metrics are flowing:
+#   kubectl -n monitoring port-forward svc/kafka-exporter 9308:9308 &
+#   curl -s localhost:9308/metrics | grep -E '^kafka_consumergroup_(lag|current_offset)'
+#
+# In Prometheus UI (port-forward 9090):
+#   kafka_consumergroup_lag  should return one series per (group, topic, partition).
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: kafka-exporter
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: kafka-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kafka-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kafka-exporter
+    spec:
+      serviceAccountName: kafka-exporter
+      restartPolicy: Always
+      containers:
+        - name: exporter
+          image: danielqsj/kafka-exporter:v1.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            # k8s `$(VAR)` syntax substitutes env vars at container runtime,
+            # so the secret values never appear in the committed YAML.
+            - --kafka.server=$(KAFKA_BROKER)
+            - --sasl.enabled
+            - --sasl.username=$(KAFKA_USERNAME)
+            - --sasl.password=$(KAFKA_PASSWORD)
+            - --sasl.mechanism=plain
+            - --tls.enabled
+            # CA PEM is projected from the Secret as a file because the flag
+            # takes a path, not a PEM string.
+            - --tls.ca-file=/etc/kafka-tls/ca.pem
+            - --web.listen-address=:9308
+            - --log.level=info
+          env:
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-exporter-creds
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-exporter-creds
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-exporter-creds
+                  key: KAFKA_PASSWORD
+          ports:
+            - name: http
+              containerPort: 9308
+              protocol: TCP
+          volumeMounts:
+            - name: kafka-tls
+              mountPath: /etc/kafka-tls
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: kafka-tls
+          secret:
+            secretName: kafka-exporter-creds
+            items:
+              - key: KAFKA_SSL_CA_PEM
+                path: ca.pem
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: kafka-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9308
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: kafka-exporter
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kafka-exporter
+  namespace: monitoring
+  labels:
+    # The kube-prometheus-stack Prometheus CR selects ServiceMonitors with
+    # this label, matching the pattern used by api-metrics-servicemonitor.yaml,
+    # opensearch-exporter.yaml, and ingress-nginx-metrics.yaml.
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kafka-exporter
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s


### PR DESCRIPTION
## Summary

Adds [danielqsj/kafka_exporter](https://github.com/danielqsj/kafka_exporter) as a centralised Prometheus exporter for Kafka consumer-group offsets and lag, plus a Grafana dashboard and alert rules. Resolves [GEO-616](https://linear.app/defi-wonderland/issue/GEO-616/kafka-consumers-lagging-metrics).

## Why centralised, not per-service

An in-process gauge goes stale exactly when the consumer is dead — the moment you most need the signal. The exporter connects to Kafka as an admin client, auto-discovers all consumer groups, and reports lag even when consumer pods are crashing. Zero application code changes; no new `/metrics` endpoints to bootstrap across the 5 consumer services.

## What's in this PR

- `monitoring/k8s/kafka-exporter.yaml` — Deployment + Service + ServiceMonitor (`danielqsj/kafka-exporter:v1.8.0`, port 9308). Reads broker URL + SASL creds + CA PEM from a `kafka-exporter-creds` Secret in the `monitoring` namespace (recipe in the file's header comment).
- `monitoring/k8s/kafka-consumer-lag-alerts.yaml` — 4 rules: `KafkaConsumerLagHigh` (warn, lag > 1k for 2m), `KafkaConsumerLagCritical` (crit, lag > 10k for 5m), `KafkaConsumerStuck` (committed offset frozen with non-zero lag for 5m), `KafkaConsumerGroupEmpty` (zero members for 2m).
- `monitoring/k8s/kafka-consumer-lag-dashboard.yaml` — Grafana ConfigMap. Stats row (groups, max lag, total lag, empty groups), lag timeseries by group/topic, consumption + production rates, top-laggers and members tables. Templated by consumer group + topic.

Metrics exposed by the exporter:

- \`kafka_consumergroup_current_offset{consumergroup,topic,partition}\` — committed offset (the GEO-616 ask)
- \`kafka_consumergroup_lag{consumergroup,topic,partition}\` — drift
- \`kafka_topic_partition_current_offset{topic,partition}\` — high watermark
- \`kafka_consumergroup_members{consumergroup}\` — active member count

## Out of scope

- \`notification-service/notification-indexer/src/consumer_lag.rs\` (`LagMonitor`) is left in place so both signals run in parallel until the centralised exporter is validated in production. Removal in a follow-up.
- Wiki updates land separately.

## Test plan

- [ ] Create the \`kafka-exporter-creds\` Secret in \`monitoring\` (staging first) using the recipe in \`kafka-exporter.yaml\`'s header.
- [ ] \`kubectl apply -f monitoring/k8s/kafka-exporter.yaml\` and confirm the pod becomes Ready.
- [ ] \`kubectl -n monitoring port-forward svc/kafka-exporter 9308:9308\` and \`curl -s localhost:9308/metrics | grep ^kafka_consumergroup_lag\` returns one series per (group, topic, partition).
- [ ] In Prometheus UI, \`kafka_consumergroup_lag\` returns expected groups (\`kg-indexer\`, \`search-indexer\`, \`vote-indexer\`, \`topology-indexer\`, \`notification-indexer\`).
- [ ] Apply the dashboard, open Grafana, confirm the "Kafka Consumer Lag" board renders with data.
- [ ] Apply alerts and confirm rules show up in Alertmanager UI (no firing alerts under normal load).
- [ ] Repeat in production after staging soak.