### PR TITLE
docs(notification-indexer): document every supported notification

### DIFF
--- a/notification-service/notification-indexer/README.md
+++ b/notification-service/notification-indexer/README.md
@@ -1,15 +1,41 @@
 # Notification Indexer
 
-Consumes governance events from the `space.governance` Kafka topic and writes per-editor notifications to the `notification_outbox` table. Also runs a periodic rejection poller that detects proposals that expired without execution.
+Consumes blockchain events from Kafka, resolves who should be notified, and writes one row per recipient to the `notification_outbox` table. The separate **delivery-worker** service signs (HMAC-SHA256) and delivers outbox rows to registered webhooks.
 
 ## How it works
 
-1. **Kafka consumer** subscribes to `space.governance` and processes all governance event types (`PROPOSAL_CREATED`, `PROPOSAL_UPDATED`, `PROPOSAL_VOTED`, `PROPOSAL_EXECUTED`, `PROPOSAL_SETTINGS_UPDATED`)
-2. For each event, looks up all editors in the proposal's space via the `editors` table
-3. Creates one outbox row per editor with `user_space_id` in the payload
-4. The delivery-worker (separate service) picks up outbox rows and delivers them to webhooks
+Three sources feed the outbox:
 
-**Rejection poller**: Runs every `REJECTION_POLL_INTERVAL_SECS` seconds. Finds proposals where `end_time < now()` and `executed_at IS NULL` that haven't been notified yet, and writes `proposal_rejected` notifications for each editor.
+1. **Governance consumer** — subscribes to `space.governance` and handles `PROPOSAL_CREATED`, `PROPOSAL_UPDATED`, `PROPOSAL_VOTED`, `PROPOSAL_EXECUTED`, `PROPOSAL_SETTINGS_UPDATED`.
+2. **Knowledge-edits consumer** — subscribes to `knowledge.edits`, decodes the GRC-20 payload, and detects bounty and comment activity from `CreateRelation` ops.
+3. **Rejection poller** — runs every `REJECTION_POLL_INTERVAL_SECS`; finds proposals where `end_time < now()` and `executed_at IS NULL` that haven't been notified, and emits `proposal_rejected`.
+
+For each detected event the indexer resolves a recipient set (see the table below), then writes one outbox row **per recipient** with that recipient's `user_space_id` stamped into the payload. The indexer delivers the relevant *superset*; precise per-user filtering (mute/snooze/preferences) is done **app-side**.
+
+### Idempotency
+
+Each outbox row's unique key is `{block}:{sequence}:{event_type}:{instance_id}` hashed together with the recipient's `user_space_id` (SHA-256), under `ON CONFLICT (idempotency_key) DO NOTHING`. The `{instance_id}` is the per-event subject — `bounty_entity_id`, `comment_entity_id`, or the bounty `relation_id` — so a single edit emitting several events of the same type does not collide. Consequence: **one comment/entity touched repeatedly within one edit yields one notification per recipient**; each distinct bounty relation (e.g. two users expressing interest) is its own notification.
+
+## Notifications
+
+Every notification type the indexer currently creates. "Recipients" are resolved to `user_space_id`s (each recipient's personal-space UUID).
+
+| `event_type` | Category | Source / trigger | Who is notified | Notes & edge cases |
+|---|---|---|---|---|
+| `proposal_created` | governance | `space.governance` | Editors of the proposal's space | — |
+| `proposal_updated` | governance | `space.governance` | Editors **+ prior voters** of the proposal (`proposal_votes.voter_id`) | "A new version of a proposal you voted on was submitted." Voter lookup is best-effort: a miss still notifies editors. |
+| `proposal_voted` | governance | `space.governance` | Editors **+ the proposer** (`proposals.proposed_by`) | "Your proposal was voted on." Proposer is usually also an editor (deduped). |
+| `proposal_executed` | governance | `space.governance` | Editors **+ the proposer** | "Your proposal was approved/executed." |
+| `proposal_settings_updated` | governance | `space.governance` | Editors of the proposal's space | — |
+| `proposal_rejected` | governance | **Rejection poller** (not a Kafka event) | Editors **+ the proposer** | Emitted when a proposal expires (`end_time < now()`) unexecuted. Idempotency key is `{proposal_id}:proposal_rejected` so it fires at most once per proposal. |
+| `bounty_interest` | bounty | `knowledge.edits` (Interest relation) | Editors of the **bounty's** space | Bounty space resolved via the bounty's `Types → Bounty` relation; if it can't be resolved, the event is skipped. No editors → no notifications. |
+| `bounty_allocated` | bounty | `knowledge.edits` (Allocated relation) | **The curator** only (single recipient) | Not a fan-out. Curator's space resolved from the relation's `to_space`, or looked up if absent; unresolvable → skipped. |
+| `bounty_payout` | bounty | `knowledge.edits` (Payout relation) | **The curator** only (single recipient) | Same resolution/skip rules as `bounty_allocated`. |
+| `bounty_created` | bounty | `knowledge.edits` (`Types → Bounty`) | Editors of the space the bounty was **created in** (the edit's space) | Multiple bounties in one edit each notify independently. No editors → no notifications. |
+| `proposal_comment` | comment | `knowledge.edits` (`Comment` entity with `Reply to` → a proposal) | **The proposal's proposer**, gated on the commenter being a **member or editor** of the proposal's space | If the parent isn't a proposal it's routed to `comment` (below). **If the commenter is not a member/editor, no notification is created** (filtered out). |
+| `comment` | comment | `knowledge.edits` (`Comment` with `Reply to` → a non-proposal parent) | **All thread participants ∪ the thread root's creator**, excluding the comment's own author | Participants = the `space_id` of every `Reply to` relation in the thread (each comment author's personal space). Root creator is exact for proposals (`proposed_by`) and a best-effort "home space" otherwise (entities have no `created_by`). Thread root resolved by walking `Reply to` upward (depth-bounded). |
+
+Recipient resolution is intentionally a **superset** and **best-effort**: a failed lookup of a *targeted extra* (proposer/voters) only drops that extra — editors still receive the base event. The knowledge-edits consumer also waits (bounded) for the kg-indexer to catch up to the event's block before resolving, so spaces/relations/names are populated.
 
 ## Environment Variables
 
@@ -52,11 +78,16 @@ Consumes governance events from the `space.governance` Kafka topic and writes pe
 ## Database Tables
 
 **Reads from:**
-- `editors` — looks up editors per space for fan-out
-- `proposals` — rejection poller queries for expired proposals
+- `editors` — per-space fan-out (also the membership check, with `members`)
+- `members` — `proposal_comment` member/editor gate
+- `proposals` — proposer/space resolution, name/tally enrichment, and the rejection poller's expired-proposal query
+- `proposal_votes` — prior voters for `proposal_updated`
+- `relations` — bounty/comment detection support: bounty space, entity home space, and thread-root/participant resolution
+- `values` — entity/proposal name enrichment
+- `spaces` — personal-space filtering during entity→space resolution
 
 **Writes to:**
-- `notification_outbox` — one row per editor per event
+- `notification_outbox` — one row per recipient per event
 - `notification_deliveries` — one row per outbox entry per registered webhook
 
 ## Running locally


### PR DESCRIPTION
## What

The notification-indexer README still described a governance-only service. This updates it to reflect today's behavior and adds a reference table of **every notification the indexer currently creates**.

## Changes

- **Notifications table** — one row per `event_type` with category, source/trigger, the **explicit recipient set**, and notes for the trickier cases (the `proposal_comment` member/editor gate, single-recipient bounty allocations/payouts, comment-thread participants ∪ root creator with author exclusion, best-effort targeted-extra lookups, `proposal_rejected` coming from the poller).
- **"How it works"** rewritten to cover all three sources: the governance consumer (`space.governance`), the knowledge-edits consumer (`knowledge.edits`), and the rejection poller.
- **Idempotency** section documenting the key shape (`{block}:{seq}:{event_type}:{instance_id}` + `user_space_id`) and its one-notification-per-edit-subject consequence.
- **"Database Tables"** reads-from list corrected (`members`, `proposal_votes`, `relations`, `values`, `spaces`).

Docs-only — no code changes.