### PR TITLE
feat(governance): add topicId to UNSET_TOPIC actions and make topic removal topic-aware

### DIFF
--- a/api/src/proposals/__tests__/queries.test.ts
+++ b/api/src/proposals/__tests__/queries.test.ts
@@ -235,7 +235,7 @@ describe("GET /proposals/space/:spaceId/status", () => {
 					},
 					{
 						action_type: "UnsetTopic",
-						target_id: null,
+						target_id: "990e8400-e29b-41d4-a716-446655440000",
 						content_uri: null,
 						content_id: null,
 						quorum: null,
@@ -258,6 +258,35 @@ describe("GET /proposals/space/:spaceId/status", () => {
 				},
 				{
 					actionType: "UNSET_TOPIC",
+					targetTopicId: "990e8400-e29b-41d4-a716-446655440000",
+				},
+			])
+		})
+
+		it("maps UNSET_TOPIC with null target_id to UNKNOWN", async () => {
+			const row = makeDbProposalRow({
+				actions_json: [
+					{
+						action_type: "UnsetTopic",
+						target_id: null,
+						content_uri: null,
+						content_id: null,
+						quorum: null,
+						fast_threshold: null,
+						slow_threshold: null,
+						duration: null,
+					},
+				],
+			})
+			db.execute.mockResolvedValueOnce({rows: [row]})
+
+			const res = await app.request("/proposals/space/660e8400-e29b-41d4-a716-446655440000/status")
+
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			expect(body.proposals[0].actions).toEqual([
+				{
+					actionType: "UNKNOWN",
 				},
 			])
 		})

--- a/api/src/proposals/router.ts
+++ b/api/src/proposals/router.ts
@@ -150,7 +150,8 @@ function mapToActionResponse(action: ProposalWithVotes["actions"][number]): Acti
 			if (!action.targetId) return {actionType: "UNKNOWN"}
 			return {actionType: "SET_TOPIC", targetTopicId: action.targetId}
 		case "UnsetTopic":
-			return {actionType: "UNSET_TOPIC"}
+			if (!action.targetId) return {actionType: "UNKNOWN"}
+			return {actionType: "UNSET_TOPIC", targetTopicId: action.targetId}
 		default:
 			return {actionType: "UNKNOWN"}
 	}

