### PR TITLE
feat(notification-indexer): general comment-thread notifications (Phase 2b)

### DIFF
--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -109,6 +109,15 @@ const COMMENT_NONMEMBER_BYTES: [u8; 16] = [0x75; 16]; // NOT a member (commenter
 const COMMENT_ENTITY_BYTES: [u8; 16] = [0x76; 16]; // the comment entity (allowed)
 const COMMENT_ENTITY_2_BYTES: [u8; 16] = [0x78; 16]; // the comment entity (non-member, filtered)
 
+// Phase 2b — general comment thread fixtures (a reply into a seeded thread).
+const THREAD_ROOT_BYTES: [u8; 16] = [0x86; 16]; // the (non-proposal) thing being commented on
+const THREAD_HOME_SPACE_BYTES: [u8; 16] = [0x87; 16]; // root's home space == creator (recipient)
+const THREAD_GENERIC_TYPE_BYTES: [u8; 16] = [0x8F; 16]; // an arbitrary (non-bounty) type for the root
+const EXISTING_COMMENT_BYTES: [u8; 16] = [0x88; 16]; // a prior comment on the root (seeded)
+const THREAD_PARTICIPANT_SPACE_BYTES: [u8; 16] = [0x89; 16]; // author of the prior comment (recipient)
+const REPLY_COMMENT_BYTES: [u8; 16] = [0x8a; 16]; // the NEW reply (produced)
+const REPLY_AUTHOR_SPACE_BYTES: [u8; 16] = [0x8b; 16]; // author of the reply (must NOT be notified)
+
 const GOVERNANCE_TOPIC: &str = "space.governance";
 const KNOWLEDGE_EDITS_TOPIC: &str = "knowledge.edits";
 const NUM_WEBHOOKS: usize = 3;
@@ -129,11 +138,13 @@ const NUM_WEBHOOKS: usize = 3;
 // Bounty created:   1 event × 2 bounty editors × 3 = 6   (Phase 3a)
 // Proposal comment: 1 event × 1 proposer × 3 = 3         (Phase 2a; the non-member
 //                   comment is filtered out and produces 0 calls)
+// Comment thread:   1 reply × 2 recipients × 3 = 6       (Phase 2b; prior participant
+//                   + root creator; the reply author is excluded)
 //
 // The proposer (0x02), prior voter (0x0B), and comment proposer (0x73) are
 // intentionally NOT editors, so these counts also prove targeted delivery
 // reaches non-editors.
-const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3 + 6 + 3;
+const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3 + 6 + 3 + 6;
 
 const GOVERNANCE_EVENT_TYPES: &[&str] = &[
     "proposal_created",
@@ -156,6 +167,7 @@ const ALL_EVENT_TYPES: &[&str] = &[
     "bounty_payout",
     "bounty_created",
     "proposal_comment",
+    "comment",
 ];
 
 // ---------------------------------------------------------------------------
@@ -436,6 +448,35 @@ async fn seed_database(
     )
     .bind(Uuid::from_bytes(COMMENT_MEMBER_BYTES))
     .bind(Uuid::from_bytes(COMMENT_SPACE_BYTES))
+    .execute(pool)
+    .await?;
+
+    // Phase 2b: seed an existing comment thread. The notification-indexer reads
+    // these relations to resolve the thread root and its participants (kg-indexer
+    // isn't running in the e2e, so we seed the relations directly).
+    // (a) The thread root's Types relation → gives it a home space (== creator).
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, $4) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::from_bytes(THREAD_HOME_SPACE_BYTES))
+    .bind(Uuid::from_bytes(THREAD_ROOT_BYTES))
+    .bind(Uuid::from_bytes(THREAD_GENERIC_TYPE_BYTES))
+    .execute(pool)
+    .await?;
+    // (b) A prior comment on the root, authored from a participant's space
+    //     (Reply-to → root). Its space_id is that participant.
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, '310d4a24-0e5b-451c-b215-1bfce40d0fe6'::uuid, $3, $4) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::from_bytes(THREAD_PARTICIPANT_SPACE_BYTES))
+    .bind(Uuid::from_bytes(EXISTING_COMMENT_BYTES))
+    .bind(Uuid::from_bytes(THREAD_ROOT_BYTES))
     .execute(pool)
     .await?;
 
@@ -774,6 +815,29 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         .await
         .map_err(|(e, _)| e)?;
 
