### PR TITLE
feat(ranking-indexer): scaffold the rank-aggregation consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5235,6 +5235,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ranking-indexer"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dotenv",
+ "futures 0.3.31",
+ "grc-20",
+ "hermes-instrumentation",
+ "hermes-kafka",
+ "hermes-schema",
+ "indexer_utils",
+ "prost 0.13.5",
+ "rdkafka 0.38.0",
+ "sdk",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "hermes-substream",
 
     "kg-indexer",
+    "ranking-indexer",
     "scoring-service/vote-indexer",
     "scoring-service/topology-indexer",
 

--- a/ranking-indexer/Cargo.toml
+++ b/ranking-indexer/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ranking-indexer"
+version = "0.1.0"
+edition = "2021"
+description = "Aggregates GEO rank submissions into ranking results and projects them back into the knowledge graph"
+
+[[bin]]
+name = "ranking-indexer"
+path = "src/main.rs"
+
+[dependencies]
+hermes-schema = { path = "../hermes-schema" }
+hermes-instrumentation = { path = "../hermes-instrumentation" }
+hermes-kafka = { path = "../hermes-kafka" }
+indexer_utils = { path = "../indexer_utils" }
+sdk = { path = "../sdk" }
+# GRC-20 v2 binary format (same decoder the kg-indexer uses)
+grc-20 = "0.4.1"
+rdkafka = { version = "0.38.0", features = ["cmake-build", "ssl", "zstd"] }
+tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
+futures = "0.3.31"
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "uuid", "chrono", "tls-rustls"] }
+prost = "0.13.5"
+thiserror = "2.0.12"
+chrono = "0.4.41"
+uuid = { version = "1.17.0", features = ["v4", "v5"] }
+dotenv = "0.15.0"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }

--- a/ranking-indexer/src/consumer.rs
+++ b/ranking-indexer/src/consumer.rs
@@ -1,0 +1,106 @@
+//! Kafka consumer for the `knowledge.edits` topic.
+//!
+//! Mirrors the vote-indexer consumer: a manual-commit `StreamConsumer` with the
+//! environment topic prefix applied. Edits are decoded in two steps —
+//! `HermesEdit` (prost) then the raw GRC2/GRC2Z payload via the `grc-20` crate,
+//! the same decoder the kg-indexer uses.
+
+use hermes_kafka::get_topic_prefix;
+use prost::Message;
+use rdkafka::{
+    config::ClientConfig,
+    consumer::{Consumer, DefaultConsumerContext, StreamConsumer},
+    TopicPartitionList,
+};
+use std::env;
+use tracing::{debug, info};
+
+use crate::error::IndexerError;
+
+/// Base topic for knowledge edits.
+const EDITS_TOPIC: &str = "knowledge.edits";
+
+/// Kafka consumer for knowledge edits.
+pub struct KafkaConsumer {
+    consumer: StreamConsumer<DefaultConsumerContext>,
+    topic: String,
+}
+
+impl KafkaConsumer {
+    pub fn new(brokers: &str, group_id: &str) -> Result<Self, IndexerError> {
+        let mut config = ClientConfig::new();
+        config
+            .set("bootstrap.servers", brokers)
+            .set("group.id", group_id)
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .set("session.timeout.ms", "6000");
+
+        if let Ok(username) = env::var("KAFKA_USERNAME") {
+            config.set("security.protocol", "SASL_SSL");
+            config.set("sasl.mechanisms", "PLAIN");
+            config.set("sasl.username", &username);
+
+            let password = env::var("KAFKA_PASSWORD").map_err(|_| {
+                IndexerError::Config(
+                    "KAFKA_PASSWORD must be set when KAFKA_USERNAME is configured".into(),
+                )
+            })?;
+            config.set("sasl.password", &password);
+        }
+
+        if let Ok(ca_pem) = env::var("KAFKA_SSL_CA_PEM") {
+            config.set("ssl.ca.pem", &ca_pem);
+        }
+
+        let consumer: StreamConsumer = config.create()?;
+
+        let prefix = get_topic_prefix();
+        let topic = format!("{}{}", prefix, EDITS_TOPIC);
+
+        info!(
+            brokers = %brokers,
+            group_id = %group_id,
+            topic_prefix = %prefix,
+            topic = %topic,
+            "Created Kafka consumer"
+        );
+
+        Ok(Self { consumer, topic })
+    }
+
+    pub fn subscribe(&self) -> Result<(), IndexerError> {
+        self.consumer.subscribe(&[&self.topic])?;
+        info!(topic = %self.topic, "Subscribed to Kafka topic");
+        Ok(())
+    }
+
+    pub fn stream(&self) -> rdkafka::consumer::MessageStream<'_, DefaultConsumerContext> {
+        self.consumer.stream()
+    }
+
+    pub fn commit_message(
+        &self,
+        topic: &str,
+        partition: i32,
+        offset: i64,
+    ) -> Result<(), IndexerError> {
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition_offset(topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+        self.consumer
+            .commit(&tpl, rdkafka::consumer::CommitMode::Async)?;
+        debug!(topic = %topic, partition = partition, offset = offset, "Committed offset");
+        Ok(())
+    }
+}
+
+/// Decode the `HermesEdit` envelope from a Kafka payload.
+pub fn parse_edit(payload: &[u8]) -> Result<hermes_schema::pb::knowledge::HermesEdit, IndexerError> {
+    Ok(hermes_schema::pb::knowledge::HermesEdit::decode(payload)?)
+}
+
+/// Decode the raw GRC2/GRC2Z payload bytes into a `grc_20::Edit` (handles both
+/// compressed and uncompressed forms, same as the kg-indexer).
+pub fn decode_grc20(payload: &[u8]) -> Result<grc_20::Edit<'_>, IndexerError> {
+    grc_20::decode_edit(payload).map_err(|e| IndexerError::decode(format!("grc20: {e}")))
+}

