### PR TITLE
atlas: remove Member/Editor edges from canonical graph + persist emission baseline

### DIFF
--- a/api/drizzle/0057_atlas_emission_baseline.sql
+++ b/api/drizzle/0057_atlas_emission_baseline.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "atlas_checkpoints" ADD COLUMN "emission_baseline_blob" "bytea";

--- a/api/drizzle/meta/0057_snapshot.json
+++ b/api/drizzle/meta/0057_snapshot.json
@@ -1,0 +1,3314 @@
+{
+  "id": "35d7f3c5-6562-4096-955a-4543c4479274",
+  "prevId": "8844e0b6-b70a-474f-b092-307b7d002c9e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1776466400952,
       "tag": "0056_entities_ordered_by_score",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1779459255335,
+      "tag": "0057_atlas_emission_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -92,6 +92,7 @@ export const atlasCheckpoints = pgTable("atlas_checkpoints", {
 	rootSpaceId: text("root_space_id").notNull(),
 	schemaVersion: smallint("schema_version").notNull(),
 	graphStateBlob: jsonb("graph_state_blob").notNull(),
+	emissionBaselineBlob: bytea("emission_baseline_blob"),
 	updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull().defaultNow(),
 })
 

--- a/atlas/README.md
+++ b/atlas/README.md
@@ -57,7 +57,7 @@ Access Kafka UI at http://localhost:8080 to view messages.
 | `SUBSTREAMS_END_BLOCK` | No | `u64::MAX` | End block for live stream |
 | `ATLAS_CHECKPOINT_DATABASE_URL` | No | - | PostgreSQL URL for checkpoint persistence |
 | `ATLAS_INDEXER_ID` | Conditional | - | Required and non-empty when checkpoint persistence is enabled |
-| `ATLAS_RUNTIME_COMPATIBILITY_MARKER` | No | `atlas-v1` | Runtime marker used for checkpoint compatibility validation |
+| `ATLAS_RUNTIME_COMPATIBILITY_MARKER` | No | `atlas-v2` | Runtime marker used for checkpoint compatibility validation |
 | `ATLAS_CHECKPOINT_ALLOW_FRESH_START` | No | `false` | If true, incompatible/corrupt checkpoints fall back to fresh bootstrap |
 | `ATLAS_FAIL_OPEN_BOUND` | No | `10` | Max uncheckpointed blocks before Atlas pauses processing |
 | `ATLAS_CHECKPOINT_RETRY_ATTEMPTS` | No | `3` | Retry attempts for checkpoint writes |

--- a/atlas/benches/graph_diff.rs
+++ b/atlas/benches/graph_diff.rs
@@ -35,7 +35,6 @@ fn build_random_tree(node_count: usize, seed: u64) -> TreeNode {
         EdgeType::Verified,
         EdgeType::Related,
         EdgeType::Editor,
-        EdgeType::Member,
     ];
 
     // Build tree recursively from parent indices
@@ -141,9 +140,8 @@ fn mutate_tree(tree: &TreeNode, change_rate: f64, seed: u64) -> TreeNode {
             EdgeType::Verified,
             EdgeType::Related,
             EdgeType::Editor,
-            EdgeType::Member,
         ];
-        nodes.push((new_id, edge_types[rng.gen_range(0..4)], vec![]));
+        nodes.push((new_id, edge_types[rng.gen_range(0..edge_types.len())], vec![]));
 
         // Ensure parent exists (it should, we just selected it)
         let _ = parent_id;

--- a/atlas/benches/graph_diff.rs
+++ b/atlas/benches/graph_diff.rs
@@ -31,11 +31,7 @@ fn build_random_tree(node_count: usize, seed: u64) -> TreeNode {
     }
 
     // Build nodes with random edge types
