### PR TITLE
Raise search query limit to 250 chars

### DIFF
--- a/api/src/search/index.test.ts
+++ b/api/src/search/index.test.ts
@@ -229,18 +229,18 @@ describe("Search Router - Integration Tests", () => {
 
 		// Error cases
 		it("returns 400 for query longer than maximum length", async () => {
-			const longQuery = "a".repeat(101)
+			const longQuery = "a".repeat(251)
 			const request = new Request(`http://localhost/search?query=${longQuery}`)
 			const response = await app.fetch(request)
 			const result = await response.json()
 
 			expect(response.status).toBe(400)
 			expect(result.error).toBe("Invalid parameter")
-			expect(result.message).toContain("must not exceed 100 characters")
+			expect(result.message).toContain("must not exceed 250 characters")
 		})
 
-		it("accepts query exactly at the 100-char boundary", async () => {
-			const boundaryQuery = "a".repeat(100)
+		it("accepts query exactly at the 250-char boundary", async () => {
+			const boundaryQuery = "a".repeat(250)
 			const request = new Request(`http://localhost/search?query=${boundaryQuery}`)
 			const response = await app.fetch(request)
 

--- a/api/src/search/index.ts
+++ b/api/src/search/index.ts
@@ -46,12 +46,12 @@ const MAX_LIMIT = 100
  * clause explosions. The previous 500-char ceiling let long pasted text
  * (e.g. press-release blurbs) reach OpenSearch and blow past
  * `indices.query.bool.max_clause_count = 1024` via fuzzy + prefix
- * expansion. 100 chars covers realistic name/title-style search inputs
- * while keeping the worst-case clause count well under 1024 even when
- * combined with the per-sub-query token cap and fuzzy gate (see
- * MAX_TEXT_TOKENS, FUZZY_MAX_TOKENS in opensearch.ts).
+ * expansion. 250 chars admits longer name/title-style search inputs
+ * while keeping expanded query clauses bounded by the token caps and
+ * fuzzy gate in opensearch.ts (see MAX_TEXT_TOKENS,
+ * MAX_NAME_MATCH_TEXT_TOKENS, FUZZY_MAX_TOKENS, FUZZY_MAX_EXPANSIONS).
  */
-const MAX_QUERY_LENGTH = 100
+const MAX_QUERY_LENGTH = 250
 
 /**
  * Maximum length for space_id parameter (UUID format: 36 dashed, 32 dashless).
@@ -164,14 +164,14 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 					in: "query",
 					description: "Search query string (alias: q)",
 					required: false,
-					schema: {type: "string", maxLength: 100},
+					schema: {type: "string", maxLength: MAX_QUERY_LENGTH},
 				},
 				{
 					name: "q",
 					in: "query",
 					description: "Search query string (alias for query)",
 					required: false,
-					schema: {type: "string", maxLength: 100},
+					schema: {type: "string", maxLength: MAX_QUERY_LENGTH},
 				},
 				{
 					name: "scope",

--- a/api/src/services/search/opensearch.test.ts
+++ b/api/src/services/search/opensearch.test.ts
@@ -1,6 +1,15 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
 
-import {DEFAULT_AVERAGE_SCORE, MIN_SCORE_THRESHOLD, OpenSearchClient, SCORE_BOOST, SCORE_SHIFT} from "./opensearch"
+import {
+	FUZZY_MAX_EXPANSIONS,
+	MAX_NAME_MATCH_TEXT_TOKENS,
+	MAX_TEXT_TOKENS,
+	MIN_SCORE_THRESHOLD,
+	OpenSearchClient,
+	PHRASE_PREFIX_MAX_EXPANSIONS,
+	SCORE_BOOST,
+	SCORE_SHIFT,
+} from "./opensearch"
 
 describe("OpenSearchClient", () => {
 	let client: OpenSearchClient
@@ -30,14 +39,14 @@ describe("OpenSearchClient", () => {
 			expect(queryStr).toContain("match_phrase_prefix")
 		})
 
-		it("caps clause-heavy sub-queries to 20 tokens; exact-match clauses see full query", () => {
+		it("caps clause-heavy sub-queries to 20 tokens; exact-match clauses see full query within name cap", () => {
 			// Query of 30 tokens → cap should kick in at 20 for bool_prefix /
 			// match_phrase_prefix. The exact-match clauses (term: name_raw, match: name)
-			// must still see all 30 tokens so a full-name match isn't lost. Fuzzy is
-			// dropped entirely at this token count (see separate test).
+			// still see all 30 tokens because this is below MAX_NAME_MATCH_TEXT_TOKENS.
+			// Fuzzy is dropped entirely at this token count (see separate test).
 			const tokens = Array.from({length: 30}, (_, i) => `t${i + 1}`)
 			const fullQuery = tokens.join(" ")
-			const cappedQuery = tokens.slice(0, 20).join(" ")
+			const cappedQuery = tokens.slice(0, MAX_TEXT_TOKENS).join(" ")
 			const overflowToken = tokens[25] // would be present if cap weren't applied
 
 			const query = client.buildBaseTextQuery(fullQuery) as {
@@ -70,10 +79,67 @@ describe("OpenSearchClient", () => {
 			expect(boolPrefix.multi_match.query).not.toContain(overflowToken)
 			expect(phrasePrefixName.match_phrase_prefix.name.query).toBe(cappedQuery)
 			expect(phrasePrefixDesc.match_phrase_prefix.description.query).toBe(cappedQuery)
+			expect(phrasePrefixName.match_phrase_prefix.name).toHaveProperty(
+				"max_expansions",
+				PHRASE_PREFIX_MAX_EXPANSIONS,
+			)
+			expect(phrasePrefixDesc.match_phrase_prefix.description).toHaveProperty(
+				"max_expansions",
+				PHRASE_PREFIX_MAX_EXPANSIONS,
+			)
 
 			// Exact-match sub-queries: still see the full 30-token query
 			expect(matchExactToken.match.name.query).toBe(fullQuery)
 			expect(matchExactToken.match.name.query).toContain(overflowToken)
+			expect(termExactName.term.name_raw.value).toBe(fullQuery)
+		})
+
+		it("caps a 250-character adversarial token query to bounded OpenSearch clauses", () => {
+			const tokens = [...Array.from({length: 64}, (_, i) => `t${i + 1}`), "zzz"]
+			const fullQuery = tokens.join(" ")
+			expect(fullQuery).toHaveLength(250)
+
+			const cappedQuery = tokens.slice(0, MAX_TEXT_TOKENS).join(" ")
+			const nameMatchQuery = tokens.slice(0, MAX_NAME_MATCH_TEXT_TOKENS).join(" ")
+			const overflowToken = tokens[55]
+
+			const query = client.buildBaseTextQuery(fullQuery) as {
+				bool: {should: Record<string, unknown>[]}
+			}
+			const should = query.bool.should
+
+			const fuzzy = should.find(
+				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
+			)
+			const boolPrefix = should.find(
+				(c) => "multi_match" in c && (c.multi_match as {type?: string}).type === "bool_prefix",
+			) as {multi_match: {query: string}}
+			const phrasePrefixName = should.find(
+				(c) => "match_phrase_prefix" in c && (c.match_phrase_prefix as {name?: unknown}).name !== undefined,
+			) as {match_phrase_prefix: {name: {query: string; max_expansions: number}}}
+			const phrasePrefixDesc = should.find(
+				(c) =>
+					"match_phrase_prefix" in c &&
+					(c.match_phrase_prefix as {description?: unknown}).description !== undefined,
+			) as {match_phrase_prefix: {description: {query: string; max_expansions: number}}}
+			const matchExactToken = should.find(
+				(c) => "match" in c && (c.match as {name?: unknown}).name !== undefined,
+			) as {match: {name: {query: string}}}
+			const termExactName = should.find(
+				(c) =>
+					"term" in c &&
+					typeof (c.term as {name_raw?: {value?: string; boost?: number}}).name_raw?.value === "string",
+			) as {term: {name_raw: {value: string}}}
+
+			expect(fuzzy).toBeUndefined()
+			expect(boolPrefix.multi_match.query).toBe(cappedQuery)
+			expect(boolPrefix.multi_match.query).not.toContain(overflowToken)
+			expect(phrasePrefixName.match_phrase_prefix.name.query).toBe(cappedQuery)
+			expect(phrasePrefixName.match_phrase_prefix.name.max_expansions).toBe(PHRASE_PREFIX_MAX_EXPANSIONS)
+			expect(phrasePrefixDesc.match_phrase_prefix.description.query).toBe(cappedQuery)
+			expect(phrasePrefixDesc.match_phrase_prefix.description.max_expansions).toBe(PHRASE_PREFIX_MAX_EXPANSIONS)
+			expect(matchExactToken.match.name.query).toBe(nameMatchQuery)
+			expect(matchExactToken.match.name.query).not.toContain(overflowToken)
 			expect(termExactName.term.name_raw.value).toBe(fullQuery)
 		})
 
@@ -90,7 +156,24 @@ describe("OpenSearchClient", () => {
 			expect(fuzzy.multi_match.fuzziness).toBe("AUTO")
 			expect(fuzzy.multi_match.query).toBe("alpha beta gamma")
 			// max_expansions is capped (default OS value is 50; we pin lower for safety).
-			expect(fuzzy.multi_match.max_expansions).toBe(25)
+			expect(fuzzy.multi_match.max_expansions).toBe(FUZZY_MAX_EXPANSIONS)
+		})
+
+		it("keeps fuzzy enabled for a 250-character query when token count is within the fuzzy gate", () => {
+			const fullQuery = `${"a".repeat(80)} ${"b".repeat(80)} ${"c".repeat(88)}`
+			expect(fullQuery).toHaveLength(250)
+
+			const query = client.buildBaseTextQuery(fullQuery) as {
+				bool: {should: Record<string, unknown>[]}
+			}
+			const fuzzy = query.bool.should.find(
+				(c) => "multi_match" in c && (c.multi_match as {fuzziness?: string}).fuzziness !== undefined,
+			) as {multi_match: {query: string; fuzziness: string; max_expansions: number}}
+
+			expect(fuzzy).toBeDefined()
+			expect(fuzzy.multi_match.fuzziness).toBe("AUTO")
+			expect(fuzzy.multi_match.query).toBe(fullQuery)
+			expect(fuzzy.multi_match.max_expansions).toBe(FUZZY_MAX_EXPANSIONS)
 		})
 
 		it("drops fuzzy clause when token count > 3 (fan-out reduction)", () => {

--- a/api/src/services/search/opensearch.ts
+++ b/api/src/services/search/opensearch.ts
@@ -193,6 +193,15 @@ const TOKEN_BOUNDARY_REGEX = /[\s\p{P}\p{S}]+/u
 export const MAX_TEXT_TOKENS = 20
 
 /**
+ * Maximum number of tokens fed to the analyzed exact-token `match` query
+ * on `name`. This query does not have fuzzy or prefix expansion, but it
+ * still rewrites analyzed input into term clauses. Keep raw exact-name
+ * keyword clauses on the full query, and cap only this analyzed path so
+ * adversarial one-character-token input cannot add unbounded clauses.
+ */
+export const MAX_NAME_MATCH_TEXT_TOKENS = 50
+
+/**
  * Maximum token count at which fuzzy `multi_match` is included in the
  * base text query. Above this, fuzzy is skipped entirely — its
  * per-token edit-distance fan-out is the highest of any sub-query, and
@@ -215,6 +224,13 @@ export const FUZZY_MAX_TOKENS = 3
  * for the common 1-2-edit cases.
  */
 export const FUZZY_MAX_EXPANSIONS = 25
+
+/**
+ * Maximum number of terms the trailing token can expand to in
+ * `match_phrase_prefix` queries. This matches OpenSearch's default, but
+ * keeping it explicit makes the clause budget auditable.
+ */
+export const PHRASE_PREFIX_MAX_EXPANSIONS = 50
 
 /**
  * Count tokens in the query (drops empty splits from leading/trailing
@@ -989,10 +1005,11 @@ export class OpenSearchClient implements SearchClient {
 
 	buildBaseTextQuery(queryText: string): object {
 		// Heavy sub-queries (fuzzy + bool_prefix + match_phrase_prefix) see only
-		// the first MAX_TEXT_TOKENS tokens to bound clause fan-out. Exact-match
-		// sub-queries (term: name_raw, match: name) keep the full query so a
-		// full-name match still wins when available.
+		// the first MAX_TEXT_TOKENS tokens to bound clause fan-out. The analyzed
+		// name match gets its own larger cap, while raw exact-name keyword clauses
+		// keep the full query so a full-name match still wins when available.
 		const cappedQuery = truncateToTokens(queryText, MAX_TEXT_TOKENS)
+		const nameMatchQuery = truncateToTokens(queryText, MAX_NAME_MATCH_TEXT_TOKENS)
 		// Fuzzy `multi_match` AUTO is the highest-fan-out clause (each term
 		// expands into edit-distance variants × 2 fields). Drop it entirely
 		// for queries with more than FUZZY_MAX_TOKENS analyzer-aligned tokens
@@ -1053,11 +1070,13 @@ export class OpenSearchClient implements SearchClient {
 						// underscores, etc.), so "world-affairs" and "World affairs" both
 						// match as tokens ["world", "affairs"]. Unlike name.raw above,
 						// this does not differentiate based on punctuation or casing.
+						// Capped separately from prefix/fuzzy queries so adversarial input
+						// cannot add more than MAX_NAME_MATCH_TEXT_TOKENS term clauses here.
 						// e.g. query "geo" matches name "Geo" (token "geo") but NOT
 						// "geojson_preview_tool" (token "geojson" ≠ "geo").
 						match: {
 							name: {
-								query: queryText,
+								query: nameMatchQuery,
 								boost: this.b("name_exact_token_boost", NAME_EXACT_TOKEN_BOOST),
 							},
 						},
@@ -1108,6 +1127,7 @@ export class OpenSearchClient implements SearchClient {
 						match_phrase_prefix: {
 							name: {
 								query: cappedQuery,
+								max_expansions: PHRASE_PREFIX_MAX_EXPANSIONS,
 								boost: this.b("name_prefix_boost", NAME_PREFIX_BOOST),
 							},
 						},
@@ -1118,6 +1138,7 @@ export class OpenSearchClient implements SearchClient {
 						match_phrase_prefix: {
 							description: {
 								query: cappedQuery,
+								max_expansions: PHRASE_PREFIX_MAX_EXPANSIONS,
 								boost: this.b("description_prefix_boost", DESCRIPTION_PREFIX_BOOST),
 							},
 						},


### PR DESCRIPTION
## Summary
- Raises `/search` query validation and OpenAPI docs to 250 characters.
- Keeps OpenSearch clause growth bounded with explicit token and expansion caps.
- Adds boundary and adversarial query-shape coverage.

## Test plan
- `bun run test --run src/search/index.test.ts src/services/search/opensearch.test.ts`
- `bun run check`
- Local Docker OpenSearch API smoke test with long headline and adversarial queries

Made with [Cursor](https://cursor.com)