+    // Phase 2b: a reply into the seeded thread (reply → EXISTING_COMMENT). The
+    // indexer walks to the root, notifying the prior participant + the root's
+    // creator (home space), but NOT the reply's own author.
+    let thread_reply = make_comment_hermes_edit(
+        REPLY_COMMENT_BYTES,
+        EXISTING_COMMENT_BYTES,
+        REPLY_AUTHOR_SPACE_BYTES,
+        40007,
+        1700036000,
+        7,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&thread_reply.encode_to_vec())
+                .key("comment-thread-reply")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
     Ok(())
 }
 
@@ -1085,6 +1149,9 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     let curator_space = Uuid::from_bytes(CURATOR_SPACE_BYTES).to_string();
     // Phase 2a: the proposal-comment recipient (the proposer; not an editor).
     let comment_proposer = Uuid::from_bytes(COMMENT_PROPOSER_BYTES).to_string();
+    // Phase 2b: comment-thread recipients (prior participant + root creator).
+    let thread_participant = Uuid::from_bytes(THREAD_PARTICIPANT_SPACE_BYTES).to_string();
+    let thread_home = Uuid::from_bytes(THREAD_HOME_SPACE_BYTES).to_string();
 
     let all_known: Vec<String> = editors_3e
         .iter()
@@ -1097,6 +1164,9 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         .chain(std::iter::once(&update_voter_uid))
         // Phase 2a: proposal-comment recipient (proposer):
         .chain(std::iter::once(&comment_proposer))
+        // Phase 2b: comment-thread recipients (participant + root creator):
+        .chain(std::iter::once(&thread_participant))
+        .chain(std::iter::once(&thread_home))
         .cloned()
         .collect();
 
@@ -1189,8 +1259,9 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         // Bounty payout: 1 event × 1 curator = 1
         // Bounty created: 1 event × 2 bounty editors = 2
         // Proposal comment: 1 event × 1 proposer = 1
-        // Total: 30
-        keys.len() == 30
+        // Comment thread: 1 reply × 2 recipients = 2
+        // Total: 32
+        keys.len() == 32
     });
 
     // ===================================================================
@@ -1765,6 +1836,50 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
             call.body["commenter_space_id"].as_str() == Some(comment_member.as_str()),
         );
     }
+
+    // --- Phase 2b: comment thread — a reply notifies the prior participant and
+    //     the root's creator (home space), but NOT the reply's author. ---
+    let thread_root = Uuid::from_bytes(THREAD_ROOT_BYTES).to_string();
+    let reply_author = Uuid::from_bytes(REPLY_AUTHOR_SPACE_BYTES).to_string();
+    let comment_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("comment"))
+        .collect();
+    r.check(
+        "comment: 6 calls (prior participant + root creator) x 3 webhooks",
+        comment_calls.len() == 6,
+    );
+    if let Some(call) = comment_calls.first() {
+        r.check(
+            "comment: category is 'comment'",
+            call.body["category"].as_str() == Some("comment"),
+        );
+        r.check(
+            "comment: correct thread root_id",
+            call.body["root_id"].as_str() == Some(thread_root.as_str()),
+        );
+    }
+    // The prior participant and the root's creator each get 3 (one per webhook).
+    for (label, who) in [
+        ("prior participant", &thread_participant),
+        ("root creator", &thread_home),
+    ] {
+        let n = comment_calls
+            .iter()
+            .filter(|c| c.body["user_space_id"].as_str() == Some(who.as_str()))
+            .count();
+        r.check(
+            &format!("comment: {} notified on 3 webhooks", label),
+            n == 3,
+        );
+    }
+    // The reply's own author must NOT be notified.
+    r.check(
+        "comment: reply author is not notified (self-exclusion)",
+        !comment_calls
+            .iter()
+            .any(|c| c.body["user_space_id"].as_str() == Some(reply_author.as_str())),
+    );
 
     r
 }

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -28,10 +28,10 @@ use notification_indexer::error::IndexerError;
 use notification_indexer::models::{
     build_rejection_event, extract_bounty_created, extract_bounty_relations,
     extract_proposal_comments, handle_bounty_allocated, handle_bounty_created,
-    handle_bounty_interest, handle_bounty_payout, handle_proposal_comment, handle_proposal_created,
-    handle_proposal_executed, handle_proposal_settings_updated, handle_proposal_updated,
-    handle_proposal_voted, merge_recipients, BountyConfig, NotificationEventType,
-    TargetedRecipients,
+    handle_bounty_interest, handle_bounty_payout, handle_comment, handle_proposal_comment,
+    handle_proposal_created, handle_proposal_executed, handle_proposal_settings_updated,
+    handle_proposal_updated, handle_proposal_voted, merge_recipients, BountyConfig,
+    CommentThreadInfo, NotificationEventType, TargetedRecipients,
 };
 use notification_indexer::storage::Storage;
 