-    let edge_types = [
-        EdgeType::Verified,
-        EdgeType::Related,
-        EdgeType::Editor,
-    ];
+    let edge_types = [EdgeType::Verified, EdgeType::Related];
 
     // Build tree recursively from parent indices
     fn add_children(
@@ -136,11 +132,7 @@ fn mutate_tree(tree: &TreeNode, change_rate: f64, seed: u64) -> TreeNode {
         let parent_id = nodes[parent_idx].0;
         nodes[parent_idx].2.push(new_id);
 
-        let edge_types = [
-            EdgeType::Verified,
-            EdgeType::Related,
-            EdgeType::Editor,
-        ];
+        let edge_types = [EdgeType::Verified, EdgeType::Related];
         nodes.push((new_id, edge_types[rng.gen_range(0..edge_types.len())], vec![]));
 
         // Ensure parent exists (it should, we just selected it)

--- a/atlas/benches/graph_diff.rs
+++ b/atlas/benches/graph_diff.rs
@@ -133,7 +133,11 @@ fn mutate_tree(tree: &TreeNode, change_rate: f64, seed: u64) -> TreeNode {
         nodes[parent_idx].2.push(new_id);
 
         let edge_types = [EdgeType::Verified, EdgeType::Related];
-        nodes.push((new_id, edge_types[rng.gen_range(0..edge_types.len())], vec![]));
+        nodes.push((
+            new_id,
+            edge_types[rng.gen_range(0..edge_types.len())],
+            vec![],
+        ));
 
         // Ensure parent exists (it should, we just selected it)
         let _ = parent_id;

--- a/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
+++ b/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
@@ -2,20 +2,21 @@
 
 Remove member-of-space and editor-of-space relationships from Atlas's traversal and canonical graphs. Both edge types should have zero effect on any computed output.
 
-After this plan lands, the only canonical-granting edge types in Atlas are **Verified**, **Related**, and **Subtopic** (the last is topic-based, not explicit).
+After this plan lands, the only canonical-granting edge types in Atlas are **Verified** and **Related**. **Subtopic** edges appear in the canonical graph too, but they do not grant canonical membership: Phase 1 of canonical computation derives the canonical set from explicit (Verified/Related) edges only, and Phase 2 then attaches Subtopic edges filtered to nodes that are already canonical. See [`atlas/src/graph/canonical.rs`](../../../src/graph/canonical.rs) for the two-phase implementation.
 
 Tracks Linear issue [GEO-618](https://linear.app/defi-wonderland/issue/GEO-618/remove-member-relationships-from-canonical-graph).
 
-> **Status (updated 2026-05-12)**
-> - PR [#194](https://github.com/defi-wonderland/gaia/pull/194) implements the **Member** portion of this plan. Approved by automated review, not yet merged.
-> - Product team has confirmed **Editor** edges are also in scope. This plan is updated to cover both edge types symmetrically.
-> - **Decision needed** (see [Open decisions](#open-decisions)): extend PR #194 to drop Editor in the same change, or land #194 first and ship Editor as a follow-up PR. Recommendation: extend #194.
+> **Status (updated 2026-05-13)**
+> - PR [#194](https://github.com/defi-wonderland/gaia/pull/194) is **merged** (2026-05-12) into the integration branch `geo-618-remove-member-edges`. Per the resolved decision below (option A), it drops **both Member and Editor** edges in a single change and bumps the checkpoint marker `atlas-v1 → atlas-v2`. Closes [GEO-624](https://linear.app/defi-wonderland/issue/GEO-624).
+> - PR [#197](https://github.com/defi-wonderland/gaia/pull/197) is the docs follow-up — it updates `atlas/docs/graph-concepts.md` and this plan to reflect the post-merge state. Tracks [GEO-625](https://linear.app/defi-wonderland/issue/GEO-625).
+> - Operational rollout (fresh bootstrap to `atlas-v2` on staging and prod) is tracked by [GEO-626](https://linear.app/defi-wonderland/issue/GEO-626).
 
 ## Background
 
-Atlas currently treats `MEMBER_ADDED` / `MEMBER_REMOVED` and `EDITOR_ADDED` / `EDITOR_REMOVED` chain actions as topology edges that grant canonical membership. The conversion paths are structurally identical:
+Atlas previously treated `MEMBER_ADDED` / `MEMBER_REMOVED` and `EDITOR_ADDED` / `EDITOR_REMOVED` chain actions as topology edges that granted canonical membership (historical behavior, pre-0007). The conversion paths were structurally identical:
 
 ```
+// Historical behavior (pre-0007):
 chain Action (MEMBER_ADDED or EDITOR_ADDED)
   → convert.rs::convert_member_added | convert_editor_added
   → TrustExtension::MemberAdded | TrustExtension::EditorAdded
@@ -23,9 +24,9 @@ chain Action (MEMBER_ADDED or EDITOR_ADDED)
   → explicit_edges[source].push((target, EdgeType::Member | EdgeType::Editor))
 ```
 
-Once stored as explicit edges, Member and Editor edges are indistinguishable from `Verified` / `Related` in both the transitive BFS (`transitive.rs::compute`) and the canonical Phase-1 BFS (`canonical.rs::compute_if_changed`). They expand the canonical set and the transitive reachable set.
+Once stored as explicit edges, Member and Editor edges were indistinguishable from `Verified` / `Related` in both the transitive BFS (`transitive.rs::compute`) and the canonical Phase-1 BFS (`canonical.rs::compute_if_changed`). They expanded the canonical set and the transitive reachable set.
 
-This was introduced by plan [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md). We're undoing the membership portion of that plan in full.
+This was introduced by plan [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md). Plan 0007 reverses the membership portion of that plan in full.
 
 ## Goal
 
@@ -102,7 +103,7 @@ Hard-cut the checkpoint format. No Member or Editor data persists past this chan
 
 3. **Update test fixtures** that hardcode the marker string.
 
-**Marker version coordination**: see [Open decisions](#open-decisions). If we extend PR #194 to also cover Editor, the marker stays `atlas-v2` and covers both removals in a single fresh bootstrap. If Editor lands as a follow-up PR after #194 merges, the follow-up must bump to `atlas-v3` (and triggers a second fresh bootstrap).
+**Marker version coordination**: the marker is `atlas-v2` and covers both the Member and Editor removals in a single fresh bootstrap (see [Resolved decisions](#resolved-decisions)).
 
 Combined with `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` during deploy (see Rollout below), Atlas detects the marker mismatch, logs `Checkpoint rejected; … starting fresh`, and rebuilds graph state from `SUBSTREAMS_START_BLOCK`. The first new checkpoint stamps as the new marker.
 
@@ -176,7 +177,7 @@ No new "reset" signal required. No new topic version required.
 
 ## Rollout
 
-The marker bump (to `atlas-v2` if Editor lands with #194, or to `atlas-v3` if it ships as a follow-up) makes every existing checkpoint incompatible by construction. Atlas will refuse to start unless we permit a fresh bootstrap.
+The marker bump to `atlas-v2` makes every existing checkpoint incompatible by construction. Atlas will refuse to start unless we permit a fresh bootstrap.
 
 1. Land code change + tests + docs.
 2. On every environment running Atlas (staging, prod, anywhere with `ATLAS_CHECKPOINT_DATABASE_URL` set): set `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` **before** deploying the new image.
@@ -184,28 +185,17 @@ The marker bump (to `atlas-v2` if Editor lands with #194, or to `atlas-v3` if it
 4. Watch during replay:
    - Atlas `latest_block` metric catches up to chain head.
    - `topology.canonical` consumer-group lag spikes as kg-indexer / search-indexer process the rebuild stream — should settle once replay completes. Existing diff-apply logic is idempotent so no special handling required.
-   - First new checkpoint row written with `runtime_compatibility_marker = atlas-v2` (or `atlas-v3` if sequential).
+   - First new checkpoint row written with `runtime_compatibility_marker = atlas-v2`.
 5. Spot-check known Member-only and Editor-only canonical spaces: confirm they're gone from canonical queries.
 6. After Atlas is stable on the new marker, **revert `ATLAS_CHECKPOINT_ALLOW_FRESH_START` to `false`** so future checkpoint corruption fails loud instead of silently bootstrapping from genesis.
 
 **Replay-cost caveat:** default `SUBSTREAMS_START_BLOCK=82655`. Confirm acceptable replay wall-time per environment before scheduling the deploy.
 
-## Open decisions
+## Resolved decisions
 
 ### 1. Sequencing of Editor relative to PR #194
 
-PR #194 currently removes Member only and bumps to `atlas-v2`. Two paths:
-
-| Option | Description | Marker bumps | Fresh bootstraps |
-|--------|-------------|--------------|------------------|
-| **A. Extend #194** (recommended) | Add Editor changes as commits onto the existing `geo-618-remove-member-edges` branch. Single PR removes both. | `atlas-v1 → atlas-v2` (one) | 1 |
-| **B. Sequential** | Land #194 as-is. Open a follow-up PR for Editor that bumps `atlas-v2 → atlas-v3`. | Two bumps | 2 |
-
-**Recommendation: A.** Rebootstrapping is operationally expensive (replay from block 82655, downstream consumer lag spike). One bootstrap is materially better than two. Cost of option A: the approved PR may need re-review since the scope changes.
-
-If choosing A: rebase `geo-618-remove-member-edges` onto current `origin/dev`, add a second commit with the Editor changes, push, and request re-review.
-
-If choosing B: open a fresh Linear subissue (e.g. GEO-XXX) and a fresh worktree off the merged #194. Document that the team accepts a second fresh bootstrap.
+**Outcome: option A was chosen.** PR [#194](https://github.com/defi-wonderland/gaia/pull/194) was extended on the `geo-618-remove-member-edges` branch to drop **both** Member and Editor edges in a single change, and the checkpoint marker was bumped once (`atlas-v1 → atlas-v2`) to cover both removals via a single fresh bootstrap.
 
 ## File checklist
 
@@ -213,23 +203,24 @@ Reflects total scope (Member + Editor). Items already shipped by PR #194 are mar
 
 | File | Member change | Editor change |
 |------|---------------|---------------|
-| `atlas/src/graph/state.rs` | No-op (✅ #194) | No-op (new) |
-| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅ #194) | Remove `EdgeType::Editor` (new) |
-| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅ #194) | Move to no-op arm (new) |
-| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅ #194) | Drop match arms + fixture (new) |
-| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ #194 → `atlas-v2`) | Drop `PersistedEdgeType::Editor`; marker stays `atlas-v2` if extending #194, else bump to `atlas-v3` |
+| `atlas/src/graph/state.rs` | No-op (✅ #194) | No-op (✅ #194) |
+| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅ #194) | Remove `EdgeType::Editor` (✅ #194) |
+| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅ #194) | Move to no-op arm (✅ #194) |
+| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅ #194) | Drop match arms + fixture (✅ #194) |
+| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ #194 → `atlas-v2`) | Drop `PersistedEdgeType::Editor` (✅ #194, single marker bump to `atlas-v2` covers both) |
 | `atlas/src/main.rs` | Optional log annotation | Optional log annotation |
-| `atlas/tests/e2e.rs` | Flip Member expectations (✅ #194) | Flip Editor expectations (new) |
-| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅ #194) | Drop `Editor` fixture (new) |
-| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅ #194) | `test_editor_*_is_no_op` (new) |
-| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅ #194) | Editor canonical assertion (new) |
-| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅ #194) | Editor transitive assertion (new) |
-| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (pending — GEO-625) | Drop Editor from Explicit Edges (new) |
-| `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` | Drop Member from canonical-granting edges (pending) | Drop Editor from canonical-granting edges (new) |
+| `atlas/tests/e2e.rs` | Flip Member expectations (✅ #194) | Flip Editor expectations (✅ #194) |
+| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅ #194) | Drop `Editor` fixture (✅ #194) |
+| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅ #194) | `test_editor_*_is_no_op` (✅ #194) |
+| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅ #194) | Editor canonical assertion (✅ #194) |
+| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅ #194) | Editor transitive assertion (✅ #194) |
+| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (✅ PR #197 — GEO-625) | Drop Editor from Explicit Edges (✅ PR #197 — GEO-625) |
+| `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` | Drop Member from canonical-granting edges (✅ wiki) | Drop Editor from canonical-granting edges (✅ wiki) |
 
 ## Related
 
 - [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md) — introduced Member and Editor edges; this plan reverses the membership portion in full.
 - [Graph Concepts](../../graph-concepts.md)
 - [Known Issues](../../known-issues.md)
-- PR [#194](https://github.com/defi-wonderland/gaia/pull/194) — implements the Member portion of this plan.
+- PR [#194](https://github.com/defi-wonderland/gaia/pull/194) — drops both Member and Editor edges, bumps checkpoint marker to `atlas-v2`.
+- PR [#197](https://github.com/defi-wonderland/gaia/pull/197) — this docs PR; updates `atlas/docs/graph-concepts.md` and commits plan 0007.

--- a/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
+++ b/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
@@ -1,0 +1,235 @@
+# 0007: Remove Member and Editor Edges from Atlas
+
+Remove member-of-space and editor-of-space relationships from Atlas's traversal and canonical graphs. Both edge types should have zero effect on any computed output.
+
+After this plan lands, the only canonical-granting edge types in Atlas are **Verified**, **Related**, and **Subtopic** (the last is topic-based, not explicit).
+
+Tracks Linear issue [GEO-618](https://linear.app/defi-wonderland/issue/GEO-618/remove-member-relationships-from-canonical-graph).
+
+> **Status (updated 2026-05-12)**
+> - PR [#194](https://github.com/defi-wonderland/gaia/pull/194) implements the **Member** portion of this plan. Approved by automated review, not yet merged.
+> - Product team has confirmed **Editor** edges are also in scope. This plan is updated to cover both edge types symmetrically.
+> - **Decision needed** (see [Open decisions](#open-decisions)): extend PR #194 to drop Editor in the same change, or land #194 first and ship Editor as a follow-up PR. Recommendation: extend #194.
+
+## Background
+
+Atlas currently treats `MEMBER_ADDED` / `MEMBER_REMOVED` and `EDITOR_ADDED` / `EDITOR_REMOVED` chain actions as topology edges that grant canonical membership. The conversion paths are structurally identical:
+
+```
+chain Action (MEMBER_ADDED or EDITOR_ADDED)
+  → convert.rs::convert_member_added | convert_editor_added
+  → TrustExtension::MemberAdded | TrustExtension::EditorAdded
+  → GraphState::apply_trust_extended
+  → explicit_edges[source].push((target, EdgeType::Member | EdgeType::Editor))
+```
+
+Once stored as explicit edges, Member and Editor edges are indistinguishable from `Verified` / `Related` in both the transitive BFS (`transitive.rs::compute`) and the canonical Phase-1 BFS (`canonical.rs::compute_if_changed`). They expand the canonical set and the transitive reachable set.
+
+This was introduced by plan [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md). We're undoing the membership portion of that plan in full.
+
+## Goal
+
+After this change:
+- `MemberAdded` / `MemberRemoved` / `EditorAdded` / `EditorRemoved` events applied to any `GraphState` produce no change to `explicit_edges`, no change to the transitive graph rooted at any space, and no change to the canonical graph.
+- `topology.canonical` Kafka messages never contain `MemberEdge` or `EditorEdge` entries.
+- `EdgeType::Member` AND `EdgeType::Editor` cease to exist in the Atlas code.
+- The chain actions `MEMBER_ADDED` / `MEMBER_REMOVED` / `EDITOR_ADDED` / `EDITOR_REMOVED` are still parsed (chain compatibility) — they just don't mutate graph state.
+
+## Approach
+
+Two viable cuts:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A. Drop at storage** (chosen) | One change point per edge type. BFS code stays uniform. Impossible to forget a filter site. | Loses ability to expose Member/Editor as non-canonical relations later without re-introducing storage. |
+| **B. Filter at traversal** | Member/Editor still tracked in state — can be exposed elsewhere. | Two filter sites (transitive + canonical Phase 1) per edge type, must stay in sync. Easy to regress. |
+
+We pick **A**: stop applying Member and Editor events to `GraphState`, then delete the `EdgeType::Member` and `EdgeType::Editor` variants. The compiler will surface every dead match arm.
+
+## Changes
+
+### 1. No-op Member and Editor events in GraphState
+
+**File:** `atlas/src/graph/state.rs`
+
+Remove the `MemberAdded` / `MemberRemoved` and `EditorAdded` / `EditorRemoved` arms from `apply_trust_extended`. Replace with an explicit no-op arm so the next reader knows it's intentional:
+
+```rust
+// Member and Editor edges are ignored — see plan 0007. Kept in the enum
+// for chain compatibility (convert.rs still emits them).
+TrustExtension::MemberAdded { .. }
+| TrustExtension::MemberRemoved { .. }
+| TrustExtension::EditorAdded { .. }
+| TrustExtension::EditorRemoved { .. } => {}
+```
+
+No changes needed to `events.rs` — `TrustExtension::MemberAdded` / `MemberRemoved` / `EditorAdded` / `EditorRemoved` variants stay so `convert.rs` keeps compiling. They become payloads that pass through without effect.
+
+### 2. Remove EdgeType::Member and EdgeType::Editor
+
+**File:** `atlas/src/graph/tree.rs`
+
+Delete the `Member` and `Editor` variants from `EdgeType`. The compiler will fail every match site. Fix each:
+
+- **`atlas/src/kafka/emitter.rs`** — drop the `EdgeType::Member => ...` and `EdgeType::Editor => ...` arms in both `edge_to_proto` functions. The `MemberEdge` / `EditorEdge` proto types stay defined (downstream consumers may still reference them) but Atlas never emits them.
+- **`atlas/src/kafka/emitter.rs`** (test fixture) — drop the `Member` and `Editor` test fixture entries from `test_tree_node_to_proto_all_edge_types`, or substitute with `Verified` / `Related` if the test still needs multiple children.
+- **`atlas/src/persistence.rs`** — see persistence section below.
+- **`atlas/benches/graph_diff.rs`** — remove `EdgeType::Member` and `EdgeType::Editor` from both benchmark fixture arrays.
+
+### 3. Transitive cache invalidation
+
+**File:** `atlas/src/graph/transitive.rs`
+
+`handle_event` invalidates `member_space_id` for Member/Editor events. With both now no-ops, invalidation is unnecessary. Move both into the same no-op arm:
+
+```rust
+// Member and Editor edges: no-op — these events do not mutate state (plan 0007).
+TrustExtension::MemberAdded { .. }
+| TrustExtension::MemberRemoved { .. }
+| TrustExtension::EditorAdded { .. }
+| TrustExtension::EditorRemoved { .. } => {}
+```
+
+### 4. Persistence — hard cut via marker bump
+
+**Files:** `atlas/src/persistence.rs`
+
+Hard-cut the checkpoint format. No Member or Editor data persists past this change. Three coordinated edits:
+
+1. **Delete `PersistedEdgeType::Member` and `PersistedEdgeType::Editor`** and their match arms in `From<EdgeType>` / `TryFrom<PersistedEdgeType>` / the ordering helper. After this, the type system guarantees no Member or Editor edge can be serialized or deserialized.
+
+2. **Bump the default `runtime_compatibility_marker`** to `atlas-v2`. Atlas already validates this marker on load — any pre-existing checkpoint will be rejected as incompatible without us needing to rely on enum-deserialize failures.
+
+3. **Update test fixtures** that hardcode the marker string.
+
+**Marker version coordination**: see [Open decisions](#open-decisions). If we extend PR #194 to also cover Editor, the marker stays `atlas-v2` and covers both removals in a single fresh bootstrap. If Editor lands as a follow-up PR after #194 merges, the follow-up must bump to `atlas-v3` (and triggers a second fresh bootstrap).
+
+Combined with `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` during deploy (see Rollout below), Atlas detects the marker mismatch, logs `Checkpoint rejected; … starting fresh`, and rebuilds graph state from `SUBSTREAMS_START_BLOCK`. The first new checkpoint stamps as the new marker.
+
+No manual checkpoint deletion is required. No backwards-compat shim is introduced.
+
+### 5. Convert layer stays as-is
+
+**File:** `atlas/src/convert.rs`
+
+No changes. `convert_member_added` / `convert_member_removed` / `convert_editor_added` / `convert_editor_removed` keep producing their respective `TrustExtension` variants from chain actions. These flow into `GraphState::apply_trust_extended` and hit the no-op arm.
+
+Rationale: the conversion layer mirrors the chain ABI. Keeping it stable means we can re-enable Member or Editor edges later without re-plumbing the parse path.
+
+### 6. Main loop logging
+
+**File:** `atlas/src/main.rs`
+
+The diagnostic logging for `MemberAdded` / `MemberRemoved` / `EditorAdded` / `EditorRemoved` stays — useful for debugging "why didn't this space appear?" questions. Optionally annotate the log message with `(ignored)`.
+
+## Tests
+
+### Existing tests to update
+
+**`atlas/tests/e2e.rs`** — `.member_added(...)` / `.member_removed(...)` / `.editor(...)` / `.editor_removed(...)` helpers still feed events into the pipeline. Update any test that asserts canonical or transitive membership through a Member or Editor edge:
+
+- Cases where Member/Editor is the only path to a node: assert that node is NOT in canonical and NOT in the transitive set.
+- Cases where Member/Editor is one of multiple paths: assert the node is still present via the non-Member, non-Editor path.
+
+Specific tests known to need updates (relative to current state — some Member tests may already be flipped by PR #194):
+- Tests using `.editor(...)` to grant canonical membership.
+- Tests asserting `editor_removed` produces a `Removed` change.
+- Tests asserting transitive reachability through an Editor edge.
+
+### New tests to add (symmetric to the Member tests added in PR #194)
+
+In `atlas/src/graph/state.rs` tests:
+
+- `test_editor_added_is_no_op`: apply `EditorAdded(source, target)`, assert `state.explicit_edges` is empty.
+- `test_editor_removed_is_no_op`: same shape.
+
+In `atlas/src/graph/canonical.rs` tests:
+
+- `test_editor_edge_from_root_does_not_grant_canonical`: root has `EditorAdded(root, X)`, assert canonical set is `{root}` only.
+
+In `atlas/src/graph/transitive.rs` tests:
+
+- `test_editor_edge_not_in_transitive`: apply `EditorAdded(A, B)`, compute `get_full(A)`, assert B is not reachable.
+
+### Benches
+
+`atlas/benches/graph_diff.rs` — drop `EdgeType::Member` and `EdgeType::Editor` entries from both fixture arrays. If the bench depends on edge-type variety, the remaining `Verified` / `Related` types suffice.
+
+## Docs
+
+- `atlas/docs/graph-concepts.md` — drop "Member relationships" AND "Editor relationships" from the Explicit Edges list. Note Member and Editor events exist on-chain but are not represented in any Atlas graph.
+- `atlas/docs/algorithm-overview.md` — no changes needed (algorithm description already only references explicit/topic categories).
+- `atlas/README.md` — already lists only Verified/Related, no change.
+- Wiki: `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` — drop Member AND Editor from "canonical-granting edges" line. Add a note that Member and Editor events are no-oped.
+
+## Wire-format and downstream impact
+
+`topology.canonical` is a derived snapshot stream. After this change:
+
+- The next emitted `CanonicalGraphDiff` will contain `REMOVED` entries for every space that was previously canonical solely via a Member or Editor edge.
+- Downstream consumers (kg-indexer, search-indexer) apply diffs as authoritative — they will correctly drop those spaces from their projections.
+- Per `atlas/docs/known-issues.md`, downstream treats canonical updates as full state snapshots; idempotent application means no special handover is needed beyond the normal diff.
+
+No new "reset" signal required. No new topic version required.
+
+**Impact estimate**: Editor edges are likely more common than Member edges in the existing graph (every DAO has at least one editor, but not every DAO has member-only relationships). The `REMOVED` diff after this lands will be correspondingly larger if Editor and Member ship together.
+
+## Rollout
+
+The marker bump (to `atlas-v2` if Editor lands with #194, or to `atlas-v3` if it ships as a follow-up) makes every existing checkpoint incompatible by construction. Atlas will refuse to start unless we permit a fresh bootstrap.
+
+1. Land code change + tests + docs.
+2. On every environment running Atlas (staging, prod, anywhere with `ATLAS_CHECKPOINT_DATABASE_URL` set): set `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` **before** deploying the new image.
+3. Deploy. Atlas logs `Checkpoint rejected; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh` and replays from `SUBSTREAMS_START_BLOCK`.
+4. Watch during replay:
+   - Atlas `latest_block` metric catches up to chain head.
+   - `topology.canonical` consumer-group lag spikes as kg-indexer / search-indexer process the rebuild stream — should settle once replay completes. Existing diff-apply logic is idempotent so no special handling required.
+   - First new checkpoint row written with `runtime_compatibility_marker = atlas-v2` (or `atlas-v3` if sequential).
+5. Spot-check known Member-only and Editor-only canonical spaces: confirm they're gone from canonical queries.
+6. After Atlas is stable on the new marker, **revert `ATLAS_CHECKPOINT_ALLOW_FRESH_START` to `false`** so future checkpoint corruption fails loud instead of silently bootstrapping from genesis.
+
+**Replay-cost caveat:** default `SUBSTREAMS_START_BLOCK=82655`. Confirm acceptable replay wall-time per environment before scheduling the deploy.
+
+## Open decisions
+
+### 1. Sequencing of Editor relative to PR #194
+
+PR #194 currently removes Member only and bumps to `atlas-v2`. Two paths:
+
+| Option | Description | Marker bumps | Fresh bootstraps |
+|--------|-------------|--------------|------------------|
+| **A. Extend #194** (recommended) | Add Editor changes as commits onto the existing `geo-618-remove-member-edges` branch. Single PR removes both. | `atlas-v1 → atlas-v2` (one) | 1 |
+| **B. Sequential** | Land #194 as-is. Open a follow-up PR for Editor that bumps `atlas-v2 → atlas-v3`. | Two bumps | 2 |
+
+**Recommendation: A.** Rebootstrapping is operationally expensive (replay from block 82655, downstream consumer lag spike). One bootstrap is materially better than two. Cost of option A: the approved PR may need re-review since the scope changes.
+
+If choosing A: rebase `geo-618-remove-member-edges` onto current `origin/dev`, add a second commit with the Editor changes, push, and request re-review.
+
+If choosing B: open a fresh Linear subissue (e.g. GEO-XXX) and a fresh worktree off the merged #194. Document that the team accepts a second fresh bootstrap.
+
+## File checklist
+
+Reflects total scope (Member + Editor). Items already shipped by PR #194 are marked as such.
+
+| File | Member change | Editor change |
+|------|---------------|---------------|
+| `atlas/src/graph/state.rs` | No-op (✅ #194) | No-op (new) |
+| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅ #194) | Remove `EdgeType::Editor` (new) |
+| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅ #194) | Move to no-op arm (new) |
+| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅ #194) | Drop match arms + fixture (new) |
+| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ #194 → `atlas-v2`) | Drop `PersistedEdgeType::Editor`; marker stays `atlas-v2` if extending #194, else bump to `atlas-v3` |
+| `atlas/src/main.rs` | Optional log annotation | Optional log annotation |
+| `atlas/tests/e2e.rs` | Flip Member expectations (✅ #194) | Flip Editor expectations (new) |
+| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅ #194) | Drop `Editor` fixture (new) |
+| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅ #194) | `test_editor_*_is_no_op` (new) |
+| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅ #194) | Editor canonical assertion (new) |
+| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅ #194) | Editor transitive assertion (new) |
+| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (pending — GEO-625) | Drop Editor from Explicit Edges (new) |
+| `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` | Drop Member from canonical-granting edges (pending) | Drop Editor from canonical-granting edges (new) |
+
+## Related
+
+- [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md) — introduced Member and Editor edges; this plan reverses the membership portion in full.
+- [Graph Concepts](../../graph-concepts.md)
+- [Known Issues](../../known-issues.md)
+- PR [#194](https://github.com/defi-wonderland/gaia/pull/194) — implements the Member portion of this plan.

--- a/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
+++ b/atlas/docs/agents/plans/0007-remove-member-edges-plan.md
@@ -4,13 +4,6 @@ Remove member-of-space and editor-of-space relationships from Atlas's traversal 
 
 After this plan lands, the only canonical-granting edge types in Atlas are **Verified** and **Related**. **Subtopic** edges appear in the canonical graph too, but they do not grant canonical membership: Phase 1 of canonical computation derives the canonical set from explicit (Verified/Related) edges only, and Phase 2 then attaches Subtopic edges filtered to nodes that are already canonical. See [`atlas/src/graph/canonical.rs`](../../../src/graph/canonical.rs) for the two-phase implementation.
 
-Tracks Linear issue [GEO-618](https://linear.app/defi-wonderland/issue/GEO-618/remove-member-relationships-from-canonical-graph).
-
-> **Status (updated 2026-05-13)**
-> - PR [#194](https://github.com/defi-wonderland/gaia/pull/194) is **merged** (2026-05-12) into the integration branch `geo-618-remove-member-edges`. Per the resolved decision below (option A), it drops **both Member and Editor** edges in a single change and bumps the checkpoint marker `atlas-v1 → atlas-v2`. Closes [GEO-624](https://linear.app/defi-wonderland/issue/GEO-624).
-> - PR [#197](https://github.com/defi-wonderland/gaia/pull/197) is the docs follow-up — it updates `atlas/docs/graph-concepts.md` and this plan to reflect the post-merge state. Tracks [GEO-625](https://linear.app/defi-wonderland/issue/GEO-625).
-> - Operational rollout (fresh bootstrap to `atlas-v2` on staging and prod) is tracked by [GEO-626](https://linear.app/defi-wonderland/issue/GEO-626).
-
 ## Background
 
 Atlas previously treated `MEMBER_ADDED` / `MEMBER_REMOVED` and `EDITOR_ADDED` / `EDITOR_REMOVED` chain actions as topology edges that granted canonical membership (historical behavior, pre-0007). The conversion paths were structurally identical:
@@ -132,12 +125,12 @@ The diagnostic logging for `MemberAdded` / `MemberRemoved` / `EditorAdded` / `Ed
 - Cases where Member/Editor is the only path to a node: assert that node is NOT in canonical and NOT in the transitive set.
 - Cases where Member/Editor is one of multiple paths: assert the node is still present via the non-Member, non-Editor path.
 
-Specific tests known to need updates (relative to current state — some Member tests may already be flipped by PR #194):
+Specific tests known to need updates:
 - Tests using `.editor(...)` to grant canonical membership.
 - Tests asserting `editor_removed` produces a `Removed` change.
 - Tests asserting transitive reachability through an Editor edge.
 
-### New tests to add (symmetric to the Member tests added in PR #194)
+### New tests to add (symmetric to the Member tests)
 
 In `atlas/src/graph/state.rs` tests:
 
@@ -193,28 +186,28 @@ The marker bump to `atlas-v2` makes every existing checkpoint incompatible by co
 
 ## Resolved decisions
 
-### 1. Sequencing of Editor relative to PR #194
+### 1. Sequencing of Member and Editor removal
 
-**Outcome: option A was chosen.** PR [#194](https://github.com/defi-wonderland/gaia/pull/194) was extended on the `geo-618-remove-member-edges` branch to drop **both** Member and Editor edges in a single change, and the checkpoint marker was bumped once (`atlas-v1 → atlas-v2`) to cover both removals via a single fresh bootstrap.
+**Outcome: option A was chosen.** Member and Editor edges are dropped in a single change, and the checkpoint marker is bumped once (`atlas-v1 → atlas-v2`) to cover both removals via a single fresh bootstrap.
 
 ## File checklist
 
-Reflects total scope (Member + Editor). Items already shipped by PR #194 are marked as such.
+Reflects total scope (Member + Editor).
 
 | File | Member change | Editor change |
 |------|---------------|---------------|
-| `atlas/src/graph/state.rs` | No-op (✅ #194) | No-op (✅ #194) |
-| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅ #194) | Remove `EdgeType::Editor` (✅ #194) |
-| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅ #194) | Move to no-op arm (✅ #194) |
-| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅ #194) | Drop match arms + fixture (✅ #194) |
-| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ #194 → `atlas-v2`) | Drop `PersistedEdgeType::Editor` (✅ #194, single marker bump to `atlas-v2` covers both) |
+| `atlas/src/graph/state.rs` | No-op (✅) | No-op (✅) |
+| `atlas/src/graph/tree.rs` | Remove `EdgeType::Member` (✅) | Remove `EdgeType::Editor` (✅) |
+| `atlas/src/graph/transitive.rs` | Move to no-op arm (✅) | Move to no-op arm (✅) |
+| `atlas/src/kafka/emitter.rs` | Drop match arms + fixture (✅) | Drop match arms + fixture (✅) |
+| `atlas/src/persistence.rs` | Drop `PersistedEdgeType::Member` + bump marker (✅ → `atlas-v2`) | Drop `PersistedEdgeType::Editor` (✅, single marker bump to `atlas-v2` covers both) |
 | `atlas/src/main.rs` | Optional log annotation | Optional log annotation |
-| `atlas/tests/e2e.rs` | Flip Member expectations (✅ #194) | Flip Editor expectations (✅ #194) |
-| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅ #194) | Drop `Editor` fixture (✅ #194) |
-| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅ #194) | `test_editor_*_is_no_op` (✅ #194) |
-| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅ #194) | Editor canonical assertion (✅ #194) |
-| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅ #194) | Editor transitive assertion (✅ #194) |
-| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (✅ PR #197 — GEO-625) | Drop Editor from Explicit Edges (✅ PR #197 — GEO-625) |
+| `atlas/tests/e2e.rs` | Flip Member expectations (✅) | Flip Editor expectations (✅) |
+| `atlas/benches/graph_diff.rs` | Drop `Member` fixture (✅) | Drop `Editor` fixture (✅) |
+| `atlas/src/graph/state.rs` (tests) | `test_member_*_is_no_op` (✅) | `test_editor_*_is_no_op` (✅) |
+| `atlas/src/graph/canonical.rs` (tests) | Member canonical assertion (✅) | Editor canonical assertion (✅) |
+| `atlas/src/graph/transitive.rs` (tests) | Member transitive assertion (✅) | Editor transitive assertion (✅) |
+| `atlas/docs/graph-concepts.md` | Drop Member from Explicit Edges (✅) | Drop Editor from Explicit Edges (✅) |
 | `~/knowledge-base/projects/geo/concepts/atlas-canonical-graph.md` | Drop Member from canonical-granting edges (✅ wiki) | Drop Editor from canonical-granting edges (✅ wiki) |
 
 ## Related
@@ -222,5 +215,3 @@ Reflects total scope (Member + Editor). Items already shipped by PR #194 are mar
 - [0006: Live Substream, Membership, and Graph Diffing](./0006-live-substream-membership-diffing-plan.md) — introduced Member and Editor edges; this plan reverses the membership portion in full.
 - [Graph Concepts](../../graph-concepts.md)
 - [Known Issues](../../known-issues.md)
-- PR [#194](https://github.com/defi-wonderland/gaia/pull/194) — drops both Member and Editor edges, bumps checkpoint marker to `atlas-v2`.
-- PR [#197](https://github.com/defi-wonderland/gaia/pull/197) — this docs PR; updates `atlas/docs/graph-concepts.md` and commits plan 0007.

--- a/atlas/docs/graph-concepts.md
+++ b/atlas/docs/graph-concepts.md
@@ -39,16 +39,20 @@ The system tracks four different graph views:
 The system supports two categories of edges:
 
 **Explicit Edges** - Direct node-to-node connections with semantic types:
-- Editor relationships
-- Member relationships
-- Trust relationships
-- Generic related relationships
+- Trust relationships (Verified)
+- Generic related relationships (Related)
 
 **Topic Edges** - Indirect connections through group membership:
-- A node references an entire topic/group
+- A node references an entire topic/group (Subtopic)
 - Resolves dynamically to current group members at query time
 - Membership can change without updating the edge
 - Provides abstraction over bulk relationships
+
+**No-op chain events:** `EDITOR_ADDED` / `EDITOR_REMOVED` / `MEMBER_ADDED` /
+`MEMBER_REMOVED` chain events still arrive at Atlas via `convert.rs`, but the
+storage layer ignores them — they produce no edges in any graph view (transitive
+or canonical). See [plan 0007](agents/plans/0007-remove-member-edges-plan.md)
+for the rationale and the canonical-granting edge set after the change.
 
 ### Update Operations
 

--- a/atlas/src/graph/canonical.rs
+++ b/atlas/src/graph/canonical.rs
@@ -775,4 +775,36 @@ mod tests {
             "Member-only reachable space must not be canonical"
         );
     }
+
+    #[test]
+    fn test_editor_edge_from_root_does_not_grant_canonical() {
+        // Plan 0007: Editor edges no longer grant canonical membership.
+        // An EditorAdded(root, X) event must leave X outside the canonical set.
+        let mut state = GraphState::new();
+        let root = create_space(&mut state, 1);
+        let x = create_space(&mut state, 2);
+
+        let editor_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: root,
+                extension: TrustExtension::EditorAdded { member_space_id: x },
+            }),
+        };
+        state.apply_event(&editor_event);
+
+        let mut transitive = TransitiveProcessor::new();
+        let mut processor = CanonicalProcessor::new(root);
+
+        let graph = processor
+            .compute_if_changed(&state, &mut transitive)
+            .unwrap();
+
+        assert_eq!(graph.len(), 1, "canonical set must contain only root");
+        assert!(graph.contains(&root));
+        assert!(
+            !graph.contains(&x),
+            "Editor-only reachable space must not be canonical"
+        );
+    }
 }

--- a/atlas/src/graph/canonical.rs
+++ b/atlas/src/graph/canonical.rs
@@ -741,4 +741,38 @@ mod tests {
         // All explicitly connected nodes are canonical
         assert_eq!(graph.len(), 5);
     }
+
+    #[test]
+    fn test_member_edge_from_root_does_not_grant_canonical() {
+        // Plan 0007: Member edges no longer grant canonical membership.
+        // A MemberAdded(root, X) event must leave X outside the canonical set.
+        let mut state = GraphState::new();
+        let root = create_space(&mut state, 1);
+        let x = create_space(&mut state, 2);
+
+        // Apply a MemberAdded event directly — bypasses the test helpers
+        // so we exercise the same path the chain takes.
+        let member_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: root,
+                extension: TrustExtension::MemberAdded { member_space_id: x },
+            }),
+        };
+        state.apply_event(&member_event);
+
+        let mut transitive = TransitiveProcessor::new();
+        let mut processor = CanonicalProcessor::new(root);
+
+        let graph = processor
+            .compute_if_changed(&state, &mut transitive)
+            .unwrap();
+
+        assert_eq!(graph.len(), 1, "canonical set must contain only root");
+        assert!(graph.contains(&root));
+        assert!(
+            !graph.contains(&x),
+            "Member-only reachable space must not be canonical"
+        );
+    }
 }

--- a/atlas/src/graph/diff.rs
+++ b/atlas/src/graph/diff.rs
@@ -88,6 +88,26 @@ pub struct DiffTracker {
     scratch: Vec<(SpaceId, Position)>,
     /// Whether we've seen the first graph (for bootstrap detection)
     initialized: bool,
+    /// Set by [`DiffTracker::from_baseline`] and consumed by the first
+    /// [`DiffTracker::track`] call. Carries the persisted emission state
+    /// (`(space_id, distance, parent)` — no `EdgeType`, by design) so
+    /// the first diff after restart can be computed against what we last
+    /// told consumers rather than against an empty bootstrap baseline.
+    ///
+    /// Sorted by `space_id`, unique by `space_id` (closest-to-root wins on
+    /// duplicates — same rule [`track`] applies to in-memory positions).
+    pending_baseline: Option<Vec<(SpaceId, BaselinePos)>>,
+}
+
+/// Subset of [`Position`] that survives schema bumps. Used internally for the
+/// one-shot diff against a restored baseline; not exposed in the public diff
+/// output. Notably omits `edge_type` — see [`PersistedEmissionBaseline`].
+///
+/// [`PersistedEmissionBaseline`]: crate::persistence::PersistedEmissionBaseline
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BaselinePos {
+    distance: u32,
+    parent: SpaceId,
 }
 
 impl DiffTracker {
@@ -105,12 +125,73 @@ impl DiffTracker {
             last_positions: Vec::with_capacity(capacity),
             scratch: Vec::with_capacity(capacity),
             initialized: false,
+            pending_baseline: None,
+        }
+    }
+
+    /// Prime the tracker from a persisted emission baseline.
+    ///
+    /// Used on startup so the first `track()` call produces the correct diff
+    /// against what was last emitted to consumers — typically across a deploy
+    /// that changes canonical rules and discards `GraphState`. The baseline
+    /// carries `(space_id, distance, parent)` only; `edge_type` is *not*
+    /// compared in the first diff, because the persisted shape intentionally
+    /// drops it to remain schema-stable (see
+    /// [`PersistedEmissionBaseline`]).
+    ///
+    /// Implications for the first track:
+    /// - REMOVED is emitted for any space in the baseline but not in the new
+    ///   canonical graph.
+    /// - MOVED is emitted only when `distance` or `parent` changes (an
+    ///   `edge_type`-only change is not enough to qualify, since we do not
+    ///   know the old `edge_type` — assuming "unchanged" is the conservative
+    ///   choice that minimises spurious events).
+    /// - ADDED is emitted for any space in the new graph but not in the
+    ///   baseline.
+    ///
+    /// Subsequent `track()` calls behave normally (full `Position` equality).
+    ///
+    /// [`PersistedEmissionBaseline`]: crate::persistence::PersistedEmissionBaseline
+    pub fn from_baseline(baseline: &crate::persistence::PersistedEmissionBaseline) -> Self {
+        let mut entries: Vec<(SpaceId, BaselinePos)> = baseline
+            .nodes()
+            .iter()
+            .map(|n| {
+                (
+                    n.space_id,
+                    BaselinePos {
+                        distance: n.distance,
+                        parent: n.parent,
+                    },
+                )
+            })
+            .collect();
+        // `PersistedEmissionBaseline::from_nodes` already sorts and dedups,
+        // but a hand-built baseline (or a future shape that doesn't enforce
+        // the invariant) might not — so normalise defensively. The merge-join
+        // diff below relies on unique-and-sorted-by-SpaceId on both sides.
+        entries.sort_unstable_by(|(id_a, pos_a), (id_b, pos_b)| {
+            id_a.cmp(id_b)
+                .then_with(|| pos_a.distance.cmp(&pos_b.distance))
+        });
+        entries.dedup_by_key(|(id, _)| *id);
+
+        let capacity = entries.len();
+        Self {
+            last_positions: Vec::with_capacity(capacity),
+            scratch: Vec::with_capacity(capacity),
+            // Treat the tracker as initialized so the next `track()` doesn't
+            // fall into the bootstrap-all-ADDED branch.
+            initialized: true,
+            pending_baseline: Some(entries),
         }
     }
 
     /// Track a new graph and compute diff from previous state.
     ///
-    /// On first call (bootstrap), returns a diff with all nodes as ADDED.
+    /// On first call (bootstrap), returns a diff with all nodes as ADDED —
+    /// unless the tracker was constructed via [`DiffTracker::from_baseline`],
+    /// in which case the first call diffs against the restored baseline.
     /// On subsequent calls, returns changes between previous and current state.
     ///
     /// When a SpaceId appears at multiple positions in the tree (e.g., via
@@ -141,7 +222,13 @@ impl DiffTracker {
         // The merge-join diff requires unique SpaceIds.
         self.scratch.dedup_by_key(|(id, _)| *id);
 
-        let diff = if self.initialized {
+        let diff = if let Some(baseline) = self.pending_baseline.take() {
+            // One-shot path: compare against the restored baseline, which has
+            // no edge_type. After this call, last_positions carries the full
+            // current Position (including edge_type), so subsequent diffs go
+            // through the regular compute_diff path.
+            compute_diff_against_baseline(&baseline, &self.scratch)
+        } else if self.initialized {
             compute_diff(&self.last_positions, &self.scratch)
         } else {
             self.initialized = true;
@@ -161,11 +248,65 @@ impl DiffTracker {
         self.last_positions.clear();
         self.scratch.clear();
         self.initialized = false;
+        self.pending_baseline = None;
     }
 
     /// Returns the number of positions currently tracked
     pub fn position_count(&self) -> usize {
         self.last_positions.len()
+    }
+
+    /// Iterate the tracker's current emission state as
+    /// `(space_id, distance, parent)` triples — the persistable shape of a
+    /// [`PersistedEmissionBaseline`]. Order matches `last_positions`
+    /// (sorted by `space_id`, unique).
+    ///
+    /// Returns `None` when nothing has been tracked yet *and* no baseline has
+    /// been primed (i.e. there is no contract with consumers to persist).
+    /// When a baseline has been primed but `track()` hasn't been called yet,
+    /// returns the pending baseline so the force-write path on startup can
+    /// re-persist what was already on disk without losing data.
+    ///
+    /// [`PersistedEmissionBaseline`]: crate::persistence::PersistedEmissionBaseline
+    pub fn iter_emission_state(&self) -> Option<EmissionStateIter<'_>> {
+        if let Some(baseline) = self.pending_baseline.as_deref() {
+            Some(EmissionStateIter {
+                inner: EmissionStateIterInner::Pending(baseline.iter()),
+            })
+        } else if self.initialized {
+            Some(EmissionStateIter {
+                inner: EmissionStateIterInner::Live(self.last_positions.iter()),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator over a [`DiffTracker`]'s current emission state. The internal
+/// variant is intentionally opaque so the in-memory `BaselinePos` shape (and
+/// `Position`'s `edge_type`) stay implementation details.
+pub struct EmissionStateIter<'a> {
+    inner: EmissionStateIterInner<'a>,
+}
+
+enum EmissionStateIterInner<'a> {
+    Pending(std::slice::Iter<'a, (SpaceId, BaselinePos)>),
+    Live(std::slice::Iter<'a, (SpaceId, Position)>),
+}
+
+impl<'a> Iterator for EmissionStateIter<'a> {
+    type Item = (SpaceId, u32, SpaceId);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            EmissionStateIterInner::Pending(it) => {
+                it.next().map(|(id, pos)| (*id, pos.distance, pos.parent))
+            }
+            EmissionStateIterInner::Live(it) => {
+                it.next().map(|(id, pos)| (*id, pos.distance, pos.parent))
+            }
+        }
     }
 }
 
@@ -192,6 +333,79 @@ fn build_position_vec_into(tree: &TreeNode, vec: &mut Vec<(SpaceId, Position)>) 
             stack.push((child, distance + 1, node.space_id));
         }
     }
+}
+
+/// One-shot merge-join diff between a restored baseline (no `edge_type`) and
+/// the current canonical positions. Used by [`DiffTracker::track`] on the
+/// first call when the tracker was constructed with
+/// [`DiffTracker::from_baseline`].
+///
+/// Differs from [`compute_diff`] in exactly one place: the MOVED check
+/// compares only `distance` + `parent`, never `edge_type`. The persisted
+/// baseline drops `edge_type` for schema stability, so we can't know what it
+/// was previously — and "edge_type-only change" would otherwise be flagged
+/// as MOVED for every restored node, which is exactly the spurious-event
+/// storm we are trying to avoid.
+fn compute_diff_against_baseline(
+    old: &[(SpaceId, BaselinePos)],
+    new: &[(SpaceId, Position)],
+) -> GraphDiff {
+    let mut changes = Vec::new();
+    let mut old_iter = old.iter().peekable();
+    let mut new_iter = new.iter().peekable();
+
+    loop {
+        match (old_iter.peek(), new_iter.peek()) {
+            (None, None) => break,
+            (Some(_), None) => {
+                let (space_id, _) = old_iter.next().unwrap();
+                changes.push(NodeChange {
+                    space_id: *space_id,
+                    change_type: ChangeType::Removed,
+                    position: None,
+                });
+            }
+            (None, Some(_)) => {
+                let (space_id, pos) = new_iter.next().unwrap();
+                changes.push(NodeChange {
+                    space_id: *space_id,
+                    change_type: ChangeType::Added,
+                    position: Some(*pos),
+                });
+            }
+            (Some((old_id, _)), Some((new_id, _))) => match old_id.cmp(new_id) {
+                std::cmp::Ordering::Less => {
+                    let (space_id, _) = old_iter.next().unwrap();
+                    changes.push(NodeChange {
+                        space_id: *space_id,
+                        change_type: ChangeType::Removed,
+                        position: None,
+                    });
+                }
+                std::cmp::Ordering::Greater => {
+                    let (space_id, pos) = new_iter.next().unwrap();
+                    changes.push(NodeChange {
+                        space_id: *space_id,
+                        change_type: ChangeType::Added,
+                        position: Some(*pos),
+                    });
+                }
+                std::cmp::Ordering::Equal => {
+                    let (space_id, old_pos) = old_iter.next().unwrap();
+                    let (_, new_pos) = new_iter.next().unwrap();
+                    if old_pos.distance != new_pos.distance || old_pos.parent != new_pos.parent {
+                        changes.push(NodeChange {
+                            space_id: *space_id,
+                            change_type: ChangeType::Moved,
+                            position: Some(*new_pos),
+                        });
+                    }
+                }
+            },
+        }
+    }
+
+    GraphDiff { changes }
 }
 
 /// Compute diff between old and new position slices using merge-join.
@@ -706,5 +920,231 @@ mod tests {
         assert_eq!(pos.edge_type, EdgeType::Verified);
 
         assert_eq!(tracker.position_count(), 2);
+    }
+
+    // ------------------------------------------------------------------
+    // from_baseline / pending_baseline behaviour (GEO-645)
+    // ------------------------------------------------------------------
+
+    use crate::persistence::{BaselineNode, PersistedEmissionBaseline};
+
+    fn baseline_with(nodes: &[(u8, u32, u8)]) -> PersistedEmissionBaseline {
+        PersistedEmissionBaseline::from_nodes(nodes.iter().map(|(s, d, p)| BaselineNode {
+            space_id: make_space_id(*s),
+            distance: *d,
+            parent: make_space_id(*p),
+        }))
+    }
+
+    fn one_node_graph(child: u8, edge: EdgeType) -> CanonicalGraph {
+        let mut root = TreeNode::new_root(make_space_id(0x01));
+        root.add_child(TreeNode::new(make_space_id(child), edge));
+        CanonicalGraph::new(
+            make_space_id(0x01),
+            root,
+            [make_space_id(0x01), make_space_id(child)]
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn from_baseline_first_track_emits_removed_for_orphans() {
+        // Models the GEO-645 happy path: baseline contains a space that the
+        // new rules no longer treat as canonical (e.g. previously reachable
+        // only via a Member edge, which v2 removes). The first track() must
+        // emit REMOVED for that orphan, not silently drop it.
+        let baseline = baseline_with(&[
+            (0x0A, 1, 0x01), // still canonical
+            (0x0B, 1, 0x01), // orphaned in the new rules
+        ]);
+        let mut tracker = DiffTracker::from_baseline(&baseline);
+
+        let graph = one_node_graph(0x0A, EdgeType::Verified);
+        let diff = tracker.track(&graph);
+
+        // Only B should appear in the diff, and as REMOVED.
+        assert_eq!(diff.len(), 1);
+        let removed = &diff.changes[0];
+        assert_eq!(removed.space_id, make_space_id(0x0B));
+        assert_eq!(removed.change_type, ChangeType::Removed);
+        assert!(removed.position.is_none());
+    }
+
+    #[test]
+    fn from_baseline_first_track_emits_added_for_new() {
+        let baseline = baseline_with(&[(0x0A, 1, 0x01)]);
+        let mut tracker = DiffTracker::from_baseline(&baseline);
+
+        // Graph now has A + a brand-new C (was not in baseline).
+        let mut root = TreeNode::new_root(make_space_id(0x01));
+        root.add_child(TreeNode::new(make_space_id(0x0A), EdgeType::Verified));
+        root.add_child(TreeNode::new(make_space_id(0x0C), EdgeType::Verified));
+        let graph = CanonicalGraph::new(
+            make_space_id(0x01),
+            root,
+            [
+                make_space_id(0x01),
+                make_space_id(0x0A),
+                make_space_id(0x0C),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let diff = tracker.track(&graph);
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff.changes[0].space_id, make_space_id(0x0C));
+        assert_eq!(diff.changes[0].change_type, ChangeType::Added);
+    }
+
+    #[test]
+    fn from_baseline_emits_moved_only_on_distance_or_parent_change() {
+        // Baseline says A is at distance 1, parent = root.
+        let baseline = baseline_with(&[(0x0A, 1, 0x01)]);
+
+        // Case 1: distance/parent unchanged, edge_type differs — must NOT
+        // emit MOVED. The baseline has no edge_type by design (schema
+        // stability), so we cannot know whether edge_type changed. The
+        // conservative choice is to suppress the event.
+        {
+            let mut tracker = DiffTracker::from_baseline(&baseline);
+            let graph = one_node_graph(0x0A, EdgeType::Related); // edge_type differs
+            let diff = tracker.track(&graph);
+            assert!(
+                diff.is_empty(),
+                "edge_type-only delta against a baseline must not produce MOVED, got: {:?}",
+                diff.changes
+            );
+        }
+
+        // Case 2: distance changes — MOVED.
+        {
+            let mut tracker = DiffTracker::from_baseline(&baseline);
+            // Build graph where A is now at distance 2 (root -> B -> A).
+            let mut root = TreeNode::new_root(make_space_id(0x01));
+            let mut b = TreeNode::new(make_space_id(0x0B), EdgeType::Verified);
+            b.add_child(TreeNode::new(make_space_id(0x0A), EdgeType::Verified));
+            root.add_child(b);
+            let graph = CanonicalGraph::new(
+                make_space_id(0x01),
+                root,
+                [
+                    make_space_id(0x01),
+                    make_space_id(0x0A),
+                    make_space_id(0x0B),
+                ]
+                .into_iter()
+                .collect(),
+            );
+            let diff = tracker.track(&graph);
+            let a_change = diff
+                .changes
+                .iter()
+                .find(|c| c.space_id == make_space_id(0x0A))
+                .expect("A must appear in diff after distance change");
+            assert_eq!(a_change.change_type, ChangeType::Moved);
+            assert_eq!(a_change.position.unwrap().distance, 2);
+        }
+
+        // Case 3: parent changes (distance same).
+        {
+            // Build graph where A is still distance 1 but parent is now B.
+            // (Forced by making B the root via a sibling — simulate by having
+            // A attached to a new parent with distance 1. To do this with
+            // distance 1, the parent must be root, so this case overlaps
+            // with the baseline. Instead simulate by changing the baseline
+            // parent and showing parent change at the same distance.)
+            let baseline2 = baseline_with(&[(0x0A, 1, 0x0B)]); // claim A had parent=B
+            let mut tracker2 = DiffTracker::from_baseline(&baseline2);
+            let graph = one_node_graph(0x0A, EdgeType::Verified); // actual parent = root (0x01)
+            let diff = tracker2.track(&graph);
+            let a_change = diff
+                .changes
+                .iter()
+                .find(|c| c.space_id == make_space_id(0x0A))
+                .expect("A must appear in diff after parent change");
+            assert_eq!(a_change.change_type, ChangeType::Moved);
+            assert_eq!(a_change.position.unwrap().parent, make_space_id(0x01));
+        }
+    }
+
+    #[test]
+    fn from_baseline_second_track_uses_full_position_equality() {
+        // After the one-shot baseline-aware diff, subsequent track() calls
+        // must include edge_type in MOVED detection (regular compute_diff
+        // semantics). This guards against accidentally leaving the
+        // edge_type-blind comparison in place forever.
+        let baseline = baseline_with(&[(0x0A, 1, 0x01)]);
+        let mut tracker = DiffTracker::from_baseline(&baseline);
+
+        // First track: edge_type-only change is suppressed (as established
+        // above).
+        let graph_v1 = one_node_graph(0x0A, EdgeType::Verified);
+        let diff = tracker.track(&graph_v1);
+        assert!(diff.is_empty());
+
+        // Second track: change edge_type only. compute_diff (not the
+        // baseline variant) should now flag this as MOVED.
+        let graph_v2 = one_node_graph(0x0A, EdgeType::Related);
+        let diff = tracker.track(&graph_v2);
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Moved);
+        assert_eq!(
+            diff.changes[0].position.unwrap().edge_type,
+            EdgeType::Related
+        );
+    }
+
+    #[test]
+    fn iter_emission_state_returns_pending_baseline_before_first_track() {
+        // Force-write-on-startup path: when a tracker is freshly primed but
+        // no track() has run, iter_emission_state must still expose the
+        // baseline so it can be re-persisted (idempotent rewrite).
+        let baseline = baseline_with(&[(0x0A, 1, 0x01), (0x0B, 2, 0x0A)]);
+        let tracker = DiffTracker::from_baseline(&baseline);
+        let collected: Vec<_> = tracker.iter_emission_state().unwrap().collect();
+        assert_eq!(collected.len(), 2);
+        assert!(collected.contains(&(make_space_id(0x0A), 1, make_space_id(0x01))));
+        assert!(collected.contains(&(make_space_id(0x0B), 2, make_space_id(0x0A))));
+    }
+
+    #[test]
+    fn iter_emission_state_returns_none_when_uninitialized() {
+        // A brand-new tracker (no baseline, no track) has no contract with
+        // consumers to persist — iter_emission_state must signal this so the
+        // caller doesn't write an empty baseline by accident.
+        let tracker = DiffTracker::new();
+        assert!(tracker.iter_emission_state().is_none());
+    }
+
+    #[test]
+    fn iter_emission_state_reflects_live_positions_after_track() {
+        let mut tracker = DiffTracker::new();
+        let graph = one_node_graph(0x0A, EdgeType::Verified);
+        let _ = tracker.track(&graph);
+
+        let collected: Vec<_> = tracker.iter_emission_state().unwrap().collect();
+        assert_eq!(
+            collected,
+            vec![(make_space_id(0x0A), 1, make_space_id(0x01))]
+        );
+    }
+
+    #[test]
+    fn from_baseline_no_op_when_baseline_matches_current() {
+        // Sanity: priming from a baseline that exactly matches the next
+        // canonical graph must produce zero events. This is the steady-state
+        // restart case (Phase 1 restart, no rules change between deploys).
+        let baseline = baseline_with(&[(0x0A, 1, 0x01)]);
+        let mut tracker = DiffTracker::from_baseline(&baseline);
+
+        let graph = one_node_graph(0x0A, EdgeType::Verified);
+        let diff = tracker.track(&graph);
+        assert!(
+            diff.is_empty(),
+            "baseline matching current must emit no events, got: {:?}",
+            diff.changes
+        );
     }
 }

--- a/atlas/src/graph/mod.rs
+++ b/atlas/src/graph/mod.rs
@@ -17,7 +17,7 @@ mod transitive;
 mod tree;
 
 pub use canonical::{CanonicalGraph, CanonicalProcessor};
-pub use diff::{ChangeType, DiffTracker, GraphDiff, NodeChange, Position};
+pub use diff::{ChangeType, DiffTracker, EmissionStateIter, GraphDiff, NodeChange, Position};
 pub use hash::hash_tree;
 pub use state::GraphState;
 pub use transitive::{TransitiveGraph, TransitiveProcessor};

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -104,9 +104,6 @@ impl GraphState {
             TrustExtension::Subtopic { target_topic_id } => {
                 self.add_topic_edge(source, *target_topic_id);
             }
-            TrustExtension::EditorAdded { member_space_id } => {
-                self.add_explicit_edge(source, *member_space_id, EdgeType::Editor);
-            }
 
             // --- Edge Removals ---
             TrustExtension::VerifiedRemoved { target_space_id } => {
@@ -115,20 +112,22 @@ impl GraphState {
             TrustExtension::RelatedRemoved { target_space_id } => {
                 self.remove_explicit_edge(source, *target_space_id, EdgeType::Related);
             }
-            TrustExtension::EditorRemoved { member_space_id } => {
-                self.remove_explicit_edge(source, *member_space_id, EdgeType::Editor);
-            }
             TrustExtension::SubtopicRemoved { target_topic_id } => {
                 self.remove_topic_edge(source, *target_topic_id);
             }
 
-            // Member edges are ignored — see plan 0007. Variants stay in the
-            // TrustExtension enum so convert.rs (chain action parsing) is untouched.
-            TrustExtension::MemberAdded { .. } | TrustExtension::MemberRemoved { .. } => {}
+            // Member and Editor edges are ignored — see plan 0007. Variants stay
+            // in the TrustExtension enum so convert.rs (chain action parsing) is
+            // untouched. Only Verified, Related, and Subtopic remain as
+            // canonical-granting edges.
+            TrustExtension::MemberAdded { .. }
+            | TrustExtension::MemberRemoved { .. }
+            | TrustExtension::EditorAdded { .. }
+            | TrustExtension::EditorRemoved { .. } => {}
         }
     }
 
-    /// Add an explicit edge (Verified, Related, Editor)
+    /// Add an explicit edge (Verified, Related)
     fn add_explicit_edge(&mut self, source: SpaceId, target: SpaceId, edge_type: EdgeType) {
         // Intentionally allow duplicate entries.
         //
@@ -463,6 +462,65 @@ mod tests {
             state.explicit_edge_count(),
             1,
             "MemberRemoved must not remove unrelated edges"
+        );
+    }
+
+    // Editor events must also be no-ops at the state layer — see plan 0007.
+
+    fn editor_event(source: SpaceId, target: SpaceId, add: bool) -> SpaceTopologyEvent {
+        SpaceTopologyEvent {
+            meta: make_block_meta_at(2),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: source,
+                extension: if add {
+                    TrustExtension::EditorAdded {
+                        member_space_id: target,
+                    }
+                } else {
+                    TrustExtension::EditorRemoved {
+                        member_space_id: target,
+                    }
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn test_editor_added_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        state.apply_event(&editor_event(source, target, true));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            0,
+            "EditorAdded must not produce an explicit edge"
+        );
+        assert!(state.get_explicit_edges(&source).is_none());
+    }
+
+    #[test]
+    fn test_editor_removed_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        // Add a verified edge so we can verify EditorRemoved doesn't disturb it.
+        state.apply_event(&make_verified_event(source, target));
+        assert_eq!(state.explicit_edge_count(), 1);
+
+        state.apply_event(&editor_event(source, target, false));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            1,
+            "EditorRemoved must not remove unrelated edges"
         );
     }
 }

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -118,8 +118,14 @@ impl GraphState {
 
             // Member and Editor edges are ignored — see plan 0007. Variants stay
             // in the TrustExtension enum so convert.rs (chain action parsing) is
-            // untouched. Only Verified, Related, and Subtopic remain as
-            // canonical-granting edges.
+            // untouched.
+            //
+            // Edge types that still affect Atlas's output after this change:
+            //   • Verified / Related — grant *canonical membership* via the
+            //     explicit-only BFS in canonical.rs Phase 1.
+            //   • Subtopic           — does NOT grant canonical membership; it
+            //     attaches filtered subtrees between already-canonical members
+            //     in canonical.rs Phase 2 (collect_topic_subtrees).
             TrustExtension::MemberAdded { .. }
             | TrustExtension::MemberRemoved { .. }
             | TrustExtension::EditorAdded { .. }

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -107,9 +107,6 @@ impl GraphState {
             TrustExtension::EditorAdded { member_space_id } => {
                 self.add_explicit_edge(source, *member_space_id, EdgeType::Editor);
             }
-            TrustExtension::MemberAdded { member_space_id } => {
-                self.add_explicit_edge(source, *member_space_id, EdgeType::Member);
-            }
 
             // --- Edge Removals ---
             TrustExtension::VerifiedRemoved { target_space_id } => {
@@ -121,16 +118,17 @@ impl GraphState {
             TrustExtension::EditorRemoved { member_space_id } => {
                 self.remove_explicit_edge(source, *member_space_id, EdgeType::Editor);
             }
-            TrustExtension::MemberRemoved { member_space_id } => {
-                self.remove_explicit_edge(source, *member_space_id, EdgeType::Member);
-            }
             TrustExtension::SubtopicRemoved { target_topic_id } => {
                 self.remove_topic_edge(source, *target_topic_id);
             }
+
+            // Member edges are ignored — see plan 0007. Variants stay in the
+            // TrustExtension enum so convert.rs (chain action parsing) is untouched.
+            TrustExtension::MemberAdded { .. } | TrustExtension::MemberRemoved { .. } => {}
         }
     }
 
-    /// Add an explicit edge (Verified, Related, Editor, Member)
+    /// Add an explicit edge (Verified, Related, Editor)
     fn add_explicit_edge(&mut self, source: SpaceId, target: SpaceId, edge_type: EdgeType) {
         // Intentionally allow duplicate entries.
         //
@@ -405,5 +403,66 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert!(members.contains(&space1));
         assert!(members.contains(&space2));
+    }
+
+    // Member events must be no-ops at the state layer — see plan 0007.
+    // They still arrive from the chain via convert.rs but never produce
+    // edges in any graph view.
+
+    fn member_event(source: SpaceId, target: SpaceId, add: bool) -> SpaceTopologyEvent {
+        SpaceTopologyEvent {
+            meta: make_block_meta_at(2),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: source,
+                extension: if add {
+                    TrustExtension::MemberAdded {
+                        member_space_id: target,
+                    }
+                } else {
+                    TrustExtension::MemberRemoved {
+                        member_space_id: target,
+                    }
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn test_member_added_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        state.apply_event(&member_event(source, target, true));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            0,
+            "MemberAdded must not produce an explicit edge"
+        );
+        assert!(state.get_explicit_edges(&source).is_none());
+    }
+
+    #[test]
+    fn test_member_removed_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        // Add a verified edge so we can verify MemberRemoved doesn't disturb it.
+        state.apply_event(&make_verified_event(source, target));
+        assert_eq!(state.explicit_edge_count(), 1);
+
+        state.apply_event(&member_event(source, target, false));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            1,
+            "MemberRemoved must not remove unrelated edges"
+        );
     }
 }

--- a/atlas/src/graph/transitive.rs
+++ b/atlas/src/graph/transitive.rs
@@ -254,13 +254,15 @@ impl TransitiveProcessor {
                         self.cache.invalidate(target_space_id);
                     }
 
-                    // Membership edges: invalidate member space
+                    // Editor edges: invalidate member space
                     TrustExtension::EditorAdded { member_space_id }
-                    | TrustExtension::MemberAdded { member_space_id }
-                    | TrustExtension::EditorRemoved { member_space_id }
-                    | TrustExtension::MemberRemoved { member_space_id } => {
+                    | TrustExtension::EditorRemoved { member_space_id } => {
                         self.cache.invalidate(member_space_id);
                     }
+
+                    // Member edges: no-op — Member events do not mutate state (plan 0007).
+                    TrustExtension::MemberAdded { .. }
+                    | TrustExtension::MemberRemoved { .. } => {}
 
                     // Topic edges: invalidate all spaces that announced this topic
                     TrustExtension::Subtopic { target_topic_id }
@@ -616,5 +618,35 @@ mod tests {
             stats_after.reverse_deps_count, 0,
             "stale reverse_deps should be cleaned up"
         );
+    }
+
+    #[test]
+    fn test_member_edge_not_in_transitive() {
+        // Plan 0007: Member edges are no-ops. A space reachable only via a
+        // Member edge must not appear in the transitive graph rooted at the
+        // source — neither in the flat membership set nor in the tree.
+        let mut state = GraphState::new();
+        let a = create_space(&mut state, 1);
+        let b = create_space(&mut state, 2);
+
+        let member_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: a,
+                extension: TrustExtension::MemberAdded { member_space_id: b },
+            }),
+        };
+        state.apply_event(&member_event);
+
+        let mut processor = TransitiveProcessor::new();
+        let graph = processor.get_full(a, &state);
+
+        assert_eq!(graph.len(), 1, "A reaches only itself");
+        assert!(graph.contains(&a));
+        assert!(
+            !graph.contains(&b),
+            "B must not be reachable through a Member edge"
+        );
+        assert_eq!(graph.tree.node_count(), 1);
     }
 }

--- a/atlas/src/graph/transitive.rs
+++ b/atlas/src/graph/transitive.rs
@@ -254,15 +254,11 @@ impl TransitiveProcessor {
                         self.cache.invalidate(target_space_id);
                     }
 
-                    // Editor edges: invalidate member space
-                    TrustExtension::EditorAdded { member_space_id }
-                    | TrustExtension::EditorRemoved { member_space_id } => {
-                        self.cache.invalidate(member_space_id);
-                    }
-
-                    // Member edges: no-op — Member events do not mutate state (plan 0007).
+                    // Member and Editor edges: no-op — these events do not mutate state (plan 0007).
                     TrustExtension::MemberAdded { .. }
-                    | TrustExtension::MemberRemoved { .. } => {}
+                    | TrustExtension::MemberRemoved { .. }
+                    | TrustExtension::EditorAdded { .. }
+                    | TrustExtension::EditorRemoved { .. } => {}
 
                     // Topic edges: invalidate all spaces that announced this topic
                     TrustExtension::Subtopic { target_topic_id }
@@ -646,6 +642,36 @@ mod tests {
         assert!(
             !graph.contains(&b),
             "B must not be reachable through a Member edge"
+        );
+        assert_eq!(graph.tree.node_count(), 1);
+    }
+
+    #[test]
+    fn test_editor_edge_not_in_transitive() {
+        // Plan 0007: Editor edges are no-ops. A space reachable only via an
+        // Editor edge must not appear in the transitive graph rooted at the
+        // source — neither in the flat membership set nor in the tree.
+        let mut state = GraphState::new();
+        let a = create_space(&mut state, 1);
+        let b = create_space(&mut state, 2);
+
+        let editor_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: a,
+                extension: TrustExtension::EditorAdded { member_space_id: b },
+            }),
+        };
+        state.apply_event(&editor_event);
+
+        let mut processor = TransitiveProcessor::new();
+        let graph = processor.get_full(a, &state);
+
+        assert_eq!(graph.len(), 1, "A reaches only itself");
+        assert!(graph.contains(&a));
+        assert!(
+            !graph.contains(&b),
+            "B must not be reachable through an Editor edge"
         );
         assert_eq!(graph.tree.node_count(), 1);
     }

--- a/atlas/src/graph/tree.rs
+++ b/atlas/src/graph/tree.rs
@@ -18,8 +18,6 @@ pub enum EdgeType {
     Topic { topic_id: TopicId },
     /// Editor membership (canonical-granting)
     Editor,
-    /// Member membership (canonical-granting)
-    Member,
 }
 
 /// A node in the traversal tree

--- a/atlas/src/graph/tree.rs
+++ b/atlas/src/graph/tree.rs
@@ -16,8 +16,6 @@ pub enum EdgeType {
     Related,
     /// Topic-based membership — carries the topic that created this edge
     Topic { topic_id: TopicId },
-    /// Editor membership (canonical-granting)
-    Editor,
 }
 
 /// A node in the traversal tree

--- a/atlas/src/kafka/emitter.rs
+++ b/atlas/src/kafka/emitter.rs
@@ -44,7 +44,7 @@ use hermes_instrumentation::{debug_span, warn};
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata as ProtoBlockchainMetadata;
 use hermes_schema::pb::topology::{
     canonical_tree_node::Edge, edge_info, CanonicalGraphDiff, CanonicalGraphUpdated,
-    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge, MemberEdge,
+    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge,
     NodeChange as ProtoNodeChange, RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
 };
 use prost::Message;
@@ -187,7 +187,6 @@ fn edge_type_to_proto_edge(edge_type: EdgeType) -> Edge {
             topic_id: topic_id.to_vec(),
         }),
         EdgeType::Editor => Edge::Editor(EditorEdge {}),
-        EdgeType::Member => Edge::Member(MemberEdge {}),
     }
 }
 
@@ -223,7 +222,6 @@ fn position_to_edge_info(pos: &Position) -> Option<EdgeInfo> {
             topic_id: topic_id.to_vec(),
         }),
         EdgeType::Editor => edge_info::EdgeType::Editor(EditorEdge {}),
-        EdgeType::Member => edge_info::EdgeType::Member(MemberEdge {}),
         EdgeType::Root => {
             warn!(
                 parent = ?pos.parent,
@@ -293,21 +291,19 @@ mod tests {
         root.add_child(TreeNode::new(make_space_id(2), EdgeType::Verified));
         root.add_child(TreeNode::new(make_space_id(3), EdgeType::Related));
         root.add_child(TreeNode::new(make_space_id(4), EdgeType::Editor));
-        root.add_child(TreeNode::new(make_space_id(5), EdgeType::Member));
         root.add_child(TreeNode::new_with_topic(
-            make_space_id(6),
+            make_space_id(5),
             make_topic_id(0x8A),
         ));
 
         let proto = tree_node_to_proto(&root);
-        assert_eq!(proto.children.len(), 5);
+        assert_eq!(proto.children.len(), 4);
 
         assert!(matches!(proto.children[0].edge, Some(Edge::Verified(_))));
         assert!(matches!(proto.children[1].edge, Some(Edge::Related(_))));
         assert!(matches!(proto.children[2].edge, Some(Edge::Editor(_))));
-        assert!(matches!(proto.children[3].edge, Some(Edge::Member(_))));
 
-        match &proto.children[4].edge {
+        match &proto.children[3].edge {
             Some(Edge::Topic(TopicEdge { topic_id })) => {
                 assert_eq!(*topic_id, make_topic_id(0x8A).to_vec());
             }

--- a/atlas/src/kafka/emitter.rs
+++ b/atlas/src/kafka/emitter.rs
@@ -44,7 +44,7 @@ use hermes_instrumentation::{debug_span, warn};
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata as ProtoBlockchainMetadata;
 use hermes_schema::pb::topology::{
     canonical_tree_node::Edge, edge_info, CanonicalGraphDiff, CanonicalGraphUpdated,
-    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge,
+    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo,
     NodeChange as ProtoNodeChange, RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
 };
 use prost::Message;
@@ -186,7 +186,6 @@ fn edge_type_to_proto_edge(edge_type: EdgeType) -> Edge {
         EdgeType::Topic { topic_id } => Edge::Topic(TopicEdge {
             topic_id: topic_id.to_vec(),
         }),
-        EdgeType::Editor => Edge::Editor(EditorEdge {}),
     }
 }
 
@@ -221,7 +220,6 @@ fn position_to_edge_info(pos: &Position) -> Option<EdgeInfo> {
         EdgeType::Topic { topic_id } => edge_info::EdgeType::Topic(TopicEdge {
             topic_id: topic_id.to_vec(),
         }),
-        EdgeType::Editor => edge_info::EdgeType::Editor(EditorEdge {}),
         EdgeType::Root => {
             warn!(
                 parent = ?pos.parent,
@@ -290,20 +288,18 @@ mod tests {
         let mut root = TreeNode::new_root(make_space_id(1));
         root.add_child(TreeNode::new(make_space_id(2), EdgeType::Verified));
         root.add_child(TreeNode::new(make_space_id(3), EdgeType::Related));
-        root.add_child(TreeNode::new(make_space_id(4), EdgeType::Editor));
         root.add_child(TreeNode::new_with_topic(
-            make_space_id(5),
+            make_space_id(4),
             make_topic_id(0x8A),
         ));
 
         let proto = tree_node_to_proto(&root);
-        assert_eq!(proto.children.len(), 4);
+        assert_eq!(proto.children.len(), 3);
 
         assert!(matches!(proto.children[0].edge, Some(Edge::Verified(_))));
         assert!(matches!(proto.children[1].edge, Some(Edge::Related(_))));
-        assert!(matches!(proto.children[2].edge, Some(Edge::Editor(_))));
 
-        match &proto.children[3].edge {
+        match &proto.children[2].edge {
             Some(Edge::Topic(TopicEdge { topic_id })) => {
                 assert_eq!(*topic_id, make_topic_id(0x8A).to_vec());
             }

--- a/atlas/src/kafka/emitter.rs
+++ b/atlas/src/kafka/emitter.rs
@@ -44,8 +44,8 @@ use hermes_instrumentation::{debug_span, warn};
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata as ProtoBlockchainMetadata;
 use hermes_schema::pb::topology::{
     canonical_tree_node::Edge, edge_info, CanonicalGraphDiff, CanonicalGraphUpdated,
-    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo,
-    NodeChange as ProtoNodeChange, RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
+    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, NodeChange as ProtoNodeChange,
+    RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
 };
 use prost::Message;
 

--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -37,7 +37,10 @@ use atlas::convert::convert_action;
 use atlas::events::{BlockMetadata, SpaceId, SpaceTopologyEvent, SpaceTopologyPayload};
 use atlas::graph::{CanonicalProcessor, DiffTracker, GraphState, TransitiveProcessor};
 use atlas::kafka::{AtlasProducer, CanonicalGraphEmitter};
-use atlas::persistence::{CheckpointConfig, CheckpointManager, PersistedGraphState};
+use atlas::persistence::{
+    CheckpointConfig, CheckpointManager, PersistedEmissionBaseline, PersistedGraphState,
+    RestoredCheckpoint,
+};
 use hermes_instrumentation::{debug, info, info_span, Instrument};
 use hermes_relay::{Actions, HermesModule, Sink, StreamSource};
 use prost::Message;
@@ -54,6 +57,11 @@ struct PipelineState {
     diff_tracker: DiffTracker,
     event_count: usize,
     emit_count: usize,
+    /// True until atlas has persisted an emission baseline at least once.
+    /// Drives the "force-write on first canonical compute" requirement: a
+    /// quiet startup must still leave a baseline on disk so the next deploy
+    /// has something to load. See GEO-645.
+    baseline_force_write_pending: bool,
 }
 
 /// Atlas topology processor that implements the hermes-relay Sink trait.
@@ -69,25 +77,63 @@ struct AtlasSink {
 impl AtlasSink {
     async fn new(root_space: SpaceId, emitter: CanonicalGraphEmitter) -> anyhow::Result<Self> {
         let mut checkpoint_manager = CheckpointManager::from_env(root_space, 1)?;
-        let restored_state = checkpoint_manager.restore_checkpoint_on_startup().await?;
+        let RestoredCheckpoint {
+            graph_state,
+            baseline,
+        } = checkpoint_manager.restore_checkpoint_on_startup().await?;
 
-        let graph = restored_state.unwrap_or_else(GraphState::new);
+        let graph = graph_state.unwrap_or_else(GraphState::new);
         let mut transitive = TransitiveProcessor::new();
         let mut canonical = CanonicalProcessor::new(root_space);
-        let mut diff_tracker = DiffTracker::new();
+
+        // If we restored a baseline, prime DiffTracker from it — the first
+        // post-restart track() will diff against what consumers last saw,
+        // emitting REMOVED for orphans across a rules change. Otherwise the
+        // tracker starts empty; we'll fall back to "warm from restored
+        // canonical" below (legacy behaviour) and mark a force-write so the
+        // baseline gets persisted ASAP.
+        let baseline_initially_present = baseline.is_some();
+        let mut diff_tracker = match &baseline {
+            Some(b) => {
+                info!(
+                    baseline_node_count = b.len(),
+                    "DiffTracker primed from persisted emission baseline"
+                );
+                DiffTracker::from_baseline(b)
+            }
+            None => DiffTracker::new(),
+        };
 
         if checkpoint_manager.restored_cursor().is_some() {
             if let Some(restored_graph) = canonical.compute_if_changed(&graph, &mut transitive) {
-                let _ = diff_tracker.track(&restored_graph);
-                info!(
-                    restored_cursor = checkpoint_manager.restored_cursor().is_some(),
-                    warmed_nodes = restored_graph.len(),
-                    "Warmed canonical/transitive/diff caches from restored checkpoint state"
-                );
+                if baseline.is_none() {
+                    // No persisted baseline. Use the just-computed canonical
+                    // as the emission baseline so we don't emit a spurious
+                    // bootstrap-all-ADDED diff on the next track(). This
+                    // matches the pre-GEO-645 behaviour for the
+                    // "checkpoint exists, no baseline column yet" case
+                    // (i.e. the first run after this migration ships).
+                    let _ = diff_tracker.track(&restored_graph);
+                    info!(
+                        warmed_nodes = restored_graph.len(),
+                        "Warmed DiffTracker from restored canonical (no persisted baseline yet)"
+                    );
+                } else {
+                    // Baseline already loaded; don't burn the one-shot
+                    // pending_baseline diff on the warming compute. The
+                    // first real per-block track() handles it.
+                    info!(
+                        restored_canonical_nodes = restored_graph.len(),
+                        baseline_node_count = baseline.as_ref().map(|b| b.len()).unwrap_or(0),
+                        "Restored canonical computed; DiffTracker stays primed from persisted baseline"
+                    );
+                }
             }
         }
 
-        Ok(Self {
+        let baseline_force_write_pending = !baseline_initially_present;
+
+        let mut sink = Self {
             state: Mutex::new(PipelineState {
                 graph,
                 transitive,
@@ -95,10 +141,68 @@ impl AtlasSink {
                 diff_tracker,
                 event_count: 0,
                 emit_count: 0,
+                baseline_force_write_pending,
             }),
             emitter,
             checkpoint_manager,
-        })
+        };
+
+        // Force-write on startup: if there's no baseline on disk yet but we
+        // already have an emission state (from warming above), persist it
+        // immediately. Without this, an atlas with no incoming events between
+        // startup and the next restart would never write a baseline, leaving
+        // the next rules-change deploy nothing to load. See GEO-645.
+        sink.force_write_baseline_if_pending().await;
+
+        Ok(sink)
+    }
+
+    /// Persist the current emission state as a baseline if one hasn't been
+    /// persisted yet. Idempotent — clears the pending flag on success and is
+    /// safe to call repeatedly. Skips if there is no restored cursor (fresh
+    /// start; the first per-block persist handles it instead).
+    async fn force_write_baseline_if_pending(&mut self) {
+        let needs_write = {
+            let state = self.state.lock().unwrap();
+            state.baseline_force_write_pending
+        };
+        if !needs_write {
+            return;
+        }
+        let Some(cursor) = self.checkpoint_manager.restored_cursor() else {
+            // Fresh start: no cursor yet, defer to the per-block persist path.
+            return;
+        };
+        let Some(block_number) = self.checkpoint_manager.restored_block_number() else {
+            return;
+        };
+
+        let (snapshot, baseline) = {
+            let state = self.state.lock().unwrap();
+            (
+                PersistedGraphState::from(&state.graph),
+                PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker),
+            )
+        };
+
+        let Some(baseline) = baseline else {
+            // Nothing to persist yet (no canonical compute has happened).
+            return;
+        };
+
+        info!(
+            block_number,
+            cursor = %cursor,
+            baseline_node_count = baseline.len(),
+            "Force-writing emission baseline on startup (none persisted before)"
+        );
+
+        self.checkpoint_manager
+            .persist_block_checkpoint(block_number, cursor, snapshot, Some(&baseline))
+            .await;
+
+        let mut state = self.state.lock().unwrap();
+        state.baseline_force_write_pending = false;
     }
 
     fn summary(&self) {
@@ -193,6 +297,11 @@ impl Sink for AtlasSink {
                 diff_tracker,
                 event_count,
                 emit_count,
+                // The force-write flag is read/written on the per-block
+                // persist path below, which re-locks the state — not in this
+                // event loop. Keeping it out of the destructure documents
+                // that intent.
+                baseline_force_write_pending: _,
             } = &mut *s;
 
             // Phase 1: Apply all events to graph state and transitive cache.
@@ -294,14 +403,44 @@ impl Sink for AtlasSink {
         .await?;
 
         if processed_events > 0 {
-            let persisted_snapshot = {
+            let (persisted_snapshot, emission_baseline) = {
                 let state = self.state.lock().unwrap();
-                PersistedGraphState::from(&state.graph)
+                (
+                    PersistedGraphState::from(&state.graph),
+                    PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker),
+                )
             };
 
+            // Atomicity: graph_state and baseline are written in the same
+            // INSERT, so they cannot diverge. If `emission_baseline` is None
+            // (no canonical compute has ever happened yet, e.g. on a
+            // fresh-start atlas waiting for the first canonical-affecting
+            // event), the SQL `COALESCE` preserves whatever baseline is
+            // already on disk — so we never overwrite a good baseline with
+            // NULL.
             self.checkpoint_manager
-                .persist_block_checkpoint(block_number, meta.cursor.clone(), persisted_snapshot)
+                .persist_block_checkpoint(
+                    block_number,
+                    meta.cursor.clone(),
+                    persisted_snapshot,
+                    emission_baseline.as_ref(),
+                )
                 .await;
+
+            // Clear the force-write flag once we've actually written a
+            // baseline. Cheap, idempotent — the flag exists only to drive
+            // the explicit startup force-write; once the per-block path
+            // is keeping the baseline current there's nothing further to do.
+            if let Some(baseline) = emission_baseline.as_ref() {
+                let mut state = self.state.lock().unwrap();
+                if state.baseline_force_write_pending {
+                    state.baseline_force_write_pending = false;
+                    info!(
+                        baseline_node_count = baseline.len(),
+                        block_number, "Emission baseline persisted for the first time"
+                    );
+                }
+            }
         }
 
         Ok(())

--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -41,7 +41,7 @@ use atlas::persistence::{
     CheckpointConfig, CheckpointManager, PersistedEmissionBaseline, PersistedGraphState,
     RestoredCheckpoint,
 };
-use hermes_instrumentation::{debug, info, info_span, Instrument};
+use hermes_instrumentation::{debug, info, info_span, warn, Instrument};
 use hermes_relay::{Actions, HermesModule, Sink, StreamSource};
 use prost::Message;
 
@@ -158,9 +158,14 @@ impl AtlasSink {
     }
 
     /// Persist the current emission state as a baseline if one hasn't been
-    /// persisted yet. Idempotent — clears the pending flag on success and is
-    /// safe to call repeatedly. Skips if there is no restored cursor (fresh
-    /// start; the first per-block persist handles it instead).
+    /// persisted yet. Idempotent — clears the pending flag only on a
+    /// confirmed successful DB write, and is safe to call repeatedly. Skips
+    /// if there is no restored cursor (fresh start; the first per-block
+    /// persist handles it instead).
+    ///
+    /// On persist failure the pending flag stays `true` so the per-block
+    /// retry path in `process_block_scoped_data` can try again on a quiet
+    /// stream, even when no canonical-affecting events arrive.
     async fn force_write_baseline_if_pending(&mut self) {
         let needs_write = {
             let state = self.state.lock().unwrap();
@@ -197,12 +202,31 @@ impl AtlasSink {
             "Force-writing emission baseline on startup (none persisted before)"
         );
 
-        self.checkpoint_manager
+        match self
+            .checkpoint_manager
             .persist_block_checkpoint(block_number, cursor, snapshot, Some(&baseline))
-            .await;
-
-        let mut state = self.state.lock().unwrap();
-        state.baseline_force_write_pending = false;
+            .await
+        {
+            Ok(()) => {
+                let mut state = self.state.lock().unwrap();
+                state.baseline_force_write_pending = false;
+                info!(
+                    block_number,
+                    baseline_node_count = baseline.len(),
+                    "Emission baseline persisted for the first time"
+                );
+            }
+            Err(err) => {
+                // Keep `baseline_force_write_pending = true` so the per-block
+                // retry path can try again. CheckpointManager has already
+                // recorded the failure for fail-open accounting.
+                warn!(
+                    block_number,
+                    reason = %err,
+                    "Startup force-write of emission baseline failed; will retry on next block"
+                );
+            }
+        }
     }
 
     fn summary(&self) {
@@ -418,7 +442,8 @@ impl Sink for AtlasSink {
             // event), the SQL `COALESCE` preserves whatever baseline is
             // already on disk — so we never overwrite a good baseline with
             // NULL.
-            self.checkpoint_manager
+            let persist_result = self
+                .checkpoint_manager
                 .persist_block_checkpoint(
                     block_number,
                     meta.cursor.clone(),
@@ -427,18 +452,88 @@ impl Sink for AtlasSink {
                 )
                 .await;
 
-            // Clear the force-write flag once we've actually written a
-            // baseline. Cheap, idempotent — the flag exists only to drive
-            // the explicit startup force-write; once the per-block path
-            // is keeping the baseline current there's nothing further to do.
-            if let Some(baseline) = emission_baseline.as_ref() {
-                let mut state = self.state.lock().unwrap();
-                if state.baseline_force_write_pending {
-                    state.baseline_force_write_pending = false;
+            // Clear the force-write flag only after a confirmed successful
+            // write. Cheap, idempotent — the flag exists to drive the
+            // explicit startup force-write; once the per-block path has
+            // actually persisted a baseline there's nothing further to do.
+            // On failure we leave the flag set so a subsequent quiet block
+            // (handled below) or the next eventful block can retry.
+            if persist_result.is_ok() {
+                if let Some(baseline) = emission_baseline.as_ref() {
+                    let mut state = self.state.lock().unwrap();
+                    if state.baseline_force_write_pending {
+                        state.baseline_force_write_pending = false;
+                        info!(
+                            baseline_node_count = baseline.len(),
+                            block_number, "Emission baseline persisted for the first time"
+                        );
+                    }
+                }
+            }
+        } else {
+            // Quiet block: per-block persist is gated on processed_events > 0,
+            // so the startup force-write is the only persistence attempt in
+            // a fully quiet stream. If the force-write failed (e.g. transient
+            // DB outage) the pending flag is still true and the baseline is
+            // still NULL on disk — without this retry path, a quiet stream
+            // would never recover until an eventful block arrived.
+            //
+            // We reuse the restored cursor / block_number because the cursor
+            // has not advanced on a quiet block. Only attempt this when an
+            // emission baseline is available (canonical compute has run at
+            // least once during startup warming).
+            let (needs_retry, snapshot_and_baseline, retry_cursor, retry_block_number) = {
+                let state = self.state.lock().unwrap();
+                if !state.baseline_force_write_pending {
+                    (false, None, None, None)
+                } else {
+                    let baseline =
+                        PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker);
+                    let snapshot = PersistedGraphState::from(&state.graph);
+                    (
+                        baseline.is_some(),
+                        baseline.map(|b| (snapshot, b)),
+                        self.checkpoint_manager.restored_cursor(),
+                        self.checkpoint_manager.restored_block_number(),
+                    )
+                }
+            };
+
+            if needs_retry {
+                if let (Some((snapshot, baseline)), Some(cursor), Some(retry_block)) =
+                    (snapshot_and_baseline, retry_cursor, retry_block_number)
+                {
                     info!(
+                        block_number = retry_block,
+                        cursor = %cursor,
                         baseline_node_count = baseline.len(),
-                        block_number, "Emission baseline persisted for the first time"
+                        "Retrying force-write of emission baseline on quiet block"
                     );
+
+                    match self
+                        .checkpoint_manager
+                        .persist_block_checkpoint(retry_block, cursor, snapshot, Some(&baseline))
+                        .await
+                    {
+                        Ok(()) => {
+                            let mut state = self.state.lock().unwrap();
+                            if state.baseline_force_write_pending {
+                                state.baseline_force_write_pending = false;
+                                info!(
+                                    block_number = retry_block,
+                                    baseline_node_count = baseline.len(),
+                                    "Emission baseline persisted for the first time"
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            warn!(
+                                block_number = retry_block,
+                                reason = %err,
+                                "Quiet-block retry of emission baseline force-write failed; will retry on next block"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -240,6 +240,76 @@ impl AtlasSink {
             "Processing complete"
         );
     }
+
+    /// Per-block retry of the GEO-645 baseline force-write.
+    ///
+    /// Runs on every incoming block (empty-output blocks, quiet blocks with no
+    /// decoded actions, and quiet blocks where `processed_events == 0`) so a
+    /// fully quiet stream can still recover from a transient DB failure that
+    /// caused the startup force-write (and any earlier per-block writes) to
+    /// fail. Without this hoist, a stream that produced no events after a
+    /// failed startup force-write would never persist a baseline.
+    ///
+    /// The current block's `block_number` / `cursor` are passed in so the
+    /// persisted checkpoint cursor matches the in-memory graph_state +
+    /// baseline snapshot we are writing — using `restored_cursor` /
+    /// `restored_block_number` here would rewind the resume cursor on disk
+    /// even though earlier blocks may have mutated the graph (fail-open).
+    ///
+    /// Semantics:
+    /// - No-op when `baseline_force_write_pending` is already false.
+    /// - No-op when no emission baseline is available yet (canonical compute
+    ///   has not produced output, so `from_diff_tracker` returns None).
+    /// - On success: clears the flag and logs
+    ///   `"Emission baseline persisted for the first time"`.
+    /// - On failure: leaves the flag set; the next block will try again.
+    async fn retry_force_write_baseline(&self, block_number: u64, cursor: &str) {
+        let (snapshot, baseline) = {
+            let state = self.state.lock().unwrap();
+            if !state.baseline_force_write_pending {
+                return;
+            }
+            let baseline = PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker);
+            let Some(baseline) = baseline else {
+                // No canonical compute yet — nothing to persist.
+                return;
+            };
+            let snapshot = PersistedGraphState::from(&state.graph);
+            (snapshot, baseline)
+        };
+
+        info!(
+            block_number,
+            cursor = %cursor,
+            baseline_node_count = baseline.len(),
+            "Retrying force-write of emission baseline on quiet block"
+        );
+
+        match self
+            .checkpoint_manager
+            .persist_block_checkpoint(block_number, cursor.to_string(), snapshot, Some(&baseline))
+            .await
+        {
+            Ok(()) => {
+                let mut state = self.state.lock().unwrap();
+                if state.baseline_force_write_pending {
+                    state.baseline_force_write_pending = false;
+                    info!(
+                        block_number,
+                        baseline_node_count = baseline.len(),
+                        "Emission baseline persisted for the first time"
+                    );
+                }
+            }
+            Err(err) => {
+                warn!(
+                    block_number,
+                    reason = %err,
+                    "Quiet-block retry of emission baseline force-write failed; will retry on next block"
+                );
+            }
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -292,6 +362,12 @@ impl Sink for AtlasSink {
             .unwrap_or(&[]);
 
         if output.is_empty() {
+            // Empty-output block: no decoded actions at all. Still attempt the
+            // baseline force-write retry so a fully quiet stream can recover
+            // from a failed startup force-write without waiting for an
+            // eventful block.
+            self.retry_force_write_baseline(block_number, &meta.cursor)
+                .await;
             return Ok(());
         }
 
@@ -471,71 +547,14 @@ impl Sink for AtlasSink {
                 }
             }
         } else {
-            // Quiet block: per-block persist is gated on processed_events > 0,
-            // so the startup force-write is the only persistence attempt in
-            // a fully quiet stream. If the force-write failed (e.g. transient
-            // DB outage) the pending flag is still true and the baseline is
-            // still NULL on disk — without this retry path, a quiet stream
-            // would never recover until an eventful block arrived.
-            //
-            // We reuse the restored cursor / block_number because the cursor
-            // has not advanced on a quiet block. Only attempt this when an
-            // emission baseline is available (canonical compute has run at
-            // least once during startup warming).
-            let (needs_retry, snapshot_and_baseline, retry_cursor, retry_block_number) = {
-                let state = self.state.lock().unwrap();
-                if !state.baseline_force_write_pending {
-                    (false, None, None, None)
-                } else {
-                    let baseline =
-                        PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker);
-                    let snapshot = PersistedGraphState::from(&state.graph);
-                    (
-                        baseline.is_some(),
-                        baseline.map(|b| (snapshot, b)),
-                        self.checkpoint_manager.restored_cursor(),
-                        self.checkpoint_manager.restored_block_number(),
-                    )
-                }
-            };
-
-            if needs_retry {
-                if let (Some((snapshot, baseline)), Some(cursor), Some(retry_block)) =
-                    (snapshot_and_baseline, retry_cursor, retry_block_number)
-                {
-                    info!(
-                        block_number = retry_block,
-                        cursor = %cursor,
-                        baseline_node_count = baseline.len(),
-                        "Retrying force-write of emission baseline on quiet block"
-                    );
-
-                    match self
-                        .checkpoint_manager
-                        .persist_block_checkpoint(retry_block, cursor, snapshot, Some(&baseline))
-                        .await
-                    {
-                        Ok(()) => {
-                            let mut state = self.state.lock().unwrap();
-                            if state.baseline_force_write_pending {
-                                state.baseline_force_write_pending = false;
-                                info!(
-                                    block_number = retry_block,
-                                    baseline_node_count = baseline.len(),
-                                    "Emission baseline persisted for the first time"
-                                );
-                            }
-                        }
-                        Err(err) => {
-                            warn!(
-                                block_number = retry_block,
-                                reason = %err,
-                                "Quiet-block retry of emission baseline force-write failed; will retry on next block"
-                            );
-                        }
-                    }
-                }
-            }
+            // Quiet block (decoded actions present but none were convertible):
+            // per-block persist is gated on `processed_events > 0`, so without
+            // this retry a fully quiet stream that hit a transient DB failure
+            // during the startup force-write would never recover. The helper
+            // uses the CURRENT block's cursor/number to match the in-memory
+            // snapshot it persists.
+            self.retry_force_write_baseline(block_number, &meta.cursor)
+                .await;
         }
 
         Ok(())

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -611,8 +611,12 @@ impl PostgresCheckpointStore {
             return Ok(None);
         };
 
-        let graph_state_blob: PersistedGraphState = row
-            .try_get::<sqlx::types::Json<PersistedGraphState>, _>("graph_state_blob")
+        // Fetch the graph state blob as raw JSON without decoding into
+        // `PersistedGraphState`. Decoding happens lazily in `Checkpoint::graph_state()`
+        // so `restore_checkpoint_on_startup` can run `validate_compatibility()` first
+        // and route decode failures through the fresh-start fallback path.
+        let graph_state_blob: serde_json::Value = row
+            .try_get::<sqlx::types::Json<serde_json::Value>, _>("graph_state_blob")
             .map_err(|err| {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?
@@ -753,7 +757,12 @@ pub struct Checkpoint {
     pub indexer_id: String,
     pub cursor: String,
     pub block_number: u64,
-    pub graph_state_blob: PersistedGraphState,
+    // Stored as raw JSON so loading can verify the runtime_compatibility_marker
+    // before paying the cost (and risk) of decoding into `PersistedGraphState`.
+    // This lets `restore_checkpoint_on_startup` route decode failures through
+    // the `ATLAS_CHECKPOINT_ALLOW_FRESH_START` fallback path rather than
+    // hard-failing in `PostgresCheckpointStore::load`.
+    pub graph_state_blob: serde_json::Value,
     pub graph_state_version: u32,
     pub runtime_compatibility_marker: String,
     pub root_space_id: String,
@@ -770,6 +779,10 @@ impl Checkpoint {
         runtime_compatibility_marker: String,
         root_space_id: SpaceId,
     ) -> Self {
+        // `PersistedGraphState` is a plain struct of `String`/`Vec`/enum fields,
+        // so serialization to `serde_json::Value` cannot fail in practice.
+        let graph_state_blob = serde_json::to_value(graph_state_blob)
+            .expect("PersistedGraphState always serializes to valid JSON");
         Self {
             schema_version: CHECKPOINT_SCHEMA_VERSION,
             indexer_id,
@@ -804,7 +817,11 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        self.graph_state_blob.to_graph_state()
+        let persisted: PersistedGraphState =
+            serde_json::from_value(self.graph_state_blob.clone()).map_err(|err| {
+                CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
+            })?;
+        persisted.to_graph_state()
     }
 
     pub fn validate_compatibility(
@@ -1278,6 +1295,58 @@ mod tests {
             .validate_compatibility("idx-other", "atlas-v2", make_space_id(1), 1)
             .unwrap_err();
         assert!(matches!(err, CheckpointError::Incompatible(_)));
+    }
+
+    #[test]
+    fn checkpoint_with_unknown_edge_variant_validates_marker_before_decode() {
+        // Regression: a checkpoint blob containing a now-removed edge variant
+        // (e.g. "Member" from atlas-v1) must not fail to construct just because
+        // the blob can't decode into the current `PersistedGraphState`. The
+        // raw-JSON storage lets `validate_compatibility()` reject the checkpoint
+        // on its marker first, and `graph_state()` is the only path that can
+        // surface a decode failure — letting the caller route it through the
+        // fresh-start fallback.
+        let blob_with_member = serde_json::json!({
+            "spaces": ["00000000000000000000000000000001"],
+            "space_topics": [],
+            "topic_spaces": [],
+            "explicit_edges": [{
+                "source_space_id": "00000000000000000000000000000001",
+                "edges": [{
+                    "target_space_id": "00000000000000000000000000000002",
+                    "edge_type": "Member"
+                }]
+            }],
+            "topic_edges": [],
+            "topic_edge_sources": []
+        });
+
+        let checkpoint = Checkpoint {
+            schema_version: CHECKPOINT_SCHEMA_VERSION,
+            indexer_id: "idx-test".to_string(),
+            cursor: "cursor-1".to_string(),
+            block_number: 1,
+            graph_state_blob: blob_with_member,
+            graph_state_version: 1,
+            runtime_compatibility_marker: "atlas-v1".to_string(),
+            root_space_id: encode_id(make_space_id(1)),
+        };
+
+        // Marker validation runs against the in-memory marker field — no decode
+        // needed, so the incompatible marker is reported cleanly.
+        let err = checkpoint
+            .validate_compatibility("idx-test", "atlas-v2", make_space_id(1), 1)
+            .expect_err("atlas-v1 marker must be rejected against atlas-v2 expected");
+        assert!(matches!(err, CheckpointError::Incompatible(_)));
+
+        // Only `graph_state()` (called after marker validation passes) surfaces
+        // the decode failure — and only via `CheckpointError::Serialization`,
+        // which is the path `restore_checkpoint_on_startup` already routes
+        // through `ATLAS_CHECKPOINT_ALLOW_FRESH_START`.
+        let err = checkpoint
+            .graph_state()
+            .expect_err("Member variant is no longer decodable into PersistedGraphState");
+        assert!(matches!(err, CheckpointError::Serialization(_)));
     }
 
     #[test]

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -176,7 +176,7 @@ impl CheckpointConfig {
             graph_state_version,
             indexer_id,
             runtime_compatibility_marker: std::env::var("ATLAS_RUNTIME_COMPATIBILITY_MARKER")
-                .unwrap_or_else(|_| "atlas-v1".to_string()),
+                .unwrap_or_else(|_| "atlas-v2".to_string()),
             fail_open_bound,
             checkpoint_retry_attempts: retry_attempts,
             checkpoint_retry_backoff_ms: retry_backoff_ms,
@@ -901,7 +901,6 @@ pub enum PersistedEdgeType {
     Topic { topic_id: String },
     Root,
     Editor,
-    Member,
 }
 
 impl PersistedGraphState {
@@ -1064,7 +1063,6 @@ impl PersistedEdgeType {
                 topic_id: encode_id(topic_id),
             },
             EdgeType::Editor => Self::Editor,
-            EdgeType::Member => Self::Member,
         }
     }
 
@@ -1077,7 +1075,6 @@ impl PersistedEdgeType {
                 topic_id: decode_topic_id(topic_id)?,
             }),
             PersistedEdgeType::Editor => Ok(EdgeType::Editor),
-            PersistedEdgeType::Member => Ok(EdgeType::Member),
         }
     }
 
@@ -1088,7 +1085,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Related => 2,
             PersistedEdgeType::Topic { .. } => 3,
             PersistedEdgeType::Editor => 4,
-            PersistedEdgeType::Member => 5,
         }
     }
 }
@@ -1203,7 +1199,7 @@ mod tests {
             root_space_id: make_space_id(1),
             graph_state_version: 1,
             indexer_id: "idx-test".to_string(),
-            runtime_compatibility_marker: "atlas-v1".to_string(),
+            runtime_compatibility_marker: "atlas-v2".to_string(),
             fail_open_bound,
             checkpoint_retry_attempts: 1,
             checkpoint_retry_backoff_ms: 50,
@@ -1220,7 +1216,7 @@ mod tests {
             block_number,
             &GraphState::new(),
             1,
-            "atlas-v1".to_string(),
+            "atlas-v2".to_string(),
             make_space_id(1),
         )
     }
@@ -1274,16 +1270,16 @@ mod tests {
             10,
             &GraphState::new(),
             1,
-            "atlas-v1".to_string(),
+            "atlas-v2".to_string(),
             make_space_id(1),
         );
 
         checkpoint
-            .validate_compatibility("idx-test", "atlas-v1", make_space_id(1), 1)
+            .validate_compatibility("idx-test", "atlas-v2", make_space_id(1), 1)
             .unwrap();
 
         let err = checkpoint
-            .validate_compatibility("idx-other", "atlas-v1", make_space_id(1), 1)
+            .validate_compatibility("idx-other", "atlas-v2", make_space_id(1), 1)
             .unwrap_err();
         assert!(matches!(err, CheckpointError::Incompatible(_)));
     }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -900,7 +900,6 @@ pub enum PersistedEdgeType {
     Related,
     Topic { topic_id: String },
     Root,
-    Editor,
 }
 
 impl PersistedGraphState {
@@ -1062,7 +1061,6 @@ impl PersistedEdgeType {
             EdgeType::Topic { topic_id } => Self::Topic {
                 topic_id: encode_id(topic_id),
             },
-            EdgeType::Editor => Self::Editor,
         }
     }
 
@@ -1074,7 +1072,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Topic { topic_id } => Ok(EdgeType::Topic {
                 topic_id: decode_topic_id(topic_id)?,
             }),
-            PersistedEdgeType::Editor => Ok(EdgeType::Editor),
         }
     }
 
@@ -1084,7 +1081,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Verified => 1,
             PersistedEdgeType::Related => 2,
             PersistedEdgeType::Topic { .. } => 3,
-            PersistedEdgeType::Editor => 4,
         }
     }
 }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -668,15 +668,29 @@ impl CheckpointManager {
         }
     }
 
+    /// Persist a per-block checkpoint. Returns `Ok(())` on a confirmed
+    /// successful DB write, `Err(_)` if every retry failed.
+    ///
+    /// Fail-open semantics are unchanged: failures still go through
+    /// `record_persist_failure` (which feeds the consecutive-failure counter,
+    /// pause logic, and pending checkpoint). Callers that don't care about
+    /// the result can ignore the returned `Result` — this is the case on
+    /// the per-block hot path, where the next block's persist would anyway
+    /// supersede this one.
+    ///
+    /// The signal exists for callers that need to know whether a baseline
+    /// actually reached disk (e.g. the GEO-645 startup force-write and its
+    /// quiet-stream retry) before clearing pending flags or emitting a
+    /// "persisted for the first time" log.
     pub async fn persist_block_checkpoint(
         &self,
         block_number: u64,
         cursor: String,
         graph_state_blob: PersistedGraphState,
         emission_baseline: Option<&PersistedEmissionBaseline>,
-    ) {
+    ) -> Result<(), CheckpointError> {
         if self.config.store.is_none() {
-            return;
+            return Ok(());
         }
 
         let checkpoint = Checkpoint::new(
@@ -693,9 +707,11 @@ impl CheckpointManager {
         match self.try_persist_with_retries(&checkpoint).await {
             Ok(()) => {
                 self.record_persist_success();
+                Ok(())
             }
             Err(err) => {
                 self.record_persist_failure(block_number, &checkpoint, &err);
+                Err(CheckpointError::Io(err))
             }
         }
     }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -155,7 +155,25 @@ impl PersistedEmissionBaseline {
         count_bytes.copy_from_slice(&bytes[9..13]);
         let count = u32::from_le_bytes(count_bytes) as usize;
 
-        let expected_len = BASELINE_HEADER_LEN + count * BASELINE_NODE_LEN;
+        // Use checked arithmetic so a corrupted `count` header on a 32-bit
+        // target (or a pathological value on 64-bit) cannot wrap or trigger
+        // an OOM-sized allocation attempt before we get to the
+        // length-vs-payload check below. On overflow we surface
+        // `CheckpointError::Serialization`, which the startup path treats as
+        // a recoverable "no baseline" condition rather than a panic.
+        let expected_payload =
+            count
+                .checked_mul(BASELINE_NODE_LEN)
+                .ok_or_else(|| {
+                    CheckpointError::Serialization(format!(
+                        "baseline blob header count {count} overflows usize when multiplied by node size {BASELINE_NODE_LEN}"
+                    ))
+                })?;
+        let expected_len = BASELINE_HEADER_LEN.checked_add(expected_payload).ok_or_else(|| {
+            CheckpointError::Serialization(format!(
+                "baseline blob header count {count} overflows usize when added to header size {BASELINE_HEADER_LEN}"
+            ))
+        })?;
         if bytes.len() != expected_len {
             return Err(CheckpointError::Serialization(format!(
                 "baseline blob length {} does not match header count {} (expected {})",
@@ -1821,6 +1839,32 @@ mod tests {
         assert!(
             matches!(err, CheckpointError::Serialization(ref msg) if msg.contains("does not match header count")),
             "expected length-mismatch error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn baseline_rejects_count_that_would_overflow_or_overallocate() {
+        // A corrupted header with `count = u32::MAX` would, on a 32-bit
+        // target, wrap `count * BASELINE_NODE_LEN` past `usize::MAX`, and on
+        // a 64-bit target would request a ~140 GB allocation. The decode
+        // path must reject this with `CheckpointError::Serialization`
+        // rather than panicking or hitting the allocator. We hand-build a
+        // header with the pathological count and a truncated body so the
+        // arithmetic / length-mismatch check fires before any slice indexing
+        // into the (absent) node payload.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(BASELINE_MAGIC);
+        bytes.push(BASELINE_FORMAT_VERSION);
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+        // Intentionally no node payload follows.
+        let err = PersistedEmissionBaseline::decode(&bytes).unwrap_err();
+        // On 32-bit `usize`, this hits the `checked_mul` overflow branch;
+        // on 64-bit, it falls through to the length-vs-payload mismatch.
+        // Either way the contract is the same: surface as `Serialization`
+        // (never panic / OOM) so the startup path can recover.
+        assert!(
+            matches!(err, CheckpointError::Serialization(_)),
+            "expected Serialization error, got: {err:?}"
         );
     }
 

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -7,6 +7,186 @@ use hermes_instrumentation::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use sqlx::{postgres::PgPoolOptions, PgPool, Row};
 
+/// Persisted shape of atlas's emission contract: every (non-root) canonical
+/// node we last told consumers about, as a `(space_id, distance, parent)`
+/// triple.
+///
+/// This is the part of the checkpoint that must survive `GraphState` /
+/// `EdgeType` schema bumps. It is encoded as a length-prefixed flat binary
+/// blob with no field names, no enum tags, no edge-type identifier — only
+/// consumer-observable primitives — so a future change to internal graph
+/// types cannot break baseline restore.
+///
+/// On startup, `DiffTracker::from_baseline(...)` uses this to prime the
+/// emission state so the first `track()` call after a rules change produces
+/// the correct `REMOVED` events for orphaned spaces and `MOVED` events for
+/// repositioned ones. See GEO-645 for the failure mode this guards against.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PersistedEmissionBaseline {
+    /// Sorted by `space_id`, unique by `space_id` (the closest-to-root entry
+    /// wins on duplicates, matching `DiffTracker`'s collapse semantics).
+    nodes: Vec<BaselineNode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BaselineNode {
+    pub space_id: SpaceId,
+    pub distance: u32,
+    pub parent: SpaceId,
+}
+
+// Magic prefix isolates baseline blobs from any other bytea we might store on
+// the row in the future. The trailing `\x01` is the format version: bumping it
+// is the contract for "the on-disk shape of this blob changed in a
+// non-backwards-compatible way", and old atlas builds must reject anything
+// they don't recognise rather than silently misread.
+const BASELINE_MAGIC: &[u8; 8] = b"ATLBL\x00\x00\x01";
+const BASELINE_FORMAT_VERSION: u8 = 1;
+// magic (8) + version (1) + node count u32 LE (4)
+const BASELINE_HEADER_LEN: usize = 13;
+// space_id (16) + distance u32 LE (4) + parent space_id (16)
+const BASELINE_NODE_LEN: usize = 36;
+
+impl PersistedEmissionBaseline {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    pub fn nodes(&self) -> &[BaselineNode] {
+        &self.nodes
+    }
+
+    /// Build a baseline from an arbitrary iterator of node entries. The
+    /// constructor sorts by `space_id` and deduplicates, picking the entry
+    /// with the smallest `distance` on collisions — same "closest to root
+    /// wins" rule `DiffTracker` applies to in-memory positions.
+    pub fn from_nodes<I: IntoIterator<Item = BaselineNode>>(nodes: I) -> Self {
+        let mut nodes: Vec<BaselineNode> = nodes.into_iter().collect();
+        nodes.sort_unstable_by(|a, b| {
+            a.space_id
+                .cmp(&b.space_id)
+                .then_with(|| a.distance.cmp(&b.distance))
+        });
+        nodes.dedup_by_key(|n| n.space_id);
+        Self { nodes }
+    }
+
+    /// Snapshot a diff tracker's current emission state as a persistable
+    /// baseline. Returns `None` if the tracker has nothing to persist (no
+    /// canonical compute has ever produced output and no prior baseline was
+    /// loaded), in which case the caller should not write a baseline column —
+    /// writing an empty baseline would let a fresh-start atlas advertise
+    /// "consumers have nothing canonical" and force a spurious wipe on the
+    /// next restart.
+    pub fn from_diff_tracker(tracker: &crate::graph::DiffTracker) -> Option<Self> {
+        let iter = tracker.iter_emission_state()?;
+        let nodes: Vec<BaselineNode> = iter
+            .map(|(space_id, distance, parent)| BaselineNode {
+                space_id,
+                distance,
+                parent,
+            })
+            .collect();
+        // The tracker's emission state is already sorted+deduped by SpaceId,
+        // so skip the normalisation cost.
+        Some(Self { nodes })
+    }
+
+    /// Encode as a flat little-endian binary blob.
+    ///
+    /// Layout (header followed by `count` fixed-size node entries):
+    ///   bytes  0..8  : magic `ATLBL\0\0\x01`
+    ///   byte   8     : format version (currently 1)
+    ///   bytes  9..13 : node count, u32 LE
+    ///   for each node (36 bytes):
+    ///       16 bytes : space_id
+    ///        4 bytes : distance, u32 LE
+    ///       16 bytes : parent space_id
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out =
+            Vec::with_capacity(BASELINE_HEADER_LEN + self.nodes.len() * BASELINE_NODE_LEN);
+        out.extend_from_slice(BASELINE_MAGIC);
+        out.push(BASELINE_FORMAT_VERSION);
+        let count: u32 = self
+            .nodes
+            .len()
+            .try_into()
+            .expect("baseline node count fits in u32");
+        out.extend_from_slice(&count.to_le_bytes());
+        for node in &self.nodes {
+            out.extend_from_slice(&node.space_id);
+            out.extend_from_slice(&node.distance.to_le_bytes());
+            out.extend_from_slice(&node.parent);
+        }
+        out
+    }
+
+    /// Decode a baseline blob. Rejects unknown magic / version / truncated
+    /// payloads explicitly so a corrupted column can't be silently misread.
+    pub fn decode(bytes: &[u8]) -> Result<Self, CheckpointError> {
+        if bytes.len() < BASELINE_HEADER_LEN {
+            return Err(CheckpointError::Serialization(format!(
+                "baseline blob too short: {} bytes, expected at least {}",
+                bytes.len(),
+                BASELINE_HEADER_LEN
+            )));
+        }
+        if &bytes[0..8] != BASELINE_MAGIC {
+            return Err(CheckpointError::Serialization(format!(
+                "baseline blob magic mismatch: {:02x?}",
+                &bytes[0..8]
+            )));
+        }
+        let version = bytes[8];
+        if version != BASELINE_FORMAT_VERSION {
+            return Err(CheckpointError::Serialization(format!(
+                "unsupported baseline format version: {version}"
+            )));
+        }
+        let mut count_bytes = [0u8; 4];
+        count_bytes.copy_from_slice(&bytes[9..13]);
+        let count = u32::from_le_bytes(count_bytes) as usize;
+
+        let expected_len = BASELINE_HEADER_LEN + count * BASELINE_NODE_LEN;
+        if bytes.len() != expected_len {
+            return Err(CheckpointError::Serialization(format!(
+                "baseline blob length {} does not match header count {} (expected {})",
+                bytes.len(),
+                count,
+                expected_len
+            )));
+        }
+
+        let mut nodes = Vec::with_capacity(count);
+        let mut offset = BASELINE_HEADER_LEN;
+        for _ in 0..count {
+            let mut space_id = [0u8; 16];
+            space_id.copy_from_slice(&bytes[offset..offset + 16]);
+            let mut dist_bytes = [0u8; 4];
+            dist_bytes.copy_from_slice(&bytes[offset + 16..offset + 20]);
+            let distance = u32::from_le_bytes(dist_bytes);
+            let mut parent = [0u8; 16];
+            parent.copy_from_slice(&bytes[offset + 20..offset + 36]);
+            nodes.push(BaselineNode {
+                space_id,
+                distance,
+                parent,
+            });
+            offset += BASELINE_NODE_LEN;
+        }
+
+        Ok(Self { nodes })
+    }
+}
+
 const CHECKPOINT_SCHEMA_VERSION: u32 = 1;
 const FAIL_OPEN_BOUND_DEFAULT: u64 = 10;
 const FAIL_OPEN_BOUND_MIN: u64 = 1;
@@ -192,6 +372,19 @@ pub struct CheckpointManager {
     config: CheckpointConfig,
     fail_open: std::sync::Mutex<FailOpenState>,
     restored_cursor: Option<String>,
+    restored_block_number: Option<u64>,
+}
+
+/// Result of `CheckpointManager::restore_checkpoint_on_startup`.
+///
+/// `graph_state` and `baseline` decode independently. In particular, a
+/// missing/invalid `graph_state` (marker mismatch, unknown enum variant,
+/// fresh-start) must not suppress a valid `baseline` — that's how a
+/// rules-change deploy gets the contract from the previous deploy.
+#[derive(Debug, Default)]
+pub struct RestoredCheckpoint {
+    pub graph_state: Option<GraphState>,
+    pub baseline: Option<PersistedEmissionBaseline>,
 }
 
 #[derive(Debug, Default)]
@@ -208,6 +401,7 @@ impl CheckpointManager {
             config,
             fail_open: std::sync::Mutex::new(FailOpenState::default()),
             restored_cursor: None,
+            restored_block_number: None,
         }
     }
 
@@ -225,16 +419,78 @@ impl CheckpointManager {
         self.restored_cursor.clone()
     }
 
+    /// Block number associated with the restored checkpoint cursor, when
+    /// one was loaded. Used by the force-write-on-startup path to write a
+    /// baseline using the existing checkpoint coordinates rather than
+    /// inventing a synthetic one.
+    pub fn restored_block_number(&self) -> Option<u64> {
+        self.restored_block_number
+    }
+
+    /// Restore graph state and the persisted emission baseline.
+    ///
+    /// The two are independently decoded so that a `GraphState` schema bump
+    /// (runtime marker mismatch, unknown enum variant in the JSON blob) does
+    /// *not* prevent the baseline from being restored — that's the whole
+    /// point of the schema-stable baseline shape. See GEO-645.
+    ///
+    /// Returns `(graph_state, baseline)`. Either side can be `None`:
+    /// - `graph_state` is `None` on fresh-start (no checkpoint, marker
+    ///   mismatch with `ATLAS_CHECKPOINT_ALLOW_FRESH_START`, or unreadable
+    ///   graph blob with the same env flag set).
+    /// - `baseline` is `None` for a brand-new indexer that has never written
+    ///   one, or when the baseline column is `NULL` on the existing row
+    ///   (e.g. the first time this code runs against a pre-existing
+    ///   checkpoint). Callers should force-write a baseline once they have
+    ///   one to persist.
     pub async fn restore_checkpoint_on_startup(
         &mut self,
-    ) -> Result<Option<GraphState>, CheckpointError> {
+    ) -> Result<RestoredCheckpoint, CheckpointError> {
         let Some(store) = &self.config.store else {
             info!("Checkpoint persistence disabled (no ATLAS_CHECKPOINT_DATABASE_URL)");
-            return Ok(None);
+            return Ok(RestoredCheckpoint::default());
         };
 
         match store.load(&self.config.indexer_id).await {
             Ok(Some(checkpoint)) => {
+                // Decode the baseline first and unconditionally — even when
+                // the graph_state path bails out, the caller still needs the
+                // baseline so DiffTracker can be primed.
+                let baseline = match checkpoint.emission_baseline() {
+                    Ok(Some(baseline)) => {
+                        info!(
+                            indexer_id = %self.config.indexer_id,
+                            root_space_id = %encode_id(self.config.root_space_id),
+                            baseline_node_count = baseline.len(),
+                            block_number = checkpoint.block_number,
+                            cursor = %checkpoint.cursor,
+                            "Emission baseline restored"
+                        );
+                        Some(baseline)
+                    }
+                    Ok(None) => {
+                        info!(
+                            indexer_id = %self.config.indexer_id,
+                            block_number = checkpoint.block_number,
+                            "No emission baseline on existing checkpoint; will force-write on first canonical compute"
+                        );
+                        None
+                    }
+                    Err(err) => {
+                        // A bad baseline blob is a serious operational
+                        // signal — surface it, but don't block startup.
+                        // Treating it as "no baseline" triggers the
+                        // force-write path on next compute, which will
+                        // replace the bad blob with a known-good one.
+                        error!(
+                            indexer_id = %self.config.indexer_id,
+                            reason = %err,
+                            "Emission baseline failed to decode; proceeding without prime (will force-write)"
+                        );
+                        None
+                    }
+                };
+
                 if let Err(err) = checkpoint.validate_compatibility(
                     &self.config.indexer_id,
                     &self.config.runtime_compatibility_marker,
@@ -249,9 +505,13 @@ impl CheckpointManager {
                             reason = %err,
                             block_number = checkpoint.block_number,
                             cursor = %checkpoint.cursor,
-                            "Checkpoint rejected; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh"
+                            baseline_node_count = baseline.as_ref().map(|b| b.len()).unwrap_or(0),
+                            "Checkpoint rejected; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh (baseline retained if present)"
                         );
-                        return Ok(None);
+                        return Ok(RestoredCheckpoint {
+                            graph_state: None,
+                            baseline,
+                        });
                     }
 
                     error!(
@@ -277,9 +537,13 @@ impl CheckpointManager {
                                 reason = %err,
                                 block_number = checkpoint.block_number,
                                 cursor = %checkpoint.cursor,
-                                "Checkpoint graph state unreadable; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh"
+                                baseline_node_count = baseline.as_ref().map(|b| b.len()).unwrap_or(0),
+                                "Checkpoint graph state unreadable; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh (baseline retained if present)"
                             );
-                            return Ok(None);
+                            return Ok(RestoredCheckpoint {
+                                graph_state: None,
+                                baseline,
+                            });
                         }
 
                         error!(
@@ -296,6 +560,7 @@ impl CheckpointManager {
                 };
 
                 self.restored_cursor = Some(checkpoint.cursor.clone());
+                self.restored_block_number = Some(checkpoint.block_number);
                 info!(
                     indexer_id = %self.config.indexer_id,
                     root_space_id = %encode_id(self.config.root_space_id),
@@ -304,7 +569,10 @@ impl CheckpointManager {
                     cursor = %checkpoint.cursor,
                     "Checkpoint restored"
                 );
-                Ok(Some(graph_state))
+                Ok(RestoredCheckpoint {
+                    graph_state: Some(graph_state),
+                    baseline,
+                })
             }
             Ok(None) => {
                 info!(
@@ -313,7 +581,7 @@ impl CheckpointManager {
                     graph_state_version = self.config.graph_state_version,
                     "No checkpoint found; starting fresh"
                 );
-                Ok(None)
+                Ok(RestoredCheckpoint::default())
             }
             Err(err) => {
                 error!(
@@ -405,6 +673,7 @@ impl CheckpointManager {
         block_number: u64,
         cursor: String,
         graph_state_blob: PersistedGraphState,
+        emission_baseline: Option<&PersistedEmissionBaseline>,
     ) {
         if self.config.store.is_none() {
             return;
@@ -415,6 +684,7 @@ impl CheckpointManager {
             cursor,
             block_number,
             graph_state_blob,
+            emission_baseline,
             self.config.graph_state_version,
             self.config.runtime_compatibility_marker.clone(),
             self.config.root_space_id,
@@ -598,7 +868,8 @@ impl PostgresCheckpointStore {
                 graph_state_blob,
                 graph_state_version,
                 runtime_compatibility_marker,
-                root_space_id
+                root_space_id,
+                emission_baseline_blob
              FROM atlas_checkpoints
              WHERE indexer_id = $1",
         )
@@ -621,6 +892,18 @@ impl PostgresCheckpointStore {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?
             .0;
+
+        // Baseline column is nullable: pre-existing rows from before this
+        // migration shipped will return None here, which triggers the
+        // force-write-on-startup path on the caller. Decoding is lazy
+        // (`Checkpoint::emission_baseline()`) for the same reason graph
+        // state decode is lazy — keep raw bytes here so a bad blob doesn't
+        // prevent the rest of the checkpoint from loading.
+        let emission_baseline_blob: Option<Vec<u8>> = row
+            .try_get::<Option<Vec<u8>>, _>("emission_baseline_blob")
+            .map_err(|err| {
+                CheckpointError::Serialization(format!("decode emission_baseline_blob: {err}"))
+            })?;
 
         let schema_version_i16 = row.try_get::<i16, _>("schema_version").map_err(|err| {
             CheckpointError::Serialization(format!("decode schema_version: {err}"))
@@ -672,6 +955,7 @@ impl PostgresCheckpointStore {
             root_space_id: row.try_get("root_space_id").map_err(|err| {
                 CheckpointError::Serialization(format!("decode root_space_id: {err}"))
             })?,
+            emission_baseline_blob,
         }))
     }
 
@@ -700,6 +984,10 @@ impl PostgresCheckpointStore {
             ))
         })?;
 
+        // The baseline column is written in the *same* INSERT as the graph
+        // state, so they cannot diverge — they share the row's transaction.
+        // Passing `None` (when the caller has no baseline yet) preserves any
+        // existing value, since COALESCE keeps the prior row's bytes.
         let row = sqlx::query(
             "INSERT INTO atlas_checkpoints (
                 indexer_id,
@@ -710,8 +998,9 @@ impl PostgresCheckpointStore {
                 runtime_compatibility_marker,
                 root_space_id,
                 schema_version,
+                emission_baseline_blob,
                 updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
             ON CONFLICT (indexer_id) DO UPDATE SET
                 cursor = EXCLUDED.cursor,
                 block_number = EXCLUDED.block_number,
@@ -720,8 +1009,10 @@ impl PostgresCheckpointStore {
                 runtime_compatibility_marker = EXCLUDED.runtime_compatibility_marker,
                 root_space_id = EXCLUDED.root_space_id,
                 schema_version = EXCLUDED.schema_version,
+                emission_baseline_blob = COALESCE(EXCLUDED.emission_baseline_blob, atlas_checkpoints.emission_baseline_blob),
                 updated_at = NOW()
-            RETURNING pg_column_size(graph_state_blob) AS snapshot_size_bytes",
+            RETURNING pg_column_size(graph_state_blob) AS snapshot_size_bytes,
+                      pg_column_size(emission_baseline_blob) AS baseline_size_bytes",
         )
         .bind(&checkpoint.indexer_id)
         .bind(&checkpoint.cursor)
@@ -731,6 +1022,7 @@ impl PostgresCheckpointStore {
         .bind(&checkpoint.runtime_compatibility_marker)
         .bind(&checkpoint.root_space_id)
         .bind(db_schema_version)
+        .bind(checkpoint.emission_baseline_blob.as_deref())
         .fetch_one(&self.pool)
         .await
         .map_err(|err| CheckpointError::Io(format!("save checkpoint: {err}")))?;
@@ -766,6 +1058,13 @@ pub struct Checkpoint {
     pub graph_state_version: u32,
     pub runtime_compatibility_marker: String,
     pub root_space_id: String,
+    // Raw bytes of the persisted emission baseline (see
+    // `PersistedEmissionBaseline`). Stored as a separate column so a
+    // `graph_state_blob` decode failure cannot prevent the baseline from
+    // loading. `None` for indexers that haven't written one yet (either
+    // pre-migration rows or a brand-new fresh-start).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emission_baseline_blob: Option<Vec<u8>>,
 }
 
 impl Checkpoint {
@@ -775,6 +1074,7 @@ impl Checkpoint {
         cursor: String,
         block_number: u64,
         graph_state_blob: PersistedGraphState,
+        emission_baseline: Option<&PersistedEmissionBaseline>,
         graph_state_version: u32,
         runtime_compatibility_marker: String,
         root_space_id: SpaceId,
@@ -783,6 +1083,7 @@ impl Checkpoint {
         // so serialization to `serde_json::Value` cannot fail in practice.
         let graph_state_blob = serde_json::to_value(graph_state_blob)
             .expect("PersistedGraphState always serializes to valid JSON");
+        let emission_baseline_blob = emission_baseline.map(|b| b.encode());
         Self {
             schema_version: CHECKPOINT_SCHEMA_VERSION,
             indexer_id,
@@ -792,6 +1093,7 @@ impl Checkpoint {
             graph_state_version,
             runtime_compatibility_marker,
             root_space_id: encode_id(root_space_id),
+            emission_baseline_blob,
         }
     }
 
@@ -801,6 +1103,7 @@ impl Checkpoint {
         cursor: String,
         block_number: u64,
         graph_state: &GraphState,
+        emission_baseline: Option<&PersistedEmissionBaseline>,
         graph_state_version: u32,
         runtime_compatibility_marker: String,
         root_space_id: SpaceId,
@@ -810,6 +1113,7 @@ impl Checkpoint {
             cursor,
             block_number,
             PersistedGraphState::from(graph_state),
+            emission_baseline,
             graph_state_version,
             runtime_compatibility_marker,
             root_space_id,
@@ -822,6 +1126,18 @@ impl Checkpoint {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?;
         persisted.to_graph_state()
+    }
+
+    /// Lazily decode the persisted emission baseline. Returns `Ok(None)` when
+    /// the column is `NULL` (no baseline persisted yet). Decode failures are
+    /// returned as `Err` so the caller can choose whether to abort or treat
+    /// the row as "no baseline" (the startup path takes the latter approach
+    /// and force-writes a fresh one).
+    pub fn emission_baseline(&self) -> Result<Option<PersistedEmissionBaseline>, CheckpointError> {
+        let Some(blob) = self.emission_baseline_blob.as_deref() else {
+            return Ok(None);
+        };
+        PersistedEmissionBaseline::decode(blob).map(Some)
     }
 
     pub fn validate_compatibility(
@@ -1228,6 +1544,7 @@ mod tests {
             format!("cursor-{block_number}"),
             block_number,
             &GraphState::new(),
+            None,
             1,
             "atlas-v2".to_string(),
             make_space_id(1),
@@ -1282,6 +1599,7 @@ mod tests {
             "cursor-10".to_string(),
             10,
             &GraphState::new(),
+            None,
             1,
             "atlas-v2".to_string(),
             make_space_id(1),
@@ -1330,6 +1648,7 @@ mod tests {
             graph_state_version: 1,
             runtime_compatibility_marker: "atlas-v1".to_string(),
             root_space_id: encode_id(make_space_id(1)),
+            emission_baseline_blob: None,
         };
 
         // Marker validation runs against the in-memory marker field — no decode
@@ -1392,5 +1711,171 @@ mod tests {
         assert_eq!(state.consecutive_uncheckpointed_blocks, 0);
         assert!(!state.paused);
         assert!(state.pending_checkpoint.is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // PersistedEmissionBaseline (GEO-645)
+    // ------------------------------------------------------------------
+
+    fn baseline_node(space: u8, distance: u32, parent: u8) -> BaselineNode {
+        BaselineNode {
+            space_id: make_space_id(space),
+            distance,
+            parent: make_space_id(parent),
+        }
+    }
+
+    #[test]
+    fn baseline_round_trips_through_encode_decode() {
+        let baseline = PersistedEmissionBaseline::from_nodes([
+            baseline_node(0x0A, 1, 0x01),
+            baseline_node(0x0B, 2, 0x0A),
+            baseline_node(0x0C, 1, 0x01),
+        ]);
+        let bytes = baseline.encode();
+        let decoded = PersistedEmissionBaseline::decode(&bytes).unwrap();
+        assert_eq!(decoded, baseline);
+        // Ordering invariant: sorted by space_id.
+        let ids: Vec<u8> = decoded.nodes().iter().map(|n| n.space_id[15]).collect();
+        assert_eq!(ids, vec![0x0A, 0x0B, 0x0C]);
+    }
+
+    #[test]
+    fn baseline_empty_encoding_is_just_header() {
+        let bytes = PersistedEmissionBaseline::empty().encode();
+        // 8 magic + 1 version + 4 count
+        assert_eq!(bytes.len(), 13);
+        let decoded = PersistedEmissionBaseline::decode(&bytes).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn baseline_byte_pinned_layout() {
+        // Pin the on-disk layout against a hand-built expected byte sequence.
+        // If this test fails, a future change has broken the schema-stable
+        // promise — bump BASELINE_FORMAT_VERSION and write a compat reader
+        // before merging.
+        let baseline =
+            PersistedEmissionBaseline::from_nodes([baseline_node(0x0A, 0x01020304, 0x0B)]);
+        let bytes = baseline.encode();
+
+        let mut expected = Vec::new();
+        // magic: ATLBL\0\0\x01
+        expected.extend_from_slice(b"ATLBL\x00\x00\x01");
+        // version byte
+        expected.push(1);
+        // count = 1, LE
+        expected.extend_from_slice(&1u32.to_le_bytes());
+        // node: space_id (0x0A in last byte), distance LE, parent (0x0B in last byte)
+        expected.extend_from_slice(&make_space_id(0x0A));
+        expected.extend_from_slice(&0x01020304u32.to_le_bytes());
+        expected.extend_from_slice(&make_space_id(0x0B));
+
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn baseline_rejects_bad_magic() {
+        let mut bytes = PersistedEmissionBaseline::empty().encode();
+        bytes[0] = b'X';
+        let err = PersistedEmissionBaseline::decode(&bytes).unwrap_err();
+        assert!(
+            matches!(err, CheckpointError::Serialization(ref msg) if msg.contains("magic mismatch")),
+            "expected magic mismatch, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn baseline_rejects_unknown_version() {
+        let mut bytes = PersistedEmissionBaseline::empty().encode();
+        bytes[8] = 2; // pretend a future version wrote this
+        let err = PersistedEmissionBaseline::decode(&bytes).unwrap_err();
+        assert!(
+            matches!(err, CheckpointError::Serialization(ref msg) if msg.contains("unsupported baseline format version")),
+            "expected version error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn baseline_rejects_truncated_payload() {
+        let baseline = PersistedEmissionBaseline::from_nodes([baseline_node(0x0A, 1, 0x01)]);
+        let mut bytes = baseline.encode();
+        bytes.pop(); // drop one byte from the node payload
+        let err = PersistedEmissionBaseline::decode(&bytes).unwrap_err();
+        assert!(
+            matches!(err, CheckpointError::Serialization(ref msg) if msg.contains("does not match header count")),
+            "expected length-mismatch error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn baseline_dedupe_keeps_smallest_distance() {
+        // Same space_id appearing twice at different distances: the smaller
+        // distance must win (closest-to-root rule, matches DiffTracker).
+        let baseline = PersistedEmissionBaseline::from_nodes([
+            baseline_node(0x0B, 5, 0x0A),
+            baseline_node(0x0B, 1, 0x01),
+        ]);
+        assert_eq!(baseline.len(), 1);
+        let node = &baseline.nodes()[0];
+        assert_eq!(node.distance, 1);
+        assert_eq!(node.parent, make_space_id(0x01));
+    }
+
+    #[test]
+    fn checkpoint_carries_baseline_through_struct_constructor() {
+        let baseline = PersistedEmissionBaseline::from_nodes([baseline_node(0x0A, 1, 0x01)]);
+        let cp = Checkpoint::from_graph_state(
+            "idx-test".to_string(),
+            "cursor-1".to_string(),
+            1,
+            &GraphState::new(),
+            Some(&baseline),
+            1,
+            "atlas-v2".to_string(),
+            make_space_id(1),
+        );
+        let restored = cp
+            .emission_baseline()
+            .expect("baseline decodes")
+            .expect("baseline present");
+        assert_eq!(restored, baseline);
+    }
+
+    #[test]
+    fn checkpoint_omits_baseline_when_none() {
+        let cp = Checkpoint::from_graph_state(
+            "idx-test".to_string(),
+            "cursor-1".to_string(),
+            1,
+            &GraphState::new(),
+            None,
+            1,
+            "atlas-v2".to_string(),
+            make_space_id(1),
+        );
+        assert!(cp.emission_baseline_blob.is_none());
+        assert!(cp.emission_baseline().unwrap().is_none());
+    }
+
+    #[test]
+    fn baseline_decode_failure_surfaces_serialization_error() {
+        // A `Checkpoint` with a corrupted baseline blob must report the
+        // failure as `Serialization` so the startup path can route it
+        // through the "treat as no baseline, force-write" fallback rather
+        // than aborting.
+        let cp = Checkpoint {
+            schema_version: CHECKPOINT_SCHEMA_VERSION,
+            indexer_id: "idx-test".to_string(),
+            cursor: "cursor-1".to_string(),
+            block_number: 1,
+            graph_state_blob: serde_json::Value::Null,
+            graph_state_version: 1,
+            runtime_compatibility_marker: "atlas-v2".to_string(),
+            root_space_id: encode_id(make_space_id(1)),
+            emission_baseline_blob: Some(b"not a baseline".to_vec()),
+        };
+        let err = cp.emission_baseline().unwrap_err();
+        assert!(matches!(err, CheckpointError::Serialization(_)));
     }
 }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -817,8 +817,8 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        let persisted: PersistedGraphState =
-            serde_json::from_value(self.graph_state_blob.clone()).map_err(|err| {
+        let persisted: PersistedGraphState = serde_json::from_value(self.graph_state_blob.clone())
+            .map_err(|err| {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?;
         persisted.to_graph_state()

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -817,10 +817,8 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        let persisted: PersistedGraphState = serde_json::from_value(self.graph_state_blob.clone())
-            .map_err(|err| {
-                CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
-            })?;
+        let persisted = PersistedGraphState::deserialize(&self.graph_state_blob)
+            .map_err(|err| CheckpointError::Serialization(format!("decode graph_state_blob: {err}")))?;
         persisted.to_graph_state()
     }
 

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -817,8 +817,10 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        let persisted = PersistedGraphState::deserialize(&self.graph_state_blob)
-            .map_err(|err| CheckpointError::Serialization(format!("decode graph_state_blob: {err}")))?;
+        let persisted =
+            PersistedGraphState::deserialize(&self.graph_state_blob).map_err(|err| {
+                CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
+            })?;
         persisted.to_graph_state()
     }
 

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -637,8 +637,15 @@ fn test_e2e_editor_add_then_remove_produces_no_diff_for_editor() {
         .editor_removed(SPACE_A, SPACE_B)
         .build();
 
-    let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
+    let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
+
+    // Positive assertion: the verified Root -> A edge must produce a real
+    // diff. Without this, an empty diff stream (e.g. broken canonical emission)
+    // would satisfy the absence checks below and pass silently.
+    let graph = last_graph.expect("canonical graph should be computed");
+    assert!(graph.contains(&SPACE_A), "editor_no_diff: SPACE_A should be canonical via verified edge");
+    assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "editor_no_diff");
 
     assert!(
         find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
@@ -669,8 +676,15 @@ fn test_e2e_member_add_then_remove_produces_no_diff_for_member() {
         .member_removed(SPACE_A, SPACE_B)
         .build();
 
-    let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
+    let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
+
+    // Positive assertion: the verified Root -> A edge must produce a real
+    // diff. Without this, an empty diff stream (e.g. broken canonical emission)
+    // would satisfy the absence checks below and pass silently.
+    let graph = last_graph.expect("canonical graph should be computed");
+    assert!(graph.contains(&SPACE_A), "member_no_diff: SPACE_A should be canonical via verified edge");
+    assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "member_no_diff");
 
     assert!(
         find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -497,7 +497,11 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
 // =============================================================================
 
 #[test]
-fn test_e2e_editor_member_edges_grant_canonical() {
+fn test_e2e_editor_edges_grant_canonical_member_does_not() {
+    // Editor edges still grant canonical membership. Member edges do not — see
+    // plan 0007. Same topology: Root --verified--> A --editor--> B,
+    //                                              A --member-->  C
+    // Expected: B is canonical, C is NOT.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -515,9 +519,10 @@ fn test_e2e_editor_member_edges_grant_canonical() {
 
     assert_all_canonical(
         &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B, SPACE_C],
-        "editor_member",
+        &[ROOT_SPACE_ID, SPACE_A, SPACE_B],
+        "editor_grants_canonical",
     );
+    assert_none_canonical(&graph, &[SPACE_C], "member_does_not_grant_canonical");
 }
 
 #[test]
@@ -539,11 +544,14 @@ fn test_e2e_topic_edges_dont_grant_canonical() {
 }
 
 // =============================================================================
-// Test: Transitive Edges from Members
+// Test: Member edges are ignored by canonical computation (plan 0007)
 // =============================================================================
 
 #[test]
-fn test_e2e_member_spaces_edges_are_followed() {
+fn test_e2e_member_edges_do_not_propagate_to_subspaces() {
+    // Root --verified--> A --member--> B --verified--> C
+    // Member edges are no-ops, so the canonical graph stops at A.
+    // Neither B (reached only via member) nor C (only reachable through B) is canonical.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -559,13 +567,9 @@ fn test_e2e_member_spaces_edges_are_followed() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    // All should be canonical: Root -> A -> B -> C
-    assert_all_canonical(
-        &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B, SPACE_C],
-        "member_transitive",
-    );
-    assert_eq!(graph.len(), 4);
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "member_ignored");
+    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_ignored");
+    assert_eq!(graph.len(), 2);
 }
 
 // =============================================================================
@@ -627,7 +631,11 @@ fn test_e2e_editor_removal_causes_removed_diff() {
 }
 
 #[test]
-fn test_e2e_member_removal_causes_removed_diff() {
+fn test_e2e_member_add_then_remove_produces_no_diff_for_member() {
+    // Member edges are no-ops in canonical computation (plan 0007). A
+    // Member-add followed by a Member-remove must not produce any Added,
+    // Moved, or Removed change for the member space — only the verified
+    // edge from Root -> A should show up.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -640,7 +648,18 @@ fn test_e2e_member_removal_causes_removed_diff() {
     let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
 
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "member_removal");
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
+        "member_no_diff: SPACE_B should not appear as Added"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Removed).is_none(),
+        "member_no_diff: SPACE_B should not appear as Removed"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Moved).is_none(),
+        "member_no_diff: SPACE_B should not appear as Moved"
+    );
 }
 
 // =============================================================================
@@ -677,10 +696,10 @@ fn test_e2e_cascading_removal_disconnects_subtree() {
 }
 
 #[test]
-fn test_e2e_member_removal_cascades_to_member_subspaces() {
-    // P2: Member removal cascading
-    // Root -> A (verified), A -> B (member), B -> C (verified)
-    // Remove B as member, C should also become non-canonical
+fn test_e2e_member_removal_does_not_cascade_because_member_is_noop() {
+    // Plan 0007: Member edges never enter the graph, so a Member-remove
+    // also has no effect. Root -> A is canonical; B and C are never reachable
+    // through Member; no Member-related diff is emitted.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -697,10 +716,21 @@ fn test_e2e_member_removal_cascades_to_member_subspaces() {
 
     let graph = last_graph.expect("Should have canonical graph");
 
-    // B and C should be non-canonical
-    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_cascade");
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "member_cascade");
-    assert_change_exists(&diffs, SPACE_C, ChangeType::Removed, "member_cascade");
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "member_noop");
+    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_noop");
+
+    for space in [SPACE_B, SPACE_C] {
+        assert!(
+            find_change(&diffs, space, ChangeType::Added).is_none(),
+            "member_noop: 0x{:02x} should not appear as Added",
+            space[15]
+        );
+        assert!(
+            find_change(&diffs, space, ChangeType::Removed).is_none(),
+            "member_noop: 0x{:02x} should not appear as Removed",
+            space[15]
+        );
+    }
 }
 
 #[test]

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -296,8 +296,11 @@ fn test_e2e_canonical_set_from_test_topology() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    // Verify expected canonical spaces
-    // Note: SPACE_H = make_id(0x11), so member added by Proposal 1 is the same as SPACE_H
+    // After plan 0007: Member and Editor edges are no-ops, so spaces reachable
+    // only through them are no longer canonical.
+    // - SPACE_H = make_id(0x11): added as member of A via Proposal 1, but also
+    //   verified by Root elsewhere in the topology — stays canonical via that path.
+    // - 0x50: added only as editor of B via Proposal 3, no other path — now non-canonical.
     let expected_canonical: Vec<SpaceId> = vec![
         ROOT_SPACE_ID,
         SPACE_A,
@@ -307,17 +310,23 @@ fn test_e2e_canonical_set_from_test_topology() {
         SPACE_E,
         SPACE_F,
         SPACE_G,
-        SPACE_H, // Also added as member of A via Proposal 1 (0x11)
+        SPACE_H, // verified elsewhere, not via Member
         SPACE_I,
         SPACE_J,
-        mock_events::make_id(0x50), // Added as editor of B via Proposal 3
     ];
 
     assert_all_canonical(&graph, &expected_canonical, "test_topology");
 
     // Verify non-canonical spaces
     let expected_non_canonical: Vec<SpaceId> = vec![
-        SPACE_X, SPACE_Y, SPACE_Z, SPACE_W, SPACE_P, SPACE_Q, SPACE_S,
+        SPACE_X,
+        SPACE_Y,
+        SPACE_Z,
+        SPACE_W,
+        SPACE_P,
+        SPACE_Q,
+        SPACE_S,
+        mock_events::make_id(0x50), // editor-only — now non-canonical
     ];
 
     assert_none_canonical(&graph, &expected_non_canonical, "test_topology");
@@ -455,8 +464,9 @@ fn test_e2e_moved_diff_when_parent_changes() {
 }
 
 #[test]
-fn test_e2e_moved_diff_when_edge_type_changes() {
-    // B changes from verified child to editor
+fn test_e2e_moved_diff_when_edge_type_changes_between_canonical_types() {
+    // B changes from verified child to related (both canonical-granting per plan 0007).
+    // Previously this test exercised verified -> editor, but editor is now a no-op.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -464,9 +474,9 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
         // Initial: Root -> A, A -> B (verified)
         .verified(ROOT_SPACE_ID, SPACE_A)
         .verified(SPACE_A, SPACE_B)
-        // Remove verified, add editor (same parent, different edge type)
+        // Remove verified, add related (same parent, different canonical-granting edge type)
         .unverified(SPACE_A, SPACE_B)
-        .editor(SPACE_A, SPACE_B)
+        .related(SPACE_A, SPACE_B)
         .build();
 
     let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
@@ -475,7 +485,7 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
     let graph = last_graph.expect("Should have canonical graph");
     assert!(graph.contains(&SPACE_B), "B should still be canonical");
 
-    // B should have been REMOVED when verified edge removed, then ADDED when editor added
+    // B should have been REMOVED when verified edge removed, then ADDED when related added
     // OR have a MOVED if the implementation tracks edge type changes
     let b_removed = find_change(&diffs, SPACE_B, ChangeType::Removed);
     let b_added_count = diffs
@@ -484,8 +494,6 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
         .filter(|c| c.space_id == SPACE_B && c.change_type == ChangeType::Added)
         .count();
 
-    // Either: B was removed then re-added, or B was moved
-    // Both are valid behaviors for edge type change
     assert!(
         b_removed.is_some() || b_added_count >= 1,
         "B should have REMOVED then ADDED, or MOVED when edge type changes"
@@ -497,11 +505,12 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
 // =============================================================================
 
 #[test]
-fn test_e2e_editor_edges_grant_canonical_member_does_not() {
-    // Editor edges still grant canonical membership. Member edges do not — see
-    // plan 0007. Same topology: Root --verified--> A --editor--> B,
-    //                                              A --member-->  C
-    // Expected: B is canonical, C is NOT.
+fn test_e2e_editor_and_member_edges_do_not_grant_canonical() {
+    // Plan 0007: neither Editor nor Member edges grant canonical membership.
+    // Only Verified, Related, and Subtopic do.
+    // Topology: Root --verified--> A --editor--> B,
+    //                              A --member-->  C
+    // Expected: only Root and A are canonical.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -517,12 +526,12 @@ fn test_e2e_editor_edges_grant_canonical_member_does_not() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    assert_all_canonical(
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "verified_only");
+    assert_none_canonical(
         &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B],
-        "editor_grants_canonical",
+        &[SPACE_B, SPACE_C],
+        "editor_and_member_do_not_grant_canonical",
     );
-    assert_none_canonical(&graph, &[SPACE_C], "member_does_not_grant_canonical");
 }
 
 #[test]
@@ -614,7 +623,11 @@ fn test_e2e_related_edge_removal() {
 }
 
 #[test]
-fn test_e2e_editor_removal_causes_removed_diff() {
+fn test_e2e_editor_add_then_remove_produces_no_diff_for_editor() {
+    // Editor edges are no-ops in canonical computation (plan 0007). An
+    // Editor-add followed by an Editor-remove must not produce any Added,
+    // Moved, or Removed change for the editor space — only the verified
+    // edge from Root -> A should show up.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -627,7 +640,18 @@ fn test_e2e_editor_removal_causes_removed_diff() {
     let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
 
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "editor_removal");
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Added"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Removed).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Removed"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Moved).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Moved"
+    );
 }
 
 #[test]

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -644,7 +644,10 @@ fn test_e2e_editor_add_then_remove_produces_no_diff_for_editor() {
     // diff. Without this, an empty diff stream (e.g. broken canonical emission)
     // would satisfy the absence checks below and pass silently.
     let graph = last_graph.expect("canonical graph should be computed");
-    assert!(graph.contains(&SPACE_A), "editor_no_diff: SPACE_A should be canonical via verified edge");
+    assert!(
+        graph.contains(&SPACE_A),
+        "editor_no_diff: SPACE_A should be canonical via verified edge"
+    );
     assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "editor_no_diff");
 
     assert!(
@@ -683,7 +686,10 @@ fn test_e2e_member_add_then_remove_produces_no_diff_for_member() {
     // diff. Without this, an empty diff stream (e.g. broken canonical emission)
     // would satisfy the absence checks below and pass silently.
     let graph = last_graph.expect("canonical graph should be computed");
-    assert!(graph.contains(&SPACE_A), "member_no_diff: SPACE_A should be canonical via verified edge");
+    assert!(
+        graph.contains(&SPACE_A),
+        "member_no_diff: SPACE_A should be canonical via verified edge"
+    );
     assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "member_no_diff");
 
     assert!(

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -25,6 +25,7 @@ use atlas::graph::{
     CanonicalGraph, CanonicalProcessor, ChangeType, DiffTracker, EdgeType, GraphDiff, GraphState,
     TransitiveProcessor,
 };
+use atlas::persistence::{BaselineNode, PersistedEmissionBaseline};
 use hermes_relay::source::mock_events::test_topology::{
     ROOT_SPACE_ID, SPACE_A, SPACE_B, SPACE_C, SPACE_D, SPACE_E, SPACE_F, SPACE_G, SPACE_H, SPACE_I,
     SPACE_J, SPACE_P, SPACE_Q, SPACE_S, SPACE_W, SPACE_X, SPACE_Y, SPACE_Z,
@@ -1550,4 +1551,156 @@ fn test_e2e_diff_tracker_reset() {
             "After reset, should produce bootstrap-like diff"
         );
     }
+}
+
+// =============================================================================
+// Deploy-flow simulation (GEO-645)
+// =============================================================================
+//
+// Models the load-bearing rollout from the issue: phase 1 atlas writes a
+// baseline reflecting v1 canonical rules; phase 2 atlas — with smaller
+// canonical rules — primes its DiffTracker from that persisted baseline and
+// emits REMOVED for every space that was canonical under v1 but is not
+// canonical under v2.
+//
+// The atlas crate on this branch already runs the "v2" rules (Member/Editor
+// edges no longer grant canonical inclusion). To simulate the deploy, we
+// build a baseline that includes spaces that *would* have been canonical
+// under v1 — including a synthetic orphan that the current pipeline cannot
+// reach — and assert the first track() after restart REMOVEs them all.
+
+/// Build a canonical graph from a topology and pull its current positions
+/// out as a persistable baseline. Mirrors what an atlas would persist after
+/// a steady run: every space that was canonical *and* its position.
+fn baseline_from_canonical(graph: &CanonicalGraph) -> PersistedEmissionBaseline {
+    let mut tracker = DiffTracker::new();
+    let _ = tracker.track(graph);
+    PersistedEmissionBaseline::from_diff_tracker(&tracker)
+        .expect("freshly-tracked tracker must have emission state")
+}
+
+#[test]
+fn test_e2e_baseline_simulation_phase2_removes_orphans() {
+    // Phase 1 (simulated): build a baseline reflecting v1 canonical rules.
+    // We piggy-back on the existing v2 test topology to seed a realistic
+    // canonical set, then inject a synthetic "orphan" space — modelling a
+    // node that v1 considered canonical (via Member/Editor) but v2 does not.
+    let v1_actions = test_topology::generate();
+    let (_v1_state, _v1_transitive, _v1_canonical, _v1_tracker, _v1_diffs, v1_last_graph) =
+        process_with_canonical(&v1_actions, ROOT_SPACE_ID);
+    let v1_graph = v1_last_graph.expect("v1 simulation must produce a canonical graph");
+
+    // Pull the v1 baseline out and add a synthetic orphan that the v2
+    // pipeline will *not* re-discover. This represents a space that was
+    // canonical only through edges v2 has removed.
+    let orphan = make_orphan_space(0xEE);
+    let baseline = {
+        let mut snapshot = baseline_from_canonical(&v1_graph);
+        // Push the orphan in via a fresh `from_nodes` call so the sort/dedup
+        // invariants are preserved.
+        let mut nodes: Vec<BaselineNode> = snapshot.nodes().to_vec();
+        nodes.push(BaselineNode {
+            space_id: orphan,
+            distance: 1,
+            parent: ROOT_SPACE_ID,
+        });
+        snapshot = PersistedEmissionBaseline::from_nodes(nodes);
+        // Sanity: encode/decode round-trips through the schema-stable shape,
+        // so this is genuinely modelling "loaded back from the DB".
+        let bytes = snapshot.encode();
+        PersistedEmissionBaseline::decode(&bytes).expect("baseline round-trips")
+    };
+    assert!(
+        baseline.nodes().iter().any(|n| n.space_id == orphan),
+        "test setup: orphan must be in the baseline before phase 2"
+    );
+
+    // Phase 2: a fresh atlas starts up with the same v2 topology. Its
+    // DiffTracker is primed from the (v1) baseline above. The first track()
+    // against the v2 canonical must emit REMOVED for the orphan because it
+    // is no longer reachable; all other v1 canonical spaces are still in
+    // the v2 set, so they should emit nothing (positions unchanged).
+    let mut state = GraphState::new();
+    let mut transitive = TransitiveProcessor::new();
+    let mut canonical = CanonicalProcessor::new(ROOT_SPACE_ID);
+    let mut tracker = DiffTracker::from_baseline(&baseline);
+
+    for (i, action) in v1_actions.iter().enumerate() {
+        let meta = make_meta(i as u64);
+        if let Some(event) = convert_action(action, &meta) {
+            transitive.handle_event(&event, &state);
+            state.apply_event(&event);
+        }
+    }
+
+    let v2_graph = canonical
+        .compute_if_changed(&state, &mut transitive)
+        .expect("v2 canonical compute must produce a graph");
+
+    let diff = tracker.track(&v2_graph);
+
+    // The orphan must be removed. Nothing else should be — every v1
+    // canonical space (other than the orphan) is also v2 canonical because
+    // the topology generator's edges all happen to be Verified/Related/Topic
+    // (no Member/Editor in test_topology). Position-stable spaces emit no
+    // event because the baseline-aware diff path drops `edge_type` from the
+    // MOVED check.
+    let removed_ids: Vec<SpaceId> = diff
+        .changes
+        .iter()
+        .filter(|c| c.change_type == ChangeType::Removed)
+        .map(|c| c.space_id)
+        .collect();
+    assert!(
+        removed_ids.contains(&orphan),
+        "orphan must be REMOVED; diff was: {:?}",
+        diff.changes
+    );
+
+    // No spurious ADDED for spaces that were already in the baseline at the
+    // same (distance, parent). This is the key correctness property: the
+    // restored baseline suppresses bootstrap-all-ADDED.
+    for change in &diff.changes {
+        if change.change_type == ChangeType::Added {
+            // Anything ADDED here would mean we lost the contract with
+            // consumers — they'd see ADDED for spaces they already think are
+            // canonical. Fail loudly.
+            panic!(
+                "no ADDED expected, but got space {:?} as ADDED",
+                change.space_id
+            );
+        }
+    }
+}
+
+#[test]
+fn test_e2e_baseline_simulation_steady_state_restart_emits_nothing() {
+    // The flip side of the deploy test: a routine restart (no rules change)
+    // loads a baseline that exactly matches what the new compute produces.
+    // First track must emit zero events — otherwise restart would
+    // continuously churn consumer state.
+    let actions = test_topology::generate();
+    let (_, _, _, _, _, last_graph) = process_with_canonical(&actions, ROOT_SPACE_ID);
+    let graph = last_graph.expect("topology must produce a canonical graph");
+
+    let baseline = baseline_from_canonical(&graph);
+    // Round-trip through the persisted bytes — restart loads from disk.
+    let baseline = PersistedEmissionBaseline::decode(&baseline.encode())
+        .expect("baseline round-trips through encode/decode");
+
+    let mut tracker = DiffTracker::from_baseline(&baseline);
+    let diff = tracker.track(&graph);
+    assert!(
+        diff.is_empty(),
+        "steady-state restart must emit zero events, got: {:?}",
+        diff.changes
+    );
+}
+
+// Tiny helper so the simulation test stays self-contained without exposing
+// crate-internal test_utils.
+fn make_orphan_space(last: u8) -> SpaceId {
+    let mut id = [0u8; 16];
+    id[15] = last;
+    id
 }

--- a/hermes/k8s/production/atlas.yaml
+++ b/hermes/k8s/production/atlas.yaml
@@ -75,7 +75,7 @@ spec:
             - name: ATLAS_INDEXER_ID
               value: "atlas-production"
             - name: ATLAS_RUNTIME_COMPATIBILITY_MARKER
-              value: "atlas-v1"
+              value: "atlas-v2"
             - name: ATLAS_FAIL_OPEN_BOUND
               value: "10"
             - name: ATLAS_CHECKPOINT_RETRY_ATTEMPTS
@@ -84,8 +84,11 @@ spec:
               value: "200"
             - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
               value: "120"
+            # Set to "true" for the atlas-v1 → atlas-v2 rollout window so the
+            # incompatible checkpoint is rejected and Atlas bootstraps fresh.
+            # Revert to "false" once Atlas has stamped a new atlas-v2 checkpoint.
             - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
-              value: "false"
+              value: "true"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/staging/atlas.yaml
+++ b/hermes/k8s/staging/atlas.yaml
@@ -77,7 +77,7 @@ spec:
             - name: ATLAS_INDEXER_ID
               value: "atlas-staging"
             - name: ATLAS_RUNTIME_COMPATIBILITY_MARKER
-              value: "atlas-v1"
+              value: "atlas-v2"
             - name: ATLAS_FAIL_OPEN_BOUND
               value: "10"
             - name: ATLAS_CHECKPOINT_RETRY_ATTEMPTS
@@ -86,8 +86,11 @@ spec:
               value: "200"
             - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
               value: "120"
+            # Set to "true" for the atlas-v1 → atlas-v2 rollout window so the
+            # incompatible checkpoint is rejected and Atlas bootstraps fresh.
+            # Revert to "false" once Atlas has stamped a new atlas-v2 checkpoint.
             - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
-              value: "false"
+              value: "true"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Two related atlas changes bundled together because the canonical-graph rules change invalidates any existing in-memory emission baseline, and the baseline-persistence work is what makes that rollout safe.

### Remove Member/Editor edges from canonical graph

- Drop `Member` edges entirely from the canonical graph, and drop `Editor` edges from both the canonical and transitive graphs. Membership/editorship are no longer canonical-granting relations.
- Clarify `Subtopic` semantics in `apply_trust_extended`: `Verified` / `Related` expand the canonical member set, while `Subtopic` only attaches filtered subtrees between already-canonical members.
- Bump the runtime compatibility marker from `atlas-v1` to `atlas-v2`. Old checkpoints containing removed edge variants are rejected at startup via the marker mismatch path; `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` is enabled for the rollout window so a fresh baseline can be stamped.
- Defer checkpoint `graph_state` decoding until after `validate_compatibility()` so removed-variant blobs fail the marker check instead of panicking on deserialization. Borrow the blob during decode to avoid an extra clone.

### Persist emission baseline across rules-change deploys

- New `atlas_emission_baseline` table (drizzle migration `0057`) and `PersistedEmissionBaseline` codec, written through `CheckpointManager::persist_block_checkpoint`.
- After a rules-change restart the in-memory baseline is empty, which would otherwise re-emit the entire canonical graph as `Added` diffs. The persisted baseline is loaded on startup and force-written once before resuming.
- `persist_block_checkpoint` now returns `Result<(), CheckpointError>` so the force-write pending flag is only cleared on a confirmed successful write. A quiet-block retry path covers both `output.is_empty()` and `processed_events == 0` blocks, using the *current* cursor (not the restored cursor) so a later successful retry doesn't rewind the resume position.
- `PersistedEmissionBaseline::decode` uses `checked_mul` / `checked_add` so a corrupted `count` header surfaces as `Serialization` rather than wrapping on 32-bit or triggering a pathological allocation. Regression test included.

## Test plan

- [x] `cargo test -p atlas --lib`
- [x] `cargo test -p atlas --test e2e`
- [ ] Staging deploy with `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true`, confirm baseline is stamped on first eventful block and that subsequent restarts resume without re-emitting `Added` diffs for the full canonical graph
- [ ] Revert `ATLAS_CHECKPOINT_ALLOW_FRESH_START` to `false` once a fresh atlas-v2 checkpoint exists in prod
