### PR TITLE
fix(notification-indexer): comment parent_id = immediate parent (cascade)

### DIFF
--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -899,12 +899,14 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         .await
         .map_err(|(e, _)| e)?;
 
-    // Phase 2b: a reply into the seeded thread (reply → EXISTING_COMMENT). The
-    // indexer walks to the root, notifying the prior participant + the root's
-    // creator (home space), but NOT the reply's own author.
-    let thread_reply = make_comment_hermes_edit(
+    // Phase 2b: a reply into the seeded thread, using the curator-app CASCADE —
+    // reply-to the root FIRST (carried forward) and the immediate parent LAST.
+    // The indexer walks to the root (notifying the prior participant + the root's
+    // creator, but NOT the reply's author) and resolves the immediate parent
+    // (EXISTING_COMMENT) for the payload's parent_id rather than the root.
+    let thread_reply = make_cascade_comment_hermes_edit(
         REPLY_COMMENT_BYTES,
-        EXISTING_COMMENT_BYTES,
+        &[THREAD_ROOT_BYTES, EXISTING_COMMENT_BYTES],
         REPLY_AUTHOR_SPACE_BYTES,
         40007,
         1700036000,
@@ -1107,6 +1109,76 @@ fn make_comment_hermes_edit(
     hermes_schema::pb::knowledge::HermesEdit {
         id: comment_entity.to_vec(),
         name: "comment edit".into(),
+        payload,
+        authors: vec![commenter_space.to_vec()],
+        language: None,
+        space_id: commenter_space.to_vec(),
+        is_canonical: true,
+        meta: Some(hermes_schema::pb::blockchain_metadata::BlockchainMetadata {
+            created_at,
+            created_by: vec![],
+            block_number,
+            cursor: String::new(),
+            sequence,
+            is_last: false,
+        }),
+    }
+}
+
+/// Build a HermesEdit for a comment with the curator-app *cascade* `Reply to`
+/// pattern: one Reply-to edge per `reply_targets` entry (root carried forward
+/// first, the immediate parent appended last). Exercises the consumer's
+/// immediate-parent resolution.
+fn make_cascade_comment_hermes_edit(
+    comment_entity: [u8; 16],
+    reply_targets: &[[u8; 16]],
+    commenter_space: [u8; 16],
+    block_number: u64,
+    created_at: u64,
+    sequence: u32,
+) -> hermes_schema::pb::knowledge::HermesEdit {
+    use std::borrow::Cow;
+    let types = Uuid::parse_str("8f151ba4-de20-4e3c-9cb4-99ddf96f48f1")
+        .expect("valid Types id")
+        .into_bytes();
+    let comment_type = Uuid::parse_str("82f6123a-0323-4c6c-a811-701c5bc026e9")
+        .expect("valid Comment type id")
+        .into_bytes();
+    let reply_to = Uuid::parse_str("310d4a24-0e5b-451c-b215-1bfce40d0fe6")
+        .expect("valid Reply-to id")
+        .into_bytes();
+    let mk = |id: [u8; 16], rt: [u8; 16], from: [u8; 16], to: [u8; 16]| {
+        grc_20::Op::CreateRelation(grc_20::CreateRelation {
+            id,
+            relation_type: rt,
+            from,
+            from_is_value_ref: false,
+            to,
+            to_is_value_ref: false,
+            from_space: None,
+            from_version: None,
+            to_space: None,
+            to_version: None,
+            entity: None,
+            position: None,
+            context: None,
+        })
+    };
+    let mut ops = vec![mk([0xA1; 16], types, comment_entity, comment_type)];
+    for (i, target) in reply_targets.iter().enumerate() {
+        ops.push(mk([0xB0 + i as u8; 16], reply_to, comment_entity, *target));
+    }
+    let edit = grc_20::Edit {
+        id: comment_entity,
+        name: Cow::Borrowed("cascade comment edit"),
+        authors: vec![commenter_space],
+        created_at: created_at as i64,
+        ops,
+    };
+    let payload = grc_20::encode_edit(&edit).expect("GRC-20 encode should succeed");
+    hermes_schema::pb::knowledge::HermesEdit {
+        id: comment_entity.to_vec(),
+        name: "cascade comment edit".into(),
         payload,
         authors: vec![commenter_space.to_vec()],
         language: None,
@@ -2047,6 +2119,13 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         r.check(
             "comment: correct thread root_id",
             call.body["root_id"].as_str() == Some(thread_root.as_str()),
+        );
+        // Cascade fidelity: parent_id is the IMMEDIATE parent (EXISTING_COMMENT),
+        // not the root target — even though the cascade lists the root first.
+        let existing_comment = Uuid::from_bytes(EXISTING_COMMENT_BYTES).to_string();
+        r.check(
+            "comment: parent_id is the immediate parent (not the root) for a cascade reply",
+            call.body["parent_id"].as_str() == Some(existing_comment.as_str()),
         );
     }
     // The prior participant and the root's creator each get 3 (one per webhook).

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -797,7 +797,28 @@ async fn async_main() -> Result<(), IndexerError> {
                                     // it's a general comment / reply in a thread: notify all thread
                                     // participants plus the thread root's creator (Phase 2b).
                                     // App servers handle per-user muting/snoozing.
+                                    //
+                                    // A single comment can produce several `Reply to` edges (curator-app
+                                    // cascades them up the ancestor chain), surfacing as one info per
+                                    // edge. Group the edges per comment so we resolve the thread once and
+                                    // can pick the *immediate* parent for the payload, rather than letting
+                                    // the first-processed edge (the root) win.
+                                    let mut reply_targets_by_comment: std::collections::HashMap<uuid::Uuid, Vec<uuid::Uuid>> =
+                                        std::collections::HashMap::new();
+                                    for info in &comments {
+                                        reply_targets_by_comment
+                                            .entry(info.comment_entity_id)
+                                            .or_default()
+                                            .push(info.proposal_id);
+                                    }
+                                    let mut processed_comments: std::collections::HashSet<uuid::Uuid> =
+                                        std::collections::HashSet::new();
+
                                     for mut info in comments {
+                                        // Cascade edges share a comment; process each comment once.
+                                        if !processed_comments.insert(info.comment_entity_id) {
+                                            continue;
+                                        }
                                         if ke_bd > 0 {
                                             wait_for_kg_catchup(&ke_stor, info.block_number, ke_bd, ke_bd_timeout).await;
                                         }
@@ -843,9 +864,27 @@ async fn async_main() -> Result<(), IndexerError> {
                                                     ke_processed += 1;
                                                     continue;
                                                 }
+                                                // Immediate parent for the payload. With a cascade the
+                                                // comment has several reply-to targets; the immediate
+                                                // parent is the deepest of them. With a single target it
+                                                // IS the parent — skip the query.
+                                                let parent_id = match reply_targets_by_comment.get(&info.comment_entity_id) {
+                                                    Some(targets) if targets.len() > 1 => {
+                                                        match ke_stor.find_deepest_reply_target(targets).await {
+                                                            Ok(Some(p)) => p,
+                                                            Ok(None) => info.proposal_id,
+                                                            Err(e) => {
+                                                                error!(error = %e, "DB error resolving immediate comment parent, will retry");
+                                                                ke_errors += 1;
+                                                                return Err(());
+                                                            }
+                                                        }
+                                                    }
+                                                    _ => info.proposal_id,
+                                                };
                                                 let cinfo = CommentThreadInfo {
                                                     comment_entity_id: info.comment_entity_id,
-                                                    parent_id: info.proposal_id,
+                                                    parent_id,
                                                     root_id: root,
                                                     commenter_space_id: info.commenter_space_id,
                                                     root_space_id: root_space,

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -3373,6 +3373,64 @@ mod tests {
         assert!(thread_keys.iter().all(|k| k.starts_with("300:2:comment:")));
     }
 
+    #[test]
+    fn extract_proposal_comments_cascade_reply_emits_edge_per_target_in_op_order() {
+        // Mirrors curator-app's cascade: a reply carries a `Reply to` edge to the
+        // whole ancestor chain — the root target FIRST (carried forward) and the
+        // immediate parent LAST (appended). extract_proposal_comments emits one
+        // ProposalCommentInfo per reply-to edge, in op order.
+        let types = crate::ids::types_relation_type().into_bytes();
+        let comment_type = crate::ids::comment_type().into_bytes();
+        let reply_to = crate::ids::reply_to_property().into_bytes();
+        let root_target = [0xA0; 16]; // e.g. the bounty (thread root)
+        let immediate_parent = [0xB0; 16]; // the comment being replied to
+        let reply = [0xC0; 16]; // the new reply
+        let ops = vec![
+            create_relation([0x01; 16], types, reply, comment_type),
+            create_relation([0x02; 16], reply_to, reply, root_target), // carried-forward (first)
+            create_relation([0x03; 16], reply_to, reply, immediate_parent), // immediate parent (last)
+        ];
+        let edit = make_edit_with_ops(ops, [0x50; 16], 400, 0);
+
+        let out = extract_proposal_comments(&edit).expect("extract");
+        // One info per reply-to edge, all for the same comment, in op order.
+        assert_eq!(out.len(), 2);
+        assert!(out
+            .iter()
+            .all(|i| i.comment_entity_id == Uuid::from_bytes(reply)));
+        assert_eq!(
+            out[0].proposal_id,
+            Uuid::from_bytes(root_target),
+            "first edge targets the root"
+        );
+        assert_eq!(
+            out[1].proposal_id,
+            Uuid::from_bytes(immediate_parent),
+            "last edge targets the immediate parent"
+        );
+        // Both edges share one idempotency key (keyed on comment_entity_id), so the
+        // consumer dedups to a single notification. The consumer therefore must pick
+        // the immediate parent deliberately (via find_deepest_reply_target) rather
+        // than letting the first-processed edge (the root) decide parent_id.
+        let keys: std::collections::HashSet<String> = out
+            .iter()
+            .map(|i| {
+                let c = CommentThreadInfo {
+                    comment_entity_id: i.comment_entity_id,
+                    parent_id: i.proposal_id,
+                    root_id: Uuid::from_bytes(root_target),
+                    commenter_space_id: i.commenter_space_id,
+                    root_space_id: Uuid::from_bytes([0x5E; 16]),
+                    block_number: i.block_number,
+                    sequence: i.sequence,
+                    timestamp: i.timestamp,
+                };
+                handle_comment(&c).idempotency_key
+            })
+            .collect();
+        assert_eq!(keys.len(), 1, "cascade edges of one comment share one key");
+    }
+
     // -----------------------------------------------------------------------
     // Entity vote-threshold (vote poller)
     // -----------------------------------------------------------------------

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -436,6 +436,41 @@ impl Storage {
         Ok(rows.iter().map(|r| r.get("space_id")).collect())
     }
 
+    /// The immediate parent among a comment's `Reply to` targets.
+    ///
+    /// Curator-app cascades `Reply to` edges across the whole ancestor chain, so a
+    /// reply points at the root, every ancestor comment, AND its immediate parent.
+    /// The immediate parent is the deepest of those — the target that itself
+    /// replies to the most of the *other* targets. Returns `None` when there is no
+    /// such relation among the set (e.g. a single-target / non-cascade comment),
+    /// so the caller can fall back to the lone target.
+    #[instrument(
+        name = "notification_indexer.storage.find_deepest_reply_target",
+        skip(self, targets)
+    )]
+    pub async fn find_deepest_reply_target(
+        &self,
+        targets: &[Uuid],
+    ) -> Result<Option<Uuid>, StorageError> {
+        let result = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            SELECT from_entity_id
+            FROM relations
+            WHERE type_id = $1
+              AND from_entity_id = ANY($2)
+              AND to_entity_id = ANY($2)
+            GROUP BY from_entity_id
+            ORDER BY count(*) DESC, from_entity_id
+            LIMIT 1
+            "#,
+        )
+        .bind(ids::reply_to_property())
+        .bind(targets)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(result)
+    }
+
     /// Best-effort "home" space of an entity — the `space_id` of its `Types`
     /// relation (where it was created). For entities created in a personal space
     /// this equals the creator. Used as the root-creator recipient for


### PR DESCRIPTION
## What

For general comment-thread notifications, the payload's `parent_id` was the **thread root** instead of the comment the reply actually replied to. This fixes it to the **immediate parent**, and adds tests verifying the behavior.

## Root cause

curator-app builds a reply's `Reply to` relations with a **cascade**: it carries forward the whole ancestor chain (root target first) and appends the immediate parent **last**. The indexer emits one `ProposalCommentInfo` per reply-to edge, all sharing one `comment_entity_id`-keyed idempotency key. The consumer processed them per-edge, so the **first-processed edge (the root) won** the payload's `parent_id`.

Recipients were always correct (thread participants ∪ root creator); only the payload's `parent_id` fidelity was off — it mattered only for an app wanting the precise "X replied to *your* comment" parent.

## Fix

- **storage** `find_deepest_reply_target(targets)` — among a comment's reply-to targets, the immediate parent is the one that replies to the most of the *others* (deepest in the cascade). Returns `None` for single-target / non-cascade comments so the caller falls back to the lone target.
- **consumer** — group reply-to edges per comment, **process each comment once** (this also removes the prior N× thread-resolution for deep comments), and set `parent_id` to the resolved immediate parent.

This is robust to op order (it uses the thread topology, not the edge order), and unchanged for single-reply-to comments (geogenesis proposal comments).

## Tests

- **Unit**: `extract_proposal_comments_cascade_reply_emits_edge_per_target_in_op_order` documents the cascade extraction (one info per edge, in op order, sharing one idempotency key).
- **E2E**: the Phase-2b reply now uses a cascade builder (`reply-to [root, parent]`) and asserts `parent_id` == the **immediate parent**, not the root — this fails without the fix.
- 83 unit + 200 e2e green.

## Background

Came out of cross-checking the indexer against curator-app's `create-comment.ts`. Detection/routing/recipients/author-exclusion all already matched curator's comment shape; this `parent_id` fidelity was the one gap.