@@ -599,10 +599,11 @@ async fn async_main() -> Result<(), IndexerError> {
                                         })?;
                                     }
 
-                                    // Phase 2a: comments on a proposal → notify the proposer, but
-                                    // only when the commenter is a member/editor of the proposal's
-                                    // space. A reply whose parent is not a proposal is a general
-                                    // comment (out of scope here) and is skipped.
+                                    // Comments. If the comment replies *directly* to a proposal,
+                                    // notify the proposer gated on member/editor (Phase 2a). Otherwise
+                                    // it's a general comment / reply in a thread: notify all thread
+                                    // participants plus the thread root's creator (Phase 2b).
+                                    // App servers handle per-user muting/snoozing.
                                     for mut info in comments {
                                         if ke_bd > 0 {
                                             wait_for_kg_catchup(&ke_stor, info.block_number, ke_bd, ke_bd_timeout).await;
@@ -610,7 +611,72 @@ async fn async_main() -> Result<(), IndexerError> {
                                         let (proposer, proposal_space) = match ke_stor.find_proposal_proposer_and_space(info.proposal_id).await {
                                             Ok(Some(pair)) => pair,
                                             Ok(None) => {
-                                                ke_skipped += 1;
+                                                // Phase 2b: general comment thread.
+                                                let root = ke_stor.resolve_thread_root(info.proposal_id).await.map_err(|e| {
+                                                    error!(error = %e, "DB error resolving comment thread root, will retry");
+                                                    ke_errors += 1;
+                                                })?;
+                                                let mut recipients = ke_stor.find_thread_participants(root).await.map_err(|e| {
+                                                    error!(error = %e, "DB error resolving thread participants, will retry");
+                                                    ke_errors += 1;
+                                                })?;
+                                                // Root creator: exact for proposals (proposer),
+                                                // best-effort home space otherwise.
+                                                let root_space = match ke_stor.find_proposal_proposer_and_space(root).await.map_err(|e| {
+                                                    error!(error = %e, "DB error resolving thread root proposal, will retry");
+                                                    ke_errors += 1;
+                                                })? {
+                                                    Some((root_proposer, space)) => {
+                                                        recipients.push(root_proposer);
+                                                        space
+                                                    }
+                                                    None => match ke_stor.find_entity_home_space(root).await.map_err(|e| {
+                                                        error!(error = %e, "DB error resolving thread root home space, will retry");
+                                                        ke_errors += 1;
+                                                    })? {
+                                                        Some(home) => {
+                                                            recipients.push(home);
+                                                            home
+                                                        }
+                                                        None => info.commenter_space_id,
+                                                    },
+                                                };
+                                                // Don't notify the comment's own author.
+                                                let recipients: Vec<uuid::Uuid> = merge_recipients(recipients, vec![])
+                                                    .into_iter()
+                                                    .filter(|r| *r != info.commenter_space_id)
+                                                    .collect();
+                                                if recipients.is_empty() {
+                                                    ke_processed += 1;
+                                                    continue;
+                                                }
+                                                let cinfo = CommentThreadInfo {
+                                                    comment_entity_id: info.comment_entity_id,
+                                                    parent_id: info.proposal_id,
+                                                    root_id: root,
+                                                    commenter_space_id: info.commenter_space_id,
+                                                    root_space_id: root_space,
+                                                    block_number: info.block_number,
+                                                    sequence: info.sequence,
+                                                    timestamp: info.timestamp,
+                                                };
+                                                let mut event = handle_comment(&cinfo);
+                                                enrich_payload(&ke_stor, &mut event, root_space).await;
+                                                ke_stor.insert_notifications_for_users(&event, &recipients).await.map(|count| {
+                                                    if count > 0 {
+                                                        info!(
+                                                            event_type = "comment",
+                                                            root_id = %root,
+                                                            recipients = recipients.len(),
+                                                            inserted = count,
+                                                            "Inserted comment thread notifications"
+                                                        );
+                                                    }
+                                                    ke_processed += 1;
+                                                }).map_err(|e| {
+                                                    error!(error = %e, "DB error inserting comment notifications, will retry");
+                                                    ke_errors += 1;
+                                                })?;
                                                 continue;
                                             }
                                             Err(e) => {
@@ -1137,6 +1203,12 @@ async fn enrich_payload(
             // Proposal name (the proposal being commented on).
             if let Ok(pid) = uuid::Uuid::parse_str(&comment.proposal_id) {
                 comment.proposal_name = storage.lookup_proposal_name(pid).await;
+            }
+        }
+        NotificationData::GeneralComment(ref mut c) => {
+            // Name of the thread root (looked up in its home space, == `space_id`).
+            if let Ok(rid) = uuid::Uuid::parse_str(&c.root_id) {
+                c.root_name = storage.lookup_entity_name(rid, space_id).await;
             }
         }
     }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -29,6 +29,8 @@ pub enum NotificationEventType {
     // Comment events
     /// A comment was posted on a proposal (from `knowledge.edits`).
     ProposalComment,
+    /// A comment or reply in a (non-proposal) thread (from `knowledge.edits`).
+    Comment,
 }
 
 impl NotificationEventType {
@@ -45,6 +47,7 @@ impl NotificationEventType {
             NotificationEventType::BountyPayout => "bounty_payout",
             NotificationEventType::BountyCreated => "bounty_created",
             NotificationEventType::ProposalComment => "proposal_comment",
+            NotificationEventType::Comment => "comment",
         }
     }
 
@@ -61,7 +64,7 @@ impl NotificationEventType {
             | NotificationEventType::BountyAllocated
             | NotificationEventType::BountyPayout
             | NotificationEventType::BountyCreated => "bounty",
-            NotificationEventType::ProposalComment => "comment",
+            NotificationEventType::ProposalComment | NotificationEventType::Comment => "comment",
         }
     }
 
@@ -153,6 +156,7 @@ pub enum NotificationData {
     Bounty(BountyData),
     BountyCreated(BountyCreatedData),
     Comment(CommentData),
+    GeneralComment(GeneralCommentData),
 }
 
 /// Governance-specific payload fields.
@@ -281,6 +285,23 @@ pub struct CommentData {
     pub proposal_name: Option<String>,
 }
 
+/// Payload fields for a comment/reply in a non-proposal thread (`comment`).
+#[derive(Debug, Clone, Serialize)]
+pub struct GeneralCommentData {
+    /// The comment entity that was created.
+    pub comment_entity_id: String,
+    /// The entity the comment directly replies to (a comment, for a reply, or the
+    /// commented-on entity for a top-level comment).
+    pub parent_id: String,
+    /// The thread root — the entity the whole thread hangs off of.
+    pub root_id: String,
+    /// The commenter's personal space (the `HermesEdit.space_id`).
+    pub commenter_space_id: String,
+    /// Human-readable name of the thread root (best-effort).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_name: Option<String>,
+}
+
 /// Result of handling a governance event: payload + idempotency key.
 #[derive(Debug)]
 pub struct NotificationEvent {
@@ -300,7 +321,8 @@ impl NotificationEvent {
             NotificationData::Governance(gov) => Uuid::parse_str(&gov.proposal_id).ok(),
             NotificationData::Bounty(_)
             | NotificationData::BountyCreated(_)
-            | NotificationData::Comment(_) => None,
+            | NotificationData::Comment(_)
+            | NotificationData::GeneralComment(_) => None,
         }
     }
 }
@@ -1188,6 +1210,58 @@ pub fn extract_proposal_comments(
         }
     }
     Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// General comment threads (Phase 2b) — comments/replies not directly on a proposal
+// ---------------------------------------------------------------------------
+
+/// A comment in a (non-proposal) thread, with the thread context resolved by the
+/// consumer. Recipients are the thread participants plus the root's creator.
+#[derive(Debug, Clone)]
+pub struct CommentThreadInfo {
+    pub comment_entity_id: Uuid,
+    /// The entity the comment directly replies to.
+    pub parent_id: Uuid,
+    /// The thread root (the "thing being commented on"), resolved by walking
+    /// `Reply to` up from `parent_id`.
+    pub root_id: Uuid,
+    /// The commenter's personal space (the edit's space).
+    pub commenter_space_id: Uuid,
+    /// The root's home/owning space — used as the payload `space_id` and for
+    /// name enrichment. Resolved by the consumer.
+    pub root_space_id: Uuid,
+    pub block_number: u64,
+    pub sequence: u64,
+    pub timestamp: u64,
+}
+
+/// Build a notification event for a comment/reply in a thread.
+pub fn handle_comment(info: &CommentThreadInfo) -> NotificationEvent {
+    let idempotency_base = format!("{}:{}:comment", info.block_number, info.sequence);
+
+    NotificationEvent {
+        event_type: NotificationEventType::Comment,
+        idempotency_key: idempotency_base,
+        payload: NotificationPayload {
+            version: PAYLOAD_VERSION,
+            event_type: NotificationEventType::Comment.as_str().to_string(),
+            category: NotificationEventType::Comment.category().to_string(),
+            space_id: info.root_space_id.to_string(),
+            user_space_id: None,
+            idempotency_key: None,
+            block_number: Some(info.block_number),
+            timestamp: Some(info.timestamp),
+            space_name: None,
+            data: NotificationData::GeneralComment(GeneralCommentData {
+                comment_entity_id: info.comment_entity_id.to_string(),
+                parent_id: info.parent_id.to_string(),
+                root_id: info.root_id.to_string(),
+                commenter_space_id: info.commenter_space_id.to_string(),
+                root_name: None,
+            }),
+        },
+    }
 }
 
 #[cfg(test)]
@@ -2860,5 +2934,36 @@ mod tests {
             json["commenter_space_id"],
             Uuid::from_bytes([0x11; 16]).to_string()
         );
+    }
+
+    #[test]
+    fn handle_comment_payload_structure() {
+        let info = CommentThreadInfo {
+            comment_entity_id: Uuid::from_bytes([0xC0; 16]),
+            parent_id: Uuid::from_bytes([0x91; 16]), // parent (a comment or entity)
+            root_id: Uuid::from_bytes([0x9A; 16]),
+            commenter_space_id: Uuid::from_bytes([0x11; 16]),
+            root_space_id: Uuid::from_bytes([0x5E; 16]),
+            block_number: 100,
+            sequence: 4,
+            timestamp: 1700000000,
+        };
+        let event = handle_comment(&info);
+        assert_eq!(event.event_type, NotificationEventType::Comment);
+        let json = serde_json::to_value(&event.payload).expect("serialize");
+        assert_eq!(json["event_type"], "comment");
+        assert_eq!(json["category"], "comment");
+        assert_eq!(json["space_id"], Uuid::from_bytes([0x5E; 16]).to_string()); // root's space
+        assert_eq!(json["root_id"], Uuid::from_bytes([0x9A; 16]).to_string());
+        assert_eq!(
+            json["comment_entity_id"],
+            Uuid::from_bytes([0xC0; 16]).to_string()
+        );
+        assert_eq!(
+            json["commenter_space_id"],
+            Uuid::from_bytes([0x11; 16]).to_string()
+        );
+        // not a governance/proposal payload
+        assert!(json.get("proposal_id").is_none());
     }
 }

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -348,6 +348,94 @@ impl Storage {
         Ok(exists)
     }
 