--- a/ranking-indexer/src/dedup.rs
+++ b/ranking-indexer/src/dedup.rs
@@ -1,0 +1,82 @@
+//! Deduplication: keep only the most-recently-updated submission per
+//! (block, personal space). A user who submits twice to the same block counts
+//! once, with the later submission superseding the earlier (design §7).
+
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::models::Ranking;
+
+/// Reduce a set of submissions to the latest per (block_id, space_id).
+///
+/// "Latest" is ordered by the update markers `(updated_at_block, update_index)`.
+/// Submissions whose `block_id` is still null contribute to no block and are
+/// dropped here (they're held until their link arrives).
+pub fn dedup_latest(rankings: Vec<Ranking>) -> Vec<Ranking> {
+    let mut latest: HashMap<(Uuid, Uuid), Ranking> = HashMap::new();
+    for r in rankings {
+        let Some(block_id) = r.block_id else { continue };
+        let key = (block_id, r.space_id);
+        let incoming = (r.updated_at_block, r.update_index);
+        match latest.get(&key) {
+            Some(existing)
+                if (existing.updated_at_block, existing.update_index) >= incoming => {}
+            _ => {
+                latest.insert(key, r);
+            }
+        }
+    }
+    latest.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn ranking(id: u128, block: Option<u128>, space: u128, blk: i64, idx: i64) -> Ranking {
+        Ranking {
+            id: Uuid::from_u128(id),
+            block_id: block.map(Uuid::from_u128),
+            space_id: Uuid::from_u128(space),
+            author_address: None,
+            rank_type: None,
+            submitted_at: Some(Utc::now()),
+            updated_at_block: blk,
+            update_index: idx,
+        }
+    }
+
+    #[test]
+    fn keeps_latest_per_block_and_space() {
+        let earlier = ranking(1, Some(100), 200, 10, 0);
+        let later = ranking(2, Some(100), 200, 20, 0);
+        let out = dedup_latest(vec![earlier, later]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, Uuid::from_u128(2));
+    }
+
+    #[test]
+    fn tie_breaks_on_update_index() {
+        let a = ranking(1, Some(100), 200, 20, 1);
+        let b = ranking(2, Some(100), 200, 20, 5);
+        let out = dedup_latest(vec![a, b]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, Uuid::from_u128(2));
+    }
+
+    #[test]
+    fn different_spaces_both_kept() {
+        let a = ranking(1, Some(100), 200, 10, 0);
+        let b = ranking(2, Some(100), 201, 10, 0);
+        let out = dedup_latest(vec![a, b]);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn unlinked_rankings_dropped() {
+        let unlinked = ranking(1, None, 200, 10, 0);
+        let out = dedup_latest(vec![unlinked]);
+        assert!(out.is_empty());
+    }
+}

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -2,19 +2,77 @@
 //!
 //! The indexer keeps only the four op patterns from the design (§5) and
 //! discards everything else:
+//!   - `CreateEntity` typed `Rank`           -> a [`Ranking`]
 //!   - `CreateEntity` typed `Ranking Block`  -> a [`RankingBlock`]
-//!   - `CreateEntity` typed `Rank`           -> a [`Ranking`] (+ its items)
 //!   - `RANK_VOTES` relations                -> [`RankingItem`] rows
 //!   - `CreateRelation` of type `RANK_BLOCK`  -> a rank -> block link
 //!
-//! Type membership is read from the `TYPES` relation, matching how the rest of
-//! gaia resolves entity types. The relevant system IDs live in
-//! [`sdk::core::ids`] (`RANK_TYPE_ID`, `RANKING_BLOCK_TYPE_ID`,
-//! `RANK_VOTES_RELATION_TYPE_ID`, `RANK_BLOCK_RELATION_TYPE_ID`, …).
+//! Type membership is read from the `TYPES` relation (a `CreateRelation` of
+//! type `TYPE_RELATION_TYPE_ID` whose `to` is the type entity), matching how
+//! the rest of gaia resolves entity types.
 
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use grc_20::{Id as Grc20Id, Op as Grc20Op, PropertyValue, Value as Grc20Value};
 use uuid::Uuid;
 
 use crate::models::{Ranking, RankingBlock, RankingItem};
+
+/// System IDs we match against, parsed once from their string constants.
+struct DetectIds {
+    type_relation: Uuid,
+    name_property: Uuid,
+    rank_type: Uuid,
+    ranking_block_type: Uuid,
+    rank_type_property: Uuid,
+    rank_votes_relation: Uuid,
+    rank_block_relation: Uuid,
+    vote_weighted_value_property: Uuid,
+}
+
+static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
+    use sdk::core::ids::*;
+    let uid = |s: &str| Uuid::parse_str(s).expect("invalid system ID constant");
+    DetectIds {
+        type_relation: uid(TYPE_RELATION_TYPE_ID),
+        name_property: uid(NAME_PROPERTY_ID),
+        rank_type: uid(RANK_TYPE_ID),
+        ranking_block_type: uid(RANKING_BLOCK_TYPE_ID),
+        rank_type_property: uid(RANK_TYPE_PROPERTY_ID),
+        rank_votes_relation: uid(RANK_VOTES_RELATION_TYPE_ID),
+        rank_block_relation: uid(RANK_BLOCK_RELATION_TYPE_ID),
+        vote_weighted_value_property: uid(VOTE_WEIGHTED_VALUE_PROPERTY_ID),
+    }
+});
+
+fn id_to_uuid(id: &Grc20Id) -> Uuid {
+    Uuid::from_bytes(*id)
+}
+
+fn text_value(values: &[PropertyValue], property: Uuid) -> Option<String> {
+    values.iter().find_map(|pv| {
+        if id_to_uuid(&pv.property) != property {
+            return None;
+        }
+        match &pv.value {
+            Grc20Value::Text { value, .. } => Some(value.to_string()),
+            _ => None,
+        }
+    })
+}
+
+fn float_value(values: &[PropertyValue], property: Uuid) -> Option<f64> {
+    values.iter().find_map(|pv| {
+        if id_to_uuid(&pv.property) != property {
+            return None;
+        }
+        match &pv.value {
+            Grc20Value::Float { value, .. } => Some(*value),
+            _ => None,
+        }
+    })
+}
 
 /// The rank-relevant ops extracted from a single edit.
 #[derive(Debug, Default)]
