### PR TITLE
fix(notification-service): give staging consumer groups distinct IDs

### DIFF
--- a/notification-service/deployment/staging/notification-indexer.yaml
+++ b/notification-service/deployment/staging/notification-indexer.yaml
@@ -67,9 +67,9 @@ spec:
             - name: ENVIRONMENT
               value: "staging"
             - name: KAFKA_GROUP_ID_GOVERNANCE
-              value: "notification-indexer-governance-v1-staging"
+              value: "notification-indexer-governance-staging-v1"
             - name: KAFKA_GROUP_ID_KNOWLEDGE_EDITS
-              value: "notification-indexer-knowledge-edits-v1-staging"
+              value: "notification-indexer-knowledge-edits-staging-v1"
             - name: REJECTION_POLL_INTERVAL_SECS
               value: "60"
             # Logging

--- a/notification-service/deployment/staging/notification-indexer.yaml
+++ b/notification-service/deployment/staging/notification-indexer.yaml
@@ -67,9 +67,9 @@ spec:
             - name: ENVIRONMENT
               value: "staging"
             - name: KAFKA_GROUP_ID_GOVERNANCE
-              value: "notification-indexer-governance-v1"
+              value: "notification-indexer-governance-v1-staging"
             - name: KAFKA_GROUP_ID_KNOWLEDGE_EDITS
-              value: "notification-indexer-knowledge-edits-v1"
+              value: "notification-indexer-knowledge-edits-v1-staging"
             - name: REJECTION_POLL_INTERVAL_SECS
               value: "60"
             # Logging


### PR DESCRIPTION
## Summary
Staging and production `notification-indexer` deployments use **identical Kafka `group.id`s** (`notification-indexer-governance-v1`, `notification-indexer-knowledge-edits-v1`) against the **same Kafka cluster**. Because group identity is broker-side, the coordinator treats them as one logical group whose two members subscribe to a union of `staging.*` and unprefixed (prod) topics. Kafka's PartitionAssignor then distributes partitions of both topics across both consumers — meaning a staging pod can be assigned a prod partition (and vice versa), receive messages it shouldn't, and commit offsets against the shared group.

Insert `-staging` before the version suffix so each env owns its own broker-side group:

| Env | Before | After |
|---|---|---|
| prod | `notification-indexer-governance-v1` | unchanged |
| staging | `notification-indexer-governance-v1` | `notification-indexer-governance-staging-v1` |
| prod | `notification-indexer-knowledge-edits-v1` | unchanged |
| staging | `notification-indexer-knowledge-edits-v1` | `notification-indexer-knowledge-edits-staging-v1` |

This matches the convention already used by `kg-indexer` (`kg-indexer-v8-staging`), `scoring-service` (`vote-indexer-staging`, `topology-indexer-staging`), and `search-indexer` staging groups. It also makes the group name a reliable env signal for alert routing — `KafkaConsumerGroupEmpty` lacks a `topic` label, so `consumergroup` is the only env hint available for that rule.

## Side effects (read carefully before merging)
- **Staging will reset to earliest offset** on the next deploy under the new group ID. Acceptable in staging, but expect a one-time replay of `staging.space.governance` and `staging.knowledge.edits`.
- **Prod's existing group keeps its committed offsets**, but those offsets reflect a history of mixed staging/prod commits from the shared group. Prod may briefly re-process or skip events around the cut-over until the group settles on prod-only members.

## Follow-up (separate PR, not this one)
With staging group IDs now consistently containing `-staging` across services, the alertmanager route in `monitoring/values.yaml` can pick up staging Kafka alerts that lack a `topic` label (notably `KafkaConsumerGroupEmpty`) by matching `consumergroup =~ ".*-staging.*|^staging-.*"` (note: `-staging-v1` suffixes do not match a `.*-staging$` anchor). Doing that in a separate PR keeps this one scoped to the data-correctness fix.

## Test plan
- [ ] Deploy to staging, confirm new consumer groups `notification-indexer-*-staging-v1` appear in the broker and start consuming `staging.*` topics from earliest.
- [ ] Confirm prod `notification-indexer-*-v1` group now reports a stable single membership (no staging pod).
- [ ] Spot-check delivery: trigger a staging event, confirm notification fires; trigger a prod event, confirm notification fires. Neither cross-contaminates.