+    // -----------------------------------------------------------------------
+    // Comment-thread resolution (Phase 2b)
+    // -----------------------------------------------------------------------
+
+    /// Walk `Reply to` relations upward from `parent` to the thread root.
+    ///
+    /// A comment replies to its parent; that parent may itself be a comment that
+    /// replies to another, and so on. The root is the first ancestor with no
+    /// outgoing `Reply to` relation (the actual "thing being commented on").
+    /// Bounded to a fixed depth as a cycle/abuse guard.
+    #[instrument(name = "notification_indexer.storage.resolve_thread_root", skip(self))]
+    pub async fn resolve_thread_root(&self, parent: Uuid) -> Result<Uuid, StorageError> {
+        let reply_to = ids::reply_to_property();
+        let mut current = parent;
+        for _ in 0..64 {
+            let next: Option<Uuid> = sqlx::query_scalar::<_, Uuid>(
+                "SELECT to_entity_id FROM relations WHERE type_id = $1 AND from_entity_id = $2 LIMIT 1",
+            )
+            .bind(reply_to)
+            .bind(current)
+            .fetch_optional(&self.pool)
+            .await?;
+            match next {
+                Some(n) if n != current => current = n,
+                _ => break,
+            }
+        }
+        Ok(current)
+    }
+
+    /// All distinct participant spaces in the thread rooted at `root`.
+    ///
+    /// Participants are the authors of every comment in the thread — derived
+    /// from the `space_id` of each `Reply to` relation in the subtree (a
+    /// relation's `space_id` is the space it was published from, i.e. the
+    /// comment author's personal space). `UNION` (not `UNION ALL`) makes the
+    /// recursion cycle-safe.
+    #[instrument(
+        name = "notification_indexer.storage.find_thread_participants",
+        skip(self)
+    )]
+    pub async fn find_thread_participants(&self, root: Uuid) -> Result<Vec<Uuid>, StorageError> {
+        let reply_to = ids::reply_to_property();
+        let rows = sqlx::query(
+            r#"
+            WITH RECURSIVE thread AS (
+                SELECT from_entity_id AS comment_id, space_id
+                FROM relations
+                WHERE type_id = $1 AND to_entity_id = $2
+                UNION
+                SELECT r.from_entity_id, r.space_id
+                FROM relations r
+                JOIN thread t ON r.to_entity_id = t.comment_id
+                WHERE r.type_id = $1
+            )
+            SELECT DISTINCT space_id FROM thread
+            "#,
+        )
+        .bind(reply_to)
+        .bind(root)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("space_id")).collect())
+    }
+
+    /// Best-effort "home" space of an entity — the `space_id` of its `Types`
+    /// relation (where it was created). For entities created in a personal space
+    /// this equals the creator. Used as the root-creator recipient for
+    /// non-proposal comment threads (proposals resolve their creator exactly via
+    /// `find_proposal_proposer_and_space`).
+    #[instrument(
+        name = "notification_indexer.storage.find_entity_home_space",
+        skip(self)
+    )]
+    pub async fn find_entity_home_space(
+        &self,
+        entity_id: Uuid,
+    ) -> Result<Option<Uuid>, StorageError> {
+        let result = sqlx::query_scalar::<_, Uuid>(
+            "SELECT space_id FROM relations WHERE from_entity_id = $1 AND type_id = $2 LIMIT 1",
+        )
+        .bind(entity_id)
+        .bind(ids::types_relation_type())
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(result)
+    }
+
     /// Find proposals that have expired (end_time < now) without being executed,
     /// and for which we haven't yet sent a rejection notification.
     ///


