### PR TITLE
feat(api): multi-space filtering via spaceIds in entities_ordered_by_property

### DIFF
--- a/api/drizzle/0060_optimize-entities-ordered-by-property.sql
+++ b/api/drizzle/0060_optimize-entities-ordered-by-property.sql
@@ -7,7 +7,9 @@
 -- property's DATA_TYPE relation (ORDER BY r.id for determinism; empty set on an
 -- unsupported/unresolved type). Predicates are appended only for the args present (no
 -- "arg IS NULL OR ..." guards) so the planner can use indexes and the type semi-join.
--- `type_ids` is an optional, space-scoped NECESSARY type superset (OR semantics) — the app
+-- `space_ids` is an optional set of spaces to restrict the sort to (OR semantics:
+-- v.space_id = ANY(space_ids)); omitting it sorts across all spaces. `type_ids` is an
+-- optional, space-scoped NECESSARY type superset (OR semantics) — the app
 -- still applies the exact filter as a PostGraphile residual, and omitting it reproduces the
 -- prior no-type behavior (backward compatible). DISTINCT ON returns one row per entity; the
 -- e.id tie-break keeps pagination stable.
@@ -20,9 +22,11 @@ DROP FUNCTION IF EXISTS public.entities_ordered_by_property(uuid, uuid, sort_ord
 --> statement-breakpoint
 DROP FUNCTION IF EXISTS public.entities_ordered_by_property(uuid, uuid, sort_order, text, uuid);
 --> statement-breakpoint
+DROP FUNCTION IF EXISTS public.entities_ordered_by_property(uuid, uuid, sort_order, text, uuid[]);
+--> statement-breakpoint
 CREATE OR REPLACE FUNCTION public.entities_ordered_by_property(
   property_id uuid,
-  space_id uuid DEFAULT NULL,
+  space_ids uuid[] DEFAULT NULL,
   sort_direction sort_order DEFAULT 'ASC',
   data_type text DEFAULT NULL,
   type_ids uuid[] DEFAULT NULL
@@ -67,8 +71,8 @@ BEGIN
 
   dir := CASE WHEN sort_direction::text = 'DESC' THEN 'DESC' ELSE 'ASC' END;
 
-  IF space_id IS NOT NULL THEN
-    space_pred := format(' AND v.space_id = %L', space_id);
+  IF space_ids IS NOT NULL AND cardinality(space_ids) > 0 THEN
+    space_pred := format(' AND v.space_id = ANY(%L::uuid[])', space_ids);
   END IF;
 
   IF type_ids IS NOT NULL AND cardinality(type_ids) > 0 THEN


### PR DESCRIPTION
## What

Replaces the singular `space_id uuid` argument on `entities_ordered_by_property` with `space_ids uuid[]` (OR semantics), mirroring the existing `type_ids` array. The auto-derived GraphQL field argument becomes `spaceIds: [UUID]`, so sorted tables/collections can now span multiple spaces in a single query.

## Why

Follow-up to #720 (GEO-675), which optimized the sorted path but only accepted a single `spaceId`. Product needs multiple spaces for this to be useful — same shape as `typeIds`.

## How

- Edits migration `0060` **in place** (no new migration step). It is idempotent — `DROP IF EXISTS` + `CREATE OR REPLACE`.
- Predicate uses the same cardinality-guarded array idiom as `type_ids`: `AND v.space_id = ANY(space_ids)`.
- Adds a `DROP` for the retired singular signature `(uuid, uuid, sort_order, text, uuid[])` so the new overload doesn't coexist and create PostGraphile ambiguity.
- The `type_ids` semi-join's correlated `r.space_id = v.space_id` stays correct across multiple spaces.
- Updates the frontend integration doc (signature, behavior matrix, examples).