--- a/api/src/proposals/types.ts
+++ b/api/src/proposals/types.ts
@@ -265,6 +265,8 @@ export interface SetTopicAction {
  */
 export interface UnsetTopicAction {
 	actionType: "UNSET_TOPIC"
+	/** Topic entity ID */
+	targetTopicId: string
 }
 
 /**

--- a/hermes-pipeline/src/pipelines/governance.rs
+++ b/hermes-pipeline/src/pipelines/governance.rs
@@ -367,7 +367,9 @@ fn decode_ping_governance_action(calldata: &[u8]) -> Option<proposal_action::Act
                 warn!("All-zero target ID in ping unset-topic action, storing as Unknown");
                 return None;
             }
-            Some(proposal_action::Action::UnsetTopic(UnsetTopicAction {}))
+            Some(proposal_action::Action::UnsetTopic(UnsetTopicAction {
+                target_topic_id: target,
+            }))
         }
         x if x == actions::SUBSPACE_VERIFIED
             || x == actions::SUBSPACE_UNVERIFIED
@@ -1624,7 +1626,9 @@ mod tests {
 
         let result = decode_ping_governance_action(&calldata);
         match result {
-            Some(proposal_action::Action::UnsetTopic(_)) => {}
+            Some(proposal_action::Action::UnsetTopic(action)) => {
+                assert_eq!(action.target_topic_id, target_id.to_vec());
+            }
             other => panic!("Expected UnsetTopic, got {other:?}"),
         }
     }

--- a/hermes-relay/src/source/mock_events.rs
+++ b/hermes-relay/src/source/mock_events.rs
@@ -1168,6 +1168,9 @@ pub mod test_topology {
     // column ends up NULL on the affected space.
     pub const SPACE_TOPIC_KEPT: TopicId = make_id(0x93);
     pub const SPACE_TOPIC_CLEARED: TopicId = make_id(0x94);
+    // A topic that is never the current topic of SPACE_J; a TOPIC_REMOVED for it
+    // must be a no-op (conditional clear) and leave SPACE_TOPIC_KEPT in place.
+    pub const SPACE_TOPIC_STALE: TopicId = make_id(0x95);
 
     // Object types for voting
     pub const OBJECT_TYPE_ENTITY: [u8; 4] = [0x00, 0x00, 0x00, 0x01];
@@ -1259,6 +1262,9 @@ pub mod test_topology {
         actions.push(topic_declared(SPACE_J, SPACE_TOPIC_KEPT));
         actions.push(topic_declared(SPACE_I, SPACE_TOPIC_CLEARED));
         actions.push(topic_removed(SPACE_I, SPACE_TOPIC_CLEARED));
+        // Stale removal: SPACE_J's current topic is SPACE_TOPIC_KEPT, so a
+        // TOPIC_REMOVED for SPACE_TOPIC_STALE must NOT clear it (conditional clear).
+        actions.push(topic_removed(SPACE_J, SPACE_TOPIC_STALE));
 
         // Phase 5: Editor/member operations
         actions.push(editor_added(SPACE_A, SPACE_B));

--- a/hermes-schema/proto/governance.proto
+++ b/hermes-schema/proto/governance.proto
@@ -109,7 +109,9 @@ message SetTopicAction {
 }
 
 // Decoded action: unset the current space topic
-message UnsetTopicAction {}
+message UnsetTopicAction {
+  bytes target_topic_id = 1;  // 16 bytes - topic entity ID
+}
 
 // Action to be executed when proposal passes
 message ProposalAction {

--- a/hermes-schema/src/pb/governance.rs
+++ b/hermes-schema/src/pb/governance.rs
@@ -85,8 +85,12 @@ pub struct SetTopicAction {
     pub target_topic_id: ::prost::alloc::vec::Vec<u8>,
 }
 /// Decoded action: unset the current space topic
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct UnsetTopicAction {}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnsetTopicAction {
+    /// 16 bytes - topic entity ID
+    #[prost(bytes = "vec", tag = "1")]
+    pub target_topic_id: ::prost::alloc::vec::Vec<u8>,
+}
 /// Decoded action: update voting settings
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct UpdateVotingSettingsAction {

--- a/kg-indexer/src/handlers/governance.rs
+++ b/kg-indexer/src/handlers/governance.rs
@@ -378,7 +378,12 @@ fn map_proposal_action(
             },
             None => ProposalActionPayload::Unknown,
         },
-        Some(Action::UnsetTopic(_)) => ProposalActionPayload::UnsetTopic,
+        Some(Action::UnsetTopic(a)) => match bytes_to_uuid(&a.target_topic_id) {
+            Some(id) => ProposalActionPayload::UnsetTopic {
+                target_topic_id: id,
+            },
+            None => ProposalActionPayload::Unknown,
+        },
         None => ProposalActionPayload::Unknown,
     };
 

--- a/kg-indexer/src/main.rs
+++ b/kg-indexer/src/main.rs
@@ -1144,7 +1144,9 @@ async fn process_message(
         }
         KgMessage::TopicRemoved(event) => {
             let removal = handlers::topics::handle_topic_removed(&event)?;
-            storage.clear_space_topic(removal.space_id, &mut tx).await?;
+            storage
+                .clear_space_topic(removal.space_id, removal.topic_id, &mut tx)
+                .await?;
             1
         }
         KgMessage::ProposalCreated(event) => {
@@ -1627,7 +1629,9 @@ async fn process_block(
                     event_span.record("space_id", display(removal.space_id));
                     event_span.record("topic_id", display(removal.topic_id));
 
-                    storage.clear_space_topic(removal.space_id, &mut tx).await?;
+                    storage
+                        .clear_space_topic(removal.space_id, removal.topic_id, &mut tx)
+                        .await?;
                     pending_space_topics.insert(removal.space_id, None);
                     1
                 }

--- a/kg-indexer/src/models/governance.rs
+++ b/kg-indexer/src/models/governance.rs
@@ -59,7 +59,7 @@ pub enum ProposalActionPayload {
     /// Set the space topic
     SetTopic { target_topic_id: Uuid },
     /// Unset the current space topic
-    UnsetTopic,
+    UnsetTopic { target_topic_id: Uuid },
     /// Unknown or undecoded action
     Unknown,
 }

--- a/kg-indexer/src/storage.rs
+++ b/kg-indexer/src/storage.rs
@@ -472,13 +472,18 @@ impl Storage {
     }
 
     /// Clear the topic assignment from a space.
+    ///
+    /// Only clears when the removed `topic_id` matches the currently-set topic,
+    /// guarding against a stale/out-of-order unset clearing a newer topic.
     pub async fn clear_space_topic(
         &self,
         space_id: Uuid,
+        topic_id: Uuid,
         tx: &mut sqlx::Transaction<'_, Postgres>,
     ) -> Result<(), IndexerError> {
-        sqlx::query("UPDATE spaces SET topic_id = NULL WHERE id = $1")
+        sqlx::query("UPDATE spaces SET topic_id = NULL WHERE id = $1 AND topic_id = $2")
             .bind(space_id)
+            .bind(topic_id)
             .execute(&mut **tx)
             .await?;
 
@@ -998,7 +1003,12 @@ impl Storage {
                     target_id = Some(*id);
                     "SetTopic"
                 }
-                ProposalActionPayload::UnsetTopic => "UnsetTopic",
+                ProposalActionPayload::UnsetTopic {
+                    target_topic_id: id,
+                } => {
+                    target_id = Some(*id);
+                    "UnsetTopic"
+                }
                 ProposalActionPayload::Unknown => "Unknown",
             };
 

--- a/kg-indexer/tests/e2e.rs
+++ b/kg-indexer/tests/e2e.rs
@@ -85,7 +85,6 @@ mod expected {
     // Top-level space topic IDs (declared / removed via TOPIC_DECLARED & TOPIC_REMOVED actions).
     pub const SPACE_TOPIC_KEPT: [u8; 16] = make_id(0x93);
     pub const SPACE_TOPIC_CLEARED: [u8; 16] = make_id(0x94);
-    pub const SPACE_TOPIC_STALE: [u8; 16] = make_id(0x95);
 
     /// All 18 space IDs that should be created
     pub fn all_space_ids() -> Vec<Uuid> {

--- a/kg-indexer/tests/e2e.rs
+++ b/kg-indexer/tests/e2e.rs
@@ -72,6 +72,7 @@ mod expected {
     pub const SUBSPACE_TARGET_TOPIC_DECLARED: [u8; 16] = make_id(0xC5);
     pub const SUBSPACE_TARGET_TOPIC_REMOVED: [u8; 16] = make_id(0xC6);
     pub const SPACE_TARGET_TOPIC_SET: [u8; 16] = make_id(0xD1);
+    pub const SPACE_TARGET_TOPIC_REMOVED: [u8; 16] = make_id(0xD2);
 
     // Topic IDs for trust pipeline subtopic tests
     pub const TOPIC_H: [u8; 16] = make_id(0x91);
@@ -84,6 +85,7 @@ mod expected {
     // Top-level space topic IDs (declared / removed via TOPIC_DECLARED & TOPIC_REMOVED actions).
     pub const SPACE_TOPIC_KEPT: [u8; 16] = make_id(0x93);
     pub const SPACE_TOPIC_CLEARED: [u8; 16] = make_id(0x94);
+    pub const SPACE_TOPIC_STALE: [u8; 16] = make_id(0x95);
 
     /// All 18 space IDs that should be created
     pub fn all_space_ids() -> Vec<Uuid> {
@@ -218,7 +220,11 @@ mod expected {
                 "SetTopic",
                 Some(uuid_from_bytes(SPACE_TARGET_TOPIC_SET)),
             ),
-            (uuid_from_bytes(PROPOSAL_15), "UnsetTopic", None),
+            (
+                uuid_from_bytes(PROPOSAL_15),
+                "UnsetTopic",
+                Some(uuid_from_bytes(SPACE_TARGET_TOPIC_REMOVED)),
+            ),
         ]
     }
 }
@@ -570,7 +576,7 @@ async fn test_space_topic_declared_and_removed() {
     assert_eq!(
         kept_row.0,
         Some(kept),
-        "SPACE_J.topic_id should be SPACE_TOPIC_KEPT"
+        "SPACE_J.topic_id should be SPACE_TOPIC_KEPT (and survive the stale TOPIC_REMOVED)"
     );
 
     // SPACE_I: topic_id should be NULL after declare + remove
@@ -599,6 +605,33 @@ async fn test_space_topic_declared_and_removed() {
             topic_id
         );
     }
+}
+
+/// Verify the conditional `clear_space_topic`: a TOPIC_REMOVED whose topicId does
+/// NOT match the space's current topic must be a no-op.
+///
+/// The mock topology declares SPACE_TOPIC_KEPT on SPACE_J, then emits a
+/// `topic_removed(SPACE_J, SPACE_TOPIC_STALE)`. Because SPACE_TOPIC_STALE is not
+/// the current topic, the clear must not fire and SPACE_J must retain
+/// SPACE_TOPIC_KEPT.
+#[tokio::test]
+async fn test_space_topic_stale_removal_is_noop() {
+    let pool = get_pool().await;
+
+    let space_j = uuid_from_bytes(expected::SPACE_J);
+    let kept = uuid_from_bytes(expected::SPACE_TOPIC_KEPT);
+
+    let row: (Option<Uuid>,) = sqlx::query_as("SELECT topic_id FROM spaces WHERE id = $1")
+        .bind(space_j)
+        .fetch_one(&pool)
+        .await
+        .expect("Failed to query SPACE_J.topic_id");
+
+    assert_eq!(
+        row.0,
+        Some(kept),
+        "A TOPIC_REMOVED for a non-current topic must not clear SPACE_J.topic_id"
+    );
 }
 
 /// Verify proposal action types and target IDs for all 15 proposals.

--- a/scoring-service/topology-indexer/src/main.rs
+++ b/scoring-service/topology-indexer/src/main.rs
@@ -113,8 +113,7 @@ async fn async_main() -> Result<(), IndexerError> {
         tokio::time::interval(tokio::time::Duration::from_millis(batch_timeout_ms));
     let mut processed_count: u64 = 0;
     let mut error_count: u64 = 0;
-    let mut heartbeat_timer =
-        tokio::time::interval(tokio::time::Duration::from_secs(60));
+    let mut heartbeat_timer = tokio::time::interval(tokio::time::Duration::from_secs(60));
     heartbeat_timer.tick().await; // skip immediate first tick
 
     info!(

--- a/scoring-service/vote-indexer/src/storage.rs
+++ b/scoring-service/vote-indexer/src/storage.rs
@@ -211,8 +211,8 @@ impl Storage {
             return Ok(());
         }
 
-        let property_id = Uuid::parse_str(SCORE_PROPERTY_ID)
-            .expect("SCORE_PROPERTY_ID is a valid UUID constant");
+        let property_id =
+            Uuid::parse_str(SCORE_PROPERTY_ID).expect("SCORE_PROPERTY_ID is a valid UUID constant");
 
         let mut ids = Vec::with_capacity(rows.len());
         let mut entity_ids = Vec::with_capacity(rows.len());

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -75,8 +75,7 @@ mod tests {
     /// and ensures the derivation inputs in the design doc stay correct.
     #[test]
     fn system_ids_match_derivations() {
-        let namespace_url =
-            Uuid::parse_str("6ba7b811-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let namespace_url = Uuid::parse_str("6ba7b811-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let ns = Uuid::new_v5(&namespace_url, b"geo:system");
         assert_eq!(GEO_SYSTEM_NAMESPACE, ns.to_string());
 

--- a/search-admin/src/commands/backfill_name_raw.rs
+++ b/search-admin/src/commands/backfill_name_raw.rs
@@ -109,7 +109,10 @@ impl BackfillNameRawCommand {
 
         if self.dry_run {
             println!();
-            println!("Dry run complete. {} documents would be updated.", docs_to_update);
+            println!(
+                "Dry run complete. {} documents would be updated.",
+                docs_to_update
+            );
             println!("Run without --dry-run to apply changes.");
             return Ok(());
         }
@@ -147,7 +150,11 @@ impl BackfillNameRawCommand {
         let status = response.status_code();
         if !status.is_success() {
             let error_body = response.text().await.unwrap_or_default();
-            anyhow::bail!("update_by_query failed with status {}: {}", status, error_body);
+            anyhow::bail!(
+                "update_by_query failed with status {}: {}",
+                status,
+                error_body
+            );
         }
 
         let response_json: serde_json::Value = response
@@ -183,13 +190,15 @@ impl BackfillNameRawCommand {
 
                     if !resp_status.is_success() {
                         let error_body = resp.text().await.unwrap_or_default();
-                        anyhow::bail!("Failed to get task status: {} - {}", resp_status, error_body);
+                        anyhow::bail!(
+                            "Failed to get task status: {} - {}",
+                            resp_status,
+                            error_body
+                        );
                     }
 
-                    let task_json: serde_json::Value = resp
-                        .json()
-                        .await
-                        .context("Failed to parse task response")?;
+                    let task_json: serde_json::Value =
+                        resp.json().await.context("Failed to parse task response")?;
 
                     let completed = task_json["completed"].as_bool().unwrap_or(false);
 

--- a/search-admin/src/commands/full_migration.rs
+++ b/search-admin/src/commands/full_migration.rs
@@ -108,7 +108,10 @@ impl FullMigrationCommand {
         println!();
         println!("Next steps:");
         println!("  1. Monitor the search-indexer logs for any issues:");
-        println!("     kubectl logs -n {} -l app={} -f", self.namespace, self.statefulset_name);
+        println!(
+            "     kubectl logs -n {} -l app={} -f",
+            self.namespace, self.statefulset_name
+        );
         println!();
         println!("  2. Verify search functionality in your application");
         println!();
@@ -240,7 +243,10 @@ impl FullMigrationCommand {
                 .context("Failed to get statefulset status")?;
 
             if let Some(status) = sts.status {
-                let ready_replicas = status.ready_replicas.or(status.available_replicas).unwrap_or(0);
+                let ready_replicas = status
+                    .ready_replicas
+                    .or(status.available_replicas)
+                    .unwrap_or(0);
 
                 if ready_replicas == 0 {
                     info!("All replicas terminated");
@@ -592,7 +598,10 @@ impl FullMigrationCommand {
             .await
             .context("Failed to update statefulset")?;
 
-        println!("✓ Updated ENTITIES_INDEX_VERSION to {}", self.target_version);
+        println!(
+            "✓ Updated ENTITIES_INDEX_VERSION to {}",
+            self.target_version
+        );
         println!("✓ Scaled up {} to 1 replica", self.statefulset_name);
         println!();
         println!("⏳ Waiting for pod to be ready...");

--- a/search-indexer-repository/src/opensearch/bulk.rs
+++ b/search-indexer-repository/src/opensearch/bulk.rs
@@ -83,8 +83,9 @@ fn serialize_bulk_operations<B: Serialize>(
 ) -> Result<Bytes, SearchIndexError> {
     let mut buf = bytes::BytesMut::new();
     for op in &operations {
-        Body::write(op, &mut buf)
-            .map_err(|e| SearchIndexError::bulk_index(format!("Failed to serialize bulk op: {e}")))?;
+        Body::write(op, &mut buf).map_err(|e| {
+            SearchIndexError::bulk_index(format!("Failed to serialize bulk op: {e}"))
+        })?;
         // BulkOperation::write already appends newlines, but guard against missing trailing newline
         if buf.last() != Some(&b'\n') {
             buf.extend_from_slice(b"\n");
@@ -164,7 +165,10 @@ pub async fn execute_bulk<B: Serialize>(
                 .await
                 .map_err(|e| SearchIndexError::parse(e.to_string()))?;
 
-            let took_ms = response_body.get("took").and_then(|v| v.as_u64()).unwrap_or(0);
+            let took_ms = response_body
+                .get("took")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
             let mut summary = parse_bulk_response(&response_body, metas, action);
             summary.wall_ms = wall_ms;
             summary.took_ms = took_ms;
@@ -272,8 +276,7 @@ pub fn parse_bulk_response(
                     || meta.operation_type == "UpdateSpaceTopicEntityIdByDoc"
                     || meta.operation_type == "ClearSpaceTopicEntityIdByDoc"
                     || meta.operation_type == "UpdateInCanonicalGraphByDoc");
-            let is_success =
-                (200..300).contains(&(status as u16)) || is_not_found_ok;
+            let is_success = (200..300).contains(&(status as u16)) || is_not_found_ok;
 
             if is_success {
                 (true, None)

--- a/search-indexer-repository/src/opensearch/provider.rs
+++ b/search-indexer-repository/src/opensearch/provider.rs
@@ -96,7 +96,11 @@ macro_rules! flush_bulk_if_full {
     ($self:expr, $bulk_ops:expr, $metas:expr, $total_succeeded:expr, $total_failed:expr, $all_results:expr, $total_wall_ms:expr, $total_took_ms:expr, $bulk_call_count:expr) => {
         if $bulk_ops.len() >= opensearch_max_bulk_size() {
             let chunk_size = $bulk_ops.len();
-            debug!(chunk_size, max_bulk_size = opensearch_max_bulk_size(), "Flushing bulk chunk (size limit reached)");
+            debug!(
+                chunk_size,
+                max_bulk_size = opensearch_max_bulk_size(),
+                "Flushing bulk chunk (size limit reached)"
+            );
             let batch_ops = std::mem::take(&mut $bulk_ops);
             let batch_metas = std::mem::take(&mut $metas);
             let summary = execute_bulk(
@@ -122,7 +126,13 @@ macro_rules! flush_bulk_if_full {
 /// Outcome of an `update_by_query` call with retry.
 enum UpdateByQueryOutcome {
     /// The query succeeded. Contains response stats and timing.
-    Success { updated: u64, total: u64, conflicts: u64, took_ms: u64, wall_ms: u64 },
+    Success {
+        updated: u64,
+        total: u64,
+        conflicts: u64,
+        took_ms: u64,
+        wall_ms: u64,
+    },
     /// The query failed after all retries. Contains the error body.
     Failed(String),
 }
@@ -260,12 +270,17 @@ impl OpenSearchProvider {
                     "update_by_query completed"
                 );
 
-                return Ok(UpdateByQueryOutcome::Success { updated, total, conflicts, took_ms, wall_ms });
+                return Ok(UpdateByQueryOutcome::Success {
+                    updated,
+                    total,
+                    conflicts,
+                    took_ms,
+                    wall_ms,
+                });
             }
 
             let status_code = status.as_u16();
-            let is_retryable = status_code == 409
-                || retry::is_retryable_status(status_code);
+            let is_retryable = status_code == 409 || retry::is_retryable_status(status_code);
 
             if is_retryable && attempt < self.retry_config.max_retries {
                 let error_body = response.text().await.unwrap_or_default();
@@ -783,8 +798,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         }
                     });
 
-                    match self.update_by_query_with_retry(body, "RemoveRelationById").await? {
-                        UpdateByQueryOutcome::Success { updated, total, conflicts, took_ms, wall_ms } => {
+                    match self
+                        .update_by_query_with_retry(body, "RemoveRelationById")
+                        .await?
+                    {
+                        UpdateByQueryOutcome::Success {
+                            updated,
+                            total,
+                            conflicts,
+                            took_ms,
+                            wall_ms,
+                        } => {
                             if updated == 0 {
                                 warn!(
                                     relation_id = %relation_uuid,
@@ -882,7 +906,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                             space_id: request.space_id.clone(),
                             operation_type: "AddRelation".to_string(),
                         });
-                        flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                        flush_bulk_if_full!(
+                            self,
+                            bulk_ops,
+                            metas,
+                            total_succeeded,
+                            total_failed,
+                            all_results,
+                            total_wall_ms,
+                            total_took_ms,
+                            _bulk_call_count
+                        );
                         has_operation = true;
                     }
 
@@ -913,7 +947,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                             space_id: request.space_id.clone(),
                             operation_type: "Update".to_string(),
                         });
-                        flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                        flush_bulk_if_full!(
+                            self,
+                            bulk_ops,
+                            metas,
+                            total_succeeded,
+                            total_failed,
+                            all_results,
+                            total_wall_ms,
+                            total_took_ms,
+                            _bulk_call_count
+                        );
                         has_operation = true;
                     }
 
@@ -940,7 +984,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: request.space_id.clone(),
                         operation_type: "Delete".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::Unset(request) => {
                     if request.property_keys.is_empty() {
@@ -983,7 +1037,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: request.space_id.clone(),
                         operation_type: "Unset".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::UpdateEntityGlobalScore(request) => {
                     // Flush before executing the update_by_query to maintain ordering
@@ -1021,8 +1085,13 @@ impl SearchIndexProvider for OpenSearchProvider {
                         }
                     });
 
-                    match self.update_by_query_with_retry(body, "UpdateEntityGlobalScore").await? {
-                        UpdateByQueryOutcome::Success { took_ms, wall_ms, .. } => {
+                    match self
+                        .update_by_query_with_retry(body, "UpdateEntityGlobalScore")
+                        .await?
+                    {
+                        UpdateByQueryOutcome::Success {
+                            took_ms, wall_ms, ..
+                        } => {
                             total_succeeded += 1;
                             total_wall_ms += wall_ms;
                             total_took_ms += took_ms;
@@ -1086,8 +1155,13 @@ impl SearchIndexProvider for OpenSearchProvider {
                         }
                     });
 
-                    match self.update_by_query_with_retry(body, "UpdateSpaceScore").await? {
-                        UpdateByQueryOutcome::Success { took_ms, wall_ms, .. } => {
+                    match self
+                        .update_by_query_with_retry(body, "UpdateSpaceScore")
+                        .await?
+                    {
+                        UpdateByQueryOutcome::Success {
+                            took_ms, wall_ms, ..
+                        } => {
                             total_succeeded += 1;
                             total_wall_ms += wall_ms;
                             total_took_ms += took_ms;
@@ -1137,7 +1211,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: request.space_id.clone(),
                         operation_type: "UpdateEntitySpaceScore".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::UpdateEntityGlobalScoreByDoc(request) => {
                     // Direct doc-ID update for entity global score (resolved via Postgres lookup).
@@ -1154,7 +1238,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: String::new(),
                         operation_type: "UpdateEntityGlobalScoreByDoc".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::UpdateSpaceScoreByDoc(request) => {
                     // Direct doc-ID update for space score (resolved via Postgres lookup).
@@ -1171,7 +1265,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: String::new(),
                         operation_type: "UpdateSpaceScoreByDoc".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::RemoveRelationByDoc(request) => {
                     // Direct doc-ID update for relation removal (resolved via Postgres lookup).
@@ -1192,7 +1296,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: request.relation_id.clone(),
                         operation_type: "RemoveRelationByDoc".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::UpdateSpaceTopicEntityIdByDoc(request) => {
                     // Direct doc-ID update for space topic entity ID (resolved via Postgres lookup).
@@ -1209,7 +1323,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: request.topic_entity_id.clone(),
                         operation_type: "UpdateSpaceTopicEntityIdByDoc".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::UpdateInCanonicalGraphByDoc(request) => {
                     // Direct doc-ID update for canonical graph flag (resolved via Postgres lookup).
@@ -1226,7 +1350,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: String::new(),
                         operation_type: "UpdateInCanonicalGraphByDoc".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::ClearSpaceTopicEntityIdByDoc(request) => {
                     // Direct doc-ID clear of `space_topic_entity_id` using a painless
@@ -1245,7 +1379,17 @@ impl SearchIndexProvider for OpenSearchProvider {
                         space_id: String::new(),
                         operation_type: "ClearSpaceTopicEntityIdByDoc".to_string(),
                     });
-                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                    flush_bulk_if_full!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
                 }
                 EntityOperation::UpdateSpaceTopicEntityId(request) => {
                     // Flush before executing the update_by_query to maintain ordering
@@ -1291,8 +1435,13 @@ impl SearchIndexProvider for OpenSearchProvider {
                         }
                     });
 
-                    match self.update_by_query_with_retry(body, "UpdateSpaceTopicEntityId").await? {
-                        UpdateByQueryOutcome::Success { took_ms, wall_ms, .. } => {
+                    match self
+                        .update_by_query_with_retry(body, "UpdateSpaceTopicEntityId")
+                        .await?
+                    {
+                        UpdateByQueryOutcome::Success {
+                            took_ms, wall_ms, ..
+                        } => {
                             total_succeeded += 1;
                             total_wall_ms += wall_ms;
                             total_took_ms += took_ms;
@@ -1359,7 +1508,9 @@ impl SearchIndexProvider for OpenSearchProvider {
                         .update_by_query_with_retry(body, "ClearSpaceTopicEntityId")
                         .await?
                     {
-                        UpdateByQueryOutcome::Success { took_ms, wall_ms, .. } => {
+                        UpdateByQueryOutcome::Success {
+                            took_ms, wall_ms, ..
+                        } => {
                             total_succeeded += 1;
                             total_wall_ms += wall_ms;
                             total_took_ms += took_ms;
@@ -1423,8 +1574,13 @@ impl SearchIndexProvider for OpenSearchProvider {
                         }
                     });
 
-                    match self.update_by_query_with_retry(body, "UpdateInCanonicalGraph").await? {
-                        UpdateByQueryOutcome::Success { took_ms, wall_ms, .. } => {
+                    match self
+                        .update_by_query_with_retry(body, "UpdateInCanonicalGraph")
+                        .await?
+                    {
+                        UpdateByQueryOutcome::Success {
+                            took_ms, wall_ms, ..
+                        } => {
                             total_succeeded += 1;
                             total_wall_ms += wall_ms;
                             total_took_ms += took_ms;

--- a/search-indexer/src/consumer/mod.rs
+++ b/search-indexer/src/consumer/mod.rs
@@ -11,8 +11,8 @@ mod topology_consumer;
 
 pub use entities_consumer::EntitiesConsumer;
 pub use messages::{
-    EntityEvent, EntityEventType, ScoreEvent, ScoreEventType, SpaceTopicEvent,
-    SpaceTopicEventKind, StreamMessage,
+    EntityEvent, EntityEventType, ScoreEvent, ScoreEventType, SpaceTopicEvent, SpaceTopicEventKind,
+    StreamMessage,
 };
 pub use scores_consumer::ScoresConsumer;
 pub use space_topics_consumer::SpaceTopicsConsumer;

--- a/search-indexer/src/processor/mod.rs
+++ b/search-indexer/src/processor/mod.rs
@@ -569,6 +569,24 @@ impl Processor {
                     processed.push(ProcessedEvent::Index(doc));
                 }
                 SpaceTopicEventKind::Removed => {
+                    // Topic-aware removal: only clear when the removed topic is the
+                    // one currently set for this space. Guards against a stale or
+                    // out-of-order removal clearing a newer topic. A cache miss means
+                    // no topic is currently set, so the removal is a no-op.
+                    if self.space_topic_cache.get(&event.space_id)
+                        != Some(&event.topic_entity_id)
+                    {
+                        if self.should_sample(SampleCategory::UpdateSpaceTopicEntityId) {
+                            info!(
+                                space_id = %event.space_id,
+                                topic_entity_id = %event.topic_entity_id,
+                                cached_topic_entity_id = ?self.space_topic_cache.get(&event.space_id),
+                                "[sample] Skipping ClearSpaceTopicEntityId — removed topic does not match current"
+                            );
+                        }
+                        continue;
+                    }
+
                     self.space_topic_cache.remove(&event.space_id);
 
                     if self.should_sample(SampleCategory::UpdateSpaceTopicEntityId) {
@@ -2004,6 +2022,56 @@ mod tests {
             assert_eq!(
                 doc.space_topic_entity_id, None,
                 "After Removed, subsequent upserts must not auto-tag the removed topic"
+            );
+        } else {
+            panic!("Expected ProcessedEvent::Index");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_space_topic_batch_removed_non_matching_topic_is_noop() {
+        // The space currently has `current_topic`; a Removed event arrives for a
+        // different (stale) topic. The current topic must be preserved.
+        let space_id = Uuid::new_v4();
+        let current_topic = Uuid::new_v4();
+        let stale_topic = Uuid::new_v4();
+        let mut cache = HashMap::new();
+        cache.insert(space_id, current_topic);
+        let mut processor = Processor::with_space_topic_cache(cache, 0);
+        assert_eq!(processor.space_topic_cache_len(), 1);
+
+        let events = vec![SpaceTopicEvent {
+            space_id,
+            topic_entity_id: stale_topic,
+            kind: SpaceTopicEventKind::Removed,
+        }];
+        let processed = processor.process_space_topic_batch(events).await.unwrap();
+
+        // Non-matching removal must not emit any clear ops.
+        assert!(
+            processed.is_empty(),
+            "Non-matching Removed must not emit clear events, got: {processed:?}"
+        );
+
+        // Cache must still carry the current topic.
+        assert_eq!(processor.space_topic_cache_len(), 1);
+
+        // A subsequent upsert in that space should still carry the current topic.
+        let event = EntityEvent::upsert(
+            Uuid::new_v4(),
+            space_id,
+            Some("Entity".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+        let result = processor.process_event(event).unwrap();
+        if let Some(ProcessedEvent::Index(doc)) = result {
+            assert_eq!(
+                doc.space_topic_entity_id,
+                Some(current_topic.to_string()),
+                "A stale Removed must not clear the still-current topic"
             );
         } else {
             panic!("Expected ProcessedEvent::Index");

--- a/search-indexer/src/processor/mod.rs
+++ b/search-indexer/src/processor/mod.rs
@@ -11,8 +11,7 @@ use tokio::task::JoinHandle;
 
 use crate::consumer::StreamMessage;
 use crate::consumer::{
-    EntityEvent, EntityEventType, ScoreEvent, ScoreEventType, SpaceTopicEvent,
-    SpaceTopicEventKind,
+    EntityEvent, EntityEventType, ScoreEvent, ScoreEventType, SpaceTopicEvent, SpaceTopicEventKind,
 };
 use crate::errors::IngestError;
 use crate::lookup::EntitySpaceLookup;
@@ -573,9 +572,7 @@ impl Processor {
                     // one currently set for this space. Guards against a stale or
                     // out-of-order removal clearing a newer topic. A cache miss means
                     // no topic is currently set, so the removal is a no-op.
-                    if self.space_topic_cache.get(&event.space_id)
-                        != Some(&event.topic_entity_id)
-                    {
+                    if self.space_topic_cache.get(&event.space_id) != Some(&event.topic_entity_id) {
                         if self.should_sample(SampleCategory::UpdateSpaceTopicEntityId) {
                             info!(
                                 space_id = %event.space_id,
@@ -613,7 +610,8 @@ impl Processor {
         // Resolve space_id → entity docs via Postgres, or fall back to update_by_query.
         // Use the same Postgres call for both kinds so we don't double-query when a
         // declare + remove for different spaces land in the same batch.
-        let mut fast_path_spaces: Vec<Uuid> = declared_updates.iter().map(|(sid, _)| *sid).collect();
+        let mut fast_path_spaces: Vec<Uuid> =
+            declared_updates.iter().map(|(sid, _)| *sid).collect();
         fast_path_spaces.extend(removed_spaces.iter().copied());
 
         if !fast_path_spaces.is_empty() {


### PR DESCRIPTION
## Summary

Carries the topic entity ID (`topicId`) through the full `UNSET_TOPIC` action pipeline so the API exposes a **required** `targetTopicId` on `UNSET_TOPIC` actions (mirroring `SET_TOPIC`), and makes topic removal in the `spaces` table and the search index **topic-aware** — an unset only clears the topic when the removed `topicId` matches the currently-set one.

The on-chain `ping(TOPIC_REMOVED, bytes32(topicId), data)` event already carries the topicId and the pipeline validates it as non-zero, so `targetTopicId` is non-nullable, exactly like `SET_TOPIC`.

No DB migration is needed — `proposalActions.target_id` and `spaces.topic_id` already exist.

## Part 1 — Proposal-action path (add topicId to `UNSET_TOPIC`)

- **hermes-schema**: add `target_topic_id` to `UnsetTopicAction` (proto + checked-in generated struct; drop the `Copy` derive since it now holds a `Vec`)
- **hermes-pipeline**: pass the already-extracted, validated `target` into `UnsetTopicAction`
- **kg-indexer**: decode `target_topic_id` via `bytes_to_uuid` (→ `Unknown` on failure) and persist it to `proposal_actions.target_id`
- **api**: add required `targetTopicId` to `UnsetTopicAction`; map to `UNKNOWN` when `target_id` is null

## Part 2 — `spaces.topic_id` conditional clear (kg-indexer)

- `clear_space_topic` now takes a `topic_id` and guards the update with `WHERE id = $1 AND topic_id = $2`; both call sites pass `removal.topic_id`. Only clears when the removed topic is the current one.

## Part 3 — search-indexer conditional clear

- The `SpaceTopicEventKind::Removed` arm only clears when the cached topic for the space equals the removed `topic_entity_id`; otherwise it skips (with a sampled log), so non-matching spaces never enter the Postgres fast-path or the `update_by_query` fallback.

## Tests

- **hermes-pipeline**: unit test asserts `target_topic_id` on the decoded `UnsetTopic` action
- **kg-indexer e2e**: expects the persisted `target_id` for the `UNSET_TOPIC` proposal action, and adds a stale-removal no-op case (mock relay emits `topic_removed` for a non-current topic on `SPACE_J`, which must retain its topic)
- **search-indexer**: processor test covers matching (clears) vs non-matching (no-op) removal
- **api**: tests cover the `targetTopicId` mapping and the `UNKNOWN` fallback

## Verification

- `cargo test --workspace --lib --bins` — hermes-schema, hermes-pipeline, hermes-relay, search-indexer ✅
- `bunx vitest run src/proposals` — 77 passed ✅
- kg-indexer e2e — runs in the **KG Indexer E2E Tests** workflow (needs seeded Postgres + Kafka)

## Notes

- Backfill of pre-existing `UNSET_TOPIC` rows (`target_id = NULL`) is out of scope — only newly indexed actions get the topicId.
- Conditional-clear behavior was chosen deliberately to guard against a stale/out-of-order unset clearing a newer topic. If the product expectation is "unset always clears," Parts 2 & 3 can revert to unconditional.