### PR TITLE
chore(atlas): revert ATLAS_CHECKPOINT_ALLOW_FRESH_START to false post atlas-v2 rollout

### DIFF
--- a/hermes/k8s/production/atlas.yaml
+++ b/hermes/k8s/production/atlas.yaml
@@ -84,11 +84,8 @@ spec:
               value: "200"
             - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
               value: "120"
-            # Set to "true" for the atlas-v1 → atlas-v2 rollout window so the
-            # incompatible checkpoint is rejected and Atlas bootstraps fresh.
-            # Revert to "false" once Atlas has stamped a new atlas-v2 checkpoint.
             - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
-              value: "true"
+              value: "false"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/staging/atlas.yaml
+++ b/hermes/k8s/staging/atlas.yaml
@@ -86,11 +86,8 @@ spec:
               value: "200"
             - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
               value: "120"
-            # Set to "true" for the atlas-v1 → atlas-v2 rollout window so the
-            # incompatible checkpoint is rejected and Atlas bootstraps fresh.
-            # Revert to "false" once Atlas has stamped a new atlas-v2 checkpoint.
             - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
-              value: "true"
+              value: "false"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Reverts `ATLAS_CHECKPOINT_ALLOW_FRESH_START` to `"false"` in the production and staging atlas manifests now that the `atlas-v1 → atlas-v2` rollout is complete.

The marker bump in #697 flipped this flag to `"true"` for the rollout window so the incompatible `atlas-v1` checkpoint would be rejected and Atlas would bootstrap fresh while carrying the persisted emission baseline (#696) forward. With an `atlas-v2` checkpoint now stamped, the flag goes back to `"false"` so future incompatible/corrupt checkpoints fail loudly instead of silently bootstrapping fresh.

- `ATLAS_RUNTIME_COMPATIBILITY_MARKER` stays at `atlas-v2` (unchanged).
- Only the fresh-start flag changes, in both prod and staging.

## Merge gate

Merge/deploy this only after the prod `atlas-v2` checkpoint is confirmed stamped (marker = `atlas-v2`, block advancing, baseline present on the `atlas-production` row).