### PR TITLE
fix(monitoring): stop committing Grafana admin password into the repo

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -39,11 +39,31 @@ kubectl port-forward svc/kube-prometheus-stack-grafana 3000:80 -n monitoring
 
 **Credentials:**
 - Username: `admin`
-- Password: Run this to retrieve:
-  ```bash
-  kubectl get secret kube-prometheus-stack-grafana -n monitoring \
-    -o jsonpath="{.data.admin-password}" | base64 -d && echo
-  ```
+- Password lives in the `kube-prometheus-stack-grafana` Secret (managed manually — the chart no longer renders it, see `values.yaml` `grafana.admin.existingSecret`).
+
+Retrieve:
+```bash
+kubectl -n monitoring get secret kube-prometheus-stack-grafana \
+  -o jsonpath="{.data.admin-password}" | base64 -d && echo
+```
+
+Create on a fresh cluster (Grafana pod CrashLoops until this exists):
+```bash
+PW=$(openssl rand -base64 24)
+kubectl -n monitoring create secret generic kube-prometheus-stack-grafana \
+  --from-literal=admin-user=admin \
+  --from-literal=admin-password="$PW"
+echo "save to password manager: $PW"
+```
+
+Rotate:
+```bash
+PW=$(openssl rand -base64 24)
+kubectl -n monitoring patch secret kube-prometheus-stack-grafana --type=json \
+  -p="[{\"op\":\"replace\",\"path\":\"/data/admin-password\",\"value\":\"$(printf %s "$PW" | base64)\"}]"
+kubectl -n monitoring rollout restart deployment/kube-prometheus-stack-grafana
+echo "save to password manager: $PW"
+```
 
 ## Access Prometheus UI
 

--- a/monitoring/k8s/prometheus-stack.yaml
+++ b/monitoring/k8s/prometheus-stack.yaml
@@ -74599,26 +74599,6 @@ metadata:
 automountServiceAccountToken: true
 
 ---
-# Source: kube-prometheus-stack/charts/grafana/templates/secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kube-prometheus-stack-grafana
-  namespace: monitoring
-  labels:
-    helm.sh/chart: grafana-10.5.12
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/version: "12.3.1"
-    app.kubernetes.io/component: admin-secret
-type: Opaque
-data:
-  
-  admin-user: "YWRtaW4="
-  admin-password: "dGVGZ3Zyc080MHNOMklmejBOZU0xemVlZWs1cFBTYmxvRUJUekJkWQ=="
-  ldap-toml: ""
-
----
 # Source: kube-prometheus-stack/templates/alertmanager/secret.yaml
 apiVersion: v1
 kind: Secret
@@ -76131,7 +76111,6 @@ spec:
       annotations:
         checksum/config: 5bceeca3808849664f09f642547ce17fdf495522238ef9ce952b20cfa36b7de5
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
-        checksum/secret: 7ca6374aec4ac2e2302144a2b142aa41295e31a6795b36b890ecd86b3f4e7df1
         kubectl.kubernetes.io/default-container: grafana
     spec:
       

--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -4,9 +4,16 @@
 # Grafana configuration
 grafana:
   enabled: true
-  adminUser: admin
-  # Password will be auto-generated and stored in a Secret
-  # Retrieve with: kubectl get secret kube-prometheus-stack-grafana -n monitoring -o jsonpath="{.data.admin-password}" | base64 -d
+  # Read admin user/password from the existing Secret instead of letting the
+  # chart regenerate the password on every `helm template` run. The Secret
+  # was originally created by the chart and lives in the cluster — we just
+  # stop overwriting it. Retrieve the password with:
+  #   kubectl -n monitoring get secret kube-prometheus-stack-grafana \
+  #     -o jsonpath="{.data.admin-password}" | base64 -d
+  admin:
+    existingSecret: kube-prometheus-stack-grafana
+    userKey: admin-user
+    passwordKey: admin-password
 
   service:
     type: ClusterIP


### PR DESCRIPTION
## Why
The kube-prometheus-stack Grafana subchart, when not given an `existingSecret`, **generates a random admin password and embeds it (base64) directly in the rendered Secret manifest**. That manifest got committed to `monitoring/k8s/prometheus-stack.yaml`, meaning the live Grafana admin password has been visible in this repo since the file was first generated — and every re-render rotated it, so `git log -p monitoring/k8s/prometheus-stack.yaml` walks through every previously-rendered password too. Base64 is not encryption; one shell command decodes it.

Secondary benefit: each re-render had to manually revert the password (and its derived `checksum/secret` pod annotation) to avoid rotating the live one. This eliminates that ritual.

## What this changes
- `values.yaml`: set `grafana.admin.existingSecret: kube-prometheus-stack-grafana` so the chart references the existing in-cluster Secret instead of generating its own. Adds a comment explaining the lifecycle.
- `prometheus-stack.yaml`: -21 lines — the Grafana Secret manifest is no longer rendered, and the dependent `checksum/secret` annotation is gone from the Deployment.
- `README.md`: documents retrieving, creating (fresh cluster), and rotating the Secret.

## What this does NOT fix
**The password is still in git history.** This PR only stops *future* renders from committing one. To fully remediate, rotate the live password after merging — the password-in-history is now a known-leaked credential. The README has the rotation command.

## Operational notes
- **Live Secret untouched** on apply: `kubectl apply --server-side` does not prune resources missing from the manifest, so the cluster's existing `kube-prometheus-stack-grafana` Secret stays.
- **Fresh-cluster gotcha:** the Grafana pod will `CrashLoop` with `CreateContainerConfigError` if the Secret doesn't exist, because the Deployment references it via `secretKeyRef`. README documents the create command.
- **Manual rotations no longer auto-restart Grafana** — the `checksum/secret` annotation that used to force a pod restart when the Secret changed is gone. Use `kubectl -n monitoring rollout restart deployment/kube-prometheus-stack-grafana` after a manual rotation.
- **One-time rolling restart** of the Grafana pod expected on first apply (annotation removal changes the pod template hash).

## Test plan
- [ ] Apply: `kubectl apply -f monitoring/k8s/prometheus-stack.yaml --server-side`
- [ ] Confirm `kube-prometheus-stack-grafana` Secret still exists in `monitoring` namespace with the same password (no value change).
- [ ] Confirm Grafana pod restarts cleanly and existing login still works.
- [ ] Re-run `helm template ... > monitoring/k8s/prometheus-stack.yaml` — diff should be empty (no password to revert).
- [ ] **Rotate the live password** per README's rotation command (the previously-committed one is leaked).