### PR TITLE
fix(monitoring): show full block numbers on Hermes Lag dashboard

### DIFF
--- a/monitoring/k8s/hermes-lag-dashboard.yaml
+++ b/monitoring/k8s/hermes-lag-dashboard.yaml
@@ -86,7 +86,7 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "short",
+              "unit": "none",
               "decimals": 0,
               "color": { "mode": "thresholds" },
               "thresholds": {
@@ -120,7 +120,7 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "short",
+              "unit": "none",
               "decimals": 0,
               "color": { "mode": "thresholds" },
               "thresholds": {
@@ -154,7 +154,7 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "short",
+              "unit": "none",
               "decimals": 0,
               "color": { "mode": "thresholds" },
               "thresholds": {
@@ -362,7 +362,7 @@ data:
           ],
           "fieldConfig": {
             "defaults": {
-              "unit": "short",
+              "unit": "none",
               "decimals": 0,
               "custom": {
                 "drawStyle": "line",


### PR DESCRIPTION
## Summary

Block-number panels on the Hermes Lag dashboard were rendering with Grafana's `short` unit, so values like `30,567,890` showed up abbreviated as `30.5M` / `130k` — too coarse to read against pipeline drift of ~10 blocks.

Switched `unit` from `short` to `none` on the four panels that show absolute block numbers: Chain Tip Block, Pipeline Block, Cache Block, and Latest Block Number Over Time. The lag panels (Pipeline Lag, Cache Lag, Lag in Blocks timeseries) keep `short` — small values aren't abbreviated anyway, and SI prefixes remain useful if lag ever spikes.

Closes [GEO-612](https://linear.app/defi-wonderland/issue/GEO-612/change-units-on-hermes-lag-dashboard).

## Test plan
- [x] `kubectl apply -f monitoring/k8s/hermes-lag-dashboard.yaml`
- [x] Confirm Chain Tip / Pipeline / Cache block tiles show full block numbers in Grafana
- [x] Confirm lag panels render unchanged