### PR TITLE
feat(notification-indexer): target proposer + voters for governance notifications

### DIFF
--- a/notification-service/e2e-tests/setup.sql
+++ b/notification-service/e2e-tests/setup.sql
@@ -30,6 +30,21 @@ CREATE TABLE IF NOT EXISTS editors (
 );
 CREATE INDEX IF NOT EXISTS editors_space_id_idx ON editors (space_id);
 
+-- Required by notification-indexer to resolve prior voters of a proposal
+-- (recipients of "a new version of a proposal you voted on was submitted").
+-- Simplified version of the full proposal_votes table. voter_id is the voter's
+-- personal-space UUID, usable directly as a notification recipient.
+CREATE TABLE IF NOT EXISTS proposal_votes (
+    proposal_id uuid NOT NULL,
+    voter_id uuid NOT NULL,
+    space_id uuid,
+    vote text,
+    created_at text NOT NULL DEFAULT '0',
+    created_at_block text NOT NULL DEFAULT '0',
+    PRIMARY KEY (proposal_id, voter_id)
+);
+CREATE INDEX IF NOT EXISTS proposal_votes_proposal_id_idx ON proposal_votes (proposal_id);
+
 -- Notification service tables (matches migration 0050)
 CREATE TABLE IF NOT EXISTS app_webhooks (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -54,6 +54,9 @@ const SPACE_0E_BYTES: [u8; 16] = [0x22; 16];
 
 const PROPOSER_ID_BYTES: [u8; 16] = [0x02; 16];
 const VOTER_ID_BYTES: [u8; 16] = [0x0A; 16];
+// A prior voter on the 3-editor space's UPDATED proposal who is NOT an editor —
+// proves voter-targeted delivery of "a new version of a proposal you voted on".
+const UPDATE_VOTER_BYTES: [u8; 16] = [0x0B; 16];
 
 // Proposal IDs for 3-editor space (one per on-chain event type + rejection)
 const PROP_3E_CREATED_BYTES: [u8; 16] = [0x03; 16];
@@ -97,14 +100,23 @@ const GOVERNANCE_TOPIC: &str = "space.governance";
 const KNOWLEDGE_EDITS_TOPIC: &str = "knowledge.edits";
 const NUM_WEBHOOKS: usize = 3;
 
-// Expected calls:
-// 3-editor space: 6 event types × 3 editors × 3 webhooks = 54
-// 1-editor space: 1 event type  × 1 editor  × 3 webhooks = 3
-// 0-editor space: 1 event type  × 0 editors × 3 webhooks = 0
-// Bounty interest: 1 event × 2 editors × 3 webhooks = 6
-// Bounty allocated: 1 event × 1 curator × 3 webhooks = 3
-// Bounty payout: 1 event × 1 curator × 3 webhooks = 3
-const EXPECTED_CALLS: usize = 54 + 3 + 6 + 3 + 3;
+// Expected calls (3 webhooks each):
+// 3-editor space (66):
+//   proposal_created            3 editors                  × 3 = 9
+//   proposal_updated            3 editors + 1 prior voter  × 3 = 12
+//   proposal_voted              3 editors + proposer       × 3 = 12
+//   proposal_executed           3 editors + proposer       × 3 = 12
+//   proposal_settings_updated   3 editors                  × 3 = 9
+//   proposal_rejected           3 editors + proposer       × 3 = 12
+// 1-editor space: 1 event type  × 1 editor  × 3 = 3
+// 0-editor space: 1 event type  × 0 editors × 3 = 0
+// Bounty interest:  1 event × 2 editors × 3 = 6
+// Bounty allocated: 1 event × 1 curator × 3 = 3
+// Bounty payout:    1 event × 1 curator × 3 = 3
+//
+// The proposer (0x02) and the prior voter (0x0B) are intentionally NOT editors,
+// so these counts also prove targeted delivery reaches non-editors.
+const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3;
 
 const GOVERNANCE_EVENT_TYPES: &[&str] = &[
     "proposal_created",
@@ -246,6 +258,36 @@ async fn seed_database(
     .bind(proposer)
     .bind(now - 7200)
     .bind(now - 3600)
+    .execute(pool)
+    .await?;
+
+    // Proposals for the VOTED and EXECUTED events so the indexer can resolve the
+    // proposer (find_proposer_for_proposal) and deliver "your proposal was voted
+    // on / approved" to them. end_time is in the FUTURE so the rejection poller
+    // does NOT also reject these (it only rejects end_time < now).
+    for prop in [PROP_3E_VOTED_BYTES, PROP_3E_EXECUTED_BYTES] {
+        sqlx::query(
+            "INSERT INTO proposals (id, space_id, proposed_by, start_time, end_time, created_at, created_at_block) \
+             VALUES ($1, $2, $3, $4, $5, '0', '0') ON CONFLICT DO NOTHING",
+        )
+        .bind(Uuid::from_bytes(prop))
+        .bind(space_3e)
+        .bind(proposer)
+        .bind(now - 3600)
+        .bind(now + 3600)
+        .execute(pool)
+        .await?;
+    }
+
+    // A prior vote on the UPDATED proposal by a NON-editor, so the indexer
+    // delivers "a new version of a proposal you voted on" to that voter.
+    sqlx::query(
+        "INSERT INTO proposal_votes (proposal_id, voter_id, space_id, vote) \
+         VALUES ($1, $2, $3, 'yes') ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::from_bytes(PROP_3E_UPDATED_BYTES))
+    .bind(Uuid::from_bytes(UPDATE_VOTER_BYTES))
+    .bind(space_3e)
     .execute(pool)
     .await?;
 
@@ -716,6 +758,9 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         .map(|b| Uuid::from_bytes(*b).to_string())
         .collect();
     let editor_solo = Uuid::from_bytes(EDITOR_SOLO_BYTES).to_string();
+    // Phase 1 targeted recipients (intentionally NOT editors):
+    let proposer_uid = Uuid::from_bytes(PROPOSER_ID_BYTES).to_string();
+    let update_voter_uid = Uuid::from_bytes(UPDATE_VOTER_BYTES).to_string();
 
     // ===================================================================
     // Total count
@@ -776,28 +821,35 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     }
 
     // ===================================================================
-    // 3-editor space: 6 event types × 3 editors × 3 webhooks = 54 calls
+    // 3-editor space: 66 calls (editors on every event + targeted recipients)
     // ===================================================================
     let calls_3e: Vec<_> = calls
         .iter()
         .filter(|c| c.body["space_id"].as_str() == Some(space_3e.as_str()))
         .collect();
     r.check(
-        "3-editor space: exactly 54 calls (6 events x 3 editors x 3 webhooks)",
-        calls_3e.len() == 54,
+        "3-editor space: exactly 66 calls (editors + proposer/voter targeting)",
+        calls_3e.len() == 66,
     );
 
-    // Per governance event-type fan-out (3-editor space)
+    // Per governance event-type fan-out (3-editor space). Targeted events add one
+    // non-editor recipient: the proposer (voted/executed/rejected) or a prior
+    // voter (updated).
     for et in GOVERNANCE_EVENT_TYPES {
         let et_calls: Vec<_> = calls_3e
             .iter()
             .filter(|c| c.body["event_type"].as_str() == Some(et))
             .collect();
+        let expected_recipients = match *et {
+            "proposal_voted" | "proposal_executed" | "proposal_rejected" => editors_3e.len() + 1, // + proposer
+            "proposal_updated" => editors_3e.len() + 1, // + prior voter
+            _ => editors_3e.len(),
+        };
         r.check(
-            &format!("3e {}: 9 calls (3 editors x 3 webhooks)", et),
-            et_calls.len() == 9,
+            &format!("3e {}: {} calls", et, expected_recipients * NUM_WEBHOOKS),
+            et_calls.len() == expected_recipients * NUM_WEBHOOKS,
         );
-        // Each editor gets exactly 3 (one per webhook)
+        // Each editor still gets exactly 3 (one per webhook) on every event type.
         for editor_str in &editors_3e {
             let n = et_calls
                 .iter()
@@ -809,6 +861,32 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
             );
         }
     }
+
+    // Phase 1: targeted recipients beyond editors reach non-editors.
+    for et in ["proposal_voted", "proposal_executed", "proposal_rejected"] {
+        let n = calls_3e
+            .iter()
+            .filter(|c| {
+                c.body["event_type"].as_str() == Some(et)
+                    && c.body["user_space_id"].as_str() == Some(proposer_uid.as_str())
+            })
+            .count();
+        r.check(
+            &format!("3e {}: proposer (non-editor) notified on 3 webhooks", et),
+            n == 3,
+        );
+    }
+    let upd_voter_calls = calls_3e
+        .iter()
+        .filter(|c| {
+            c.body["event_type"].as_str() == Some("proposal_updated")
+                && c.body["user_space_id"].as_str() == Some(update_voter_uid.as_str())
+        })
+        .count();
+    r.check(
+        "3e proposal_updated: prior voter (non-editor) notified on 3 webhooks",
+        upd_voter_calls == 3,
+    );
 
     // ===================================================================
     // Every call has user_space_id and it's a known editor
@@ -823,6 +901,9 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         .chain(std::iter::once(&bounty_editor_1))
         .chain(std::iter::once(&bounty_editor_2))
         .chain(std::iter::once(&curator_space))
+        // Phase 1 targeted recipients (non-editors):
+        .chain(std::iter::once(&proposer_uid))
+        .chain(std::iter::once(&update_voter_uid))
         .cloned()
         .collect();
 
@@ -907,13 +988,14 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     r.check("idempotency keys are unique per (event, user) pair", {
         let keys: std::collections::HashSet<&str> =
             calls.iter().map(|c| c.idempotency_key.as_str()).collect();
-        // 3-editor space: 6 events × 3 editors = 18 distinct keys
-        // 1-editor space: 1 event × 1 editor = 1 distinct key
-        // Bounty interest: 1 event × 2 editors = 2 distinct keys
-        // Bounty allocated: 1 event × 1 curator = 1 distinct key
-        // Bounty payout: 1 event × 1 curator = 1 distinct key
-        // Total: 23
-        keys.len() == 23
+        // 3-editor space: per (event, user) pair —
+        //   created 3 + settings 3 + updated 4 + voted 4 + executed 4 + rejected 4 = 22
+        // 1-editor space: 1 event × 1 editor = 1
+        // Bounty interest: 1 event × 2 editors = 2
+        // Bounty allocated: 1 event × 1 curator = 1
+        // Bounty payout: 1 event × 1 curator = 1
+        // Total: 27
+        keys.len() == 27
     });
 
     // ===================================================================

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -223,21 +223,27 @@ async fn async_main() -> Result<(), IndexerError> {
                                     // Enrich rejection with names (proposal is guaranteed to exist)
                                     enrich_payload(&poller_storage, &mut event, proposal.space_id).await;
 
-                                    let editors = match poller_storage.find_editors_for_space(proposal.space_id).await {
+                                    let mut recipients = match poller_storage.find_editors_for_space(proposal.space_id).await {
                                         Ok(eds) => eds,
                                         Err(e) => {
                                             error!(error = %e, space_id = %proposal.space_id, "Failed to look up editors for rejection, will retry next poll");
                                             continue;
                                         }
                                     };
-                                    if editors.is_empty() {
+                                    // Notify the proposer that their proposal was rejected, even
+                                    // if they are not an editor. `proposed_by` is the proposer's
+                                    // personal-space UUID, usable directly as a recipient.
+                                    recipients.push(proposal.proposed_by);
+                                    recipients.sort();
+                                    recipients.dedup();
+                                    if recipients.is_empty() {
                                         continue;
                                     }
-                                    match poller_storage.insert_notifications_for_editors(&event, &editors).await {
+                                    match poller_storage.insert_notifications_for_users(&event, &recipients).await {
                                         Ok(count) if count > 0 => {
                                             info!(
                                                 proposal_id = %proposal.id,
-                                                editors = editors.len(),
+                                                recipients = recipients.len(),
                                                 inserted = count,
                                                 "Inserted rejection notifications"
                                             );
@@ -460,7 +466,7 @@ async fn async_main() -> Result<(), IndexerError> {
                                                     continue;
                                                 }
 
-                                                ke_stor.insert_notifications_for_editors(&event, &editors).await.map(|count| {
+                                                ke_stor.insert_notifications_for_users(&event, &editors).await.map(|count| {
                                                     if count > 0 {
                                                         info!(
                                                             event_type = "bounty_interest",
@@ -744,7 +750,7 @@ async fn async_main() -> Result<(), IndexerError> {
                                     // Enrich payload with human-readable names (best-effort)
                                     enrich_payload(&storage, &mut event, space_id).await;
 
-                                    let editors = match storage.find_editors_for_space(space_id).await {
+                                    let mut recipients = match storage.find_editors_for_space(space_id).await {
                                         Ok(eds) => eds,
                                         Err(e) => {
                                             // DB error — don't commit offset so we retry on restart
@@ -759,20 +765,60 @@ async fn async_main() -> Result<(), IndexerError> {
                                         }
                                     };
 
-                                    if editors.is_empty() {
-                                        // Genuinely no editors — this is normal, not an error
+                                    // Targeted recipients beyond the space's editors. Filtering to
+                                    // a specific audience is done app-side, so we deliver the
+                                    // relevant superset:
+                                    //   - "your proposal was voted on / approved" -> the proposer
+                                    //   - "a new version of a proposal you voted on" -> prior voters
+                                    // proposer_id / voter_id are personal-space UUIDs (same
+                                    // namespace as editors), usable directly as recipients.
+                                    // Best-effort: a lookup miss only drops the *targeted*
+                                    // recipient — the proposer is usually also an editor and is
+                                    // still notified, and editors always get the base event.
+                                    if let Some(pid) = event.governance_proposal_id() {
+                                        match event.event_type {
+                                            NotificationEventType::ProposalVoted
+                                            | NotificationEventType::ProposalExecuted => {
+                                                match storage.find_proposer_for_proposal(pid).await {
+                                                    Ok(Some(proposer)) => recipients.push(proposer),
+                                                    Ok(None) => {}
+                                                    Err(e) => warn!(
+                                                        error = %e,
+                                                        proposal_id = %pid,
+                                                        "Failed to resolve proposer; notifying editors only"
+                                                    ),
+                                                }
+                                            }
+                                            NotificationEventType::ProposalUpdated => {
+                                                match storage.find_voters_for_proposal(pid).await {
+                                                    Ok(voters) => recipients.extend(voters),
+                                                    Err(e) => warn!(
+                                                        error = %e,
+                                                        proposal_id = %pid,
+                                                        "Failed to resolve voters; notifying editors only"
+                                                    ),
+                                                }
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                    recipients.sort();
+                                    recipients.dedup();
+
+                                    if recipients.is_empty() {
+                                        // Genuinely no recipients — this is normal, not an error
                                         processed_count += 1;
                                         should_commit = true;
                                     } else {
-                                        match storage.insert_notifications_for_editors(&event, &editors).await {
+                                        match storage.insert_notifications_for_users(&event, &recipients).await {
                                             Ok(count) => {
                                                 if count > 0 {
                                                     info!(
                                                         event_type = %event.payload.event_type,
                                                         category = %event.payload.category,
-                                                        editors = editors.len(),
+                                                        recipients = recipients.len(),
                                                         inserted = count,
-                                                        "Inserted per-editor notifications"
+                                                        "Inserted per-user notifications"
                                                     );
                                                 }
                                                 processed_count += 1;

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -29,7 +29,8 @@ use notification_indexer::models::{
     build_rejection_event, extract_bounty_relations, handle_bounty_allocated,
     handle_bounty_interest, handle_bounty_payout, handle_proposal_created,
     handle_proposal_executed, handle_proposal_settings_updated, handle_proposal_updated,
-    handle_proposal_voted, BountyConfig, NotificationEventType,
+    handle_proposal_voted, merge_recipients, BountyConfig, NotificationEventType,
+    TargetedRecipients,
 };
 use notification_indexer::storage::Storage;
 
@@ -223,19 +224,17 @@ async fn async_main() -> Result<(), IndexerError> {
                                     // Enrich rejection with names (proposal is guaranteed to exist)
                                     enrich_payload(&poller_storage, &mut event, proposal.space_id).await;
 
-                                    let mut recipients = match poller_storage.find_editors_for_space(proposal.space_id).await {
+                                    let editors = match poller_storage.find_editors_for_space(proposal.space_id).await {
                                         Ok(eds) => eds,
                                         Err(e) => {
                                             error!(error = %e, space_id = %proposal.space_id, "Failed to look up editors for rejection, will retry next poll");
                                             continue;
                                         }
                                     };
-                                    // Notify the proposer that their proposal was rejected, even
-                                    // if they are not an editor. `proposed_by` is the proposer's
+                                    // Notify the proposer that their proposal was rejected, even if
+                                    // they are not an editor. `proposed_by` is the proposer's
                                     // personal-space UUID, usable directly as a recipient.
-                                    recipients.push(proposal.proposed_by);
-                                    recipients.sort();
-                                    recipients.dedup();
+                                    let recipients = merge_recipients(editors, vec![proposal.proposed_by]);
                                     if recipients.is_empty() {
                                         continue;
                                     }
@@ -750,7 +749,7 @@ async fn async_main() -> Result<(), IndexerError> {
                                     // Enrich payload with human-readable names (best-effort)
                                     enrich_payload(&storage, &mut event, space_id).await;
 
-                                    let mut recipients = match storage.find_editors_for_space(space_id).await {
+                                    let editors = match storage.find_editors_for_space(space_id).await {
                                         Ok(eds) => eds,
                                         Err(e) => {
                                             // DB error — don't commit offset so we retry on restart
@@ -765,45 +764,38 @@ async fn async_main() -> Result<(), IndexerError> {
                                         }
                                     };
 
-                                    // Targeted recipients beyond the space's editors. Filtering to
-                                    // a specific audience is done app-side, so we deliver the
-                                    // relevant superset:
-                                    //   - "your proposal was voted on / approved" -> the proposer
-                                    //   - "a new version of a proposal you voted on" -> prior voters
-                                    // proposer_id / voter_id are personal-space UUIDs (same
-                                    // namespace as editors), usable directly as recipients.
-                                    // Best-effort: a lookup miss only drops the *targeted*
-                                    // recipient — the proposer is usually also an editor and is
-                                    // still notified, and editors always get the base event.
-                                    if let Some(pid) = event.governance_proposal_id() {
-                                        match event.event_type {
-                                            NotificationEventType::ProposalVoted
-                                            | NotificationEventType::ProposalExecuted => {
+                                    // Targeted recipients beyond the space's editors (see
+                                    // NotificationEventType::targeted_recipients). Filtering to a
+                                    // specific audience is done app-side, so we deliver the relevant
+                                    // superset. Best-effort: a lookup miss only drops the targeted
+                                    // extra — editors always get the base event, and the proposer
+                                    // is usually also an editor.
+                                    let extra: Vec<uuid::Uuid> = match event.governance_proposal_id() {
+                                        Some(pid) => match event.event_type.targeted_recipients() {
+                                            TargetedRecipients::Proposer => {
                                                 match storage.find_proposer_for_proposal(pid).await {
-                                                    Ok(Some(proposer)) => recipients.push(proposer),
-                                                    Ok(None) => {}
-                                                    Err(e) => warn!(
-                                                        error = %e,
-                                                        proposal_id = %pid,
-                                                        "Failed to resolve proposer; notifying editors only"
-                                                    ),
+                                                    Ok(Some(proposer)) => vec![proposer],
+                                                    Ok(None) => vec![],
+                                                    Err(e) => {
+                                                        warn!(error = %e, proposal_id = %pid, "Failed to resolve proposer; notifying editors only");
+                                                        vec![]
+                                                    }
                                                 }
                                             }
-                                            NotificationEventType::ProposalUpdated => {
+                                            TargetedRecipients::Voters => {
                                                 match storage.find_voters_for_proposal(pid).await {
-                                                    Ok(voters) => recipients.extend(voters),
-                                                    Err(e) => warn!(
-                                                        error = %e,
-                                                        proposal_id = %pid,
-                                                        "Failed to resolve voters; notifying editors only"
-                                                    ),
+                                                    Ok(voters) => voters,
+                                                    Err(e) => {
+                                                        warn!(error = %e, proposal_id = %pid, "Failed to resolve voters; notifying editors only");
+                                                        vec![]
+                                                    }
                                                 }
                                             }
-                                            _ => {}
-                                        }
-                                    }
-                                    recipients.sort();
-                                    recipients.dedup();
+                                            TargetedRecipients::None => vec![],
+                                        },
+                                        None => vec![],
+                                    };
+                                    let recipients = merge_recipients(editors, extra);
 
                                     if recipients.is_empty() {
                                         // Genuinely no recipients — this is normal, not an error

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -54,6 +54,52 @@ impl NotificationEventType {
             | NotificationEventType::BountyPayout => "bounty",
         }
     }
+
+    /// Recipients to notify *in addition to* the event space's editors.
+    ///
+    /// Editors always receive the base governance event; these targeted
+    /// recipients are delivered on top so the colleague's user-centric asks are
+    /// covered. Filtering to a precise audience is done app-side, so we resolve
+    /// and deliver the relevant superset.
+    pub fn targeted_recipients(&self) -> TargetedRecipients {
+        match self {
+            // "your proposal was voted on / approved / rejected"
+            NotificationEventType::ProposalVoted
+            | NotificationEventType::ProposalExecuted
+            | NotificationEventType::ProposalRejected => TargetedRecipients::Proposer,
+            // "a new version of a proposal you voted on was submitted"
+            NotificationEventType::ProposalUpdated => TargetedRecipients::Voters,
+            // proposal_created / settings_updated and all bounty events: editors
+            // (or the bounty's own single recipient) only.
+            _ => TargetedRecipients::None,
+        }
+    }
+}
+
+/// Recipients to resolve *in addition to* a space's editors for a governance
+/// event. The variant determines which DB resolver the consumer calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetedRecipients {
+    /// The proposer (`proposals.proposed_by`).
+    Proposer,
+    /// Prior voters of the proposal (`proposal_votes.voter_id`).
+    Voters,
+    /// Editors only — no additional targeted recipients.
+    None,
+}
+
+/// Merge targeted recipients into the editor set, returning a sorted,
+/// de-duplicated recipient list.
+///
+/// Pure so the fan-out audience is unit-testable without a database. A user who
+/// is both an editor and the proposer/a voter appears exactly once; the storage
+/// layer's `ON CONFLICT (idempotency_key) DO NOTHING` is a second line of
+/// defense against duplicates.
+pub fn merge_recipients(mut editors: Vec<Uuid>, extra: Vec<Uuid>) -> Vec<Uuid> {
+    editors.extend(extra);
+    editors.sort();
+    editors.dedup();
+    editors
 }
 
 /// Webhook payload version. Increment when the payload schema changes
@@ -2344,5 +2390,46 @@ mod tests {
         };
         let event = handle_bounty_interest(&info);
         assert_eq!(event.governance_proposal_id(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // targeted_recipients + merge_recipients (recipient routing & dedup)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn targeted_recipients_routes_by_event_type() {
+        use NotificationEventType::*;
+        // "your proposal was voted on / approved / rejected" -> proposer
+        assert_eq!(ProposalVoted.targeted_recipients(), TargetedRecipients::Proposer);
+        assert_eq!(ProposalExecuted.targeted_recipients(), TargetedRecipients::Proposer);
+        assert_eq!(ProposalRejected.targeted_recipients(), TargetedRecipients::Proposer);
+        // "a new version of a proposal you voted on" -> prior voters
+        assert_eq!(ProposalUpdated.targeted_recipients(), TargetedRecipients::Voters);
+        // editors-only (or single-recipient bounty) events get no targeted extras
+        assert_eq!(ProposalCreated.targeted_recipients(), TargetedRecipients::None);
+        assert_eq!(
+            ProposalSettingsUpdated.targeted_recipients(),
+            TargetedRecipients::None
+        );
+        assert_eq!(BountyInterest.targeted_recipients(), TargetedRecipients::None);
+        assert_eq!(BountyAllocated.targeted_recipients(), TargetedRecipients::None);
+    }
+
+    #[test]
+    fn merge_recipients_dedups_and_sorts() {
+        let a = Uuid::from_bytes([0x01; 16]);
+        let b = Uuid::from_bytes([0x02; 16]);
+        let c = Uuid::from_bytes([0x03; 16]);
+        // editors = [b, a]; extra = proposer b (already an editor) + new voter c.
+        let merged = merge_recipients(vec![b, a], vec![b, c]);
+        // sorted, and b (editor ∩ targeted) appears exactly once.
+        assert_eq!(merged, vec![a, b, c]);
+    }
+
+    #[test]
+    fn merge_recipients_dedups_editor_duplicates_with_empty_extra() {
+        let a = Uuid::from_bytes([0x01; 16]);
+        let merged = merge_recipients(vec![a, a], vec![]);
+        assert_eq!(merged, vec![a]);
     }
 }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -204,6 +204,20 @@ pub struct NotificationEvent {
     pub payload: NotificationPayload,
 }
 
+impl NotificationEvent {
+    /// The governance proposal id this event concerns, parsed from the payload.
+    ///
+    /// Returns `None` for non-governance events or an unparseable id. Used to
+    /// resolve targeted recipients (the proposer for voted/executed events, the
+    /// prior voters for an updated proposal).
+    pub fn governance_proposal_id(&self) -> Option<Uuid> {
+        match &self.payload.data {
+            NotificationData::Governance(gov) => Uuid::parse_str(&gov.proposal_id).ok(),
+            NotificationData::Bounty(_) => None,
+        }
+    }
+}
+
 /// Build a notification event from a PROPOSAL_CREATED protobuf message.
 pub fn handle_proposal_created(
     msg: &HermesProposalCreated,
@@ -2293,5 +2307,42 @@ mod tests {
 
         let result = extract_bounty_relations(&hermes_edit, &config).expect("should succeed");
         assert!(result.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // governance_proposal_id (drives targeted proposer/voter recipients)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn governance_proposal_id_extracts_from_governance_event() {
+        let msg = HermesProposalCreated {
+            space_id: make_test_uuid(0x01),
+            proposer_id: make_test_uuid(0x02),
+            proposal_id: make_test_uuid(0x03),
+            voting_mode: 0,
+            actions: vec![],
+            settings: None,
+            meta: Some(make_metadata(1, 1)),
+        };
+        let event = handle_proposal_created(&msg).expect("should parse");
+        let expected = Uuid::from_slice(&make_test_uuid(0x03)).expect("valid uuid");
+        assert_eq!(event.governance_proposal_id(), Some(expected));
+    }
+
+    #[test]
+    fn governance_proposal_id_is_none_for_bounty_event() {
+        let info = BountyRelationInfo {
+            relation_id: Uuid::nil(),
+            bounty_entity_id: Uuid::nil(),
+            curator_entity_id: Uuid::nil(),
+            curator_space_id: Uuid::nil(),
+            bounty_space_id: Uuid::nil(),
+            proposal_id: None,
+            block_number: 1,
+            sequence: 0,
+            timestamp: 1,
+        };
+        let event = handle_bounty_interest(&info);
+        assert_eq!(event.governance_proposal_id(), None);
     }
 }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -2400,19 +2400,40 @@ mod tests {
     fn targeted_recipients_routes_by_event_type() {
         use NotificationEventType::*;
         // "your proposal was voted on / approved / rejected" -> proposer
-        assert_eq!(ProposalVoted.targeted_recipients(), TargetedRecipients::Proposer);
-        assert_eq!(ProposalExecuted.targeted_recipients(), TargetedRecipients::Proposer);
-        assert_eq!(ProposalRejected.targeted_recipients(), TargetedRecipients::Proposer);
+        assert_eq!(
+            ProposalVoted.targeted_recipients(),
+            TargetedRecipients::Proposer
+        );
+        assert_eq!(
+            ProposalExecuted.targeted_recipients(),
+            TargetedRecipients::Proposer
+        );
+        assert_eq!(
+            ProposalRejected.targeted_recipients(),
+            TargetedRecipients::Proposer
+        );
         // "a new version of a proposal you voted on" -> prior voters
-        assert_eq!(ProposalUpdated.targeted_recipients(), TargetedRecipients::Voters);
+        assert_eq!(
+            ProposalUpdated.targeted_recipients(),
+            TargetedRecipients::Voters
+        );
         // editors-only (or single-recipient bounty) events get no targeted extras
-        assert_eq!(ProposalCreated.targeted_recipients(), TargetedRecipients::None);
+        assert_eq!(
+            ProposalCreated.targeted_recipients(),
+            TargetedRecipients::None
+        );
         assert_eq!(
             ProposalSettingsUpdated.targeted_recipients(),
             TargetedRecipients::None
         );
-        assert_eq!(BountyInterest.targeted_recipients(), TargetedRecipients::None);
-        assert_eq!(BountyAllocated.targeted_recipients(), TargetedRecipients::None);
+        assert_eq!(
+            BountyInterest.targeted_recipients(),
+            TargetedRecipients::None
+        );
+        assert_eq!(
+            BountyAllocated.targeted_recipients(),
+            TargetedRecipients::None
+        );
     }
 
     #[test]

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -279,17 +279,19 @@ impl Storage {
     /// `proposer_id` is "the space creating the proposal"), so it is directly
     /// usable as a notification recipient — no entity→space resolution needed.
     /// Used to deliver "your proposal was voted on / approved / rejected".
-    #[instrument(name = "notification_indexer.storage.find_proposer_for_proposal", skip(self))]
+    #[instrument(
+        name = "notification_indexer.storage.find_proposer_for_proposal",
+        skip(self)
+    )]
     pub async fn find_proposer_for_proposal(
         &self,
         proposal_id: Uuid,
     ) -> Result<Option<Uuid>, StorageError> {
-        let result = sqlx::query_scalar::<_, Uuid>(
-            "SELECT proposed_by FROM proposals WHERE id = $1",
-        )
-        .bind(proposal_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let result =
+            sqlx::query_scalar::<_, Uuid>("SELECT proposed_by FROM proposals WHERE id = $1")
+                .bind(proposal_id)
+                .fetch_optional(&self.pool)
+                .await?;
         Ok(result)
     }
 
@@ -299,17 +301,19 @@ impl Storage {
     /// `voter_id` is "the space casting the vote"), so it is directly usable as
     /// a notification recipient. Used to deliver "a new version of a proposal
     /// you voted on was submitted" to prior voters.
-    #[instrument(name = "notification_indexer.storage.find_voters_for_proposal", skip(self))]
+    #[instrument(
+        name = "notification_indexer.storage.find_voters_for_proposal",
+        skip(self)
+    )]
     pub async fn find_voters_for_proposal(
         &self,
         proposal_id: Uuid,
     ) -> Result<Vec<Uuid>, StorageError> {
-        let rows = sqlx::query(
-            "SELECT DISTINCT voter_id FROM proposal_votes WHERE proposal_id = $1",
-        )
-        .bind(proposal_id)
-        .fetch_all(&self.pool)
-        .await?;
+        let rows =
+            sqlx::query("SELECT DISTINCT voter_id FROM proposal_votes WHERE proposal_id = $1")
+                .bind(proposal_id)
+                .fetch_all(&self.pool)
+                .await?;
         Ok(rows.iter().map(|r| r.get("voter_id")).collect())
     }
 

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -88,25 +88,31 @@ impl Storage {
         Ok(rows.iter().map(|r| r.get("member_space_id")).collect())
     }
 
-    /// Insert per-editor notifications into the outbox and fan out deliveries.
+    /// Insert per-user notifications into the outbox and fan out deliveries.
     ///
-    /// For each editor in the space, creates an outbox row with that editor's
+    /// For each recipient user, creates an outbox row with that user's
     /// `user_space_id` stamped into the payload, then fans out delivery rows
-    /// to all registered webhooks. Idempotency keys include the editor ID.
+    /// to all registered webhooks. Idempotency keys include the user ID.
+    ///
+    /// Recipients are the relevant *superset* for the event (e.g. a space's
+    /// editors, plus the proposer or prior voters for targeted governance
+    /// events). The caller is responsible for de-duplicating the slice; the
+    /// `ON CONFLICT (idempotency_key) DO NOTHING` clause also makes duplicate
+    /// recipients a no-op. Filtering to a specific audience is done app-side.
     ///
     /// Returns the number of new outbox rows inserted (0 if all were duplicates).
     #[instrument(
-        name = "notification_indexer.storage.insert_notifications_for_editors",
-        skip(self, event, editors)
+        name = "notification_indexer.storage.insert_notifications_for_users",
+        skip(self, event, users)
     )]
-    pub async fn insert_notifications_for_editors(
+    pub async fn insert_notifications_for_users(
         &self,
         event: &NotificationEvent,
-        editors: &[Uuid],
+        users: &[Uuid],
     ) -> Result<u64, StorageError> {
         let mut inserted_count: u64 = 0;
 
-        // Serialize the payload once before the editor loop. Per-editor fields
+        // Serialize the payload once before the recipient loop. Per-user fields
         // (user_space_id, idempotency_key) are stamped into the Value clone,
         // avoiding N struct clones + N serializations.
         let base_value = serde_json::to_value(&event.payload).map_err(|e| {
@@ -116,27 +122,27 @@ impl Storage {
             )))
         })?;
 
-        // Single transaction for all editors — either all fan-out rows are
+        // Single transaction for all recipients — either all fan-out rows are
         // committed or none are. On error the transaction is dropped (implicit
         // rollback), and the Kafka offset is not committed so the message
         // will be reprocessed. The ON CONFLICT DO NOTHING clause on the outbox
-        // insert ensures safe reprocessing of already-committed editors.
+        // insert ensures safe reprocessing of already-committed recipients.
         let mut tx = self.pool.begin().await?;
 
-        for editor_id in editors {
-            // Raw key for debugging: e.g. "12345:0:proposal_created:editor-uuid"
-            let raw_key = format!("{}:{}", event.idempotency_key, editor_id);
+        for user_id in users {
+            // Raw key for debugging: e.g. "12345:0:proposal_created:user-uuid"
+            let raw_key = format!("{}:{}", event.idempotency_key, user_id);
             // SHA-256 hash for the DB UNIQUE constraint (fixed-length, collision-resistant)
             let db_key = hex::encode(Sha256::digest(raw_key.as_bytes()));
 
-            // Clone the pre-serialized Value and stamp per-editor fields.
+            // Clone the pre-serialized Value and stamp per-user fields.
             // The payload sends the raw string so app servers can debug/log it;
             // the DB stores the hash for indexing.
             let mut serialized_payload = base_value.clone();
             if let serde_json::Value::Object(ref mut map) = serialized_payload {
                 map.insert(
                     "user_space_id".to_string(),
-                    serde_json::Value::String(editor_id.to_string()),
+                    serde_json::Value::String(user_id.to_string()),
                 );
                 map.insert(
                     "idempotency_key".to_string(),
@@ -162,7 +168,7 @@ impl Storage {
             let outbox_id: Uuid = match result {
                 Some(row) => row.get("id"),
                 None => {
-                    // Duplicate — already processed, skip this editor
+                    // Duplicate — already processed, skip this recipient
                     continue;
                 }
             };
@@ -252,7 +258,7 @@ impl Storage {
     /// Insert a notification for a single user (curator) into the outbox.
     ///
     /// Used for bounty_allocated and bounty_payout where there's one recipient.
-    /// Delegates to `insert_notifications_for_editors` with a single-element slice.
+    /// Delegates to `insert_notifications_for_users` with a single-element slice.
     #[instrument(
         name = "notification_indexer.storage.insert_notification_for_user",
         skip(self, event)
@@ -262,8 +268,49 @@ impl Storage {
         event: &NotificationEvent,
         user_space_id: Uuid,
     ) -> Result<u64, StorageError> {
-        self.insert_notifications_for_editors(event, &[user_space_id])
+        self.insert_notifications_for_users(event, &[user_space_id])
             .await
+    }
+
+    /// Resolve the proposer (`proposed_by`) of a proposal as a recipient
+    /// `user_space_id`.
+    ///
+    /// `proposals.proposed_by` is the proposer's personal-space UUID (the proto
+    /// `proposer_id` is "the space creating the proposal"), so it is directly
+    /// usable as a notification recipient — no entity→space resolution needed.
+    /// Used to deliver "your proposal was voted on / approved / rejected".
+    #[instrument(name = "notification_indexer.storage.find_proposer_for_proposal", skip(self))]
+    pub async fn find_proposer_for_proposal(
+        &self,
+        proposal_id: Uuid,
+    ) -> Result<Option<Uuid>, StorageError> {
+        let result = sqlx::query_scalar::<_, Uuid>(
+            "SELECT proposed_by FROM proposals WHERE id = $1",
+        )
+        .bind(proposal_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(result)
+    }
+
+    /// Resolve the distinct voters of a proposal as recipient `user_space_id`s.
+    ///
+    /// `proposal_votes.voter_id` is the voter's personal-space UUID (the proto
+    /// `voter_id` is "the space casting the vote"), so it is directly usable as
+    /// a notification recipient. Used to deliver "a new version of a proposal
+    /// you voted on was submitted" to prior voters.
+    #[instrument(name = "notification_indexer.storage.find_voters_for_proposal", skip(self))]
+    pub async fn find_voters_for_proposal(
+        &self,
+        proposal_id: Uuid,
+    ) -> Result<Vec<Uuid>, StorageError> {
+        let rows = sqlx::query(
+            "SELECT DISTINCT voter_id FROM proposal_votes WHERE proposal_id = $1",
+        )
+        .bind(proposal_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("voter_id")).collect())
     }
 
     /// Find proposals that have expired (end_time < now) without being executed,


### PR DESCRIPTION
## What

Broadens governance notification recipients so the user-centric onboarding asks are covered, in addition to the existing per-editor fan-out. **Filtering to a precise audience stays app-side** — the indexer delivers the relevant *superset*.

| Onboarding ask | Now delivered to |
|---|---|
| New proposal in a space I edit | editors *(already worked)* |
| **My proposal was voted on / approved** | **proposer** (+ editors) — new |
| **My proposal was rejected** | **proposer** (+ editors), via the rejection poller — new |
| **New version of a proposal I voted on** | **prior voters** (+ editors) — new |

## How (Phase 0 + Phase 1)

- **Phase 0 (foundations):** generalized the fan-out (`insert_notifications_for_editors` → `insert_notifications_for_users`) and added recipient resolvers `find_proposer_for_proposal` / `find_voters_for_proposal`. Per the governance proto, `proposer_id`/`voter_id` are **personal-space UUIDs in the same namespace as `editors.member_space_id`**, so they're usable directly as recipients — no entity→space resolution, no new payload fields.
- **Phase 1:** the governance consumer and rejection poller build a de-duplicated recipient **superset** (editors ∪ proposer/voters as appropriate), routed via a pure, unit-tested `NotificationEventType::targeted_recipients()` + `merge_recipients()`.
- No new event types or payload-schema changes → low-risk, reversible.

## Tests

- **Unit (64 pass):** routing map (`event → proposer/voters/none`), dedup/merge (a user who is both an editor and proposer/voter appears once), `governance_proposal_id`.
- **E2E (169 pass):** added a `proposal_votes` table to `setup.sql`; seed a **non-editor** proposer + prior voter; assert they receive the targeted events; updated exact fan-out counts (3-editor space 54→66) and distinct idempotency keys (23→27).

Verified locally (toolchain 1.92.0), mirroring CI: `cargo fmt --check`, `cargo clippy -p notification-indexer -p delivery-worker -- -D warnings`, `cargo test -p notification-indexer`, the full docker-compose **e2e (169/0)**, and the release build.

## Deferred (separate phases, pending product decisions)

Comments (general / on-my-proposal / replies), Bounty-created, Points-vs-payout, and Votes (entity up/down + trending). Each needs a decision (points-vs-`bounty_payout` semantics, vote milestone thresholds, entity-authorship tracking, comment recipient model). Supporting refactors (centralized system IDs, `NotificationData::Comment/Vote` variants, Kafka offset-commit hardening, `lookup_entity_space` `Personal`-filter fix) are sequenced into those phases.