### PR TITLE
feat(sdk): add rank + ranking-block system IDs for the ranking-indexer

### DIFF
--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -43,10 +43,9 @@ pub const SCORE_PROPERTY_ID: &str = "85a4668a-42fa-4f48-8969-c0a9de0c294b";
 // (`@graphprotocol/grc-20` core/ids/system) — these are the user-authored
 // shapes the ranking-indexer detects on the `knowledge.edits` stream.
 //
-// NOTE: the indexer-owned output relation type (`RANK_POSITION`) is
-// intentionally NOT defined here yet — it is not part of the SDK and needs a
-// canonical system-ID assignment before it can be added to
-// `PROTECTED_RELATION_TYPE_IDS`.
+// The indexer-owned output IDs (`RANK_POSITION` etc.) are defined below: they
+// are system-minted (not SDK shapes), assigned as a random v4 like
+// `SCORE_PROPERTY_ID` rather than derived.
 pub const RANK_TYPE_ID: &str = "5c74731d-fabb-4dc8-b5c5-3346521c639a";
 pub const RANK_TYPE_PROPERTY_ID: &str = "48e01bc8-324e-48c2-a6c9-cab3f49290c6";
 pub const RANK_VOTES_RELATION_TYPE_ID: &str = "19a4cfff-45f2-4150-abf2-af0f43eb2eec";
@@ -64,6 +63,16 @@ pub const RANK_START_DATE_PROPERTY_ID: &str = "eed03a04-0acd-4a9e-81e0-8272ed70a
 pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011c";
 pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
 pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
+
+// Indexer-owned ranking output IDs. System-minted (not SDK shapes), assigned as
+// a random v4 like SCORE_PROPERTY_ID. `RANK_POSITION` is the relation type the
+// ranking-indexer publishes per ranked target — no user edit may author it, so
+// it is reserved in `PROTECTED_RELATION_TYPE_IDS` below.
+pub const RANK_POSITION_RELATION_TYPE_ID: &str = "890deffb-3843-49fa-8269-74000e3dcef6";
+// Aggregated-rankings property — canonical id captured, but its exact role in
+// the (still-gated) publish stage vs the RANK_POSITION relation is pending
+// confirmation, so it is intentionally NOT yet added to PROTECTED_PROPERTY_IDS.
+pub const AGGREGATED_RANKINGS_PROPERTY_ID: &str = "67651da6-11a9-4246-9ff4-039aafbe9e43";
 
 /// Onchain-derived ID of the "root" space whose editors are authorized to
 /// publish edits that mutate the system property-definition entities — i.e.
@@ -89,7 +98,8 @@ pub const PROTECTED_PROPERTY_IDS: &[&str] = &[
     SCORE_PROPERTY_ID,
 ];
 
