### PR TITLE
feat(atlas): drop Member/Editor edges, bump checkpoint to atlas-v2

### DIFF
--- a/atlas/README.md
+++ b/atlas/README.md
@@ -57,7 +57,7 @@ Access Kafka UI at http://localhost:8080 to view messages.
 | `SUBSTREAMS_END_BLOCK` | No | `u64::MAX` | End block for live stream |
 | `ATLAS_CHECKPOINT_DATABASE_URL` | No | - | PostgreSQL URL for checkpoint persistence |
 | `ATLAS_INDEXER_ID` | Conditional | - | Required and non-empty when checkpoint persistence is enabled |
-| `ATLAS_RUNTIME_COMPATIBILITY_MARKER` | No | `atlas-v1` | Runtime marker used for checkpoint compatibility validation |
+| `ATLAS_RUNTIME_COMPATIBILITY_MARKER` | No | `atlas-v2` | Runtime marker used for checkpoint compatibility validation |
 | `ATLAS_CHECKPOINT_ALLOW_FRESH_START` | No | `false` | If true, incompatible/corrupt checkpoints fall back to fresh bootstrap |
 | `ATLAS_FAIL_OPEN_BOUND` | No | `10` | Max uncheckpointed blocks before Atlas pauses processing |
 | `ATLAS_CHECKPOINT_RETRY_ATTEMPTS` | No | `3` | Retry attempts for checkpoint writes |

--- a/atlas/benches/graph_diff.rs
+++ b/atlas/benches/graph_diff.rs
@@ -35,7 +35,6 @@ fn build_random_tree(node_count: usize, seed: u64) -> TreeNode {
         EdgeType::Verified,
         EdgeType::Related,
         EdgeType::Editor,
-        EdgeType::Member,
     ];
 
     // Build tree recursively from parent indices
@@ -141,9 +140,8 @@ fn mutate_tree(tree: &TreeNode, change_rate: f64, seed: u64) -> TreeNode {
             EdgeType::Verified,
             EdgeType::Related,
             EdgeType::Editor,
-            EdgeType::Member,
         ];
-        nodes.push((new_id, edge_types[rng.gen_range(0..4)], vec![]));
+        nodes.push((new_id, edge_types[rng.gen_range(0..edge_types.len())], vec![]));
 
         // Ensure parent exists (it should, we just selected it)
         let _ = parent_id;

--- a/atlas/benches/graph_diff.rs
+++ b/atlas/benches/graph_diff.rs
@@ -31,11 +31,7 @@ fn build_random_tree(node_count: usize, seed: u64) -> TreeNode {
     }
 
     // Build nodes with random edge types