### PR DESCRIPTION
## What

Phase 2b — the **Comments** category beyond proposal comments. A comment (a `Comment` entity that `Reply to`'s a parent) that is **not** a direct comment on a proposal now notifies the **whole thread**:

> **Recipients = all thread participants ∪ the creator of the thing the thread hangs off of.**

App servers handle per-user muting/snoozing, so the indexer delivers the full relevant set (per the agreed model).

Covers your colleague's asks: *"New comment (General)"* and *"new reply to a comment I created / a thread I'm involved in."*

> **Stacked on #705** (reuses the comment detection + `ids` module + `CommentData`). Base will auto-retarget to `dev` once #705 merges.

## How

- New `comment` event type + `NotificationData::GeneralComment` (`comment_entity_id`, `parent_id`, `root_id`, `commenter_space_id`, `root_name`).
- Storage:
  - `resolve_thread_root` — walk `Reply to` upward from the comment's parent to the thread root (depth-bounded as a cycle guard).
  - `find_thread_participants` — recursive CTE over `Reply to` edges rooted at the root; participants are the `space_id` of each relation (the comment author's personal space). `UNION` makes it cycle-safe.
  - `find_entity_home_space` — best-effort root creator for non-proposal roots.
- Consumer: the "parent is not a proposal" branch (previously skipped in #705) now emits comment-thread notifications. Recipients = participants ∪ root creator, deduped, **excluding the comment's own author**.

## Recipient resolution detail

- **Participants** are fully accurate — derived from `relations.space_id` on each `Reply to` edge.
- **Root creator** is **exact for proposals** (`proposed_by`); for a general entity it's **approximated by the root's home space** (its `Types`-relation `space_id`), since `entities` has no `created_by` column. For personal-space content this equals the creator.

## Tests

- **Unit (72):** `handle_comment` payload + the existing extraction/handler suite.
- **E2E (186):** seeds a thread (root + a prior comment by a participant); a produced **reply** notifies the **prior participant** and the **root creator**, on 3 webhooks each, and asserts the **reply author is NOT notified** (self-exclusion).

Verified locally (toolchain 1.92.0): `cargo fmt --check`, `cargo clippy -p notification-indexer -p delivery-worker -- -D warnings`, `cargo test -p notification-indexer`, the full docker-compose **e2e (186/0)**, release build.

## Deferred

Points (likely covered by `bounty_payout`), Votes (entity up/down + trending — needs milestone thresholds + votes data source). Kafka offset-commit hardening + `lookup_entity_space` `Personal`-filter fix still tracked.