### PR TITLE
perf(scoring): index users by id in the entity ranking hot loop

### DIFF
--- a/scoring-service/cronjob/src/algorithm/scoring.py
+++ b/scoring-service/cronjob/src/algorithm/scoring.py
@@ -68,10 +68,23 @@ class EntityScorer:
 
         return hot_score
 
+    @staticmethod
+    def _index_users_by_id(users: list[User]) -> dict[str, User]:
+        """Index users by id for O(1) lookup.
+
+        Keeps the first occurrence of any duplicate id, matching the
+        previous next()-based linear scan.
+        """
+        by_id: dict[str, User] = {}
+        for user in users:
+            by_id.setdefault(user.id, user)
+        return by_id
+
     def filter_valid_votes(
         self, votes: list[Vote], users: list[User], entity: Entity
     ) -> list[Vote]:
         """Filter votes to only include valid ones based on anti-sybil rules."""
+        users_by_id = self._index_users_by_id(users)
         relevant_votes = []
         for vote in votes:
             # Find the perspective this vote is for
@@ -90,7 +103,7 @@ class EntityScorer:
                 continue
 
             # Find the user who cast this vote
-            user = next((u for u in users if u.id == vote.user_id), None)
+            user = users_by_id.get(vote.user_id)
             if not user:
                 continue
 
@@ -114,10 +127,11 @@ class EntityScorer:
         # Calculate distance hash table between all spaces
         space_distances = calculate_space_distances(spaces, self.config.max_distance)
 
+        users_by_id = self._index_users_by_id(users)
         weighted_votes = []
         for vote in votes:
             # Find voting user
-            user = next((u for u in users if u.id == vote.user_id), None)
+            user = users_by_id.get(vote.user_id)
             if not user:
                 weighted_votes.append(vote)
                 continue


### PR DESCRIPTION
## What

`rank_entities` calls `EntityScorer.filter_valid_votes` **once per entity**, and that method located each vote's user with a linear scan over all users:

```python
user = next((u for u in users if u.id == vote.user_id), None)
```

So entity ranking was **O(entities × votes × users)**. `apply_distance_weighting` had the same per-vote scan (**O(votes × users)**).

## Change

Build a `{user_id: user}` dict once per call and look up via `.get()`:

- `filter_valid_votes` and `apply_distance_weighting` drop to **O(votes + users)**.
- A small `_index_users_by_id` helper keeps the **first** occurrence of any duplicate id, exactly matching the previous `next()` behavior — so this is a pure speedup with no behavior change.

## Verification

- Full cronjob suite green: 84 passed (`uv run --extra dev pytest`).
- The member-filtering keep/drop paths are additionally characterized in #717.

`+16 / -2`, single file.