-    let edge_types = [
-        EdgeType::Verified,
-        EdgeType::Related,
-        EdgeType::Editor,
-    ];
+    let edge_types = [EdgeType::Verified, EdgeType::Related];
 
     // Build tree recursively from parent indices
     fn add_children(
@@ -136,11 +132,7 @@ fn mutate_tree(tree: &TreeNode, change_rate: f64, seed: u64) -> TreeNode {
         let parent_id = nodes[parent_idx].0;
         nodes[parent_idx].2.push(new_id);
 
-        let edge_types = [
-            EdgeType::Verified,
-            EdgeType::Related,
-            EdgeType::Editor,
-        ];
+        let edge_types = [EdgeType::Verified, EdgeType::Related];
         nodes.push((new_id, edge_types[rng.gen_range(0..edge_types.len())], vec![]));
 
         // Ensure parent exists (it should, we just selected it)

--- a/atlas/benches/graph_diff.rs
+++ b/atlas/benches/graph_diff.rs
@@ -133,7 +133,11 @@ fn mutate_tree(tree: &TreeNode, change_rate: f64, seed: u64) -> TreeNode {
         nodes[parent_idx].2.push(new_id);
 
         let edge_types = [EdgeType::Verified, EdgeType::Related];
-        nodes.push((new_id, edge_types[rng.gen_range(0..edge_types.len())], vec![]));
+        nodes.push((
+            new_id,
+            edge_types[rng.gen_range(0..edge_types.len())],
+            vec![],
+        ));
 
         // Ensure parent exists (it should, we just selected it)
         let _ = parent_id;

--- a/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
+++ b/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
@@ -2,20 +2,21 @@
 
 Remove member-of-space and editor-of-space relationships from Atlas's traversal and canonical graphs. Both edge types should have zero effect on any computed output.
 
-After this plan lands, the only canonical-granting edge types in Atlas are **Verified**, **Related**, and **Subtopic** (the last is topic-based, not explicit).
+After this plan lands, the only canonical-granting edge types in Atlas are **Verified** and **Related**. **Subtopic** edges appear in the canonical graph too, but they do not grant canonical membership: Phase 1 of canonical computation derives the canonical set from explicit (Verified/Related) edges only, and Phase 2 then attaches Subtopic edges filtered to nodes that are already canonical. See [`atlas/src/graph/canonical.rs`](../../../src/graph/canonical.rs) for the two-phase implementation.
 
 Tracks Linear issue [GEO-618](https://linear.app/defi-wonderland/issue/GEO-618/remove-member-relationships-from-canonical-graph).
 
-> **Status (updated 2026-05-12)**
-> - PR [#194](https://github.com/defi-wonderland/gaia/pull/194) implements the **Member** portion of this plan. Approved by automated review, not yet merged.
-> - Product team has confirmed **Editor** edges are also in scope. This plan is updated to cover both edge types symmetrically.
-> - **Decision needed** (see [Open decisions](#open-decisions)): extend PR #194 to drop Editor in the same change, or land #194 first and ship Editor as a follow-up PR. Recommendation: extend #194.
+> **Status (updated 2026-05-13)**
+> - PR [#194](https://github.com/defi-wonderland/gaia/pull/194) is **merged** (2026-05-12) into the integration branch `geo-618-remove-member-edges`. Per the resolved decision below (option A), it drops **both Member and Editor** edges in a single change and bumps the checkpoint marker `atlas-v1 → atlas-v2`. Closes [GEO-624](https://linear.app/defi-wonderland/issue/GEO-624).
+> - PR [#197](https://github.com/defi-wonderland/gaia/pull/197) is the docs follow-up — it updates `atlas/docs/graph-concepts.md` and this plan to reflect the post-merge state. Tracks [GEO-625](https://linear.app/defi-wonderland/issue/GEO-625).
+> - Operational rollout (fresh bootstrap to `atlas-v2` on staging and prod) is tracked by [GEO-626](https://linear.app/defi-wonderland/issue/GEO-626).
 
 ## Background
 
-Atlas currently treats `MEMBER_ADDED` / `MEMBER_REMOVED` and `EDITOR_ADDED` / `EDITOR_REMOVED` chain actions as topology edges that grant canonical membership. The conversion paths are structurally identical:
+Atlas previously treated `MEMBER_ADDED` / `MEMBER_REMOVED` and `EDITOR_ADDED` / `EDITOR_REMOVED` chain actions as topology edges that granted canonical membership (historical behavior, pre-0007). The conversion paths were structurally identical:
 
 ```
+// Historical behavior (pre-0007):
 chain Action (MEMBER_ADDED or EDITOR_ADDED)
   → convert.rs::convert_member_added | convert_editor_added
   → TrustExtension::MemberAdded | TrustExtension::EditorAdded
@@ -23,9 +24,9 @@ chain Action (MEMBER_ADDED or EDITOR_ADDED)
   → explicit_edges[source].push((target, EdgeType::Member | EdgeType::Editor))
 ```
 
-Once stored as explicit edges, Member and Editor edges are indistinguishable from `Verified` / `Related` in both the transitive BFS (`transitive.rs::compute`) and the canonical Phase-1 BFS (`canonical.rs::compute_if_changed`). They expand the canonical set and the transitive reachable set.
+Once stored as explicit edges, Member and Editor edges were indistinguishable from `Verified` / `Related` in both the transitive BFS (`transitive.rs::compute`) and the canonical Phase-1 BFS (`canonical.rs::compute_if_changed`). They expanded the canonical set and the transitive reachable set.
 
-This was introduced by plan [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md). We're undoing the membership portion of that plan in full.
+This was introduced by plan [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md). Plan 0007 reverses the membership portion of that plan in full.
 
 ## Goal
 
@@ -102,7 +103,7 @@ Hard-cut the checkpoint format. No Member or Editor data persists past this chan
 
 3. **Update test fixtures** that hardcode the marker string.
 
-**Marker version coordination**: see [Open decisions](#open-decisions). If we extend PR #194 to also cover Editor, the marker stays `atlas-v2` and covers both removals in a single fresh bootstrap. If Editor lands as a follow-up PR after #194 merges, the follow-up must bump to `atlas-v3` (and triggers a second fresh bootstrap).
+**Marker version coordination**: the marker is `atlas-v2` and covers both the Member and Editor removals in a single fresh bootstrap (see [Resolved decisions](#resolved-decisions)).
 
 Combined with `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` during deploy (see Rollout below), Atlas detects the marker mismatch, logs `Checkpoint rejected; … starting fresh`, and rebuilds graph state from `SUBSTREAMS_START_BLOCK`. The first new checkpoint stamps as the new marker.
 
@@ -176,7 +177,7 @@ No new "reset" signal required. No new topic version required.
 
 ## Rollout
 
-The marker bump (to `atlas-v2` if Editor lands with #194, or to `atlas-v3` if it ships as a follow-up) makes every existing checkpoint incompatible by construction. Atlas will refuse to start unless we permit a fresh bootstrap.
+The marker bump to `atlas-v2` makes every existing checkpoint incompatible by construction. Atlas will refuse to start unless we permit a fresh bootstrap.
 
 1. Land code change + tests + docs.
 2. On every environment running Atlas (staging, prod, anywhere with `ATLAS_CHECKPOINT_DATABASE_URL` set): set `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` **before** deploying the new image.
@@ -184,28 +185,17 @@ The marker bump (to `atlas-v2` if Editor lands with #194, or to `atlas-v3` if it
 4. Watch during replay:
    - Atlas `latest_block` metric catches up to chain head.
    - `topology.canonical` consumer-group lag spikes as kg-indexer / search-indexer process the rebuild stream — should settle once replay completes. Existing diff-apply logic is idempotent so no special handling required.
-   - First new checkpoint row written with `runtime_compatibility_marker = atlas-v2` (or `atlas-v3` if sequential).
+   - First new checkpoint row written with `runtime_compatibility_marker = atlas-v2`.
 5. Spot-check known Member-only and Editor-only canonical spaces: confirm they're gone from canonical queries.
 6. After Atlas is stable on the new marker, **revert `ATLAS_CHECKPOINT_ALLOW_FRESH_START` to `false`** so future checkpoint corruption fails loud instead of silently bootstrapping from genesis.
 
 **Replay-cost caveat:** default `SUBSTREAMS_START_BLOCK=82655`. Confirm acceptable replay wall-time per environment before scheduling the deploy.
 
-## Open decisions
+## Resolved decisions
 
 ### 1. Sequencing of Editor relative to PR #194
 
-PR #194 currently removes Member only and bumps to `atlas-v2`. Two paths:
-
-| Option | Description | Marker bumps | Fresh bootstraps |
-|--------|-------------|--------------|------------------|
-| **A. Extend #194** (recommended) | Add Editor changes as commits onto the existing `geo-618-remove-member-edges` branch. Single PR removes both. | `atlas-v1 → atlas-v2` (one) | 1 |
-| **B. Sequential** | Land #194 as-is. Open a follow-up PR for Editor that bumps `atlas-v2 → atlas-v3`. | Two bumps | 2 |
-
-**Recommendation: A.** Rebootstrapping is operationally expensive (replay from block 82655, downstream consumer lag spike). One bootstrap is materially better than two. Cost of option A: the approved PR may need re-review since the scope changes.
-
-If choosing A: rebase `geo-618-remove-member-edges` onto current `origin/dev`, add a second commit with the Editor changes, push, and request re-review.
-
-If choosing B: open a fresh Linear subissue (e.g. GEO-XXX) and a fresh worktree off the merged #194. Document that the team accepts a second fresh bootstrap.
+**Outcome: option A was chosen.** PR [#194](https://github.com/defi-wonderland/gaia/pull/194) was extended on the `geo-618-remove-member-edges` branch to drop **both** Member and Editor edges in a single change, and the checkpoint marker was bumped once (`atlas-v1 → atlas-v2`) to cover both removals via a single fresh bootstrap.
 
 ## File checklist
 
@@ -213,23 +203,24 @@ Reflects total scope (Member + Editor). Items already shipped by PR #194 are mar
 
 | File | Member change | Editor change |
 |------|---------------|---------------|
-| `atlas/src/graph/state.rs` | No-op (✅ #194) | No-op (new) |
-| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅ #194) | Remove `EdgeType::Editor` (new) |
-| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅ #194) | Move to no-op arm (new) |
-| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅ #194) | Drop match arms + fixture (new) |
-| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ #194 → `atlas-v2`) | Drop `PersistedEdgeType::Editor`; marker stays `atlas-v2` if extending #194, else bump to `atlas-v3` |
+| `atlas/src/graph/state.rs` | No-op (✅ #194) | No-op (✅ #194) |
+| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅ #194) | Remove `EdgeType::Editor` (✅ #194) |
+| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅ #194) | Move to no-op arm (✅ #194) |
+| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅ #194) | Drop match arms + fixture (✅ #194) |
+| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ #194 → `atlas-v2`) | Drop `PersistedEdgeType::Editor` (✅ #194, single marker bump to `atlas-v2` covers both) |
 | `atlas/src/main.rs` | Optional log annotation | Optional log annotation |
-| `atlas/tests/e2e.rs` | Flip Member expectations (✅ #194) | Flip Editor expectations (new) |
-| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅ #194) | Drop `Editor` fixture (new) |
-| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅ #194) | `test_editor_*_is_no_op` (new) |
-| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅ #194) | Editor canonical assertion (new) |
-| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅ #194) | Editor transitive assertion (new) |
-| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (pending — GEO-625) | Drop Editor from Explicit Edges (new) |
-| `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` | Drop Member from canonical-granting edges (pending) | Drop Editor from canonical-granting edges (new) |
+| `atlas/tests/e2e.rs` | Flip Member expectations (✅ #194) | Flip Editor expectations (✅ #194) |
+| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅ #194) | Drop `Editor` fixture (✅ #194) |
+| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅ #194) | `test_editor_*_is_no_op` (✅ #194) |
+| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅ #194) | Editor canonical assertion (✅ #194) |
+| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅ #194) | Editor transitive assertion (✅ #194) |
+| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (✅ PR #197 — GEO-625) | Drop Editor from Explicit Edges (✅ PR #197 — GEO-625) |
+| `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` | Drop Member from canonical-granting edges (✅ wiki) | Drop Editor from canonical-granting edges (✅ wiki) |
 
 ## Related
 
 - [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md) — introduced Member and Editor edges; this plan reverses the membership portion in full.
 - [Graph Concepts](../../graph-concepts.md)
 - [Known Issues](../../known-issues.md)
-- PR [#194](https://github.com/defi-wonderland/gaia/pull/194) — implements the Member portion of this plan.
+- PR [#194](https://github.com/defi-wonderland/gaia/pull/194) — drops both Member and Editor edges, bumps checkpoint marker to `atlas-v2`.
+- PR [#197](https://github.com/defi-wonderland/gaia/pull/197) — this docs PR; updates `atlas/docs/graph-concepts.md` and commits plan 0007.

--- a/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
+++ b/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
@@ -1,0 +1,235 @@
+# 0007: Remove Member and Editor Edges from Atlas
+
+Remove member-of-space and editor-of-space relationships from Atlas's traversal and canonical graphs. Both edge types should have zero effect on any computed output.
+
+After this plan lands, the only canonical-granting edge types in Atlas are **Verified**, **Related**, and **Subtopic** (the last is topic-based, not explicit).
+
+Tracks Linear issue [GEO-618](https://linear.app/defi-wonderland/issue/GEO-618/remove-member-relationships-from-canonical-graph).
+
+> **Status (updated 2026-05-12)**
+> - PR [#194](https://github.com/defi-wonderland/gaia/pull/194) implements the **Member** portion of this plan. Approved by automated review, not yet merged.
+> - Product team has confirmed **Editor** edges are also in scope. This plan is updated to cover both edge types symmetrically.
+> - **Decision needed** (see [Open decisions](#open-decisions)): extend PR #194 to drop Editor in the same change, or land #194 first and ship Editor as a follow-up PR. Recommendation: extend #194.
+
+## Background
+
+Atlas currently treats `MEMBER_ADDED` / `MEMBER_REMOVED` and `EDITOR_ADDED` / `EDITOR_REMOVED` chain actions as topology edges that grant canonical membership. The conversion paths are structurally identical:
+
+```
+chain Action (MEMBER_ADDED or EDITOR_ADDED)
+  → convert.rs::convert_member_added | convert_editor_added
+  → TrustExtension::MemberAdded | TrustExtension::EditorAdded
+  → GraphState::apply_trust_extended
+  → explicit_edges[source].push((target, EdgeType::Member | EdgeType::Editor))
+```
+
+Once stored as explicit edges, Member and Editor edges are indistinguishable from `Verified` / `Related` in both the transitive BFS (`transitive.rs::compute`) and the canonical Phase-1 BFS (`canonical.rs::compute_if_changed`). They expand the canonical set and the transitive reachable set.
+
+This was introduced by plan [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md). We're undoing the membership portion of that plan in full.
+
+## Goal
+
+After this change:
+- `MemberAdded` / `MemberRemoved` / `EditorAdded` / `EditorRemoved` events applied to any `GraphState` produce no change to `explicit_edges`, no change to the transitive graph rooted at any space, and no change to the canonical graph.
+- `topology.canonical` Kafka messages never contain `MemberEdge` or `EditorEdge` entries.
+- `EdgeType::Member` AND `EdgeType::Editor` cease to exist in the Atlas code.
+- The chain actions `MEMBER_ADDED` / `MEMBER_REMOVED` / `EDITOR_ADDED` / `EDITOR_REMOVED` are still parsed (chain compatibility) — they just don't mutate graph state.
+
+## Approach
+
+Two viable cuts:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A. Drop at storage** (chosen) | One change point per edge type. BFS code stays uniform. Impossible to forget a filter site. | Loses ability to expose Member/Editor as non-canonical relations later without re-introducing storage. |
+| **B. Filter at traversal** | Member/Editor still tracked in state — can be exposed elsewhere. | Two filter sites (transitive + canonical Phase 1) per edge type, must stay in sync. Easy to regress. |
+
+We pick **A**: stop applying Member and Editor events to `GraphState`, then delete the `EdgeType::Member` and `EdgeType::Editor` variants. The compiler will surface every dead match arm.
+
+## Changes
+
+### 1. No-op Member and Editor events in GraphState
+
+**File:** `atlas/src/graph/state.rs`
+
+Remove the `MemberAdded` / `MemberRemoved` and `EditorAdded` / `EditorRemoved` arms from `apply_trust_extended`. Replace with an explicit no-op arm so the next reader knows it's intentional:
+
+```rust
+// Member and Editor edges are ignored — see plan 0007. Kept in the enum
+// for chain compatibility (convert.rs still emits them).
+TrustExtension::MemberAdded { .. }
+| TrustExtension::MemberRemoved { .. }
+| TrustExtension::EditorAdded { .. }
+| TrustExtension::EditorRemoved { .. } => {}
+```
+
+No changes needed to `events.rs` — `TrustExtension::MemberAdded` / `MemberRemoved` / `EditorAdded` / `EditorRemoved` variants stay so `convert.rs` keeps compiling. They become payloads that pass through without effect.
+
+### 2. Remove EdgeType::Member and EdgeType::Editor
+
+**File:** `atlas/src/graph/tree.rs`
+
+Delete the `Member` and `Editor` variants from `EdgeType`. The compiler will fail every match site. Fix each:
+
+- **`atlas/src/kafka/emitter.rs`** — drop the `EdgeType::Member => ...` and `EdgeType::Editor => ...` arms in both `edge_to_proto` functions. The `MemberEdge` / `EditorEdge` proto types stay defined (downstream consumers may still reference them) but Atlas never emits them.
+- **`atlas/src/kafka/emitter.rs`** (test fixture) — drop the `Member` and `Editor` test fixture entries from `test_tree_node_to_proto_all_edge_types`, or substitute with `Verified` / `Related` if the test still needs multiple children.
+- **`atlas/src/persistence.rs`** — see persistence section below.
+- **`atlas/benches/graph_diff.rs`** — remove `EdgeType::Member` and `EdgeType::Editor` from both benchmark fixture arrays.
+
+### 3. Transitive cache invalidation
+
+**File:** `atlas/src/graph/transitive.rs`
+
+`handle_event` invalidates `member_space_id` for Member/Editor events. With both now no-ops, invalidation is unnecessary. Move both into the same no-op arm:
+
+```rust
+// Member and Editor edges: no-op — these events do not mutate state (plan 0007).
+TrustExtension::MemberAdded { .. }
+| TrustExtension::MemberRemoved { .. }
+| TrustExtension::EditorAdded { .. }
+| TrustExtension::EditorRemoved { .. } => {}
+```
+
+### 4. Persistence — hard cut via marker bump
+
+**Files:** `atlas/src/persistence.rs`
+
+Hard-cut the checkpoint format. No Member or Editor data persists past this change. Three coordinated edits:
+
+1. **Delete `PersistedEdgeType::Member` and `PersistedEdgeType::Editor`** and their match arms in `From<EdgeType>` / `TryFrom<PersistedEdgeType>` / the ordering helper. After this, the type system guarantees no Member or Editor edge can be serialized or deserialized.
+
+2. **Bump the default `runtime_compatibility_marker`** to `atlas-v2`. Atlas already validates this marker on load — any pre-existing checkpoint will be rejected as incompatible without us needing to rely on enum-deserialize failures.
+
+3. **Update test fixtures** that hardcode the marker string.
+
+**Marker version coordination**: see [Open decisions](#open-decisions). If we extend PR #194 to also cover Editor, the marker stays `atlas-v2` and covers both removals in a single fresh bootstrap. If Editor lands as a follow-up PR after #194 merges, the follow-up must bump to `atlas-v3` (and triggers a second fresh bootstrap).
+
+Combined with `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` during deploy (see Rollout below), Atlas detects the marker mismatch, logs `Checkpoint rejected; … starting fresh`, and rebuilds graph state from `SUBSTREAMS_START_BLOCK`. The first new checkpoint stamps as the new marker.
+
+No manual checkpoint deletion is required. No backwards-compat shim is introduced.
+
+### 5. Convert layer stays as-is
+
+**File:** `atlas/src/convert.rs`
+
+No changes. `convert_member_added` / `convert_member_removed` / `convert_editor_added` / `convert_editor_removed` keep producing their respective `TrustExtension` variants from chain actions. These flow into `GraphState::apply_trust_extended` and hit the no-op arm.
+
+Rationale: the conversion layer mirrors the chain ABI. Keeping it stable means we can re-enable Member or Editor edges later without re-plumbing the parse path.
+
+### 6. Main loop logging
+
+**File:** `atlas/src/main.rs`
+
+The diagnostic logging for `MemberAdded` / `MemberRemoved` / `EditorAdded` / `EditorRemoved` stays — useful for debugging "why didn't this space appear?" questions. Optionally annotate the log message with `(ignored)`.
+
+## Tests
+
+### Existing tests to update
+
+**`atlas/tests/e2e.rs`** — `.member_added(...)` / `.member_removed(...)` / `.editor(...)` / `.editor_removed(...)` helpers still feed events into the pipeline. Update any test that asserts canonical or transitive membership through a Member or Editor edge:
+
+- Cases where Member/Editor is the only path to a node: assert that node is NOT in canonical and NOT in the transitive set.
+- Cases where Member/Editor is one of multiple paths: assert the node is still present via the non-Member, non-Editor path.
+
+Specific tests known to need updates (relative to current state — some Member tests may already be flipped by PR #194):
+- Tests using `.editor(...)` to grant canonical membership.
+- Tests asserting `editor_removed` produces a `Removed` change.
+- Tests asserting transitive reachability through an Editor edge.
+
+### New tests to add (symmetric to the Member tests added in PR #194)
+
+In `atlas/src/graph/state.rs` tests:
+
+- `test_editor_added_is_no_op`: apply `EditorAdded(source, target)`, assert `state.explicit_edges` is empty.
+- `test_editor_removed_is_no_op`: same shape.
+
+In `atlas/src/graph/canonical.rs` tests:
+
+- `test_editor_edge_from_root_does_not_grant_canonical`: root has `EditorAdded(root, X)`, assert canonical set is `{root}` only.
+
+In `atlas/src/graph/transitive.rs` tests:
+
+- `test_editor_edge_not_in_transitive`: apply `EditorAdded(A, B)`, compute `get_full(A)`, assert B is not reachable.
+
+### Benches
+
+`atlas/benches/graph_diff.rs` — drop `EdgeType::Member` and `EdgeType::Editor` entries from both fixture arrays. If the bench depends on edge-type variety, the remaining `Verified` / `Related` types suffice.
+
+## Docs
+
+- `atlas/docs/graph-concepts.md` — drop "Member relationships" AND "Editor relationships" from the Explicit Edges list. Note Member and Editor events exist on-chain but are not represented in any Atlas graph.
+- `atlas/docs/algorithm-overview.md` — no changes needed (algorithm description already only references explicit/topic categories).
+- `atlas/README.md` — already lists only Verified/Related, no change.
+- Wiki: `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` — drop Member AND Editor from "canonical-granting edges" line. Add a note that Member and Editor events are no-oped.
+
+## Wire-format and downstream impact
+
+`topology.canonical` is a derived snapshot stream. After this change:
+
+- The next emitted `CanonicalGraphDiff` will contain `REMOVED` entries for every space that was previously canonical solely via a Member or Editor edge.
+- Downstream consumers (kg-indexer, search-indexer) apply diffs as authoritative — they will correctly drop those spaces from their projections.
+- Per `atlas/docs/known-issues.md`, downstream treats canonical updates as full state snapshots; idempotent application means no special handover is needed beyond the normal diff.
+
+No new "reset" signal required. No new topic version required.
+
+**Impact estimate**: Editor edges are likely more common than Member edges in the existing graph (every DAO has at least one editor, but not every DAO has member-only relationships). The `REMOVED` diff after this lands will be correspondingly larger if Editor and Member ship together.
+
+## Rollout
+
+The marker bump (to `atlas-v2` if Editor lands with #194, or to `atlas-v3` if it ships as a follow-up) makes every existing checkpoint incompatible by construction. Atlas will refuse to start unless we permit a fresh bootstrap.
+
+1. Land code change + tests + docs.
+2. On every environment running Atlas (staging, prod, anywhere with `ATLAS_CHECKPOINT_DATABASE_URL` set): set `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` **before** deploying the new image.
+3. Deploy. Atlas logs `Checkpoint rejected; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh` and replays from `SUBSTREAMS_START_BLOCK`.
+4. Watch during replay:
+   - Atlas `latest_block` metric catches up to chain head.
+   - `topology.canonical` consumer-group lag spikes as kg-indexer / search-indexer process the rebuild stream — should settle once replay completes. Existing diff-apply logic is idempotent so no special handling required.
+   - First new checkpoint row written with `runtime_compatibility_marker = atlas-v2` (or `atlas-v3` if sequential).
+5. Spot-check known Member-only and Editor-only canonical spaces: confirm they're gone from canonical queries.
+6. After Atlas is stable on the new marker, **revert `ATLAS_CHECKPOINT_ALLOW_FRESH_START` to `false`** so future checkpoint corruption fails loud instead of silently bootstrapping from genesis.
+
+**Replay-cost caveat:** default `SUBSTREAMS_START_BLOCK=82655`. Confirm acceptable replay wall-time per environment before scheduling the deploy.
+
+## Open decisions
+
+### 1. Sequencing of Editor relative to PR #194
+
+PR #194 currently removes Member only and bumps to `atlas-v2`. Two paths:
+
+| Option | Description | Marker bumps | Fresh bootstraps |
+|--------|-------------|--------------|------------------|
+| **A. Extend #194** (recommended) | Add Editor changes as commits onto the existing `geo-618-remove-member-edges` branch. Single PR removes both. | `atlas-v1 → atlas-v2` (one) | 1 |
+| **B. Sequential** | Land #194 as-is. Open a follow-up PR for Editor that bumps `atlas-v2 → atlas-v3`. | Two bumps | 2 |
+
+**Recommendation: A.** Rebootstrapping is operationally expensive (replay from block 82655, downstream consumer lag spike). One bootstrap is materially better than two. Cost of option A: the approved PR may need re-review since the scope changes.
+
+If choosing A: rebase `geo-618-remove-member-edges` onto current `origin/dev`, add a second commit with the Editor changes, push, and request re-review.
+
+If choosing B: open a fresh Linear subissue (e.g. GEO-XXX) and a fresh worktree off the merged #194. Document that the team accepts a second fresh bootstrap.
+
+## File checklist
+
+Reflects total scope (Member + Editor). Items already shipped by PR #194 are marked as such.
+
+| File | Member change | Editor change |
+|------|---------------|---------------|
+| `atlas/src/graph/state.rs` | No-op (✅ #194) | No-op (new) |
+| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅ #194) | Remove `EdgeType::Editor` (new) |
+| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅ #194) | Move to no-op arm (new) |
+| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅ #194) | Drop match arms + fixture (new) |
+| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ #194 → `atlas-v2`) | Drop `PersistedEdgeType::Editor`; marker stays `atlas-v2` if extending #194, else bump to `atlas-v3` |
+| `atlas/src/main.rs` | Optional log annotation | Optional log annotation |
+| `atlas/tests/e2e.rs` | Flip Member expectations (✅ #194) | Flip Editor expectations (new) |
+| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅ #194) | Drop `Editor` fixture (new) |
+| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅ #194) | `test_editor_*_is_no_op` (new) |
+| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅ #194) | Editor canonical assertion (new) |
+| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅ #194) | Editor transitive assertion (new) |
+| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (pending — GEO-625) | Drop Editor from Explicit Edges (new) |
+| `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` | Drop Member from canonical-granting edges (pending) | Drop Editor from canonical-granting edges (new) |
+
+## Related
+
+- [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md) — introduced Member and Editor edges; this plan reverses the membership portion in full.
+- [Graph Concepts](../../graph-concepts.md)
+- [Known Issues](../../known-issues.md)
+- PR [#194](https://github.com/defi-wonderland/gaia/pull/194) — implements the Member portion of this plan.

--- a/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
+++ b/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
@@ -4,13 +4,6 @@ Remove member-of-space and editor-of-space relationships from Atlas's traversal 
 
 After this plan lands, the only canonical-granting edge types in Atlas are **Verified** and **Related**. **Subtopic** edges appear in the canonical graph too, but they do not grant canonical membership: Phase 1 of canonical computation derives the canonical set from explicit (Verified/Related) edges only, and Phase 2 then attaches Subtopic edges filtered to nodes that are already canonical. See [`atlas/src/graph/canonical.rs`](../../../src/graph/canonical.rs) for the two-phase implementation.
 
-Tracks Linear issue [GEO-618](https://linear.app/defi-wonderland/issue/GEO-618/remove-member-relationships-from-canonical-graph).
-
-> **Status (updated 2026-05-13)**
-> - PR [#194](https://github.com/defi-wonderland/gaia/pull/194) is **merged** (2026-05-12) into the integration branch `geo-618-remove-member-edges`. Per the resolved decision below (option A), it drops **both Member and Editor** edges in a single change and bumps the checkpoint marker `atlas-v1 → atlas-v2`. Closes [GEO-624](https://linear.app/defi-wonderland/issue/GEO-624).
-> - PR [#197](https://github.com/defi-wonderland/gaia/pull/197) is the docs follow-up — it updates `atlas/docs/graph-concepts.md` and this plan to reflect the post-merge state. Tracks [GEO-625](https://linear.app/defi-wonderland/issue/GEO-625).
-> - Operational rollout (fresh bootstrap to `atlas-v2` on staging and prod) is tracked by [GEO-626](https://linear.app/defi-wonderland/issue/GEO-626).
-
 ## Background
 
 Atlas previously treated `MEMBER_ADDED` / `MEMBER_REMOVED` and `EDITOR_ADDED` / `EDITOR_REMOVED` chain actions as topology edges that granted canonical membership (historical behavior, pre-0007). The conversion paths were structurally identical:
@@ -132,12 +125,12 @@ The diagnostic logging for `MemberAdded` / `MemberRemoved` / `EditorAdded` / `Ed
 - Cases where Member/Editor is the only path to a node: assert that node is NOT in canonical and NOT in the transitive set.
 - Cases where Member/Editor is one of multiple paths: assert the node is still present via the non-Member, non-Editor path.
 
-Specific tests known to need updates (relative to current state — some Member tests may already be flipped by PR #194):
+Specific tests known to need updates:
 - Tests using `.editor(...)` to grant canonical membership.
 - Tests asserting `editor_removed` produces a `Removed` change.
 - Tests asserting transitive reachability through an Editor edge.
 
-### New tests to add (symmetric to the Member tests added in PR #194)
+### New tests to add (symmetric to the Member tests)
 
 In `atlas/src/graph/state.rs` tests:
 
@@ -193,28 +186,28 @@ The marker bump to `atlas-v2` makes every existing checkpoint incompatible by co
 
 ## Resolved decisions
 
-### 1. Sequencing of Editor relative to PR #194
+### 1. Sequencing of Member and Editor removal
 
-**Outcome: option A was chosen.** PR [#194](https://github.com/defi-wonderland/gaia/pull/194) was extended on the `geo-618-remove-member-edges` branch to drop **both** Member and Editor edges in a single change, and the checkpoint marker was bumped once (`atlas-v1 → atlas-v2`) to cover both removals via a single fresh bootstrap.
+**Outcome: option A was chosen.** Member and Editor edges are dropped in a single change, and the checkpoint marker is bumped once (`atlas-v1 → atlas-v2`) to cover both removals via a single fresh bootstrap.
 
 ## File checklist
 
-Reflects total scope (Member + Editor). Items already shipped by PR #194 are marked as such.
+Reflects total scope (Member + Editor).
 
 | File | Member change | Editor change |
 |------|---------------|---------------|
-| `atlas/src/graph/state.rs` | No-op (✅ #194) | No-op (✅ #194) |
-| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅ #194) | Remove `EdgeType::Editor` (✅ #194) |
-| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅ #194) | Move to no-op arm (✅ #194) |
-| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅ #194) | Drop match arms + fixture (✅ #194) |
-| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ #194 → `atlas-v2`) | Drop `PersistedEdgeType::Editor` (✅ #194, single marker bump to `atlas-v2` covers both) |
+| `atlas/src/graph/state.rs` | No-op (✅) | No-op (✅) |
+| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅) | Remove `EdgeType::Editor` (✅) |
+| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅) | Move to no-op arm (✅) |
+| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅) | Drop match arms + fixture (✅) |
+| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ → `atlas-v2`) | Drop `PersistedEdgeType::Editor` (✅, single marker bump to `atlas-v2` covers both) |
 | `atlas/src/main.rs` | Optional log annotation | Optional log annotation |
-| `atlas/tests/e2e.rs` | Flip Member expectations (✅ #194) | Flip Editor expectations (✅ #194) |
-| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅ #194) | Drop `Editor` fixture (✅ #194) |
-| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅ #194) | `test_editor_*_is_no_op` (✅ #194) |
-| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅ #194) | Editor canonical assertion (✅ #194) |
-| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅ #194) | Editor transitive assertion (✅ #194) |
-| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (✅ PR #197 — GEO-625) | Drop Editor from Explicit Edges (✅ PR #197 — GEO-625) |
+| `atlas/tests/e2e.rs` | Flip Member expectations (✅) | Flip Editor expectations (✅) |
+| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅) | Drop `Editor` fixture (✅) |
+| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅) | `test_editor_*_is_no_op` (✅) |
+| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅) | Editor canonical assertion (✅) |
+| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅) | Editor transitive assertion (✅) |
+| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (✅) | Drop Editor from Explicit Edges (✅) |
 | `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` | Drop Member from canonical-granting edges (✅ wiki) | Drop Editor from canonical-granting edges (✅ wiki) |
 
 ## Related
@@ -222,5 +215,3 @@ Reflects total scope (Member + Editor). Items already shipped by PR #194 are mar
 - [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md) — introduced Member and Editor edges; this plan reverses the membership portion in full.
 - [Graph Concepts](../../graph-concepts.md)
 - [Known Issues](../../known-issues.md)
-- PR [#194](https://github.com/defi-wonderland/gaia/pull/194) — drops both Member and Editor edges, bumps checkpoint marker to `atlas-v2`.
-- PR [#197](https://github.com/defi-wonderland/gaia/pull/197) — this docs PR; updates `atlas/docs/graph-concepts.md` and commits plan 0007.

--- a/atlas/docs/graph-concepts.md
+++ b/atlas/docs/graph-concepts.md
@@ -39,16 +39,20 @@ The system tracks four different graph views:
 The system supports two categories of edges:
 
 **Explicit Edges** - Direct node-to-node connections with semantic types:
-- Editor relationships
-- Member relationships
-- Trust relationships
-- Generic related relationships
+- Trust relationships (Verified)
+- Generic related relationships (Related)
 
 **Topic Edges** - Indirect connections through group membership:
-- A node references an entire topic/group
+- A node references an entire topic/group (Subtopic)
 - Resolves dynamically to current group members at query time
 - Membership can change without updating the edge
 - Provides abstraction over bulk relationships
+
+**No-op chain events:** `EDITOR_ADDED` / `EDITOR_REMOVED` / `MEMBER_ADDED` /
+`MEMBER_REMOVED` chain events still arrive at Atlas via `convert.rs`, but the
+storage layer ignores them — they produce no edges in any graph view (transitive
+or canonical). See [plan 0007](agents/plans/0007-remove-member-edges-plan.md)
+for the rationale and the canonical-granting edge set after the change.
 
 ### Update Operations
 

--- a/atlas/src/graph/canonical.rs
+++ b/atlas/src/graph/canonical.rs
@@ -775,4 +775,36 @@ mod tests {
             "Member-only reachable space must not be canonical"
         );
     }
+
+    #[test]
+    fn test_editor_edge_from_root_does_not_grant_canonical() {
+        // Plan 0007: Editor edges no longer grant canonical membership.
+        // An EditorAdded(root, X) event must leave X outside the canonical set.
+        let mut state = GraphState::new();
+        let root = create_space(&mut state, 1);
+        let x = create_space(&mut state, 2);
+
+        let editor_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: root,
+                extension: TrustExtension::EditorAdded { member_space_id: x },
+            }),
+        };
+        state.apply_event(&editor_event);
+
+        let mut transitive = TransitiveProcessor::new();
+        let mut processor = CanonicalProcessor::new(root);
+
+        let graph = processor
+            .compute_if_changed(&state, &mut transitive)
+            .unwrap();
+
+        assert_eq!(graph.len(), 1, "canonical set must contain only root");
+        assert!(graph.contains(&root));
+        assert!(
+            !graph.contains(&x),
+            "Editor-only reachable space must not be canonical"
+        );
+    }
 }

--- a/atlas/src/graph/canonical.rs
+++ b/atlas/src/graph/canonical.rs
@@ -741,4 +741,38 @@ mod tests {
         // All explicitly connected nodes are canonical
         assert_eq!(graph.len(), 5);
     }
+
+    #[test]
+    fn test_member_edge_from_root_does_not_grant_canonical() {
+        // Plan 0007: Member edges no longer grant canonical membership.
+        // A MemberAdded(root, X) event must leave X outside the canonical set.
+        let mut state = GraphState::new();
+        let root = create_space(&mut state, 1);
+        let x = create_space(&mut state, 2);
+
+        // Apply a MemberAdded event directly — bypasses the test helpers
+        // so we exercise the same path the chain takes.
+        let member_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: root,
+                extension: TrustExtension::MemberAdded { member_space_id: x },
+            }),
+        };
+        state.apply_event(&member_event);
+
+        let mut transitive = TransitiveProcessor::new();
+        let mut processor = CanonicalProcessor::new(root);
+
+        let graph = processor
+            .compute_if_changed(&state, &mut transitive)
+            .unwrap();
+
+        assert_eq!(graph.len(), 1, "canonical set must contain only root");
+        assert!(graph.contains(&root));
+        assert!(
+            !graph.contains(&x),
+            "Member-only reachable space must not be canonical"
+        );
+    }
 }

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -104,9 +104,6 @@ impl GraphState {
             TrustExtension::Subtopic { target_topic_id } => {
                 self.add_topic_edge(source, *target_topic_id);
             }
-            TrustExtension::EditorAdded { member_space_id } => {
-                self.add_explicit_edge(source, *member_space_id, EdgeType::Editor);
-            }
 
             // --- Edge Removals ---
             TrustExtension::VerifiedRemoved { target_space_id } => {
@@ -115,20 +112,22 @@ impl GraphState {
             TrustExtension::RelatedRemoved { target_space_id } => {
                 self.remove_explicit_edge(source, *target_space_id, EdgeType::Related);
             }
-            TrustExtension::EditorRemoved { member_space_id } => {
-                self.remove_explicit_edge(source, *member_space_id, EdgeType::Editor);
-            }
             TrustExtension::SubtopicRemoved { target_topic_id } => {
                 self.remove_topic_edge(source, *target_topic_id);
             }
 
-            // Member edges are ignored — see plan 0007. Variants stay in the
-            // TrustExtension enum so convert.rs (chain action parsing) is untouched.
-            TrustExtension::MemberAdded { .. } | TrustExtension::MemberRemoved { .. } => {}
+            // Member and Editor edges are ignored — see plan 0007. Variants stay
+            // in the TrustExtension enum so convert.rs (chain action parsing) is
+            // untouched. Only Verified, Related, and Subtopic remain as
+            // canonical-granting edges.
+            TrustExtension::MemberAdded { .. }
+            | TrustExtension::MemberRemoved { .. }
+            | TrustExtension::EditorAdded { .. }
+            | TrustExtension::EditorRemoved { .. } => {}
         }
     }
 
-    /// Add an explicit edge (Verified, Related, Editor)
+    /// Add an explicit edge (Verified, Related)
     fn add_explicit_edge(&mut self, source: SpaceId, target: SpaceId, edge_type: EdgeType) {
         // Intentionally allow duplicate entries.
         //
@@ -463,6 +462,65 @@ mod tests {
             state.explicit_edge_count(),
             1,
             "MemberRemoved must not remove unrelated edges"
+        );
+    }
+
+    // Editor events must also be no-ops at the state layer — see plan 0007.
+
+    fn editor_event(source: SpaceId, target: SpaceId, add: bool) -> SpaceTopologyEvent {
+        SpaceTopologyEvent {
+            meta: make_block_meta_at(2),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: source,
+                extension: if add {
+                    TrustExtension::EditorAdded {
+                        member_space_id: target,
+                    }
+                } else {
+                    TrustExtension::EditorRemoved {
+                        member_space_id: target,
+                    }
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn test_editor_added_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        state.apply_event(&editor_event(source, target, true));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            0,
+            "EditorAdded must not produce an explicit edge"
+        );
+        assert!(state.get_explicit_edges(&source).is_none());
+    }
+
+    #[test]
+    fn test_editor_removed_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        // Add a verified edge so we can verify EditorRemoved doesn't disturb it.
+        state.apply_event(&make_verified_event(source, target));
+        assert_eq!(state.explicit_edge_count(), 1);
+
+        state.apply_event(&editor_event(source, target, false));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            1,
+            "EditorRemoved must not remove unrelated edges"
         );
     }
 }

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -118,8 +118,14 @@ impl GraphState {
 
             // Member and Editor edges are ignored — see plan 0007. Variants stay
             // in the TrustExtension enum so convert.rs (chain action parsing) is
-            // untouched. Only Verified, Related, and Subtopic remain as
-            // canonical-granting edges.
+            // untouched.
+            //
+            // Edge types that still affect Atlas's output after this change:
+            //   • Verified / Related — grant *canonical membership* via the
+            //     explicit-only BFS in canonical.rs Phase 1.
+            //   • Subtopic           — does NOT grant canonical membership; it
+            //     attaches filtered subtrees between already-canonical members
+            //     in canonical.rs Phase 2 (collect_topic_subtrees).
             TrustExtension::MemberAdded { .. }
             | TrustExtension::MemberRemoved { .. }
             | TrustExtension::EditorAdded { .. }

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -107,9 +107,6 @@ impl GraphState {
             TrustExtension::EditorAdded { member_space_id } => {
                 self.add_explicit_edge(source, *member_space_id, EdgeType::Editor);
             }
-            TrustExtension::MemberAdded { member_space_id } => {
-                self.add_explicit_edge(source, *member_space_id, EdgeType::Member);
-            }
 
             // --- Edge Removals ---
             TrustExtension::VerifiedRemoved { target_space_id } => {
@@ -121,16 +118,17 @@ impl GraphState {
             TrustExtension::EditorRemoved { member_space_id } => {
                 self.remove_explicit_edge(source, *member_space_id, EdgeType::Editor);
             }
-            TrustExtension::MemberRemoved { member_space_id } => {
-                self.remove_explicit_edge(source, *member_space_id, EdgeType::Member);
-            }
             TrustExtension::SubtopicRemoved { target_topic_id } => {
                 self.remove_topic_edge(source, *target_topic_id);
             }
+
+            // Member edges are ignored — see plan 0007. Variants stay in the
+            // TrustExtension enum so convert.rs (chain action parsing) is untouched.
+            TrustExtension::MemberAdded { .. } | TrustExtension::MemberRemoved { .. } => {}
         }
     }
 
-    /// Add an explicit edge (Verified, Related, Editor, Member)
+    /// Add an explicit edge (Verified, Related, Editor)
     fn add_explicit_edge(&mut self, source: SpaceId, target: SpaceId, edge_type: EdgeType) {
         // Intentionally allow duplicate entries.
         //
@@ -405,5 +403,66 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert!(members.contains(&space1));
         assert!(members.contains(&space2));
+    }
+
+    // Member events must be no-ops at the state layer — see plan 0007.
+    // They still arrive from the chain via convert.rs but never produce
+    // edges in any graph view.
+
+    fn member_event(source: SpaceId, target: SpaceId, add: bool) -> SpaceTopologyEvent {
+        SpaceTopologyEvent {
+            meta: make_block_meta_at(2),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: source,
+                extension: if add {
+                    TrustExtension::MemberAdded {
+                        member_space_id: target,
+                    }
+                } else {
+                    TrustExtension::MemberRemoved {
+                        member_space_id: target,
+                    }
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn test_member_added_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        state.apply_event(&member_event(source, target, true));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            0,
+            "MemberAdded must not produce an explicit edge"
+        );
+        assert!(state.get_explicit_edges(&source).is_none());
+    }
+
+    #[test]
+    fn test_member_removed_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        // Add a verified edge so we can verify MemberRemoved doesn't disturb it.
+        state.apply_event(&make_verified_event(source, target));
+        assert_eq!(state.explicit_edge_count(), 1);
+
+        state.apply_event(&member_event(source, target, false));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            1,
+            "MemberRemoved must not remove unrelated edges"
+        );
     }
 }

--- a/atlas/src/graph/transitive.rs
+++ b/atlas/src/graph/transitive.rs
@@ -254,13 +254,15 @@ impl TransitiveProcessor {
                         self.cache.invalidate(target_space_id);
                     }
 
-                    // Membership edges: invalidate member space
+                    // Editor edges: invalidate member space
                     TrustExtension::EditorAdded { member_space_id }
-                    | TrustExtension::MemberAdded { member_space_id }
-                    | TrustExtension::EditorRemoved { member_space_id }
-                    | TrustExtension::MemberRemoved { member_space_id } => {
+                    | TrustExtension::EditorRemoved { member_space_id } => {
                         self.cache.invalidate(member_space_id);
                     }
+
+                    // Member edges: no-op — Member events do not mutate state (plan 0007).
+                    TrustExtension::MemberAdded { .. }
+                    | TrustExtension::MemberRemoved { .. } => {}
 
                     // Topic edges: invalidate all spaces that announced this topic
                     TrustExtension::Subtopic { target_topic_id }
@@ -616,5 +618,35 @@ mod tests {
             stats_after.reverse_deps_count, 0,
             "stale reverse_deps should be cleaned up"
         );
+    }
+
+    #[test]
+    fn test_member_edge_not_in_transitive() {
+        // Plan 0007: Member edges are no-ops. A space reachable only via a
+        // Member edge must not appear in the transitive graph rooted at the
+        // source — neither in the flat membership set nor in the tree.
+        let mut state = GraphState::new();
+        let a = create_space(&mut state, 1);
+        let b = create_space(&mut state, 2);
+
+        let member_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: a,
+                extension: TrustExtension::MemberAdded { member_space_id: b },
+            }),
+        };
+        state.apply_event(&member_event);
+
+        let mut processor = TransitiveProcessor::new();
+        let graph = processor.get_full(a, &state);
+
+        assert_eq!(graph.len(), 1, "A reaches only itself");
+        assert!(graph.contains(&a));
+        assert!(
+            !graph.contains(&b),
+            "B must not be reachable through a Member edge"
+        );
+        assert_eq!(graph.tree.node_count(), 1);
     }
 }

--- a/atlas/src/graph/transitive.rs
+++ b/atlas/src/graph/transitive.rs
@@ -254,15 +254,11 @@ impl TransitiveProcessor {
                         self.cache.invalidate(target_space_id);
                     }
 
-                    // Editor edges: invalidate member space
-                    TrustExtension::EditorAdded { member_space_id }
-                    | TrustExtension::EditorRemoved { member_space_id } => {
-                        self.cache.invalidate(member_space_id);
-                    }
-
-                    // Member edges: no-op — Member events do not mutate state (plan 0007).
+                    // Member and Editor edges: no-op — these events do not mutate state (plan 0007).
                     TrustExtension::MemberAdded { .. }
-                    | TrustExtension::MemberRemoved { .. } => {}
+                    | TrustExtension::MemberRemoved { .. }
+                    | TrustExtension::EditorAdded { .. }
+                    | TrustExtension::EditorRemoved { .. } => {}
 
                     // Topic edges: invalidate all spaces that announced this topic
                     TrustExtension::Subtopic { target_topic_id }
@@ -646,6 +642,36 @@ mod tests {
         assert!(
             !graph.contains(&b),
             "B must not be reachable through a Member edge"
+        );
+        assert_eq!(graph.tree.node_count(), 1);
+    }
+
+    #[test]
+    fn test_editor_edge_not_in_transitive() {
+        // Plan 0007: Editor edges are no-ops. A space reachable only via an
+        // Editor edge must not appear in the transitive graph rooted at the
+        // source — neither in the flat membership set nor in the tree.
+        let mut state = GraphState::new();
+        let a = create_space(&mut state, 1);
+        let b = create_space(&mut state, 2);
+
+        let editor_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: a,
+                extension: TrustExtension::EditorAdded { member_space_id: b },
+            }),
+        };
+        state.apply_event(&editor_event);
+
+        let mut processor = TransitiveProcessor::new();
+        let graph = processor.get_full(a, &state);
+
+        assert_eq!(graph.len(), 1, "A reaches only itself");
+        assert!(graph.contains(&a));
+        assert!(
+            !graph.contains(&b),
+            "B must not be reachable through an Editor edge"
         );
         assert_eq!(graph.tree.node_count(), 1);
     }

--- a/atlas/src/graph/tree.rs
+++ b/atlas/src/graph/tree.rs
@@ -18,8 +18,6 @@ pub enum EdgeType {
     Topic { topic_id: TopicId },
     /// Editor membership (canonical-granting)
     Editor,
-    /// Member membership (canonical-granting)
-    Member,
 }
 
 /// A node in the traversal tree

--- a/atlas/src/graph/tree.rs
+++ b/atlas/src/graph/tree.rs
@@ -16,8 +16,6 @@ pub enum EdgeType {
     Related,
     /// Topic-based membership — carries the topic that created this edge
     Topic { topic_id: TopicId },
-    /// Editor membership (canonical-granting)
-    Editor,
 }
 
 /// A node in the traversal tree

--- a/atlas/src/kafka/emitter.rs
+++ b/atlas/src/kafka/emitter.rs
@@ -44,7 +44,7 @@ use hermes_instrumentation::{debug_span, warn};
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata as ProtoBlockchainMetadata;
 use hermes_schema::pb::topology::{
     canonical_tree_node::Edge, edge_info, CanonicalGraphDiff, CanonicalGraphUpdated,
-    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge, MemberEdge,
+    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge,
     NodeChange as ProtoNodeChange, RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
 };
 use prost::Message;
@@ -187,7 +187,6 @@ fn edge_type_to_proto_edge(edge_type: EdgeType) -> Edge {
             topic_id: topic_id.to_vec(),
         }),
         EdgeType::Editor => Edge::Editor(EditorEdge {}),
-        EdgeType::Member => Edge::Member(MemberEdge {}),
     }
 }
 
@@ -223,7 +222,6 @@ fn position_to_edge_info(pos: &Position) -> Option<EdgeInfo> {
             topic_id: topic_id.to_vec(),
         }),
         EdgeType::Editor => edge_info::EdgeType::Editor(EditorEdge {}),
-        EdgeType::Member => edge_info::EdgeType::Member(MemberEdge {}),
         EdgeType::Root => {
             warn!(
                 parent = ?pos.parent,
@@ -293,21 +291,19 @@ mod tests {
         root.add_child(TreeNode::new(make_space_id(2), EdgeType::Verified));
         root.add_child(TreeNode::new(make_space_id(3), EdgeType::Related));
         root.add_child(TreeNode::new(make_space_id(4), EdgeType::Editor));
-        root.add_child(TreeNode::new(make_space_id(5), EdgeType::Member));
         root.add_child(TreeNode::new_with_topic(
-            make_space_id(6),
+            make_space_id(5),
             make_topic_id(0x8A),
         ));
 
         let proto = tree_node_to_proto(&root);
-        assert_eq!(proto.children.len(), 5);
+        assert_eq!(proto.children.len(), 4);
 
         assert!(matches!(proto.children[0].edge, Some(Edge::Verified(_))));
         assert!(matches!(proto.children[1].edge, Some(Edge::Related(_))));
         assert!(matches!(proto.children[2].edge, Some(Edge::Editor(_))));
-        assert!(matches!(proto.children[3].edge, Some(Edge::Member(_))));
 
-        match &proto.children[4].edge {
+        match &proto.children[3].edge {
             Some(Edge::Topic(TopicEdge { topic_id })) => {
                 assert_eq!(*topic_id, make_topic_id(0x8A).to_vec());
             }

--- a/atlas/src/kafka/emitter.rs
+++ b/atlas/src/kafka/emitter.rs
@@ -44,7 +44,7 @@ use hermes_instrumentation::{debug_span, warn};
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata as ProtoBlockchainMetadata;
 use hermes_schema::pb::topology::{
     canonical_tree_node::Edge, edge_info, CanonicalGraphDiff, CanonicalGraphUpdated,
-    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge,
+    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo,
     NodeChange as ProtoNodeChange, RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
 };
 use prost::Message;
@@ -186,7 +186,6 @@ fn edge_type_to_proto_edge(edge_type: EdgeType) -> Edge {
         EdgeType::Topic { topic_id } => Edge::Topic(TopicEdge {
             topic_id: topic_id.to_vec(),
         }),
-        EdgeType::Editor => Edge::Editor(EditorEdge {}),
     }
 }
 
@@ -221,7 +220,6 @@ fn position_to_edge_info(pos: &Position) -> Option<EdgeInfo> {
         EdgeType::Topic { topic_id } => edge_info::EdgeType::Topic(TopicEdge {
             topic_id: topic_id.to_vec(),
         }),
-        EdgeType::Editor => edge_info::EdgeType::Editor(EditorEdge {}),
         EdgeType::Root => {
             warn!(
                 parent = ?pos.parent,
@@ -290,20 +288,18 @@ mod tests {
         let mut root = TreeNode::new_root(make_space_id(1));
         root.add_child(TreeNode::new(make_space_id(2), EdgeType::Verified));
         root.add_child(TreeNode::new(make_space_id(3), EdgeType::Related));
-        root.add_child(TreeNode::new(make_space_id(4), EdgeType::Editor));
         root.add_child(TreeNode::new_with_topic(
-            make_space_id(5),
+            make_space_id(4),
             make_topic_id(0x8A),
         ));
 
         let proto = tree_node_to_proto(&root);
-        assert_eq!(proto.children.len(), 4);
+        assert_eq!(proto.children.len(), 3);
 
         assert!(matches!(proto.children[0].edge, Some(Edge::Verified(_))));
         assert!(matches!(proto.children[1].edge, Some(Edge::Related(_))));
-        assert!(matches!(proto.children[2].edge, Some(Edge::Editor(_))));
 
-        match &proto.children[3].edge {
+        match &proto.children[2].edge {
             Some(Edge::Topic(TopicEdge { topic_id })) => {
                 assert_eq!(*topic_id, make_topic_id(0x8A).to_vec());
             }

--- a/atlas/src/kafka/emitter.rs
+++ b/atlas/src/kafka/emitter.rs
@@ -44,8 +44,8 @@ use hermes_instrumentation::{debug_span, warn};
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata as ProtoBlockchainMetadata;
 use hermes_schema::pb::topology::{
     canonical_tree_node::Edge, edge_info, CanonicalGraphDiff, CanonicalGraphUpdated,
-    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo,
-    NodeChange as ProtoNodeChange, RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
+    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, NodeChange as ProtoNodeChange,
+    RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
 };
 use prost::Message;
 

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -611,8 +611,12 @@ impl PostgresCheckpointStore {
             return Ok(None);
         };
 
-        let graph_state_blob: PersistedGraphState = row
-            .try_get::<sqlx::types::Json<PersistedGraphState>, _>("graph_state_blob")
+        // Fetch the graph state blob as raw JSON without decoding into
+        // `PersistedGraphState`. Decoding happens lazily in `Checkpoint::graph_state()`
+        // so `restore_checkpoint_on_startup` can run `validate_compatibility()` first
+        // and route decode failures through the fresh-start fallback path.
+        let graph_state_blob: serde_json::Value = row
+            .try_get::<sqlx::types::Json<serde_json::Value>, _>("graph_state_blob")
             .map_err(|err| {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?
@@ -753,7 +757,12 @@ pub struct Checkpoint {
     pub indexer_id: String,
     pub cursor: String,
     pub block_number: u64,
-    pub graph_state_blob: PersistedGraphState,
+    // Stored as raw JSON so loading can verify the runtime_compatibility_marker
+    // before paying the cost (and risk) of decoding into `PersistedGraphState`.
+    // This lets `restore_checkpoint_on_startup` route decode failures through
+    // the `ATLAS_CHECKPOINT_ALLOW_FRESH_START` fallback path rather than
+    // hard-failing in `PostgresCheckpointStore::load`.
+    pub graph_state_blob: serde_json::Value,
     pub graph_state_version: u32,
     pub runtime_compatibility_marker: String,
     pub root_space_id: String,
@@ -770,6 +779,10 @@ impl Checkpoint {
         runtime_compatibility_marker: String,
         root_space_id: SpaceId,
     ) -> Self {
+        // `PersistedGraphState` is a plain struct of `String`/`Vec`/enum fields,
+        // so serialization to `serde_json::Value` cannot fail in practice.
+        let graph_state_blob = serde_json::to_value(graph_state_blob)
+            .expect("PersistedGraphState always serializes to valid JSON");
         Self {
             schema_version: CHECKPOINT_SCHEMA_VERSION,
             indexer_id,
@@ -804,7 +817,11 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        self.graph_state_blob.to_graph_state()
+        let persisted: PersistedGraphState =
+            serde_json::from_value(self.graph_state_blob.clone()).map_err(|err| {
+                CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
+            })?;
+        persisted.to_graph_state()
     }
 
     pub fn validate_compatibility(
@@ -1278,6 +1295,58 @@ mod tests {
             .validate_compatibility("idx-other", "atlas-v2", make_space_id(1), 1)
             .unwrap_err();
         assert!(matches!(err, CheckpointError::Incompatible(_)));
+    }
+
+    #[test]
+    fn checkpoint_with_unknown_edge_variant_validates_marker_before_decode() {
+        // Regression: a checkpoint blob containing a now-removed edge variant
+        // (e.g. "Member" from atlas-v1) must not fail to construct just because
+        // the blob can't decode into the current `PersistedGraphState`. The
+        // raw-JSON storage lets `validate_compatibility()` reject the checkpoint
+        // on its marker first, and `graph_state()` is the only path that can
+        // surface a decode failure — letting the caller route it through the
+        // fresh-start fallback.
+        let blob_with_member = serde_json::json!({
+            "spaces": ["00000000000000000000000000000001"],
+            "space_topics": [],
+            "topic_spaces": [],
+            "explicit_edges": [{
+                "source_space_id": "00000000000000000000000000000001",
+                "edges": [{
+                    "target_space_id": "00000000000000000000000000000002",
+                    "edge_type": "Member"
+                }]
+            }],
+            "topic_edges": [],
+            "topic_edge_sources": []
+        });
+
+        let checkpoint = Checkpoint {
+            schema_version: CHECKPOINT_SCHEMA_VERSION,
+            indexer_id: "idx-test".to_string(),
+            cursor: "cursor-1".to_string(),
+            block_number: 1,
+            graph_state_blob: blob_with_member,
+            graph_state_version: 1,
+            runtime_compatibility_marker: "atlas-v1".to_string(),
+            root_space_id: encode_id(make_space_id(1)),
+        };
+
+        // Marker validation runs against the in-memory marker field — no decode
+        // needed, so the incompatible marker is reported cleanly.
+        let err = checkpoint
+            .validate_compatibility("idx-test", "atlas-v2", make_space_id(1), 1)
+            .expect_err("atlas-v1 marker must be rejected against atlas-v2 expected");
+        assert!(matches!(err, CheckpointError::Incompatible(_)));
+
+        // Only `graph_state()` (called after marker validation passes) surfaces
+        // the decode failure — and only via `CheckpointError::Serialization`,
+        // which is the path `restore_checkpoint_on_startup` already routes
+        // through `ATLAS_CHECKPOINT_ALLOW_FRESH_START`.
+        let err = checkpoint
+            .graph_state()
+            .expect_err("Member variant is no longer decodable into PersistedGraphState");
+        assert!(matches!(err, CheckpointError::Serialization(_)));
     }
 
     #[test]

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -176,7 +176,7 @@ impl CheckpointConfig {
             graph_state_version,
             indexer_id,
             runtime_compatibility_marker: std::env::var("ATLAS_RUNTIME_COMPATIBILITY_MARKER")
-                .unwrap_or_else(|_| "atlas-v1".to_string()),
+                .unwrap_or_else(|_| "atlas-v2".to_string()),
             fail_open_bound,
             checkpoint_retry_attempts: retry_attempts,
             checkpoint_retry_backoff_ms: retry_backoff_ms,
@@ -901,7 +901,6 @@ pub enum PersistedEdgeType {
     Topic { topic_id: String },
     Root,
     Editor,
-    Member,
 }
 
 impl PersistedGraphState {
@@ -1064,7 +1063,6 @@ impl PersistedEdgeType {
                 topic_id: encode_id(topic_id),
             },
             EdgeType::Editor => Self::Editor,
-            EdgeType::Member => Self::Member,
         }
     }
 
@@ -1077,7 +1075,6 @@ impl PersistedEdgeType {
                 topic_id: decode_topic_id(topic_id)?,
             }),
             PersistedEdgeType::Editor => Ok(EdgeType::Editor),
-            PersistedEdgeType::Member => Ok(EdgeType::Member),
         }
     }
 
@@ -1088,7 +1085,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Related => 2,
             PersistedEdgeType::Topic { .. } => 3,
             PersistedEdgeType::Editor => 4,
-            PersistedEdgeType::Member => 5,
         }
     }
 }
@@ -1203,7 +1199,7 @@ mod tests {
             root_space_id: make_space_id(1),
             graph_state_version: 1,
             indexer_id: "idx-test".to_string(),
-            runtime_compatibility_marker: "atlas-v1".to_string(),
+            runtime_compatibility_marker: "atlas-v2".to_string(),
             fail_open_bound,
             checkpoint_retry_attempts: 1,
             checkpoint_retry_backoff_ms: 50,
@@ -1220,7 +1216,7 @@ mod tests {
             block_number,
             &GraphState::new(),
             1,
-            "atlas-v1".to_string(),
+            "atlas-v2".to_string(),
             make_space_id(1),
         )
     }
@@ -1274,16 +1270,16 @@ mod tests {
             10,
             &GraphState::new(),
             1,
-            "atlas-v1".to_string(),
+            "atlas-v2".to_string(),
             make_space_id(1),
         );
 
         checkpoint
-            .validate_compatibility("idx-test", "atlas-v1", make_space_id(1), 1)
+            .validate_compatibility("idx-test", "atlas-v2", make_space_id(1), 1)
             .unwrap();
 
         let err = checkpoint
-            .validate_compatibility("idx-other", "atlas-v1", make_space_id(1), 1)
+            .validate_compatibility("idx-other", "atlas-v2", make_space_id(1), 1)
             .unwrap_err();
         assert!(matches!(err, CheckpointError::Incompatible(_)));
     }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -900,7 +900,6 @@ pub enum PersistedEdgeType {
     Related,
     Topic { topic_id: String },
     Root,
-    Editor,
 }
 
 impl PersistedGraphState {
@@ -1062,7 +1061,6 @@ impl PersistedEdgeType {
             EdgeType::Topic { topic_id } => Self::Topic {
                 topic_id: encode_id(topic_id),
             },
-            EdgeType::Editor => Self::Editor,
         }
     }
 
@@ -1074,7 +1072,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Topic { topic_id } => Ok(EdgeType::Topic {
                 topic_id: decode_topic_id(topic_id)?,
             }),
-            PersistedEdgeType::Editor => Ok(EdgeType::Editor),
         }
     }
 
@@ -1084,7 +1081,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Verified => 1,
             PersistedEdgeType::Related => 2,
             PersistedEdgeType::Topic { .. } => 3,
-            PersistedEdgeType::Editor => 4,
         }
     }
 }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -817,8 +817,8 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        let persisted: PersistedGraphState =
-            serde_json::from_value(self.graph_state_blob.clone()).map_err(|err| {
+        let persisted: PersistedGraphState = serde_json::from_value(self.graph_state_blob.clone())
+            .map_err(|err| {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?;
         persisted.to_graph_state()

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -817,10 +817,8 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        let persisted: PersistedGraphState = serde_json::from_value(self.graph_state_blob.clone())
-            .map_err(|err| {
-                CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
-            })?;
+        let persisted = PersistedGraphState::deserialize(&self.graph_state_blob)
+            .map_err(|err| CheckpointError::Serialization(format!("decode graph_state_blob: {err}")))?;
         persisted.to_graph_state()
     }
 

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -817,8 +817,10 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        let persisted = PersistedGraphState::deserialize(&self.graph_state_blob)
-            .map_err(|err| CheckpointError::Serialization(format!("decode graph_state_blob: {err}")))?;
+        let persisted =
+            PersistedGraphState::deserialize(&self.graph_state_blob).map_err(|err| {
+                CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
+            })?;
         persisted.to_graph_state()
     }
 

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -637,8 +637,15 @@ fn test_e2e_editor_add_then_remove_produces_no_diff_for_editor() {
         .editor_removed(SPACE_A, SPACE_B)
         .build();
 
-    let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
+    let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
+
+    // Positive assertion: the verified Root -> A edge must produce a real
+    // diff. Without this, an empty diff stream (e.g. broken canonical emission)
+    // would satisfy the absence checks below and pass silently.
+    let graph = last_graph.expect("canonical graph should be computed");
+    assert!(graph.contains(&SPACE_A), "editor_no_diff: SPACE_A should be canonical via verified edge");
+    assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "editor_no_diff");
 
     assert!(
         find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
@@ -669,8 +676,15 @@ fn test_e2e_member_add_then_remove_produces_no_diff_for_member() {
         .member_removed(SPACE_A, SPACE_B)
         .build();
 
-    let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
+    let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
+
+    // Positive assertion: the verified Root -> A edge must produce a real
+    // diff. Without this, an empty diff stream (e.g. broken canonical emission)
+    // would satisfy the absence checks below and pass silently.
+    let graph = last_graph.expect("canonical graph should be computed");
+    assert!(graph.contains(&SPACE_A), "member_no_diff: SPACE_A should be canonical via verified edge");
+    assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "member_no_diff");
 
     assert!(
         find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -497,7 +497,11 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
 // =============================================================================
 
 #[test]
-fn test_e2e_editor_member_edges_grant_canonical() {
+fn test_e2e_editor_edges_grant_canonical_member_does_not() {
+    // Editor edges still grant canonical membership. Member edges do not — see
+    // plan 0007. Same topology: Root --verified--> A --editor--> B,
+    //                                              A --member-->  C
+    // Expected: B is canonical, C is NOT.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -515,9 +519,10 @@ fn test_e2e_editor_member_edges_grant_canonical() {
 
     assert_all_canonical(
         &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B, SPACE_C],
-        "editor_member",
+        &[ROOT_SPACE_ID, SPACE_A, SPACE_B],
+        "editor_grants_canonical",
     );
+    assert_none_canonical(&graph, &[SPACE_C], "member_does_not_grant_canonical");
 }
 
 #[test]
@@ -539,11 +544,14 @@ fn test_e2e_topic_edges_dont_grant_canonical() {
 }
 
 // =============================================================================
-// Test: Transitive Edges from Members
+// Test: Member edges are ignored by canonical computation (plan 0007)
 // =============================================================================
 
 #[test]
-fn test_e2e_member_spaces_edges_are_followed() {
+fn test_e2e_member_edges_do_not_propagate_to_subspaces() {
+    // Root --verified--> A --member--> B --verified--> C
+    // Member edges are no-ops, so the canonical graph stops at A.
+    // Neither B (reached only via member) nor C (only reachable through B) is canonical.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -559,13 +567,9 @@ fn test_e2e_member_spaces_edges_are_followed() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    // All should be canonical: Root -> A -> B -> C
-    assert_all_canonical(
-        &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B, SPACE_C],
-        "member_transitive",
-    );
-    assert_eq!(graph.len(), 4);
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "member_ignored");
+    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_ignored");
+    assert_eq!(graph.len(), 2);
 }
 
 // =============================================================================
@@ -627,7 +631,11 @@ fn test_e2e_editor_removal_causes_removed_diff() {
 }
 
 #[test]
-fn test_e2e_member_removal_causes_removed_diff() {
+fn test_e2e_member_add_then_remove_produces_no_diff_for_member() {
+    // Member edges are no-ops in canonical computation (plan 0007). A
+    // Member-add followed by a Member-remove must not produce any Added,
+    // Moved, or Removed change for the member space — only the verified
+    // edge from Root -> A should show up.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -640,7 +648,18 @@ fn test_e2e_member_removal_causes_removed_diff() {
     let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
 
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "member_removal");
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
+        "member_no_diff: SPACE_B should not appear as Added"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Removed).is_none(),
+        "member_no_diff: SPACE_B should not appear as Removed"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Moved).is_none(),
+        "member_no_diff: SPACE_B should not appear as Moved"
+    );
 }
 
 // =============================================================================
@@ -677,10 +696,10 @@ fn test_e2e_cascading_removal_disconnects_subtree() {
 }
 
 #[test]
-fn test_e2e_member_removal_cascades_to_member_subspaces() {
-    // P2: Member removal cascading
-    // Root -> A (verified), A -> B (member), B -> C (verified)
-    // Remove B as member, C should also become non-canonical
+fn test_e2e_member_removal_does_not_cascade_because_member_is_noop() {
+    // Plan 0007: Member edges never enter the graph, so a Member-remove
+    // also has no effect. Root -> A is canonical; B and C are never reachable
+    // through Member; no Member-related diff is emitted.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -697,10 +716,21 @@ fn test_e2e_member_removal_cascades_to_member_subspaces() {
 
     let graph = last_graph.expect("Should have canonical graph");
 
-    // B and C should be non-canonical
-    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_cascade");
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "member_cascade");
-    assert_change_exists(&diffs, SPACE_C, ChangeType::Removed, "member_cascade");
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "member_noop");
+    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_noop");
+
+    for space in [SPACE_B, SPACE_C] {
+        assert!(
+            find_change(&diffs, space, ChangeType::Added).is_none(),
+            "member_noop: 0x{:02x} should not appear as Added",
+            space[15]
+        );
+        assert!(
+            find_change(&diffs, space, ChangeType::Removed).is_none(),
+            "member_noop: 0x{:02x} should not appear as Removed",
+            space[15]
+        );
+    }
 }
 
 #[test]

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -296,8 +296,11 @@ fn test_e2e_canonical_set_from_test_topology() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    // Verify expected canonical spaces
-    // Note: SPACE_H = make_id(0x11), so member added by Proposal 1 is the same as SPACE_H
+    // After plan 0007: Member and Editor edges are no-ops, so spaces reachable
+    // only through them are no longer canonical.
+    // - SPACE_H = make_id(0x11): added as member of A via Proposal 1, but also
+    //   verified by Root elsewhere in the topology — stays canonical via that path.
+    // - 0x50: added only as editor of B via Proposal 3, no other path — now non-canonical.
     let expected_canonical: Vec<SpaceId> = vec![
         ROOT_SPACE_ID,
         SPACE_A,
@@ -307,17 +310,23 @@ fn test_e2e_canonical_set_from_test_topology() {
         SPACE_E,
         SPACE_F,
         SPACE_G,
-        SPACE_H, // Also added as member of A via Proposal 1 (0x11)
+        SPACE_H, // verified elsewhere, not via Member
         SPACE_I,
         SPACE_J,
-        mock_events::make_id(0x50), // Added as editor of B via Proposal 3
     ];
 
     assert_all_canonical(&graph, &expected_canonical, "test_topology");
 
     // Verify non-canonical spaces
     let expected_non_canonical: Vec<SpaceId> = vec![
-        SPACE_X, SPACE_Y, SPACE_Z, SPACE_W, SPACE_P, SPACE_Q, SPACE_S,
+        SPACE_X,
+        SPACE_Y,
+        SPACE_Z,
+        SPACE_W,
+        SPACE_P,
+        SPACE_Q,
+        SPACE_S,
+        mock_events::make_id(0x50), // editor-only — now non-canonical
     ];
 
     assert_none_canonical(&graph, &expected_non_canonical, "test_topology");
@@ -455,8 +464,9 @@ fn test_e2e_moved_diff_when_parent_changes() {
 }
 
 #[test]
-fn test_e2e_moved_diff_when_edge_type_changes() {
-    // B changes from verified child to editor
+fn test_e2e_moved_diff_when_edge_type_changes_between_canonical_types() {
+    // B changes from verified child to related (both canonical-granting per plan 0007).
+    // Previously this test exercised verified -> editor, but editor is now a no-op.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -464,9 +474,9 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
         // Initial: Root -> A, A -> B (verified)
         .verified(ROOT_SPACE_ID, SPACE_A)
         .verified(SPACE_A, SPACE_B)
-        // Remove verified, add editor (same parent, different edge type)
+        // Remove verified, add related (same parent, different canonical-granting edge type)
         .unverified(SPACE_A, SPACE_B)
-        .editor(SPACE_A, SPACE_B)
+        .related(SPACE_A, SPACE_B)
         .build();
 
     let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
@@ -475,7 +485,7 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
     let graph = last_graph.expect("Should have canonical graph");
     assert!(graph.contains(&SPACE_B), "B should still be canonical");
 
-    // B should have been REMOVED when verified edge removed, then ADDED when editor added
+    // B should have been REMOVED when verified edge removed, then ADDED when related added
     // OR have a MOVED if the implementation tracks edge type changes
     let b_removed = find_change(&diffs, SPACE_B, ChangeType::Removed);
     let b_added_count = diffs
@@ -484,8 +494,6 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
         .filter(|c| c.space_id == SPACE_B && c.change_type == ChangeType::Added)
         .count();
 
-    // Either: B was removed then re-added, or B was moved
-    // Both are valid behaviors for edge type change
     assert!(
         b_removed.is_some() || b_added_count >= 1,
         "B should have REMOVED then ADDED, or MOVED when edge type changes"
@@ -497,11 +505,12 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
 // =============================================================================
 
 #[test]
-fn test_e2e_editor_edges_grant_canonical_member_does_not() {
-    // Editor edges still grant canonical membership. Member edges do not — see
-    // plan 0007. Same topology: Root --verified--> A --editor--> B,
-    //                                              A --member-->  C
-    // Expected: B is canonical, C is NOT.
+fn test_e2e_editor_and_member_edges_do_not_grant_canonical() {
+    // Plan 0007: neither Editor nor Member edges grant canonical membership.
+    // Only Verified, Related, and Subtopic do.
+    // Topology: Root --verified--> A --editor--> B,
+    //                              A --member-->  C
+    // Expected: only Root and A are canonical.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -517,12 +526,12 @@ fn test_e2e_editor_edges_grant_canonical_member_does_not() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    assert_all_canonical(
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "verified_only");
+    assert_none_canonical(
         &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B],
-        "editor_grants_canonical",
+        &[SPACE_B, SPACE_C],
+        "editor_and_member_do_not_grant_canonical",
     );
-    assert_none_canonical(&graph, &[SPACE_C], "member_does_not_grant_canonical");
 }
 
 #[test]
@@ -614,7 +623,11 @@ fn test_e2e_related_edge_removal() {
 }
 
 #[test]
-fn test_e2e_editor_removal_causes_removed_diff() {
+fn test_e2e_editor_add_then_remove_produces_no_diff_for_editor() {
+    // Editor edges are no-ops in canonical computation (plan 0007). An
+    // Editor-add followed by an Editor-remove must not produce any Added,
+    // Moved, or Removed change for the editor space — only the verified
+    // edge from Root -> A should show up.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -627,7 +640,18 @@ fn test_e2e_editor_removal_causes_removed_diff() {
     let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
 
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "editor_removal");
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Added"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Removed).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Removed"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Moved).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Moved"
+    );
 }
 
 #[test]

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -644,7 +644,10 @@ fn test_e2e_editor_add_then_remove_produces_no_diff_for_editor() {
     // diff. Without this, an empty diff stream (e.g. broken canonical emission)
     // would satisfy the absence checks below and pass silently.
     let graph = last_graph.expect("canonical graph should be computed");
-    assert!(graph.contains(&SPACE_A), "editor_no_diff: SPACE_A should be canonical via verified edge");
+    assert!(
+        graph.contains(&SPACE_A),
+        "editor_no_diff: SPACE_A should be canonical via verified edge"
+    );
     assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "editor_no_diff");
 
     assert!(
@@ -683,7 +686,10 @@ fn test_e2e_member_add_then_remove_produces_no_diff_for_member() {
     // diff. Without this, an empty diff stream (e.g. broken canonical emission)
     // would satisfy the absence checks below and pass silently.
     let graph = last_graph.expect("canonical graph should be computed");
-    assert!(graph.contains(&SPACE_A), "member_no_diff: SPACE_A should be canonical via verified edge");
+    assert!(
+        graph.contains(&SPACE_A),
+        "member_no_diff: SPACE_A should be canonical via verified edge"
+    );
     assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "member_no_diff");
 
     assert!(

--- a/hermes/k8s/production/atlas.yaml
+++ b/hermes/k8s/production/atlas.yaml
@@ -75,7 +75,7 @@ spec:
             - name: ATLAS_INDEXER_ID
               value: "atlas-production"
             - name: ATLAS_RUNTIME_COMPATIBILITY_MARKER
-              value: "atlas-v1"
+              value: "atlas-v2"
             - name: ATLAS_FAIL_OPEN_BOUND
               value: "10"
             - name: ATLAS_CHECKPOINT_RETRY_ATTEMPTS
@@ -84,8 +84,11 @@ spec:
               value: "200"
             - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
               value: "120"
+            # Set to "true" for the atlas-v1 → atlas-v2 rollout window so the
+            # incompatible checkpoint is rejected and Atlas bootstraps fresh.
+            # Revert to "false" once Atlas has stamped a new atlas-v2 checkpoint.
             - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
-              value: "false"
+              value: "true"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/staging/atlas.yaml
+++ b/hermes/k8s/staging/atlas.yaml
@@ -77,7 +77,7 @@ spec:
             - name: ATLAS_INDEXER_ID
               value: "atlas-staging"
             - name: ATLAS_RUNTIME_COMPATIBILITY_MARKER
-              value: "atlas-v1"
+              value: "atlas-v2"
             - name: ATLAS_FAIL_OPEN_BOUND
               value: "10"
             - name: ATLAS_CHECKPOINT_RETRY_ATTEMPTS
@@ -86,8 +86,11 @@ spec:
               value: "200"
             - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
               value: "120"
+            # Set to "true" for the atlas-v1 → atlas-v2 rollout window so the
+            # incompatible checkpoint is rejected and Atlas bootstraps fresh.
+            # Revert to "false" once Atlas has stamped a new atlas-v2 checkpoint.
             - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
-              value: "false"
+              value: "true"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- `MemberAdded` / `MemberRemoved` / `EditorAdded` / `EditorRemoved` chain events flow through ``convert.rs`` unchanged but are no-oped in ``GraphState::apply_trust_extended``. The only canonical-granting explicit edge types are now **Verified** and **Related**.
- ``EdgeType::Member`` and ``EdgeType::Editor`` deleted from the codebase. ``MemberEdge`` / ``EditorEdge`` proto types stay defined for downstream stability, but Atlas no longer emits them.
- Persistence marker bumped ``atlas-v1 → atlas-v2``. **Existing checkpoints will be rejected on load.**
- ``hermes/k8s/{production,staging}/atlas.yaml`` set ``ATLAS_CHECKPOINT_ALLOW_FRESH_START=true`` so the new image can bootstrap from ``SUBSTREAMS_START_BLOCK``.
- Docs: ``atlas/docs/graph-concepts.md`` updated; plan 0007 added at ``atlas/docs/agents/plans/0007-remove-member-edges-plan.md``.

Also brings ``wonderland/dev`` forward on monitoring commits (kafka consumer lag exporter / dashboard / alerts, Hermes Lag dashboard touchups) that are already on ``origin/dev`` of the geobrowser fork.

## Breaking — checkpoint format

After this merges and the image is built, Atlas in every environment will reject its existing ``atlas-v1`` checkpoint on next start. ``ATLAS_CHECKPOINT_ALLOW_FRESH_START=true`` (already set in the k8s manifests in this PR) lets it bootstrap fresh from ``SUBSTREAMS_START_BLOCK`` (default ``82655``).

## Rollout

1. Deploy this PR's image. Atlas logs ``Checkpoint rejected; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh`` and replays.
2. Watch ``topology.canonical`` consumer-group lag (kg-indexer, search-indexer) — expected to spike, must settle.
3. Confirm the first new checkpoint row stamps ``runtime_compatibility_marker = 'atlas-v2'``.
4. Spot-check a known Member-only canonical space is no longer canonical.
5. After Atlas is stable, revert ``ATLAS_CHECKPOINT_ALLOW_FRESH_START`` to ``false`` so future checkpoint corruption fails loud.

Per the plan, downstream indexers apply canonical diffs idempotently, so no consumer reset is needed beyond the natural lag spike.

## Test plan

- [x] ``cargo test -p atlas`` — 128 tests pass (verified on PR #194)
- [x] ``cargo build -p atlas`` and ``cargo bench -p atlas --no-run`` clean
- [x] ``grep -rn "EdgeType::Member\|EdgeType::Editor" atlas/`` returns no matches
- [ ] Staging deploy completes a fresh bootstrap to ``atlas-v2`` (GEO-626 acceptance)
- [ ] Spot-check on staging: a previously Member-only canonical space is dropped (GEO-626 acceptance)