### PR TITLE
chore(scoring): remove inert require_space_membership config flag

### DIFF
--- a/scoring-service/cronjob/main.py
+++ b/scoring-service/cronjob/main.py
@@ -291,7 +291,6 @@ def main() -> None:
         normalize_scores=os.environ.get("NORMALIZE_SCORES", "True").lower() == "true",
         normalization_method=os.environ.get("NORMALIZATION_METHOD", "z_score_sigmoid"),
         filter_non_members=os.environ.get("FILTER_NON_MEMBERS", "False").lower() == "true",
-        require_space_membership=os.environ.get("REQUIRE_SPACE_MEMBERSHIP", "False").lower() == "true",
     )
     engine = RankingEngine(config)
 
@@ -300,13 +299,13 @@ def main() -> None:
         "use_time_decay=%s, time_decay_factor=%s, use_activity_metrics=%s, "
         "use_distance_weighting=%s, distance_weight_base=%s, max_distance=%s, "
         "use_contestation_score=%s, include_subspace_votes=%s, "
-        "filter_non_members=%s, require_space_membership=%s, output_mode=%s",
+        "filter_non_members=%s, output_mode=%s",
         config.normalize_scores, config.normalization_method,
         config.use_time_decay, config.time_decay_factor,
         config.use_activity_metrics, config.use_distance_weighting,
         config.distance_weight_base, config.max_distance,
         config.use_contestation_score, config.include_subspace_votes,
-        config.filter_non_members, config.require_space_membership,
+        config.filter_non_members,
         output_mode.value,
     )
 

--- a/scoring-service/cronjob/src/algorithm/models.py
+++ b/scoring-service/cronjob/src/algorithm/models.py
@@ -239,7 +239,6 @@ class RankingConfig:
 
     # Anti-sybil
     filter_non_members: bool = True
-    require_space_membership: bool = True
 
     def __post_init__(self) -> None:
         """Validate configuration after initialisation."""


### PR DESCRIPTION
## What

`require_space_membership` on `RankingConfig` is dead config: it's defined, read from the `REQUIRE_SPACE_MEMBERSHIP` env var in `main.py`, and printed in the startup log — but **never read** by the scoring algorithm (verified across `src/`, `main.py`, tests, and deploy manifests).

Worse, it sits directly beside `filter_non_members` — the flag that *actually* gates member-only tallying — so it reads as if it does that job. That's actively misleading for anyone working in the scoring/reputation area.

## Change

Remove the field, its env wiring, and its log reference. No behavior change (the flag never affected anything).

## Note for reviewers

While here I noticed two sibling flags that look similarly inert — `use_contestation_score` and `include_subspace_votes` are also defined + env-wired + logged but never read by the algorithm. Left them out of this PR since `use_contestation_score` has dormant implementation in `scoring.py`, so whether to delete the flag or wire it up is a product call. Flagging in case it's useful.

## Verification

Full cronjob suite green: 84 passed (`uv run --extra dev pytest`).