@@ -37,16 +95,101 @@ impl DetectedEdit {
 
 /// Extract the rank-relevant ops from a decoded GRC-20 edit.
 ///
-/// TODO(ranking-indexer): implement the op-pattern matching against
-/// `grc_20::Op` variants, mirroring the kg-indexer's `extract_entities` /
-/// `extract_values` / `extract_relations` (kg-indexer/src/handlers/edits.rs).
-/// This is the focused next step: it needs the grc_20 op API and the
-/// `TYPES`-relation type-resolution pattern. Returning an empty result keeps
-/// the pipeline correct (a no-op) until the matching lands.
-pub fn detect(edit: &grc_20::Edit, _space_id: Uuid) -> DetectedEdit {
-    tracing::debug!(
-        op_count = edit.ops.len(),
-        "ranking-indexer: detect() not yet wired — skipping rank op extraction"
-    );
-    DetectedEdit::default()
+/// `space_id` is the edit's space (a Rank/Ranking Block lives in it).
+/// `block_number` seeds the dedup update markers ("most recently updated rank
+/// per (block, space) wins"); `update_index` is the op position within the edit.
+pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> DetectedEdit {
+    let ids = &*IDS;
+    let mut out = DetectedEdit::default();
+
+    // Pass 1: index entity property-values and resolve TYPES membership, and
+    // collect the rank relations (votes + block links).
+    let mut entity_values: HashMap<Uuid, &[PropertyValue]> = HashMap::new();
+    let mut types_of: HashMap<Uuid, HashSet<Uuid>> = HashMap::new();
+
+    for op in &edit.ops {
+        match op {
+            Grc20Op::CreateEntity(entity) => {
+                entity_values.insert(id_to_uuid(&entity.id), entity.values.as_slice());
+            }
+            Grc20Op::CreateRelation(relation) => {
+                let type_id = id_to_uuid(&relation.relation_type);
+                if type_id == ids.type_relation {
+                    types_of
+                        .entry(id_to_uuid(&relation.from))
+                        .or_default()
+                        .insert(id_to_uuid(&relation.to));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Pass 2: classify ops using the resolved types.
+    for (op_index, op) in edit.ops.iter().enumerate() {
+        match op {
+            Grc20Op::CreateEntity(entity) => {
+                let entity_id = id_to_uuid(&entity.id);
+                let entity_types = types_of.get(&entity_id);
+
+                let is_rank = entity_types.is_some_and(|t| t.contains(&ids.rank_type));
+                let is_block =
+                    entity_types.is_some_and(|t| t.contains(&ids.ranking_block_type));
+
+                if is_rank {
+                    out.rankings.push(Ranking {
+                        id: entity_id,
+                        block_id: None, // set when the RANK_BLOCK link is seen (here or later)
+                        space_id,
+                        author_address: None, // resolved from the personal space during aggregation
+                        rank_type: text_value(&entity.values, ids.rank_type_property),
+                        submitted_at: None, // TODO: derive from edit/block timestamp
+                        updated_at_block: block_number,
+                        update_index: op_index as i64,
+                    });
+                } else if is_block {
+                    // NOTE: only id/space_id/name are confidently extractable today.
+                    // The block's window dates, filter, and aggregation restriction
+                    // emission shapes aren't in the merged SDK yet (geo-sdk#89 adds
+                    // the IDs; block creation lands separately). Left as TODO so we
+                    // don't guess the wrong op shape.
+                    out.blocks.push(RankingBlock {
+                        id: entity_id,
+                        space_id,
+                        name: text_value(&entity.values, ids.name_property),
+                        filter: None,
+                        start_date: None,
+                        end_date: None,
+                        restriction_id: None,
+                    });
+                }
+            }
+            Grc20Op::CreateRelation(relation) => {
+                let type_id = id_to_uuid(&relation.relation_type);
+                let from = id_to_uuid(&relation.from);
+
+                if type_id == ids.rank_votes_relation {
+                    // A ranked item: position is the fractional index, to_space the
+                    // perspective, and the weighted value lives on the reified vote
+                    // entity (ordinal ranks carry only the fractional index).
+                    let reified = id_to_uuid(&relation.entity_id());
+                    let weight = entity_values
+                        .get(&reified)
+                        .and_then(|vals| float_value(vals, ids.vote_weighted_value_property));
+                    out.items.push(RankingItem {
+                        ranking_id: from,
+                        entity_id: id_to_uuid(&relation.to),
+                        space_id: relation.to_space.map(|id| id_to_uuid(&id)).unwrap_or(space_id),
+                        position: relation.position.as_ref().map(|p| p.to_string()),
+                        weight,
+                    });
+                } else if type_id == ids.rank_block_relation {
+                    out.block_links.push((from, id_to_uuid(&relation.to)));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    out
 }

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -172,6 +172,23 @@ pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> Detecte
                     // A ranked item: position is the fractional index, to_space the
                     // perspective, and the weighted value lives on the reified vote
                     // entity (ordinal ranks carry only the fractional index).
+                    //
+                    // `to_space` is the ranked entity's perspective and is required:
+                    // the SDK sets it on every vote (buildVoteOps keys uniqueness on
+                    // (entityId, spaceId)), and both aggregation and the published
+                    // projection key on it. It is normally *not* the ranking's own
+                    // (personal) space — it's wherever the ranked entity lives. A
+                    // missing one is a malformed vote we can't place in a perspective,
+                    // so skip the item rather than mis-bucketing it into the ranking's
+                    // space (which would create an aggregate row readers can't resolve).
+                    let Some(item_space) = relation.to_space.map(|id| id_to_uuid(&id)) else {
+                        tracing::warn!(
+                            ranking = %from,
+                            entity = %id_to_uuid(&relation.to),
+                            "RANK_VOTES relation missing to_space; skipping item"
+                        );
+                        continue;
+                    };
                     let reified = id_to_uuid(&relation.entity_id());
                     let weight = entity_values
                         .get(&reified)
@@ -179,7 +196,7 @@ pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> Detecte
                     out.items.push(RankingItem {
                         ranking_id: from,
                         entity_id: id_to_uuid(&relation.to),
-                        space_id: relation.to_space.map(|id| id_to_uuid(&id)).unwrap_or(space_id),
+                        space_id: item_space,
                         position: relation.position.as_ref().map(|p| p.to_string()),
                         weight,
                     });

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -1,0 +1,52 @@
+//! Detection of rank-relevant operations within a decoded GRC-20 edit.
+//!
+//! The indexer keeps only the four op patterns from the design (§5) and
+//! discards everything else:
+//!   - `CreateEntity` typed `Ranking Block`  -> a [`RankingBlock`]
+//!   - `CreateEntity` typed `Rank`           -> a [`Ranking`] (+ its items)
+//!   - `RANK_VOTES` relations                -> [`RankingItem`] rows
+//!   - `CreateRelation` of type `RANK_BLOCK`  -> a rank -> block link
+//!
+//! Type membership is read from the `TYPES` relation, matching how the rest of
+//! gaia resolves entity types. The relevant system IDs live in
+//! [`sdk::core::ids`] (`RANK_TYPE_ID`, `RANKING_BLOCK_TYPE_ID`,
+//! `RANK_VOTES_RELATION_TYPE_ID`, `RANK_BLOCK_RELATION_TYPE_ID`, …).
+
+use uuid::Uuid;
+
+use crate::models::{Ranking, RankingBlock, RankingItem};
+
+/// The rank-relevant ops extracted from a single edit.
+#[derive(Debug, Default)]
+pub struct DetectedEdit {
+    pub blocks: Vec<RankingBlock>,
+    pub rankings: Vec<Ranking>,
+    pub items: Vec<RankingItem>,
+    /// `(ranking_id, block_id)` links from `RANK_BLOCK` relations.
+    pub block_links: Vec<(Uuid, Uuid)>,
+}
+
+impl DetectedEdit {
+    pub fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+            && self.rankings.is_empty()
+            && self.items.is_empty()
+            && self.block_links.is_empty()
+    }
+}
+
+/// Extract the rank-relevant ops from a decoded GRC-20 edit.
+///
+/// TODO(ranking-indexer): implement the op-pattern matching against
+/// `grc_20::Op` variants, mirroring the kg-indexer's `extract_entities` /
+/// `extract_values` / `extract_relations` (kg-indexer/src/handlers/edits.rs).
+/// This is the focused next step: it needs the grc_20 op API and the
+/// `TYPES`-relation type-resolution pattern. Returning an empty result keeps
+/// the pipeline correct (a no-op) until the matching lands.
+pub fn detect(edit: &grc_20::Edit, _space_id: Uuid) -> DetectedEdit {
+    tracing::debug!(
+        op_count = edit.ops.len(),
+        "ranking-indexer: detect() not yet wired — skipping rank op extraction"
+    );
+    DetectedEdit::default()
+}

--- a/ranking-indexer/src/error.rs
+++ b/ranking-indexer/src/error.rs
@@ -1,0 +1,28 @@
+//! Error types for the ranking-indexer.
+
+#[derive(Debug, thiserror::Error)]
+pub enum IndexerError {
+    #[error("config error: {0}")]
+    Config(String),
+
+    #[error("kafka error: {0}")]
+    Kafka(#[from] rdkafka::error::KafkaError),
+
+    #[error("decode error: {0}")]
+    Decode(String),
+
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+impl IndexerError {
+    pub fn decode(msg: impl Into<String>) -> Self {
+        Self::Decode(msg.into())
+    }
+}
+
+impl From<prost::DecodeError> for IndexerError {
+    fn from(e: prost::DecodeError) -> Self {
+        Self::Decode(format!("prost: {e}"))
+    }
+}

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -1,0 +1,10 @@
+//! ranking-indexer: consumes `knowledge.edits`, maintains the private `ranks`
+//! working schema, and (future) projects aggregated `RANK_POSITION` relations
+//! back into the public graph.
+
+pub mod consumer;
+pub mod dedup;
+pub mod detect;
+pub mod error;
+pub mod models;
+pub mod storage;

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -112,7 +112,9 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
     }
 
     for (ranking_id, block_id) in detected.block_links {
-        storage.set_ranking_block(ranking_id, block_id).await?;
+        // The RANK_BLOCK relation is authored in the ranking's space, so the
+        // edit's `space_id` is the rank row's space.
+        storage.set_ranking_block(ranking_id, block_id, space_id).await?;
     }
 
     // TODO(ranking-indexer): recompute affected blocks (dedup -> eligibility ->

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -1,0 +1,119 @@
+//! ranking-indexer binary entrypoint.
+//!
+//! Consumes `knowledge.edits`, keeps the rank-relevant ops, and upserts them
+//! into the private `ranks` working schema. Per-edit processing (the design
+//! allows either per-edit or per-block batching, §10).
+//!
+//! NOT YET WIRED (follow-ups, gated on the design's open questions):
+//!   - `detect()` op extraction (the rank op-pattern matching)
+//!   - per-block recompute: dedup -> eligibility -> scoring
+//!   - projection of `RANK_POSITION` relations into `public.relations`
+
+use std::collections::HashMap;
+use std::env;
+
+use futures::StreamExt;
+use rdkafka::Message;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use ranking_indexer::consumer::{decode_grc20, parse_edit, KafkaConsumer};
+use ranking_indexer::detect::detect;
+use ranking_indexer::error::IndexerError;
+use ranking_indexer::storage::Storage;
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let brokers = env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".into());
+    let group_id = env::var("KAFKA_GROUP_ID").unwrap_or_else(|_| "ranking-indexer".into());
+
+    let storage = Storage::new(&database_url).await?;
+    let consumer = KafkaConsumer::new(&brokers, &group_id)?;
+    consumer.subscribe()?;
+
+    info!("ranking-indexer started");
+
+    let mut stream = consumer.stream();
+    while let Some(result) = stream.next().await {
+        let msg = match result {
+            Ok(m) => m,
+            Err(e) => {
+                error!(error = %e, "Kafka receive error");
+                continue;
+            }
+        };
+
+        let topic = msg.topic().to_string();
+        let partition = msg.partition();
+        let offset = msg.offset();
+
+        let Some(payload) = msg.payload() else {
+            // Tombstone / empty payload — nothing to do, advance past it.
+            let _ = consumer.commit_message(&topic, partition, offset);
+            continue;
+        };
+
+        match process_edit(payload, &storage).await {
+            Ok(()) => {
+                if let Err(e) = consumer.commit_message(&topic, partition, offset) {
+                    error!(error = %e, "Failed to commit offset");
+                }
+            }
+            Err(e) => {
+                // A malformed edit is logged and skipped rather than stalling the
+                // partition (design §10). The offset is still advanced.
+                warn!(error = %e, offset = offset, "Skipping unprocessable edit");
+                let _ = consumer.commit_message(&topic, partition, offset);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Decode one edit and upsert its rank-relevant ops into the `ranks` schema.
+async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerError> {
+    let edit = parse_edit(payload)?;
+    let space_id = Uuid::from_slice(&edit.space_id)
+        .map_err(|e| IndexerError::decode(format!("space_id: {e}")))?;
+
+    let grc20_edit = decode_grc20(&edit.payload)?;
+    let detected = detect(&grc20_edit, space_id);
+    if detected.is_empty() {
+        return Ok(());
+    }
+
+    for block in &detected.blocks {
+        storage.upsert_ranking_block(block).await?;
+    }
+    for ranking in &detected.rankings {
+        storage.upsert_ranking(ranking).await?;
+    }
+
+    // Re-submission rebuilds a rank's items, so replace per ranking.
+    let mut items_by_ranking: HashMap<Uuid, Vec<_>> = HashMap::new();
+    for item in detected.items {
+        items_by_ranking.entry(item.ranking_id).or_default().push(item);
+    }
+    for (ranking_id, items) in items_by_ranking {
+        storage.replace_ranking_items(ranking_id, &items).await?;
+    }
+
+    for (ranking_id, block_id) in detected.block_links {
+        storage.set_ranking_block(ranking_id, block_id).await?;
+    }
+
+    // TODO(ranking-indexer): recompute affected blocks (dedup -> eligibility ->
+    // scoring) and project RANK_POSITION relations. Gated on the design's open
+    // questions (eligibility for personal spaces, scoring normalization, the
+    // public-projection / atlas coordination).
+
+    Ok(())
+}

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -85,7 +85,12 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         .map_err(|e| IndexerError::decode(format!("space_id: {e}")))?;
 
     let grc20_edit = decode_grc20(&edit.payload)?;
-    let detected = detect(&grc20_edit, space_id);
+    let block_number = edit
+        .meta
+        .as_ref()
+        .map(|m| m.block_number as i64)
+        .unwrap_or(0);
+    let detected = detect(&grc20_edit, space_id, block_number);
     if detected.is_empty() {
         return Ok(());
     }

--- a/ranking-indexer/src/models.rs
+++ b/ranking-indexer/src/models.rs
@@ -1,0 +1,45 @@
+//! Row models mirroring the private `ranks` working schema.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+/// A `ranks.ranking_blocks` row — one per Ranking Block entity.
+#[derive(Debug, Clone)]
+pub struct RankingBlock {
+    pub id: Uuid,
+    pub space_id: Uuid,
+    pub name: Option<String>,
+    pub filter: Option<String>,
+    pub start_date: Option<DateTime<Utc>>,
+    pub end_date: Option<DateTime<Utc>>,
+    /// Aggregation restriction value entity; `None` => default "Members and editors".
+    pub restriction_id: Option<Uuid>,
+}
+
+/// A `ranks.rankings` row — one per Rank submission.
+#[derive(Debug, Clone)]
+pub struct Ranking {
+    pub id: Uuid,
+    /// `None` until the `RANK_BLOCK` link arrives (partial-state model).
+    pub block_id: Option<Uuid>,
+    pub space_id: Uuid,
+    pub author_address: Option<String>,
+    /// "ORDINAL" | "WEIGHTED".
+    pub rank_type: Option<String>,
+    pub submitted_at: Option<DateTime<Utc>>,
+    /// Update markers for dedup: most-recently-updated rank per (block, space) wins.
+    pub updated_at_block: i64,
+    pub update_index: i64,
+}
+
+/// A `ranks.ranking_items` row — keyed on (ranking, entity, space).
+#[derive(Debug, Clone)]
+pub struct RankingItem {
+    pub ranking_id: Uuid,
+    pub entity_id: Uuid,
+    pub space_id: Uuid,
+    /// Fractional index for ordinal ordering.
+    pub position: Option<String>,
+    /// Weighted value (`None` for ordinal ranks).
+    pub weight: Option<f64>,
+}

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -1,0 +1,138 @@
+//! PostgreSQL persistence for the private `ranks` working schema.
+//!
+//! All writes are upserts keyed deterministically so reprocessing an edit
+//! converges on the same state (idempotency, design §10). Uses runtime
+//! `sqlx::query` (not the compile-time macro) so the crate builds without a
+//! live database.
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::error::IndexerError;
+use crate::models::{Ranking, RankingBlock, RankingItem};
+
+#[derive(Clone)]
+pub struct Storage {
+    pool: PgPool,
+}
+
+impl Storage {
+    pub async fn new(database_url: &str) -> Result<Self, IndexerError> {
+        let pool = PgPoolOptions::new()
+            .max_connections(10)
+            .connect(database_url)
+            .await?;
+        Ok(Self { pool })
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Upsert a Ranking Block.
+    pub async fn upsert_ranking_block(&self, b: &RankingBlock) -> Result<(), IndexerError> {
+        sqlx::query(
+            r#"
+            INSERT INTO ranks.ranking_blocks
+                (id, space_id, name, filter, start_date, end_date, restriction_id, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+            ON CONFLICT (id) DO UPDATE SET
+                space_id = EXCLUDED.space_id,
+                name = EXCLUDED.name,
+                filter = EXCLUDED.filter,
+                start_date = EXCLUDED.start_date,
+                end_date = EXCLUDED.end_date,
+                restriction_id = EXCLUDED.restriction_id,
+                updated_at = now()
+            "#,
+        )
+        .bind(b.id)
+        .bind(b.space_id)
+        .bind(&b.name)
+        .bind(&b.filter)
+        .bind(b.start_date)
+        .bind(b.end_date)
+        .bind(b.restriction_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Upsert a Rank submission. A null incoming `block_id` never clobbers an
+    /// already-known link (the link may have arrived in an earlier edit).
+    pub async fn upsert_ranking(&self, r: &Ranking) -> Result<(), IndexerError> {
+        sqlx::query(
+            r#"
+            INSERT INTO ranks.rankings
+                (id, block_id, space_id, author_address, rank_type, submitted_at,
+                 updated_at_block, update_index, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+            ON CONFLICT (id) DO UPDATE SET
+                block_id = COALESCE(EXCLUDED.block_id, ranks.rankings.block_id),
+                space_id = EXCLUDED.space_id,
+                author_address = EXCLUDED.author_address,
+                rank_type = EXCLUDED.rank_type,
+                submitted_at = EXCLUDED.submitted_at,
+                updated_at_block = EXCLUDED.updated_at_block,
+                update_index = EXCLUDED.update_index,
+                updated_at = now()
+            "#,
+        )
+        .bind(r.id)
+        .bind(r.block_id)
+        .bind(r.space_id)
+        .bind(&r.author_address)
+        .bind(&r.rank_type)
+        .bind(r.submitted_at)
+        .bind(r.updated_at_block)
+        .bind(r.update_index)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Set a rank's block link (the `RANK_BLOCK` relation may land in a later edit).
+    pub async fn set_ranking_block(
+        &self,
+        ranking_id: Uuid,
+        block_id: Uuid,
+    ) -> Result<(), IndexerError> {
+        sqlx::query("UPDATE ranks.rankings SET block_id = $2, updated_at = now() WHERE id = $1")
+            .bind(ranking_id)
+            .bind(block_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Replace a submission's items wholesale (re-submission rebuilds them).
+    pub async fn replace_ranking_items(
+        &self,
+        ranking_id: Uuid,
+        items: &[RankingItem],
+    ) -> Result<(), IndexerError> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+            .bind(ranking_id)
+            .execute(&mut *tx)
+            .await?;
+        for it in items {
+            sqlx::query(
+                r#"
+                INSERT INTO ranks.ranking_items (ranking_id, entity_id, space_id, position, weight)
+                VALUES ($1, $2, $3, $4, $5)
+                "#,
+            )
+            .bind(it.ranking_id)
+            .bind(it.entity_id)
+            .bind(it.space_id)
+            .bind(&it.position)
+            .bind(it.weight)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+}

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -91,16 +91,24 @@ impl Storage {
     }
 
     /// Set a rank's block link (the `RANK_BLOCK` relation may land in a later edit).
+    /// `ranks.rankings` is keyed on `(id, space_id)`, so the update is scoped to
+    /// the rank's space — a same-id rank perspectived into another space is left
+    /// untouched.
     pub async fn set_ranking_block(
         &self,
         ranking_id: Uuid,
         block_id: Uuid,
+        space_id: Uuid,
     ) -> Result<(), IndexerError> {
-        sqlx::query("UPDATE ranks.rankings SET block_id = $2, updated_at = now() WHERE id = $1")
-            .bind(ranking_id)
-            .bind(block_id)
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(
+            "UPDATE ranks.rankings SET block_id = $2, updated_at = now() \
+             WHERE id = $1 AND space_id = $3",
+        )
+        .bind(ranking_id)
+        .bind(block_id)
+        .bind(space_id)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -37,8 +37,7 @@ impl Storage {
             INSERT INTO ranks.ranking_blocks
                 (id, space_id, name, filter, start_date, end_date, restriction_id, updated_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, now())
-            ON CONFLICT (id) DO UPDATE SET
-                space_id = EXCLUDED.space_id,
+            ON CONFLICT (id, space_id) DO UPDATE SET
                 name = EXCLUDED.name,
                 filter = EXCLUDED.filter,
                 start_date = EXCLUDED.start_date,
@@ -68,9 +67,8 @@ impl Storage {
                 (id, block_id, space_id, author_address, rank_type, submitted_at,
                  updated_at_block, update_index, updated_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
-            ON CONFLICT (id) DO UPDATE SET
+            ON CONFLICT (id, space_id) DO UPDATE SET
                 block_id = COALESCE(EXCLUDED.block_id, ranks.rankings.block_id),
-                space_id = EXCLUDED.space_id,
                 author_address = EXCLUDED.author_address,
                 rank_type = EXCLUDED.rank_type,
                 submitted_at = EXCLUDED.submitted_at,


### PR DESCRIPTION
## What

New `ranking-indexer` Rust crate — a Kafka consumer that turns rank submissions into the private `ranks` working schema. This is the **dependency-light foundation** of the ranking-indexer, and it's independent of the design's open questions (eligibility/scoring/projection), so it's safe to build now.

> **Stacked on #724** (`feat/rank-system-ids`) — base this PR there so the diff is just the new crate. Retarget to `main` once #724 lands. Also assumes the `ranks` schema from #725.

## What's built (compiles + tested)

- **consumer** — manual-commit `StreamConsumer` on `knowledge.edits`; decodes `HermesEdit` (prost) then the GRC2/GRC2Z payload via the `grc-20` crate (same decoder as kg-indexer)
- **storage** — idempotent upserts into `ranks.{ranking_blocks,rankings,ranking_items}` (runtime `sqlx`, builds without a DB)
- **dedup** — most-recently-updated submission per (block, personal space) — **unit-tested (4 cases)**
- **main** — per-edit loop (decode → detect → upsert); commits offsets; skips malformed edits without stalling the partition (design §10)

## Deliberately stubbed seams (focused follow-ups)

- `detect()` — the `grc_20::Op` pattern-matching for the four rank op shapes. Needs the grc-20 op API + `TYPES`-relation resolution, mirroring kg-indexer's `extract_*`. Returns empty for now (pipeline is a correct no-op until wired).
- **per-block recompute** (dedup → eligibility → scoring) and **`RANK_POSITION` projection** — gated on the design's open questions (personal-space eligibility, scoring normalization, the public-projection / atlas coordination raised in the design review).

## Verification

- `cargo build -p ranking-indexer` → clean.
- `cargo test -p ranking-indexer` → 4 dedup tests pass.

(Local build of the rdkafka layer needs `clang/libclang-dev`, `cmake`, `libcurl4-openssl-dev` — same native deps the existing rdkafka indexers require; CI already has them.)