### PR TITLE
fix(monitoring): kafka dashboard variable wiring + count-based throughput

### DIFF
--- a/monitoring/k8s/kafka-consumer-lag-dashboard.yaml
+++ b/monitoring/k8s/kafka-consumer-lag-dashboard.yaml
@@ -36,9 +36,12 @@ data:
             "type": "query",
             "datasource": { "type": "prometheus", "uid": "$datasource" },
             "query": "label_values(kafka_consumergroup_lag, consumergroup)",
+            "refresh": 2,
+            "sort": 1,
             "includeAll": true,
             "multi": true,
-            "current": { "selected": true, "text": "All", "value": "$__all" }
+            "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+            "options": []
           },
           {
             "name": "topic",
@@ -46,9 +49,12 @@ data:
             "type": "query",
             "datasource": { "type": "prometheus", "uid": "$datasource" },
             "query": "label_values(kafka_consumergroup_lag{consumergroup=~\"$consumergroup\"}, topic)",
+            "refresh": 2,
+            "sort": 1,
             "includeAll": true,
             "multi": true,
-            "current": { "selected": true, "text": "All", "value": "$__all" }
+            "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+            "options": []
           }
         ]
       },
@@ -253,63 +259,63 @@ data:
         },
         {
           "type": "timeseries",
-          "title": "Consumption Rate (committed offset / sec)",
+          "title": "Messages Consumed (rolling 1m window)",
           "id": 6,
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "$datasource" },
-              "expr": "sum by (consumergroup, topic) (rate(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}[5m]))",
+              "expr": "sum by (consumergroup, topic) (increase(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\"}[1m]))",
               "legendFormat": "{{consumergroup}} / {{topic}}",
               "refId": "A"
             }
           ],
           "fieldConfig": {
             "defaults": {
-              "unit": "ops",
-              "decimals": 1,
+              "unit": "short",
+              "decimals": 0,
               "custom": {
                 "drawStyle": "line",
                 "lineWidth": 1,
-                "fillOpacity": 0,
+                "fillOpacity": 10,
                 "spanNulls": true
               }
             }
           },
           "options": {
-            "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"] },
+            "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["sum", "max"] },
             "tooltip": { "mode": "multi" }
           }
         },
         {
           "type": "timeseries",
-          "title": "Production Rate (high watermark / sec)",
+          "title": "Messages Produced (rolling 1m window)",
           "id": 7,
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "$datasource" },
-              "expr": "sum by (topic) (rate(kafka_topic_partition_current_offset{topic=~\"$topic\"}[5m]))",
+              "expr": "sum by (topic) (increase(kafka_topic_partition_current_offset{topic=~\"$topic\"}[1m]))",
               "legendFormat": "{{topic}}",
               "refId": "A"
             }
           ],
           "fieldConfig": {
             "defaults": {
-              "unit": "ops",
-              "decimals": 1,
+              "unit": "short",
+              "decimals": 0,
               "custom": {
                 "drawStyle": "line",
                 "lineWidth": 1,
-                "fillOpacity": 0,
+                "fillOpacity": 10,
                 "spanNulls": true
               }
             }
           },
           "options": {
-            "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"] },
+            "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["sum", "max"] },
             "tooltip": { "mode": "multi" }
           }
         },


### PR DESCRIPTION
## Summary

Three follow-up fixes to the Kafka consumer lag dashboard added in #675 (GEO-616), found while validating the dashboard against live staging data.

## What's fixed

### 1. Consumer Group / Topic dropdowns were stuck on "All"

The template variables had no `refresh` field (defaults to `0` = never), so Grafana never executed the `label_values()` queries and the dropdowns stayed empty. Multi-select variables also need array form for `current.text` / `current.value` — scalar form caused Grafana to interpolate `$consumergroup` as the literal string `$__all`, making panel queries match nothing.

- Added `"refresh": 2` (re-run on dashboard load and time-range change).
- Switched `current.text` / `current.value` from scalar to array form (`["All"]` / `["$__all"]`).
- Added `"sort": 1` for alphabetical ordering (16 consumer groups in production).
- Added `"options": []` placeholder for compatibility with older Grafana versions.

### 2. Throughput panels reported "0.0 ops/s" for low-traffic consumers

`rate(...[5m])` on a slow consumer (a few messages per minute) produces sub-1 values like `0.003 ops/s`. With `decimals: 1`, the display rounded to `0.0` even though the underlying line was non-zero.

Switched both Throughput panels to count-based queries that read naturally for low-traffic groups:

| Field | Before | After |
|---|---|---|
| Query | `rate(...[5m])` | `increase(...[1m])` |
| Unit | `ops` (ops/sec) | `short` (raw integer) |
| Decimals | `1` | `0` |
| Title | "Consumption Rate (committed offset / sec)" | "Messages Consumed (rolling 1m window)" |
| Legend stats | mean, max | sum, max |

Each line point now reads as "messages committed in the last minute" — `7` instead of `0.003 ops/s`.

### 3. Subtle area shading on Throughput lines

Bumped `fillOpacity` from `0` to `10` on both Throughput panels so the lines have a faint gradient under them, matching the visual weight of the lag panel above.

## Trade-off note

The 1m `increase()` window contains only ~2 samples at the current 30s scrape interval, so a single jittered scrape will briefly drop the line to 0. Acceptable for a dashboard panel (no paging, just visual noise); if it flaps, bump to `[2m]`.

## Test plan

- [ ] `kubectl apply -f monitoring/k8s/kafka-consumer-lag-dashboard.yaml` against staging.
- [ ] Reload the dashboard — Consumer Group dropdown lists all 16 groups, Topic dropdown is filtered by the chosen group.
- [ ] Both Throughput panels render as integer counts (e.g. `7`, `23`) instead of `0.0 ops/s`.
- [ ] Pick a single group + topic from the dropdowns — panels narrow to that selection.
- [ ] Repeat against production after staging soak.