### PR TITLE
chore(scoring): make cronjob test recipe self-contained

### DIFF
--- a/scoring-service/cronjob/justfile
+++ b/scoring-service/cronjob/justfile
@@ -12,7 +12,7 @@ run:
 
 # Run tests
 test:
-    uv run pytest
+    uv run --extra dev pytest
 
 # Run with Docker Compose
 docker-run:


### PR DESCRIPTION
## What

The cronjob `just test` recipe ran `uv run pytest`, but `pytest` lives in the `dev` optional-dependencies group. On a fresh checkout (without running `just setup-dev` first) the recipe fails with `No such file or directory: pytest`.

## Fix

Use `uv run --extra dev pytest` so the recipe pulls its own test dependency and works standalone.

```diff
 test:
-    uv run pytest
+    uv run --extra dev pytest
```

## Verification

`uv run --extra dev pytest` → 88 passed.