### PR TITLE
feat(api): add private ranks schema for the ranking-indexer

### DIFF
--- a/api/drizzle/0061_create_ranks_schema.sql
+++ b/api/drizzle/0061_create_ranks_schema.sql
@@ -1,76 +1,48 @@
--- ranking-indexer working schema (GEO ranking aggregation).
---
--- These tables are the ranking-indexer's PRIVATE working cache. They live in a
--- dedicated `ranks` schema (NOT `public`) on purpose: PostGraphile introspects
--- only `public`, so nothing here reaches the GraphQL API. Every value is
--- derivable from the `knowledge.edits` stream and can be rebuilt by replay —
--- this is a cache, not a source of truth. The indexer joins the public
--- `members`/`editors`/`spaces`/`entities` tables cross-schema during
--- aggregation, which is why these sit in the same database.
---
--- NOTE: some column shapes are inferred from the design doc (prose-level) and
--- may be refined once the decode path is built — e.g. the dedup "update
--- markers" on `rankings`, date storage, and the restriction representation.
--- Because the schema is a rebuildable cache, those are low-risk to adjust.
-
-CREATE SCHEMA IF NOT EXISTS ranks;
+CREATE SCHEMA "ranks";
 --> statement-breakpoint
-
--- One row per Ranking Block entity.
-CREATE TABLE IF NOT EXISTS ranks.ranking_blocks (
-	"id" uuid NOT NULL,                            -- Ranking Block entity id
-	"space_id" uuid NOT NULL,                      -- space the block lives in (an entity can be perspectived across spaces)
+CREATE TABLE "ranks"."ranking_blocks" (
+	"id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
 	"name" text,
-	"filter" text,                                 -- query-data-block filter string (optional)
-	"start_date" timestamp with time zone,         -- optional submission window (inclusive)
+	"filter" text,
+	"start_date" timestamp with time zone,
 	"end_date" timestamp with time zone,
-	"restriction_id" uuid,                         -- aggregation restriction value entity; NULL => default "Members and editors"
+	"restriction_id" uuid,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	-- Composite key: the same block id can be perspectived under multiple spaces.
-	CONSTRAINT "ranking_blocks_pkey" PRIMARY KEY ("id", "space_id")
+	CONSTRAINT "ranking_blocks_id_space_id_pk" PRIMARY KEY("id","space_id")
 );
 --> statement-breakpoint
-
--- One row per Rank submission entity.
-CREATE TABLE IF NOT EXISTS ranks.rankings (
-	"id" uuid NOT NULL,                            -- Rank entity id
-	"block_id" uuid,                               -- nullable until the RANK_BLOCK link arrives (partial-state model)
-	"space_id" uuid NOT NULL,                      -- submitter's personal space (a rank can be perspectived across spaces)
-	"author_address" text,                         -- submitter address resolved from the personal space
-	"rank_type" text,                              -- 'ORDINAL' | 'WEIGHTED'
-	"submitted_at" timestamp with time zone,       -- submission timestamp used for the window check
-	"updated_at_block" bigint DEFAULT 0 NOT NULL,  -- update markers for dedup: most-recently-updated rank per (block, space) wins
-	"update_index" bigint DEFAULT 0 NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	-- Composite key: the same rank id can be perspectived under multiple spaces.
-	CONSTRAINT "rankings_pkey" PRIMARY KEY ("id", "space_id")
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "rankings_block_id_idx" ON ranks.rankings ("block_id");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "rankings_block_space_idx" ON ranks.rankings ("block_id","space_id");
---> statement-breakpoint
-
--- Decoded items of each submission, keyed on (ranking, entity, space) so a user
--- can rank competing perspectives of the same subject.
-CREATE TABLE IF NOT EXISTS ranks.ranking_items (
+CREATE TABLE "ranks"."ranking_items" (
 	"ranking_id" uuid NOT NULL,
-	"entity_id" uuid NOT NULL,                     -- ranked entity
-	"space_id" uuid NOT NULL,                      -- to_space_id (perspective of the ranked entity)
-	"position" text,                               -- fractional index (ordinal ordering)
-	"weight" double precision,                     -- weighted value (NULL for ordinal ranks)
-	CONSTRAINT "ranking_items_pkey" PRIMARY KEY ("ranking_id","entity_id","space_id")
+	"entity_id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
+	"position" text,
+	"weight" double precision,
+	CONSTRAINT "ranking_items_ranking_id_entity_id_space_id_pk" PRIMARY KEY("ranking_id","entity_id","space_id")
 );
 --> statement-breakpoint
-
--- Computed aggregate, keyed on (block, entity, space).
-CREATE TABLE IF NOT EXISTS ranks.ranking_scores (
+CREATE TABLE "ranks"."ranking_scores" (
 	"block_id" uuid NOT NULL,
 	"entity_id" uuid NOT NULL,
 	"space_id" uuid NOT NULL,
-	"score" double precision NOT NULL,             -- summed contribution across eligible submissions
-	"position" integer NOT NULL,                   -- final integer rank within the block
-	CONSTRAINT "ranking_scores_pkey" PRIMARY KEY ("block_id","entity_id","space_id")
+	"score" double precision NOT NULL,
+	"position" integer NOT NULL,
+	CONSTRAINT "ranking_scores_block_id_entity_id_space_id_pk" PRIMARY KEY("block_id","entity_id","space_id")
 );
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "ranking_scores_block_position_idx" ON ranks.ranking_scores ("block_id","position");
+CREATE TABLE "ranks"."rankings" (
+	"id" uuid NOT NULL,
+	"block_id" uuid,
+	"space_id" uuid NOT NULL,
+	"author_address" text,
+	"rank_type" text,
+	"submitted_at" timestamp with time zone,
+	"updated_at_block" bigint DEFAULT 0 NOT NULL,
+	"update_index" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "rankings_id_space_id_pk" PRIMARY KEY("id","space_id")
+);
+--> statement-breakpoint
+CREATE INDEX "ranking_scores_block_position_idx" ON "ranks"."ranking_scores" USING btree ("block_id","position");--> statement-breakpoint
+CREATE INDEX "rankings_block_id_idx" ON "ranks"."rankings" USING btree ("block_id");--> statement-breakpoint
+CREATE INDEX "rankings_block_space_idx" ON "ranks"."rankings" USING btree ("block_id","space_id");

--- a/api/drizzle/0061_create_ranks_schema.sql
+++ b/api/drizzle/0061_create_ranks_schema.sql
@@ -18,28 +18,32 @@ CREATE SCHEMA IF NOT EXISTS ranks;
 
 -- One row per Ranking Block entity.
 CREATE TABLE IF NOT EXISTS ranks.ranking_blocks (
-	"id" uuid PRIMARY KEY NOT NULL,                -- Ranking Block entity id
-	"space_id" uuid NOT NULL,                      -- space the block lives in
+	"id" uuid NOT NULL,                            -- Ranking Block entity id
+	"space_id" uuid NOT NULL,                      -- space the block lives in (an entity can be perspectived across spaces)
 	"name" text,
 	"filter" text,                                 -- query-data-block filter string (optional)
 	"start_date" timestamp with time zone,         -- optional submission window (inclusive)
 	"end_date" timestamp with time zone,
 	"restriction_id" uuid,                         -- aggregation restriction value entity; NULL => default "Members and editors"
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	-- Composite key: the same block id can be perspectived under multiple spaces.
+	CONSTRAINT "ranking_blocks_pkey" PRIMARY KEY ("id", "space_id")
 );
 --> statement-breakpoint
 
 -- One row per Rank submission entity.
 CREATE TABLE IF NOT EXISTS ranks.rankings (
-	"id" uuid PRIMARY KEY NOT NULL,                -- Rank entity id
+	"id" uuid NOT NULL,                            -- Rank entity id
 	"block_id" uuid,                               -- nullable until the RANK_BLOCK link arrives (partial-state model)
-	"space_id" uuid NOT NULL,                      -- submitter's personal space
+	"space_id" uuid NOT NULL,                      -- submitter's personal space (a rank can be perspectived across spaces)
 	"author_address" text,                         -- submitter address resolved from the personal space
 	"rank_type" text,                              -- 'ORDINAL' | 'WEIGHTED'
 	"submitted_at" timestamp with time zone,       -- submission timestamp used for the window check
 	"updated_at_block" bigint DEFAULT 0 NOT NULL,  -- update markers for dedup: most-recently-updated rank per (block, space) wins
 	"update_index" bigint DEFAULT 0 NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	-- Composite key: the same rank id can be perspectived under multiple spaces.
+	CONSTRAINT "rankings_pkey" PRIMARY KEY ("id", "space_id")
 );
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "rankings_block_id_idx" ON ranks.rankings ("block_id");

--- a/api/drizzle/0061_create_ranks_schema.sql
+++ b/api/drizzle/0061_create_ranks_schema.sql
@@ -1,0 +1,72 @@
+-- ranking-indexer working schema (GEO ranking aggregation).
+--
+-- These tables are the ranking-indexer's PRIVATE working cache. They live in a
+-- dedicated `ranks` schema (NOT `public`) on purpose: PostGraphile introspects
+-- only `public`, so nothing here reaches the GraphQL API. Every value is
+-- derivable from the `knowledge.edits` stream and can be rebuilt by replay —
+-- this is a cache, not a source of truth. The indexer joins the public
+-- `members`/`editors`/`spaces`/`entities` tables cross-schema during
+-- aggregation, which is why these sit in the same database.
+--
+-- NOTE: some column shapes are inferred from the design doc (prose-level) and
+-- may be refined once the decode path is built — e.g. the dedup "update
+-- markers" on `rankings`, date storage, and the restriction representation.
+-- Because the schema is a rebuildable cache, those are low-risk to adjust.
+
+CREATE SCHEMA IF NOT EXISTS ranks;
+--> statement-breakpoint
+
+-- One row per Ranking Block entity.
+CREATE TABLE IF NOT EXISTS ranks.ranking_blocks (
+	"id" uuid PRIMARY KEY NOT NULL,                -- Ranking Block entity id
+	"space_id" uuid NOT NULL,                      -- space the block lives in
+	"name" text,
+	"filter" text,                                 -- query-data-block filter string (optional)
+	"start_date" timestamp with time zone,         -- optional submission window (inclusive)
+	"end_date" timestamp with time zone,
+	"restriction_id" uuid,                         -- aggregation restriction value entity; NULL => default "Members and editors"
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+-- One row per Rank submission entity.
+CREATE TABLE IF NOT EXISTS ranks.rankings (
+	"id" uuid PRIMARY KEY NOT NULL,                -- Rank entity id
+	"block_id" uuid,                               -- nullable until the RANK_BLOCK link arrives (partial-state model)
+	"space_id" uuid NOT NULL,                      -- submitter's personal space
+	"author_address" text,                         -- submitter address resolved from the personal space
+	"rank_type" text,                              -- 'ORDINAL' | 'WEIGHTED'
+	"submitted_at" timestamp with time zone,       -- submission timestamp used for the window check
+	"updated_at_block" bigint DEFAULT 0 NOT NULL,  -- update markers for dedup: most-recently-updated rank per (block, space) wins
+	"update_index" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rankings_block_id_idx" ON ranks.rankings ("block_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rankings_block_space_idx" ON ranks.rankings ("block_id","space_id");
+--> statement-breakpoint
+
+-- Decoded items of each submission, keyed on (ranking, entity, space) so a user
+-- can rank competing perspectives of the same subject.
+CREATE TABLE IF NOT EXISTS ranks.ranking_items (
+	"ranking_id" uuid NOT NULL,
+	"entity_id" uuid NOT NULL,                     -- ranked entity
+	"space_id" uuid NOT NULL,                      -- to_space_id (perspective of the ranked entity)
+	"position" text,                               -- fractional index (ordinal ordering)
+	"weight" double precision,                     -- weighted value (NULL for ordinal ranks)
+	CONSTRAINT "ranking_items_pkey" PRIMARY KEY ("ranking_id","entity_id","space_id")
+);
+--> statement-breakpoint
+
+-- Computed aggregate, keyed on (block, entity, space).
+CREATE TABLE IF NOT EXISTS ranks.ranking_scores (
+	"block_id" uuid NOT NULL,
+	"entity_id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
+	"score" double precision NOT NULL,             -- summed contribution across eligible submissions
+	"position" integer NOT NULL,                   -- final integer rank within the block
+	CONSTRAINT "ranking_scores_pkey" PRIMARY KEY ("block_id","entity_id","space_id")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ranking_scores_block_position_idx" ON ranks.ranking_scores ("block_id","position");

--- a/api/drizzle/meta/0061_snapshot.json
+++ b/api/drizzle/meta/0061_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "1d5de818-469a-4f69-a4d5-af57ca863559",
+  "id": "66ae6367-a3a0-4a26-9998-a7e9914df646",
   "prevId": "31f65a89-695c-4176-a730-40c09d30c2d3",
   "version": "7",
   "dialect": "postgresql",
@@ -54,10 +54,10 @@
       "uniqueConstraints": {
         "app_webhooks_app_name_unique": {
           "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "app_name"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -197,9 +197,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -207,11 +207,11 @@
       "uniqueConstraints": {
         "edit_versions_block_sequence_unique": {
           "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "block_number",
             "sequence"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -247,9 +247,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -314,9 +314,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "entities_updated_at_id_idx": {
           "name": "entities_updated_at_id_idx",
@@ -335,9 +335,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "entities_created_at_id_idx": {
           "name": "entities_created_at_id_idx",
@@ -356,9 +356,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -453,10 +453,10 @@
       "uniqueConstraints": {
         "ipfs_cache_uri_unique": {
           "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "uri"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -504,9 +504,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "idx_local_scores_entity_id": {
           "name": "idx_local_scores_entity_id",
@@ -519,9 +519,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "idx_local_scores_space_score": {
           "name": "idx_local_scores_space_score",
@@ -540,9 +540,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -589,9 +589,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -729,48 +729,48 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "notification_deliveries_outbox_id_notification_outbox_id_fk": {
           "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
           "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
           "columnsFrom": [
             "outbox_id"
           ],
-          "tableTo": "notification_outbox",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "notification_deliveries_webhook_id_app_webhooks_id_fk": {
           "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
           "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
           "columnsFrom": [
             "webhook_id"
           ],
-          "tableTo": "app_webhooks",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "notification_deliveries_outbox_id_webhook_id_unique": {
           "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "outbox_id",
             "webhook_id"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -827,10 +827,10 @@
       "uniqueConstraints": {
         "notification_outbox_idempotency_key_unique": {
           "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "idempotency_key"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -959,9 +959,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_actions_action_type_idx": {
           "name": "proposal_actions_action_type_idx",
@@ -974,9 +974,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_actions_proposal_action_target_idx": {
           "name": "proposal_actions_proposal_action_target_idx",
@@ -1001,24 +1001,24 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "proposal_actions_proposal_id_proposals_id_fk": {
           "name": "proposal_actions_proposal_id_proposals_id_fk",
           "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
           "columnsFrom": [
             "proposal_id"
           ],
-          "tableTo": "proposals",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -1050,15 +1050,15 @@
         "proposal_tally_queue_proposal_id_proposals_id_fk": {
           "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
           "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
           "columnsFrom": [
             "proposal_id"
           ],
-          "tableTo": "proposals",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -1121,9 +1121,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_votes_voter_id_idx": {
           "name": "proposal_votes_voter_id_idx",
@@ -1136,9 +1136,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_votes_vote_idx": {
           "name": "proposal_votes_vote_idx",
@@ -1151,37 +1151,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "proposal_votes_proposal_id_proposals_id_fk": {
           "name": "proposal_votes_proposal_id_proposals_id_fk",
           "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
           "columnsFrom": [
             "proposal_id"
           ],
-          "tableTo": "proposals",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "proposal_votes_space_id_spaces_id_fk": {
           "name": "proposal_votes_space_id_spaces_id_fk",
           "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
           "columnsFrom": [
             "space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
@@ -1309,9 +1309,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_proposed_by_idx": {
           "name": "proposals_proposed_by_idx",
@@ -1324,9 +1324,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_created_at_idx": {
           "name": "proposals_created_at_idx",
@@ -1339,9 +1339,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_space_created_at_idx": {
           "name": "proposals_space_created_at_idx",
@@ -1360,9 +1360,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_space_end_time_idx": {
           "name": "proposals_space_end_time_idx",
@@ -1381,9 +1381,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_space_start_time_idx": {
           "name": "proposals_space_start_time_idx",
@@ -1402,27 +1402,338 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "proposals_space_id_spaces_id_fk": {
           "name": "proposals_space_id_spaces_id_fk",
           "tableFrom": "proposals",
+          "tableTo": "spaces",
           "columnsFrom": [
             "space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_blocks": {
+      "name": "ranking_blocks",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restriction_id": {
+          "name": "restriction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_blocks_id_space_id_pk": {
+          "name": "ranking_blocks_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_items": {
+      "name": "ranking_items",
+      "schema": "ranks",
+      "columns": {
+        "ranking_id": {
+          "name": "ranking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_items_ranking_id_entity_id_space_id_pk": {
+          "name": "ranking_items_ranking_id_entity_id_space_id_pk",
+          "columns": [
+            "ranking_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_scores": {
+      "name": "ranking_scores",
+      "schema": "ranks",
+      "columns": {
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranking_scores_block_position_idx": {
+          "name": "ranking_scores_block_position_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_scores_block_id_entity_id_space_id_pk": {
+          "name": "ranking_scores_block_id_entity_id_space_id_pk",
+          "columns": [
+            "block_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.rankings": {
+      "name": "rankings",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank_type": {
+          "name": "rank_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "update_index": {
+          "name": "update_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rankings_block_id_idx": {
+          "name": "rankings_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rankings_block_space_idx": {
+          "name": "rankings_block_space_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rankings_id_space_id_pk": {
+          "name": "rankings_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
@@ -1535,9 +1846,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relation_versions_entity_idx": {
           "name": "relation_versions_entity_idx",
@@ -1550,9 +1861,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relation_versions_open_idx": {
           "name": "relation_versions_open_idx",
@@ -1565,10 +1876,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "relation_versions_range_idx": {
           "name": "relation_versions_range_idx",
@@ -1587,9 +1898,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relation_versions_from_entity_type_idx": {
           "name": "relation_versions_from_entity_type_idx",
@@ -1614,9 +1925,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relation_versions_from_entity_valid_to_idx": {
           "name": "relation_versions_from_entity_valid_to_idx",
@@ -1635,10 +1946,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -1744,9 +2055,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_type_id_idx": {
           "name": "relations_type_id_idx",
@@ -1759,9 +2070,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_from_entity_id_idx": {
           "name": "relations_from_entity_id_idx",
@@ -1774,9 +2085,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_to_entity_id_idx": {
           "name": "relations_to_entity_id_idx",
@@ -1789,9 +2100,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_space_id_idx": {
           "name": "relations_space_id_idx",
@@ -1804,9 +2115,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_space_from_to_idx": {
           "name": "relations_space_from_to_idx",
@@ -1831,9 +2142,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_space_type_idx": {
           "name": "relations_space_type_idx",
@@ -1852,9 +2163,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_to_entity_space_idx": {
           "name": "relations_to_entity_space_idx",
@@ -1873,9 +2184,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_from_entity_space_idx": {
           "name": "relations_from_entity_space_idx",
@@ -1894,9 +2205,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_entity_type_space_idx": {
           "name": "relations_entity_type_space_idx",
@@ -1921,9 +2232,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_type_from_to_idx": {
           "name": "relations_type_from_to_idx",
@@ -1948,9 +2259,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -2033,24 +2344,24 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "spaces_topic_id_entities_id_fk": {
           "name": "spaces_topic_id_entities_id_fk",
           "tableFrom": "spaces",
+          "tableTo": "entities",
           "columnsFrom": [
             "topic_id"
           ],
-          "tableTo": "entities",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2088,9 +2399,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "subspace_topics_topic_id_idx": {
           "name": "subspace_topics_topic_id_idx",
@@ -2103,37 +2414,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "subspace_topics_space_id_spaces_id_fk": {
           "name": "subspace_topics_space_id_spaces_id_fk",
           "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
           "columnsFrom": [
             "space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "subspace_topics_topic_id_entities_id_fk": {
           "name": "subspace_topics_topic_id_entities_id_fk",
           "tableFrom": "subspace_topics",
+          "tableTo": "entities",
           "columnsFrom": [
             "topic_id"
           ],
-          "tableTo": "entities",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
@@ -2187,9 +2498,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "subspaces_child_space_id_idx": {
           "name": "subspaces_child_space_id_idx",
@@ -2202,37 +2513,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "subspaces_parent_space_id_spaces_id_fk": {
           "name": "subspaces_parent_space_id_spaces_id_fk",
           "tableFrom": "subspaces",
+          "tableTo": "spaces",
           "columnsFrom": [
             "parent_space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "subspaces_child_space_id_spaces_id_fk": {
           "name": "subspaces_child_space_id_spaces_id_fk",
           "tableFrom": "subspaces",
+          "tableTo": "spaces",
           "columnsFrom": [
             "child_space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
@@ -2315,9 +2626,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -2325,13 +2636,13 @@
       "uniqueConstraints": {
         "user_votes_user_id_object_id_object_type_space_id_unique": {
           "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "user_id",
             "object_id",
             "object_type",
             "space_id"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -2505,9 +2816,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "value_versions_lookup_idx": {
           "name": "value_versions_lookup_idx",
@@ -2532,9 +2843,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "value_versions_open_idx": {
           "name": "value_versions_open_idx",
@@ -2559,10 +2870,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"value_versions\".\"valid_to_key\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "value_versions_range_idx": {
           "name": "value_versions_range_idx",
@@ -2581,9 +2892,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "value_versions_entity_space_valid_to_idx": {
           "name": "value_versions_entity_space_valid_to_idx",
@@ -2608,10 +2919,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -2764,9 +3075,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_entity_id_idx": {
           "name": "values_entity_id_idx",
@@ -2779,9 +3090,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_space_id_idx": {
           "name": "values_space_id_idx",
@@ -2794,9 +3105,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_boolean_idx": {
           "name": "values_boolean_idx",
@@ -2809,9 +3120,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_integer_idx": {
           "name": "values_integer_idx",
@@ -2824,9 +3135,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_float_idx": {
           "name": "values_float_idx",
@@ -2839,9 +3150,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_decimal_idx": {
           "name": "values_decimal_idx",
@@ -2854,9 +3165,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_text_idx": {
           "name": "values_text_idx",
@@ -2869,10 +3180,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "length(\"values\".\"text\") <= 2000",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "values_date_idx": {
           "name": "values_date_idx",
@@ -2885,9 +3196,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_time_idx": {
           "name": "values_time_idx",
@@ -2900,9 +3211,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_datetime_idx": {
           "name": "values_datetime_idx",
@@ -2915,9 +3226,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_point_idx": {
           "name": "values_point_idx",
@@ -2930,9 +3241,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_rect_idx": {
           "name": "values_rect_idx",
@@ -2945,9 +3256,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_entity_property_idx": {
           "name": "values_entity_property_idx",
@@ -2966,9 +3277,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_entity_space_idx": {
           "name": "values_entity_space_idx",
@@ -2987,9 +3298,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_property_space_idx": {
           "name": "values_property_space_idx",
@@ -3008,9 +3319,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_entity_property_space_idx": {
           "name": "values_entity_property_space_idx",
@@ -3035,9 +3346,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_language_idx": {
           "name": "values_language_idx",
@@ -3050,9 +3361,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_unit_idx": {
           "name": "values_unit_idx",
@@ -3065,9 +3376,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_time_utc_idx": {
           "name": "values_time_utc_idx",
@@ -3080,9 +3391,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_datetime_utc_idx": {
           "name": "values_datetime_utc_idx",
@@ -3095,9 +3406,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -3179,9 +3490,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "idx_votes_object_type_object_id_space_id": {
           "name": "idx_votes_object_type_object_id_space_id",
@@ -3206,9 +3517,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -3286,10 +3597,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "object_type = 0",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -3297,12 +3608,12 @@
       "uniqueConstraints": {
         "votes_count_object_id_object_type_space_id_unique": {
           "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "object_id",
             "object_type",
             "space_id"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -3369,11 +3680,13 @@
       ]
     }
   },
-  "schemas": {},
-  "views": {},
+  "schemas": {
+    "ranks": "ranks"
+  },
   "sequences": {},
   "roles": {},
   "policies": {},
+  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},

--- a/api/drizzle/meta/0061_snapshot.json
+++ b/api/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,3382 @@
+{
+  "id": "1d5de818-469a-4f69-a4d5-af57ca863559",
+  "prevId": "31f65a89-695c-4176-a730-40c09d30c2d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "columns": [
+            "app_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "columns": [
+            "block_number",
+            "sequence"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "columns": [
+            "uri"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "tableTo": "notification_outbox",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "tableTo": "app_webhooks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_poll_cursors": {
+      "name": "notification_poll_cursors",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor_updated_at": {
+          "name": "cursor_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "tableTo": "entities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "tableTo": "entities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_count_updated_at": {
+          "name": "idx_votes_count_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "object_type = 0",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -432,7 +432,7 @@
     {
       "idx": 61,
       "version": "7",
-      "when": 1780963771035,
+      "when": 1781041240657,
       "tag": "0061_create_ranks_schema",
       "breakpoints": true
     }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1780679566128,
       "tag": "0060_optimize-entities-ordered-by-property",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1780963771035,
+      "tag": "0061_create_ranks_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -6,8 +6,10 @@ import {
 	decimal,
 	doublePrecision,
 	index,
+	integer,
 	jsonb,
 	pgEnum,
+	pgSchema,
 	pgTable,
 	primaryKey,
 	serial,
@@ -980,5 +982,81 @@ export const notificationDeliveries = pgTable(
 	(table) => [
 		unique().on(table.outboxId, table.webhookId),
 		index("idx_deliveries_pending").on(table.status, table.nextRetryAt),
+	],
+)
+
+/**
+ * Private `ranks` schema — the ranking-indexer's working cache.
+ *
+ * Lives outside `public` on purpose: PostGraphile introspects only `public`, so
+ * nothing here reaches the GraphQL API. Defined here (rather than as a hand-
+ * written migration) so drizzle-kit owns the migration. Every value is
+ * derivable from the `knowledge.edits` stream and rebuildable by replay.
+ */
+export const ranks = pgSchema("ranks")
+
+/** One row per Ranking Block entity, keyed on (id, space) for perspectives. */
+export const rankingBlocks = ranks.table(
+	"ranking_blocks",
+	{
+		id: uuid().notNull(),
+		spaceId: uuid("space_id").notNull(),
+		name: text(),
+		filter: text(),
+		startDate: timestamp("start_date", {withTimezone: true, mode: "date"}),
+		endDate: timestamp("end_date", {withTimezone: true, mode: "date"}),
+		restrictionId: uuid("restriction_id"),
+		updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull().defaultNow(),
+	},
+	(table) => [primaryKey({columns: [table.id, table.spaceId]})],
+)
+
+/** One row per Rank submission entity, keyed on (id, space) for perspectives. */
+export const rankings = ranks.table(
+	"rankings",
+	{
+		id: uuid().notNull(),
+		blockId: uuid("block_id"),
+		spaceId: uuid("space_id").notNull(),
+		authorAddress: text("author_address"),
+		rankType: text("rank_type"),
+		submittedAt: timestamp("submitted_at", {withTimezone: true, mode: "date"}),
+		updatedAtBlock: bigint("updated_at_block", {mode: "number"}).notNull().default(0),
+		updateIndex: bigint("update_index", {mode: "number"}).notNull().default(0),
+		updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull().defaultNow(),
+	},
+	(table) => [
+		primaryKey({columns: [table.id, table.spaceId]}),
+		index("rankings_block_id_idx").on(table.blockId),
+		index("rankings_block_space_idx").on(table.blockId, table.spaceId),
+	],
+)
+
+/** Decoded items of each submission, keyed on (ranking, entity, space). */
+export const rankingItems = ranks.table(
+	"ranking_items",
+	{
+		rankingId: uuid("ranking_id").notNull(),
+		entityId: uuid("entity_id").notNull(),
+		spaceId: uuid("space_id").notNull(),
+		position: text(),
+		weight: doublePrecision(),
+	},
+	(table) => [primaryKey({columns: [table.rankingId, table.entityId, table.spaceId]})],
+)
+
+/** Computed aggregate, keyed on (block, entity, space). */
+export const rankingScores = ranks.table(
+	"ranking_scores",
+	{
+		blockId: uuid("block_id").notNull(),
+		entityId: uuid("entity_id").notNull(),
+		spaceId: uuid("space_id").notNull(),
+		score: doublePrecision().notNull(),
+		position: integer().notNull(),
+	},
+	(table) => [
+		primaryKey({columns: [table.blockId, table.entityId, table.spaceId]}),
+		index("ranking_scores_block_position_idx").on(table.blockId, table.position),
 	],
 )


### PR DESCRIPTION
## What

Creates the **ranking-indexer's private working cache** as a dedicated `ranks` schema (migration `0061`). This is workstream #1 of the ranking-indexer build, and it's independent of the design's open questions (eligibility/scoring/publish semantics) — so it's safe to land now.

Four tables, per §6 of the ranking-indexer design:

| Table | Purpose | Key |
|---|---|---|
| `ranks.ranking_blocks` | one row per Ranking Block | `id` |
| `ranks.rankings` | one row per Rank submission | `id` |
| `ranks.ranking_items` | decoded items per submission | `(ranking_id, entity_id, space_id)` |
| `ranks.ranking_scores` | computed aggregate | `(block_id, entity_id, space_id)` |

## Why a private `ranks` schema

PostGraphile introspects only `public`, so putting these in `ranks` makes the indexer's intermediate state **structurally invisible** to the GraphQL API — the design's core requirement. It's a rebuildable cache (everything is derivable from `knowledge.edits`), and it lives in the same DB so the indexer can join public `members`/`editors`/`spaces`/`entities` cross-schema during aggregation.

## Verification

- `drizzle-kit migrate` applies the full chain cleanly (scaffolded with `generate --custom` so the journal + snapshot stay consistent).
- Confirmed the four tables land in `ranks` and are **absent from `public`** (0 `ranking*` tables there).

## Notes for reviewers

- **First non-`public` schema** created via Drizzle in this repo — flagging the new pattern. Alternative considered: have the ranking-indexer own its own DDL/migrations rather than the API migration chain. Went with `api/drizzle` for V1 (single migration runner, repo precedent of indexer tables living here), but happy to move it if the team prefers the indexer own its private schema.
- A few **column shapes are inferred** from the prose-level design (the dedup "update markers" on `rankings`, date storage, restriction representation) and noted in a comment. Low-risk to refine since the schema is a rebuildable cache.
- No `public` schema change, so the `0061` snapshot is an unchanged copy of `0060`'s.