### PR TITLE
fix(hermes-pipeline): distinguish errored cache entries from cache misses

### DIFF
--- a/hermes-pipeline/src/cache/mod.rs
+++ b/hermes-pipeline/src/cache/mod.rs
@@ -60,6 +60,9 @@ pub struct CachedEdit {
     /// Raw GRC2/GRC2Z payload bytes, if available.
     /// These have been validated by hermes-ipfs-cache.
     /// Will be `None` if the entry is errored or has no data.
+    ///
+    /// **Always check `is_errored` first, or use `valid_payload()`** —
+    /// reading payload from an errored entry is meaningless.
     pub payload: Option<Vec<u8>>,
 
     /// Whether the cache entry is marked as errored.
@@ -104,6 +107,16 @@ impl CachedEdit {
     #[allow(dead_code)] // Used in tests and future use
     pub fn has_content(&self) -> bool {
         !self.is_errored && self.payload.is_some()
+    }
+
+    /// Returns the payload bytes only if the entry is valid.
+    /// Prefer this over reading `payload` directly — it can't forget the
+    /// `is_errored` check.
+    pub fn valid_payload(&self) -> Option<&[u8]> {
+        if self.is_errored {
+            return None;
+        }
+        self.payload.as_deref()
     }
 }
 

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -661,11 +661,15 @@ impl Pipeline {
             error!(
                 block_number = meta.block_number,
                 count = total_cache_misses,
-                "Cache misses (retries exhausted) — edits dropped"
+                "Edits dropped: IPFS payload not found in cache (indexer pipeline issue)"
             );
         }
         if total_errored_entries > 0 {
-            warn!(count = total_errored_entries, "Errored entries in cache");
+            error!(
+                block_number = meta.block_number,
+                count = total_errored_entries,
+                "Edits dropped: IPFS payload errored (invalid user content)"
+            );
         }
         if total_fetch_failures > 0 {
             warn!(count = total_fetch_failures, "Cache fetch failures");

--- a/hermes-pipeline/src/pipelines/edits.rs
+++ b/hermes-pipeline/src/pipelines/edits.rs
@@ -73,9 +73,7 @@ pub fn transform(
         // Look up from prefetched cache
         match prefetched.get(&ipfs_uri) {
             Some(cached_edit) => {
-                if cached_edit.is_errored {
-                    result.errored_entries += 1;
-                } else if let Some(payload) = &cached_edit.payload {
+                if let Some(payload) = cached_edit.valid_payload() {
                     match convert(action, payload, meta, index as u32) {
                         Ok(event) => {
                             if let Err(encoded_len) =
@@ -108,7 +106,10 @@ pub fn transform(
                 }
             }
             None => {
-                // Cache miss - this shouldn't happen if prefetch worked correctly
+                // URI absent from prefetched map: writer hasn't produced a
+                // row within the prefetch retry budget (genuine indexer-side
+                // miss). Errored entries are inserted into the map by
+                // prefetch_block, so they don't land here.
                 warn!(
                     ipfs_uri = %ipfs_uri,
                     "Edit not found in prefetched cache"
@@ -253,5 +254,37 @@ mod tests {
         assert_eq!(config.factor, 2);
         assert_eq!(config.max_delay, Duration::from_secs(5));
         assert_eq!(config.max_retries, 10);
+    }
+
+    /// Pins the contract between prefetch.rs and edits.rs: an errored entry
+    /// inserted into the prefetched map must be counted as `errored_entries`,
+    /// not `cache_misses`. Before the fix this branch was dead code — errored
+    /// entries leaked through to the `None` branch and inflated `cache_misses`.
+    #[test]
+    fn errored_prefetched_entry_counts_as_errored_not_cache_miss() {
+        let ipfs_uri = "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+        let action = Action {
+            from_id: vec![0x01; 16],
+            to_id: vec![0; 16],
+            action: actions::EDITS_PUBLISHED.to_vec(),
+            topic: vec![0; 32],
+            data: ipfs_uri.as_bytes().to_vec(),
+        };
+
+        let mut prefetched = HashMap::new();
+        prefetched.insert(
+            ipfs_uri.to_string(),
+            CachedEdit::errored(
+                "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG".to_string(),
+                vec![0x01; 16],
+            ),
+        );
+
+        let result = transform(&[action], &test_meta(), &prefetched).unwrap();
+
+        assert_eq!(result.errored_entries, 1);
+        assert_eq!(result.cache_misses, 0);
+        assert_eq!(result.oversized_events, 0);
+        assert!(result.events.is_empty());
     }
 }

--- a/hermes-pipeline/src/pipelines/prefetch.rs
+++ b/hermes-pipeline/src/pipelines/prefetch.rs
@@ -248,10 +248,7 @@ async fn fetch_with_retry(
                 // Entry exists but no payload — normalize to an errored entry
                 // so the invariant `is_errored == true ⇔ in_cache_as_errored`
                 // holds for downstream consumers.
-                FetchResult::Errored(CachedEdit::errored(
-                    cached_edit.cid,
-                    cached_edit.space_id,
-                ))
+                FetchResult::Errored(CachedEdit::errored(cached_edit.cid, cached_edit.space_id))
             }
         }
         Err(CacheError::NotFound(_)) => {
@@ -341,7 +338,10 @@ mod tests {
             "errored entries must be inserted into the prefetched map so edits.rs can \
              distinguish them from cache misses",
         );
-        assert!(entry.is_errored, "inserted entry must carry is_errored=true");
+        assert!(
+            entry.is_errored,
+            "inserted entry must carry is_errored=true"
+        );
         assert_eq!(result.errored_entries, 1);
         assert_eq!(result.cache_misses, 0);
         assert_eq!(result.fetch_failures, 0);

--- a/hermes-pipeline/src/pipelines/prefetch.rs
+++ b/hermes-pipeline/src/pipelines/prefetch.rs
@@ -59,8 +59,10 @@ struct FetchRequest {
 /// Result of prefetching all IPFS URIs for a block.
 #[derive(Debug, Default)]
 pub struct PrefetchResult {
-    /// Map of IPFS URI to cached edit (successful lookups only).
-    /// Errored entries and cache misses are not included.
+    /// Map of IPFS URI to cached edit. Includes both successful lookups and
+    /// errored entries — consumers must check `cached_edit.is_errored` (or
+    /// use `valid_payload()`) before reading payload. Cache misses (NotFound
+    /// after retries) are not inserted.
     pub cache: HashMap<String, CachedEdit>,
     /// Number of cache misses (after all retries exhausted).
     pub cache_misses: u64,
@@ -170,8 +172,9 @@ pub async fn prefetch_block(
                 tracing::warn!(uri = %uri, "Prefetch cache miss after retries");
                 result.cache_misses += 1;
             }
-            FetchResult::Errored => {
+            FetchResult::Errored(cached_edit) => {
                 tracing::warn!(uri = %uri, "Prefetch found errored entry in cache");
+                result.cache.insert(uri, cached_edit);
                 result.errored_entries += 1;
             }
             FetchResult::FetchFailed => {
@@ -188,7 +191,7 @@ pub async fn prefetch_block(
 enum FetchResult {
     Success(CachedEdit),
     CacheMiss,
-    Errored,
+    Errored(CachedEdit),
     FetchFailed,
 }
 
@@ -238,12 +241,17 @@ async fn fetch_with_retry(
     match result {
         Ok(cached_edit) => {
             if cached_edit.is_errored {
-                FetchResult::Errored
+                FetchResult::Errored(cached_edit)
             } else if cached_edit.payload.is_some() {
                 FetchResult::Success(cached_edit)
             } else {
-                // Entry exists but no payload
-                FetchResult::Errored
+                // Entry exists but no payload — normalize to an errored entry
+                // so the invariant `is_errored == true ⇔ in_cache_as_errored`
+                // holds for downstream consumers.
+                FetchResult::Errored(CachedEdit::errored(
+                    cached_edit.cid,
+                    cached_edit.space_id,
+                ))
             }
         }
         Err(CacheError::NotFound(_)) => {
@@ -263,6 +271,7 @@ async fn fetch_with_retry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache::MockIpfsCache;
 
     #[test]
     fn test_collect_uris_deduplicates() {
@@ -289,5 +298,73 @@ mod tests {
             .collect();
 
         assert_eq!(deduped.len(), 2);
+    }
+
+    /// Fast retry config so cache-miss tests don't sit on the default 10-retry
+    /// exponential backoff.
+    fn fast_retry_config() -> RetryConfig {
+        RetryConfig {
+            initial_delay_ms: 1,
+            factor: 1,
+            max_delay: Duration::from_millis(1),
+            max_retries: 1,
+        }
+    }
+
+    fn edits_published_action(ipfs_uri: &str, space_id: u8) -> Action {
+        Action {
+            from_id: vec![space_id; 16],
+            to_id: vec![0; 16],
+            action: actions::EDITS_PUBLISHED.to_vec(),
+            topic: vec![0; 32],
+            data: format!("ipfs://{}", ipfs_uri).into_bytes(),
+        }
+    }
+
+    /// A valid 46-char CIDv0 hash that's not in the MockIpfsCache.
+    /// Reused across the two prefetch tests below for symmetry.
+    const ERRORED_HASH: &str = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+    const MISSING_HASH: &str = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdH";
+
+    #[tokio::test]
+    async fn errored_entries_are_inserted_into_cache_map() {
+        // prefetch_block calls cache.get(uri, ...) with the full "ipfs://..."
+        // URI as the lookup key, so the errored set must use the full URI too.
+        let key = format!("ipfs://{}", ERRORED_HASH);
+        let cache: Arc<dyn IpfsCache> =
+            Arc::new(MockIpfsCache::with_errored_hashes(vec![key.clone()]));
+        let actions = [edits_published_action(ERRORED_HASH, 0x01)];
+
+        let result = prefetch_block(&actions, &cache, &fast_retry_config()).await;
+
+        let entry = result.cache.get(&key).expect(
+            "errored entries must be inserted into the prefetched map so edits.rs can \
+             distinguish them from cache misses",
+        );
+        assert!(entry.is_errored, "inserted entry must carry is_errored=true");
+        assert_eq!(result.errored_entries, 1);
+        assert_eq!(result.cache_misses, 0);
+        assert_eq!(result.fetch_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn cache_misses_are_not_inserted_into_cache_map() {
+        // MockIpfsCache returns NotFound for hashes it doesn't know about, and
+        // we don't mark this hash as errored. So `fetch_with_retry` exhausts
+        // its 1 retry and lands on FetchResult::CacheMiss.
+        let cache: Arc<dyn IpfsCache> = Arc::new(MockIpfsCache::new());
+        let actions = [edits_published_action(MISSING_HASH, 0x01)];
+
+        let result = prefetch_block(&actions, &cache, &fast_retry_config()).await;
+
+        let key = format!("ipfs://{}", MISSING_HASH);
+        assert!(
+            !result.cache.contains_key(&key),
+            "cache misses must NOT be inserted into the prefetched map; \
+             edits.rs uses the `None` branch as the live indicator of a genuine miss"
+        );
+        assert_eq!(result.cache_misses, 1);
+        assert_eq!(result.errored_entries, 0);
+        assert_eq!(result.fetch_failures, 0);
     }
 }


### PR DESCRIPTION
Closes [GEO-591](https://linear.app/defi-wonderland/issue/GEO-591/edits-dropped-issues).

## Summary

- `prefetch_block` only inserted successful lookups into `PrefetchResult.cache`, so errored entries fell through to the `None` branch in `edits.rs` and got miscounted as `cache_misses`. Downstream, `main.rs` fired a paging `error!` log for both genuine indexer-side misses and user-authored bad payloads — that's what produced the Sentry alert in GEO-591.
- This PR reconciles `prefetch.rs` with the contract `edits.rs` already expected: errored entries are inserted into the prefetched map and counted separately from cache misses, and the Sentry rollup is split into two distinct fingerprints.

## Changes

- **`cache/mod.rs`** — add `CachedEdit::valid_payload()` accessor that bakes in the `is_errored` check; strengthen the `payload` doc comment so future consumers don't read it directly.
- **`prefetch.rs`** — `FetchResult::Errored(CachedEdit)` carries the entry through; `prefetch_block` inserts errored entries into `result.cache` alongside the `errored_entries` counter. Payload-absent entries are normalized to `CachedEdit::errored(...)` so the invariant `is_errored == true ⇔ in_cache_as_errored` holds. Update `PrefetchResult.cache` doc comment.
- **`edits.rs`** — switch payload read to `valid_payload()`; replace the stale `// Cache miss - this shouldn't happen if prefetch worked correctly` comment with the real meaning of the `None` branch (genuine indexer-side miss).
- **`main.rs`** — split the rollup into two distinct `error!` logs so Sentry gets two distinct fingerprints (indexer-side miss vs. invalid user content). Upgrade `errored_entries` from `warn!` → `error!` — after the contract fix, this counter is no longer 0 in prod (it picks up the events that previously leaked into `cache_misses`).
- **Tests** — 3 new tests pinning the contract:
  - `prefetch::errored_entries_are_inserted_into_cache_map`
  - `prefetch::cache_misses_are_not_inserted_into_cache_map`
  - `edits::errored_prefetched_entry_counts_as_errored_not_cache_miss`

## Test plan

- [x] \`cargo check -p hermes-pipeline\`
- [x] \`cargo test -p hermes-pipeline\` — 88 lib tests pass (up from 85)
- [x] \`cargo clippy -p hermes-pipeline --all-targets -- -D warnings\` clean

## Follow-up (out of code — sync with deploy)

The existing Sentry alert rule (\`alert_rule_id=16914859\`) currently fires on \`"Cache misses (retries exhausted) — edits dropped"\`. After this deploys, that fingerprint stops appearing. To avoid an alert blackout:

1. **Update the existing rule** to match \`"Edits dropped: IPFS payload not found in cache (indexer pipeline issue)"\`. Keeps current paging behavior for indexer-side failures.
2. **Add a second rule** for \`"Edits dropped: IPFS payload errored (invalid user content)"\`. Route somewhere non-paging — Slack channel or surface back to the user who submitted the broken edit.

## Notes

- Kept \`CachedEdit\` as the value type rather than introducing a \`PrefetchEntry::{Valid, Errored}\` enum. The footgun is mitigated by \`valid_payload()\` + doc comment. If type-system enforcement becomes important later (e.g., a new consumer that doesn't go through the accessor), a follow-up can introduce the enum without rewriting the alert pipeline.
- Existing consumers stay safe: \`edits.rs\` via \`valid_payload()\`; \`governance::enrich_publish_action_names\` because it reads \`cached_edit.name\` which is \`None\` on errored entries (the existing \`if let Some(name) = ...\` branch elides them naturally).