-pub const PROTECTED_RELATION_TYPE_IDS: &[&str] = &[SYSTEM_TYPES_RELATION_TYPE_ID];
+pub const PROTECTED_RELATION_TYPE_IDS: &[&str] =
+    &[SYSTEM_TYPES_RELATION_TYPE_ID, RANK_POSITION_RELATION_TYPE_ID];
 
 #[cfg(test)]
 mod tests {
@@ -170,7 +180,8 @@ mod tests {
 
     #[test]
     fn protected_relation_type_ids_contains_system_types() {
-        assert_eq!(PROTECTED_RELATION_TYPE_IDS.len(), 1);
+        assert_eq!(PROTECTED_RELATION_TYPE_IDS.len(), 2);
         assert!(PROTECTED_RELATION_TYPE_IDS.contains(&SYSTEM_TYPES_RELATION_TYPE_ID));
+        assert!(PROTECTED_RELATION_TYPE_IDS.contains(&RANK_POSITION_RELATION_TYPE_ID));
     }
 }

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -74,6 +74,10 @@ pub const RANK_POSITION_RELATION_TYPE_ID: &str = "890deffb-3843-49fa-8269-74000e
 // aggregated to produce its ordering (provenance). Reserved below so user edits
 // can't forge it.
 pub const AGGREGATED_RANKINGS_RELATION_TYPE_ID: &str = "67651da6-11a9-4246-9ff4-039aafbe9e43";
+// `Rank position value` is the indexer-owned integer property carrying an
+// entity's aggregated score within a ranking block (surfaced on the published
+// RANK_POSITION relation's reified entity). Reserved in PROTECTED_PROPERTY_IDS.
+pub const RANK_POSITION_VALUE_PROPERTY_ID: &str = "e1ffac9f-beb4-4654-8a50-00e1d6c662fb";
 
 /// Onchain-derived ID of the "root" space whose editors are authorized to
 /// publish edits that mutate the system property-definition entities — i.e.
@@ -97,6 +101,7 @@ pub const PROTECTED_PROPERTY_IDS: &[&str] = &[
     SPACE_ID_PROPERTY_ID,
     CREATED_AT_BLOCK_PROPERTY_ID,
     SCORE_PROPERTY_ID,
+    RANK_POSITION_VALUE_PROPERTY_ID,
 ];
 
 pub const PROTECTED_RELATION_TYPE_IDS: &[&str] = &[
@@ -171,6 +176,7 @@ mod tests {
             SPACE_ID_PROPERTY_ID,
             CREATED_AT_BLOCK_PROPERTY_ID,
             SCORE_PROPERTY_ID,
+            RANK_POSITION_VALUE_PROPERTY_ID,
         ];
         assert_eq!(PROTECTED_PROPERTY_IDS.len(), expected.len());
         for id in &expected {

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -39,6 +39,32 @@ pub const SPACE_ID_PROPERTY_ID: &str = "712adc1f-e950-5d14-bbd8-bf2166fe59c1";
 pub const CREATED_AT_BLOCK_PROPERTY_ID: &str = "da2952fb-17d6-53f3-b521-52e254106e0b";
 pub const SCORE_PROPERTY_ID: &str = "85a4668a-42fa-4f48-8969-c0a9de0c294b";
 
+// Rank submission IDs. Canonical values mirrored from the grc-20 SDK
+// (`@graphprotocol/grc-20` core/ids/system) — these are the user-authored
+// shapes the ranking-indexer detects on the `knowledge.edits` stream.
+//
+// NOTE: the indexer-owned output relation type (`RANK_POSITION`) is
+// intentionally NOT defined here yet — it is not part of the SDK and needs a
+// canonical system-ID assignment before it can be added to
+// `PROTECTED_RELATION_TYPE_IDS`.
+pub const RANK_TYPE_ID: &str = "5c74731d-fabb-4dc8-b5c5-3346521c639a";
+pub const RANK_TYPE_PROPERTY_ID: &str = "48e01bc8-324e-48c2-a6c9-cab3f49290c6";
+pub const RANK_VOTES_RELATION_TYPE_ID: &str = "19a4cfff-45f2-4150-abf2-af0f43eb2eec";
+pub const VOTE_ORDINAL_VALUE_PROPERTY_ID: &str = "49ee1b89-1820-4e75-a1ae-38a2dcaad4a5";
+pub const VOTE_WEIGHTED_VALUE_PROPERTY_ID: &str = "103701dd-cabe-4a8e-835b-10345327b647";
+
+// Ranking-block IDs. PROVISIONAL — sourced from geo-sdk#89
+// (feat/ranks-create-update), which is not yet merged; pin to the released
+// values once it lands. These are the user-authored ranking-block shapes the
+// indexer detects (block type, rank→block link, submission window, and the
+// aggregation restriction with its default "Members and editors" value).
+pub const RANKING_BLOCK_TYPE_ID: &str = "150db6de-fe23-44f0-805a-fa57502e2c32";
+pub const RANK_BLOCK_RELATION_TYPE_ID: &str = "09c219c1-03d1-4d2a-a5c7-8edbf2d0182a";
+pub const RANK_START_DATE_PROPERTY_ID: &str = "eed03a04-0acd-4a9e-81e0-8272ed70a817";
+pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011c";
+pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
+pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
+
 /// Onchain-derived ID of the "root" space whose editors are authorized to
 /// publish edits that mutate the system property-definition entities — i.e.
 /// relations whose `from` or `to` is in `PROTECTED_PROPERTY_IDS`. Edits from

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -69,10 +69,11 @@ pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-80
 // ranking-indexer publishes per ranked target — no user edit may author it, so
 // it is reserved in `PROTECTED_RELATION_TYPE_IDS` below.
 pub const RANK_POSITION_RELATION_TYPE_ID: &str = "890deffb-3843-49fa-8269-74000e3dcef6";
-// Aggregated-rankings property — canonical id captured, but its exact role in
-// the (still-gated) publish stage vs the RANK_POSITION relation is pending
-// confirmation, so it is intentionally NOT yet added to PROTECTED_PROPERTY_IDS.
-pub const AGGREGATED_RANKINGS_PROPERTY_ID: &str = "67651da6-11a9-4246-9ff4-039aafbe9e43";
+// `Aggregated rankings` is an indexer-owned relation type: from a published
+// RANK_POSITION result back to the individual Rank submissions that were
+// aggregated to produce its ordering (provenance). Reserved below so user edits
+// can't forge it.
+pub const AGGREGATED_RANKINGS_RELATION_TYPE_ID: &str = "67651da6-11a9-4246-9ff4-039aafbe9e43";
 
 /// Onchain-derived ID of the "root" space whose editors are authorized to
 /// publish edits that mutate the system property-definition entities — i.e.
@@ -98,8 +99,11 @@ pub const PROTECTED_PROPERTY_IDS: &[&str] = &[
     SCORE_PROPERTY_ID,
 ];
 
-pub const PROTECTED_RELATION_TYPE_IDS: &[&str] =
-    &[SYSTEM_TYPES_RELATION_TYPE_ID, RANK_POSITION_RELATION_TYPE_ID];
+pub const PROTECTED_RELATION_TYPE_IDS: &[&str] = &[
+    SYSTEM_TYPES_RELATION_TYPE_ID,
+    RANK_POSITION_RELATION_TYPE_ID,
+    AGGREGATED_RANKINGS_RELATION_TYPE_ID,
+];
 
 #[cfg(test)]
 mod tests {
@@ -180,8 +184,9 @@ mod tests {
 
     #[test]
     fn protected_relation_type_ids_contains_system_types() {
-        assert_eq!(PROTECTED_RELATION_TYPE_IDS.len(), 2);
+        assert_eq!(PROTECTED_RELATION_TYPE_IDS.len(), 3);
         assert!(PROTECTED_RELATION_TYPE_IDS.contains(&SYSTEM_TYPES_RELATION_TYPE_ID));
         assert!(PROTECTED_RELATION_TYPE_IDS.contains(&RANK_POSITION_RELATION_TYPE_ID));
+        assert!(PROTECTED_RELATION_TYPE_IDS.contains(&AGGREGATED_RANKINGS_RELATION_TYPE_ID));
     }
 }


### PR DESCRIPTION
## What

Defines the user-authored rank shapes in the Rust `sdk` crate (`core/ids`) so the upcoming **ranking-indexer** can detect them on the `knowledge.edits` stream — the foundational, dependency-light first piece of that work.

## IDs added

**Rank submissions** — canonical, mirrored from the *merged* grc-20 SDK (`core/ids/system`):
- `RANK_TYPE_ID`, `RANK_TYPE_PROPERTY_ID`, `RANK_VOTES_RELATION_TYPE_ID`, `VOTE_ORDINAL_VALUE_PROPERTY_ID`, `VOTE_WEIGHTED_VALUE_PROPERTY_ID`

**Ranking blocks** — ⚠️ **PROVISIONAL**, sourced from [`geo-sdk#89`](https://github.com/geobrowser/geo-sdk/pull/89) (`feat/ranks-create-update`), which is **not yet merged**:
- `RANKING_BLOCK_TYPE_ID`, `RANK_BLOCK_RELATION_TYPE_ID`, `RANK_START_DATE_PROPERTY_ID`, `RANK_END_DATE_PROPERTY_ID`, `RANK_AGGREGATION_RESTRICTION_PROPERTY_ID`, `RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID`

> The block IDs ride on an unmerged SDK PR — they should be re-pinned to the released values once #89 lands. Called out in a code comment too.

## Deliberately *not* included: `RANK_POSITION`

The indexer-owned output relation type is system-minted (not an SDK shape) and needs a canonical assignment before it can join `PROTECTED_RELATION_TYPE_IDS`. The convention here is `UUIDv5(GEO_SYSTEM_NAMESPACE, "relation_type:RankPosition")` (matching how `SYSTEM_TYPES_RELATION_TYPE_ID` is derived) → `7f74e35d-14c0-53de-812e-28e2fb96ddba`, pending sign-off from the design owner on the exact name string. Tracked as a follow-up.

## Test

`cargo test -p sdk core::ids` → 4 passed. Additions are raw constants outside any tested collection, so existing `ids` tests are unaffected.