### PR TITLE
feat(ranking-indexer): eligibility + recompute orchestration

### DIFF
--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -30,6 +30,10 @@ struct DetectIds {
     rank_votes_relation: Uuid,
     rank_block_relation: Uuid,
     vote_weighted_value_property: Uuid,
+    filter_property: Uuid,
+    start_date_property: Uuid,
+    end_date_property: Uuid,
+    aggregation_restriction_relation: Uuid,
 }
 
 static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
@@ -44,6 +48,10 @@ static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
         rank_votes_relation: uid(RANK_VOTES_RELATION_TYPE_ID),
         rank_block_relation: uid(RANK_BLOCK_RELATION_TYPE_ID),
         vote_weighted_value_property: uid(VOTE_WEIGHTED_VALUE_PROPERTY_ID),
+        filter_property: uid(RANK_FILTER_PROPERTY_ID),
+        start_date_property: uid(RANK_START_DATE_PROPERTY_ID),
+        end_date_property: uid(RANK_END_DATE_PROPERTY_ID),
+        aggregation_restriction_relation: uid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID),
     }
 });
 
@@ -73,6 +81,35 @@ fn float_value(values: &[PropertyValue], property: Uuid) -> Option<f64> {
             _ => None,
         }
     })
+}
+
+/// Read a `Date`/`Datetime` property and parse it to a UTC instant.
+fn date_value(values: &[PropertyValue], property: Uuid) -> Option<DateTime<Utc>> {
+    let raw = values.iter().find_map(|pv| {
+        if id_to_uuid(&pv.property) != property {
+            return None;
+        }
+        match &pv.value {
+            Grc20Value::Date(v) | Grc20Value::Datetime(v) => Some(v.to_string()),
+            _ => None,
+        }
+    })?;
+    parse_date(&raw)
+}
+
+/// Parse a date/datetime string defensively: RFC3339 first, then a bare
+/// `YYYY-MM-DD` date (taken as midnight UTC). Unparseable values yield `None`
+/// rather than a wrong bound (so the window check just doesn't constrain).
+fn parse_date(s: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(d) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return d
+            .and_hms_opt(0, 0, 0)
+            .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
+    }
+    None
 }
 
 /// The rank-relevant ops extracted from a single edit.
@@ -115,6 +152,8 @@ pub fn detect(
     // collect the rank relations (votes + block links).
     let mut entity_values: HashMap<Uuid, &[PropertyValue]> = HashMap::new();
     let mut types_of: HashMap<Uuid, HashSet<Uuid>> = HashMap::new();
+    // block -> aggregation-restriction value entity (e.g. "Members and editors").
+    let mut restriction_of: HashMap<Uuid, Uuid> = HashMap::new();
 
     for op in &edit.ops {
         match op {
@@ -128,6 +167,8 @@ pub fn detect(
                         .entry(id_to_uuid(&relation.from))
                         .or_default()
                         .insert(id_to_uuid(&relation.to));
+                } else if type_id == ids.aggregation_restriction_relation {
+                    restriction_of.insert(id_to_uuid(&relation.from), id_to_uuid(&relation.to));
                 }
             }
             _ => {}
@@ -157,19 +198,16 @@ pub fn detect(
                         update_index: op_index as i64,
                     });
                 } else if is_block {
-                    // NOTE: only id/space_id/name are confidently extractable today.
-                    // The block's window dates, filter, and aggregation restriction
-                    // emission shapes aren't in the merged SDK yet (geo-sdk#89 adds
-                    // the IDs; block creation lands separately). Left as TODO so we
-                    // don't guess the wrong op shape.
+                    // Block config (Name/Filter/Start/End as properties; the
+                    // aggregation restriction as a relation collected in pass 1).
                     out.blocks.push(RankingBlock {
                         id: entity_id,
                         space_id,
                         name: text_value(&entity.values, ids.name_property),
-                        filter: None,
-                        start_date: None,
-                        end_date: None,
-                        restriction_id: None,
+                        filter: text_value(&entity.values, ids.filter_property),
+                        start_date: date_value(&entity.values, ids.start_date_property),
+                        end_date: date_value(&entity.values, ids.end_date_property),
+                        restriction_id: restriction_of.get(&entity_id).copied(),
                     });
                 }
             }
@@ -314,6 +352,44 @@ mod tests {
         assert_eq!(detected.blocks[0].id, Uuid::from_u128(BLOCK));
         assert_eq!(detected.blocks[0].name.as_deref(), Some("Top Films"));
         assert!(detected.rankings.is_empty());
+    }
+
+    #[test]
+    fn detects_full_block_config() {
+        use chrono::TimeZone;
+        let edit = EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(50))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(BLOCK))
+                    .to(sid(RANKING_BLOCK_TYPE_ID))
+            })
+            // aggregation restriction relation -> "Members and editors"
+            .create_relation(|r| {
+                r.id(gid(51))
+                    .relation_type(sid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+                    .from(gid(BLOCK))
+                    .to(sid(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID))
+            })
+            .create_entity(gid(BLOCK), |e| {
+                e.text(sid(NAME_PROPERTY_ID), "Top Films", None)
+                    .text(sid(RANK_FILTER_PROPERTY_ID), "types: Movie", None)
+                    .value(sid(RANK_START_DATE_PROPERTY_ID), Grc20Value::Date("2026-06-01".into()))
+                    .value(sid(RANK_END_DATE_PROPERTY_ID), Grc20Value::Date("2026-06-30".into()))
+            })
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert_eq!(detected.blocks.len(), 1);
+        let b = &detected.blocks[0];
+        assert_eq!(b.name.as_deref(), Some("Top Films"));
+        assert_eq!(b.filter.as_deref(), Some("types: Movie"));
+        assert_eq!(b.start_date, Some(Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap()));
+        assert_eq!(b.end_date, Some(Utc.with_ymd_and_hms(2026, 6, 30, 0, 0, 0).unwrap()));
+        assert_eq!(
+            b.restriction_id,
+            Some(Uuid::parse_str(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID).unwrap())
+        );
     }
 
     #[test]

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -14,6 +14,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
+use chrono::{DateTime, Utc};
 use grc_20::{Id as Grc20Id, Op as Grc20Op, PropertyValue, Value as Grc20Value};
 use uuid::Uuid;
 
@@ -98,8 +99,16 @@ impl DetectedEdit {
 /// `space_id` is the edit's space (a Rank/Ranking Block lives in it).
 /// `block_number` seeds the dedup update markers ("most recently updated rank
 /// per (block, space) wins"); `update_index` is the op position within the edit.
-pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> DetectedEdit {
+/// `block_timestamp` is the edit's on-chain time (Unix seconds), recorded as the
+/// submission timestamp for the window check.
+pub fn detect(
+    edit: &grc_20::Edit,
+    space_id: Uuid,
+    block_number: i64,
+    block_timestamp: i64,
+) -> DetectedEdit {
     let ids = &*IDS;
+    let submitted_at = DateTime::<Utc>::from_timestamp(block_timestamp, 0);
     let mut out = DetectedEdit::default();
 
     // Pass 1: index entity property-values and resolve TYPES membership, and
@@ -143,7 +152,7 @@ pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> Detecte
                         space_id,
                         author_address: None, // resolved from the personal space during aggregation
                         rank_type: text_value(&entity.values, ids.rank_type_property),
-                        submitted_at: None, // TODO: derive from edit/block timestamp
+                        submitted_at,
                         updated_at_block: block_number,
                         update_index: op_index as i64,
                     });
@@ -209,4 +218,142 @@ pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> Detecte
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use grc_20::model::builder::EditBuilder;
+    use sdk::core::ids::*;
+
+    /// grc_20 Id ([u8; 16]) from an arbitrary u128.
+    fn gid(n: u128) -> [u8; 16] {
+        *Uuid::from_u128(n).as_bytes()
+    }
+    /// grc_20 Id from a system-ID string constant.
+    fn sid(s: &str) -> [u8; 16] {
+        *Uuid::parse_str(s).unwrap().as_bytes()
+    }
+
+    const SPACE: u128 = 7000;
+    const RANK: u128 = 1;
+    const BLOCK: u128 = 2;
+    const RANKED_ENTITY: u128 = 3;
+    const VOTE_ENTITY: u128 = 4;
+    const PERSPECTIVE: u128 = 8000;
+
+    fn space_uuid() -> Uuid {
+        Uuid::from_u128(SPACE)
+    }
+
+    #[test]
+    fn detects_weighted_rank_with_item_and_submitted_at() {
+        let edit = EditBuilder::new(gid(0))
+            // entity RANK is typed `Rank` via a TYPES relation
+            .create_relation(|r| {
+                r.id(gid(10))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(sid(RANK_TYPE_ID))
+            })
+            .create_entity(gid(RANK), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "WEIGHTED", None)
+            })
+            // a RANK_VOTES item: rank -> ranked entity, with perspective + position
+            // and an explicit reified vote entity
+            .create_relation(|r| {
+                r.id(gid(11))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(gid(RANKED_ENTITY))
+                    .to_space(gid(PERSPECTIVE))
+                    .position("a0")
+                    .entity(gid(VOTE_ENTITY))
+            })
+            // the reified vote entity carries the weighted value
+            .create_entity(gid(VOTE_ENTITY), |e| {
+                e.float(sid(VOTE_WEIGHTED_VALUE_PROPERTY_ID), 0.9, None)
+            })
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 1_700_000_000);
+
+        assert_eq!(detected.rankings.len(), 1);
+        let r = &detected.rankings[0];
+        assert_eq!(r.id, Uuid::from_u128(RANK));
+        assert_eq!(r.rank_type.as_deref(), Some("WEIGHTED"));
+        assert_eq!(r.space_id, space_uuid());
+        assert_eq!(
+            r.submitted_at,
+            DateTime::<Utc>::from_timestamp(1_700_000_000, 0)
+        );
+
+        assert_eq!(detected.items.len(), 1);
+        let it = &detected.items[0];
+        assert_eq!(it.ranking_id, Uuid::from_u128(RANK));
+        assert_eq!(it.entity_id, Uuid::from_u128(RANKED_ENTITY));
+        assert_eq!(it.space_id, Uuid::from_u128(PERSPECTIVE));
+        assert_eq!(it.position.as_deref(), Some("a0"));
+        assert_eq!(it.weight, Some(0.9));
+    }
+
+    #[test]
+    fn detects_ranking_block() {
+        let edit = EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(20))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(BLOCK))
+                    .to(sid(RANKING_BLOCK_TYPE_ID))
+            })
+            .create_entity(gid(BLOCK), |e| e.text(sid(NAME_PROPERTY_ID), "Top Films", None))
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert_eq!(detected.blocks.len(), 1);
+        assert_eq!(detected.blocks[0].id, Uuid::from_u128(BLOCK));
+        assert_eq!(detected.blocks[0].name.as_deref(), Some("Top Films"));
+        assert!(detected.rankings.is_empty());
+    }
+
+    #[test]
+    fn detects_rank_block_link() {
+        let edit = EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(30))
+                    .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(gid(BLOCK))
+            })
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert_eq!(
+            detected.block_links,
+            vec![(Uuid::from_u128(RANK), Uuid::from_u128(BLOCK))]
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_ops() {
+        let edit = EditBuilder::new(gid(0))
+            .create_entity(gid(999), |e| {
+                e.text(sid(NAME_PROPERTY_ID), "Just an entity", None)
+            })
+            .build();
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert!(detected.is_empty());
+    }
+
+    #[test]
+    fn untyped_rank_entity_is_not_detected() {
+        // A Rank-shaped entity WITHOUT the TYPES relation isn't classified as a rank.
+        let edit = EditBuilder::new(gid(0))
+            .create_entity(gid(RANK), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+            })
+            .build();
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert!(detected.rankings.is_empty());
+    }
 }

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -336,6 +336,40 @@ mod tests {
     }
 
     #[test]
+    fn rank_vote_without_to_space_is_skipped() {
+        // A RANK_VOTES relation with no `to_space` can't be placed in a
+        // perspective, so detect() drops the item rather than defaulting it to
+        // the ranking's own space (which would mis-bucket the aggregate).
+        let edit = EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(10))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(sid(RANK_TYPE_ID))
+            })
+            .create_entity(gid(RANK), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+            })
+            // RANK_VOTES item with position but NO to_space
+            .create_relation(|r| {
+                r.id(gid(11))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(gid(RANKED_ENTITY))
+                    .position("a0")
+                    .entity(gid(VOTE_ENTITY))
+            })
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 0);
+
+        // the ranking itself is still detected...
+        assert_eq!(detected.rankings.len(), 1);
+        // ...but the perspective-less item is dropped (not bucketed into SPACE).
+        assert!(detected.items.is_empty());
+    }
+
+    #[test]
     fn detects_ranking_block() {
         let edit = EditBuilder::new(gid(0))
             .create_relation(|r| {

--- a/ranking-indexer/src/eligibility.rs
+++ b/ranking-indexer/src/eligibility.rs
@@ -1,0 +1,162 @@
+//! Eligibility resolution for ranking aggregation (design §7).
+//!
+//! A submission counts toward a block only if it passes both a *restriction*
+//! check and a *window* check.
+//!
+//! Restriction (per the team decision):
+//!   - DAO-space block: the submitter must be a member or editor of the block's
+//!     space.
+//!   - Personal-space block: "All of Geo" for now — admit every submitter. (This
+//!     will narrow to verified users once verification ships.)
+//!
+//! Window: the submission timestamp must fall within the block's optional
+//! `[start, end]` bounds; an absent bound imposes no limit.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::models::{Ranking, RankingBlock};
+
+/// The kind of space a block lives in, which sets its default restriction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpaceKind {
+    /// Governed space — restrict to members/editors.
+    Dao,
+    /// Personal space — "All of Geo" for now.
+    Personal,
+}
+
+/// Does the block's restriction admit a submission from `submitter_space`?
+pub fn restriction_admits(
+    space_kind: SpaceKind,
+    submitter_space: Uuid,
+    eligible_member_spaces: &HashSet<Uuid>,
+) -> bool {
+    match space_kind {
+        // "All of Geo" for now; narrows to verified users post-verification.
+        SpaceKind::Personal => true,
+        SpaceKind::Dao => eligible_member_spaces.contains(&submitter_space),
+    }
+}
+
+/// Does the submission fall within the block's optional window?
+///
+/// An absent bound imposes no limit. If the submission time is unknown the
+/// window cannot reject it — populating `submitted_at` in `detect()` is a
+/// follow-up, so we admit rather than silently drop.
+pub fn window_admits(
+    submitted_at: Option<DateTime<Utc>>,
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+) -> bool {
+    let after_start = match (start, submitted_at) {
+        (Some(s), Some(t)) => t >= s,
+        _ => true,
+    };
+    let before_end = match (end, submitted_at) {
+        (Some(e), Some(t)) => t <= e,
+        _ => true,
+    };
+    after_start && before_end
+}
+
+/// Filter deduped submissions to those eligible for `block`.
+///
+/// `eligible_member_spaces` is the set of member/editor space ids of the
+/// block's space (ignored for personal-space blocks).
+pub fn filter_eligible(
+    block: &RankingBlock,
+    space_kind: SpaceKind,
+    eligible_member_spaces: &HashSet<Uuid>,
+    submissions: Vec<Ranking>,
+) -> Vec<Ranking> {
+    submissions
+        .into_iter()
+        .filter(|s| {
+            restriction_admits(space_kind, s.space_id, eligible_member_spaces)
+                && window_admits(s.submitted_at, block.start_date, block.end_date)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block(start: Option<DateTime<Utc>>, end: Option<DateTime<Utc>>) -> RankingBlock {
+        RankingBlock {
+            id: Uuid::from_u128(1),
+            space_id: Uuid::from_u128(900),
+            name: None,
+            filter: None,
+            start_date: start,
+            end_date: end,
+            restriction_id: None,
+        }
+    }
+
+    fn submission(space: u128, at: Option<DateTime<Utc>>) -> Ranking {
+        Ranking {
+            id: Uuid::from_u128(space + 1000),
+            block_id: Some(Uuid::from_u128(1)),
+            space_id: Uuid::from_u128(space),
+            author_address: None,
+            rank_type: None,
+            submitted_at: at,
+            updated_at_block: 0,
+            update_index: 0,
+        }
+    }
+
+    #[test]
+    fn personal_block_admits_any_submitter() {
+        let members = HashSet::new(); // none
+        assert!(restriction_admits(
+            SpaceKind::Personal,
+            Uuid::from_u128(42),
+            &members
+        ));
+    }
+
+    #[test]
+    fn dao_block_admits_only_members_or_editors() {
+        let mut members = HashSet::new();
+        members.insert(Uuid::from_u128(42));
+        assert!(restriction_admits(SpaceKind::Dao, Uuid::from_u128(42), &members));
+        assert!(!restriction_admits(SpaceKind::Dao, Uuid::from_u128(99), &members));
+    }
+
+    #[test]
+    fn window_bounds() {
+        let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0);
+        // within
+        assert!(window_admits(t(50), t(0), t(100)));
+        // before start / after end
+        assert!(!window_admits(t(50), t(60), t(100)));
+        assert!(!window_admits(t(50), t(0), t(40)));
+        // absent bounds impose no limit
+        assert!(window_admits(t(50), None, None));
+        // unknown submission time can't be rejected
+        assert!(window_admits(None, t(0), t(100)));
+    }
+
+    #[test]
+    fn filter_eligible_combines_both_checks() {
+        let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0);
+        let b = block(t(0), t(100));
+        let mut members = HashSet::new();
+        members.insert(Uuid::from_u128(1)); // space 1 is a member
+
+        let subs = vec![
+            submission(1, t(50)),  // member, in window -> keep
+            submission(2, t(50)),  // non-member -> drop
+            submission(1, t(200)), // member, out of window -> drop
+        ];
+        let kept = filter_eligible(&b, SpaceKind::Dao, &members, subs);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].space_id, Uuid::from_u128(1));
+        assert_eq!(kept[0].submitted_at, t(50));
+    }
+}

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod consumer;
 pub mod dedup;
 pub mod detect;
+pub mod eligibility;
 pub mod error;
 pub mod models;
 pub mod storage;

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -9,4 +9,5 @@ pub mod eligibility;
 pub mod error;
 pub mod models;
 pub mod recompute;
+pub mod scoring;
 pub mod storage;

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -8,4 +8,5 @@ pub mod detect;
 pub mod eligibility;
 pub mod error;
 pub mod models;
+pub mod recompute;
 pub mod storage;

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -20,6 +20,8 @@ use uuid::Uuid;
 use ranking_indexer::consumer::{decode_grc20, parse_edit, KafkaConsumer};
 use ranking_indexer::detect::detect;
 use ranking_indexer::error::IndexerError;
+use ranking_indexer::models::RankingItem;
+use ranking_indexer::recompute;
 use ranking_indexer::storage::Storage;
 
 #[tokio::main]
@@ -102,25 +104,30 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         storage.upsert_ranking(ranking).await?;
     }
 
-    // Re-submission rebuilds a rank's items, so replace per ranking.
-    let mut items_by_ranking: HashMap<Uuid, Vec<_>> = HashMap::new();
-    for item in detected.items {
-        items_by_ranking.entry(item.ranking_id).or_default().push(item);
+    // Re-submission rebuilds a rank's items, so replace per ranking. Clone into
+    // the per-ranking groups so `detected` stays intact for affected_blocks.
+    let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
+    for item in &detected.items {
+        items_by_ranking
+            .entry(item.ranking_id)
+            .or_default()
+            .push(item.clone());
     }
-    for (ranking_id, items) in items_by_ranking {
-        storage.replace_ranking_items(ranking_id, &items).await?;
+    for (ranking_id, items) in &items_by_ranking {
+        storage.replace_ranking_items(*ranking_id, items).await?;
     }
 
-    for (ranking_id, block_id) in detected.block_links {
+    for (ranking_id, block_id) in &detected.block_links {
         // The RANK_BLOCK relation is authored in the ranking's space, so the
         // edit's `space_id` is the rank row's space.
-        storage.set_ranking_block(ranking_id, block_id, space_id).await?;
+        storage.set_ranking_block(*ranking_id, *block_id, space_id).await?;
     }
 
-    // TODO(ranking-indexer): recompute affected blocks (dedup -> eligibility ->
-    // scoring) and project RANK_POSITION relations. Gated on the design's open
-    // questions (eligibility for personal spaces, scoring normalization, the
-    // public-projection / atlas coordination).
+    // Recompute every block this edit may have affected
+    // (dedup -> eligibility -> [scoring/publish stubs]).
+    for block_id in recompute::affected_blocks(&detected, storage).await? {
+        recompute::recompute_block(block_id, storage).await?;
+    }
 
     Ok(())
 }

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -87,12 +87,12 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         .map_err(|e| IndexerError::decode(format!("space_id: {e}")))?;
 
     let grc20_edit = decode_grc20(&edit.payload)?;
-    let block_number = edit
+    let (block_number, block_timestamp) = edit
         .meta
         .as_ref()
-        .map(|m| m.block_number as i64)
-        .unwrap_or(0);
-    let detected = detect(&grc20_edit, space_id, block_number);
+        .map(|m| (m.block_number as i64, m.created_at as i64))
+        .unwrap_or((0, 0));
+    let detected = detect(&grc20_edit, space_id, block_number, block_timestamp);
     if detected.is_empty() {
         return Ok(());
     }

--- a/ranking-indexer/src/models.rs
+++ b/ranking-indexer/src/models.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 /// A `ranks.ranking_blocks` row — one per Ranking Block entity.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RankingBlock {
     pub id: Uuid,
     pub space_id: Uuid,
@@ -17,7 +17,7 @@ pub struct RankingBlock {
 }
 
 /// A `ranks.rankings` row — one per Rank submission.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Ranking {
     pub id: Uuid,
     /// `None` until the `RANK_BLOCK` link arrives (partial-state model).
@@ -33,7 +33,7 @@ pub struct Ranking {
 }
 
 /// A `ranks.ranking_items` row — keyed on (ranking, entity, space).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RankingItem {
     pub ranking_id: Uuid,
     pub entity_id: Uuid,

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -1,0 +1,95 @@
+//! Per-block recompute orchestration.
+//!
+//! For each block an edit may have affected, recompute its aggregate in full
+//! (design §7): `dedup -> eligibility -> scoring -> publish`. A full recompute
+//! is always correct regardless of edit arrival order.
+//!
+//! Scoring and publish are stubs pending the open design questions (the ballot
+//! normalization method, and the aggregate-weight property + atlas inclusion
+//! for the projection). Dedup and eligibility are wired in and exercised.
+
+use std::collections::HashSet;
+
+use uuid::Uuid;
+
+use crate::dedup::dedup_latest;
+use crate::detect::DetectedEdit;
+use crate::eligibility::{filter_eligible, SpaceKind};
+use crate::error::IndexerError;
+use crate::storage::Storage;
+
+/// Block ids whose aggregate may have changed as a result of this edit:
+/// blocks whose own settings changed, blocks newly linked from a rank, and the
+/// (possibly previously-linked) block of any rank/item touched here.
+pub async fn affected_blocks(
+    detected: &DetectedEdit,
+    storage: &Storage,
+) -> Result<HashSet<Uuid>, IndexerError> {
+    let mut blocks: HashSet<Uuid> = HashSet::new();
+
+    for b in &detected.blocks {
+        blocks.insert(b.id);
+    }
+    for (_ranking_id, block_id) in &detected.block_links {
+        blocks.insert(*block_id);
+    }
+
+    // Rankings/items touched here may already be linked to a block from a prior
+    // edit — resolve their current block_id from the working tables.
+    let mut ranking_ids: HashSet<Uuid> = HashSet::new();
+    for r in &detected.rankings {
+        ranking_ids.insert(r.id);
+    }
+    for it in &detected.items {
+        ranking_ids.insert(it.ranking_id);
+    }
+    for ranking_id in ranking_ids {
+        if let Some(block_id) = storage.block_id_for_ranking(ranking_id).await? {
+            blocks.insert(block_id);
+        }
+    }
+
+    Ok(blocks)
+}
+
+/// Recompute a single block's aggregate end to end.
+pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), IndexerError> {
+    let Some(block) = storage.get_ranking_block(block_id).await? else {
+        // A rank may link to a block we haven't indexed yet; nothing to do.
+        return Ok(());
+    };
+
+    // 1. Dedup: keep the latest submission per (block, personal space).
+    let submissions = storage.get_rankings_for_block(block_id).await?;
+    let deduped = dedup_latest(submissions);
+
+    // 2. Eligibility: resolve the block's space kind + member/editor set.
+    let space_kind = storage
+        .space_kind(block.space_id)
+        .await?
+        .unwrap_or(SpaceKind::Dao); // unknown space -> conservative (membership-restricted)
+    let eligible_member_spaces = match space_kind {
+        SpaceKind::Dao => storage.member_and_editor_spaces(block.space_id).await?,
+        SpaceKind::Personal => HashSet::new(), // unused under "All of Geo"
+    };
+    let eligible = filter_eligible(&block, space_kind, &eligible_member_spaces, deduped);
+
+    tracing::debug!(
+        block_id = %block_id,
+        eligible_submissions = eligible.len(),
+        "ranking-indexer recompute: dedup + eligibility done (scoring/publish not yet wired)"
+    );
+
+    // 3. TODO(scoring): load each eligible submission's items, convert to
+    //    per-(entity, space) contributions with per-ballot normalization
+    //    (method pending Jagger), sum, sort, and upsert ranks.ranking_scores.
+    // 4. TODO(publish): project RANK_POSITION relations (+ Aggregated rankings
+    //    provenance + the aggregate weight on the reified relation entity) into
+    //    public.relations, atomically replacing the prior projection. Gated on
+    //    the weight-property and atlas-inclusion decisions.
+    //
+    // When scoring/publish land, steps 3–4 should run in a single transaction
+    // and the Kafka offset commit (in main) should follow that transaction.
+
+    Ok(())
+}

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -4,11 +4,11 @@
 //! (design §7): `dedup -> eligibility -> scoring -> publish`. A full recompute
 //! is always correct regardless of edit arrival order.
 //!
-//! Scoring and publish are stubs pending the open design questions (the ballot
-//! normalization method, and the aggregate-weight property + atlas inclusion
-//! for the projection). Dedup and eligibility are wired in and exercised.
+//! Publish is still a stub, gated on the rank-position-value property ID
+//! (Preston) and projection details. Dedup, eligibility, and scoring are wired
+//! in and exercised.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use uuid::Uuid;
 
@@ -16,6 +16,8 @@ use crate::dedup::dedup_latest;
 use crate::detect::DetectedEdit;
 use crate::eligibility::{filter_eligible, SpaceKind};
 use crate::error::IndexerError;
+use crate::models::{Ranking, RankingItem};
+use crate::scoring;
 use crate::storage::Storage;
 
 /// Block ids whose aggregate may have changed as a result of this edit:
@@ -74,22 +76,34 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
     };
     let eligible = filter_eligible(&block, space_kind, &eligible_member_spaces, deduped);
 
+    // 3. Scoring: normalize each ballot to [0.5, 1] and aggregate per (entity, space).
+    let eligible_ids: Vec<Uuid> = eligible.iter().map(|r| r.id).collect();
+    let items = storage.get_items_for_rankings(&eligible_ids).await?;
+    let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
+    for item in items {
+        items_by_ranking.entry(item.ranking_id).or_default().push(item);
+    }
+    let ballots: Vec<(&Ranking, Vec<RankingItem>)> = eligible
+        .iter()
+        .map(|r| (r, items_by_ranking.remove(&r.id).unwrap_or_default()))
+        .collect();
+    let scores = scoring::aggregate(&ballots, scoring::NORM_LO, scoring::NORM_HI);
+    storage.replace_ranking_scores(block_id, &scores).await?;
+
     tracing::debug!(
         block_id = %block_id,
-        eligible_submissions = eligible.len(),
-        "ranking-indexer recompute: dedup + eligibility done (scoring/publish not yet wired)"
+        eligible_submissions = ballots.len(),
+        ranked_entities = scores.len(),
+        "ranking-indexer recompute: scored (publish not yet wired)"
     );
 
-    // 3. TODO(scoring): load each eligible submission's items, convert to
-    //    per-(entity, space) contributions with per-ballot normalization
-    //    (method pending Jagger), sum, sort, and upsert ranks.ranking_scores.
     // 4. TODO(publish): project RANK_POSITION relations (+ Aggregated rankings
-    //    provenance + the aggregate weight on the reified relation entity) into
-    //    public.relations, atomically replacing the prior projection. Gated on
-    //    the weight-property and atlas-inclusion decisions.
+    //    provenance + the integer rank-position value on the reified relation
+    //    entity) into public.relations, atomically replacing the prior
+    //    projection. Gated on Preston minting the rank-position-value property.
     //
-    // When scoring/publish land, steps 3–4 should run in a single transaction
-    // and the Kafka offset commit (in main) should follow that transaction.
+    // When publish lands, scoring + projection should run in one transaction and
+    // the Kafka offset commit (in main) should follow it.
 
     Ok(())
 }

--- a/ranking-indexer/src/scoring.rs
+++ b/ranking-indexer/src/scoring.rs
@@ -1,0 +1,271 @@
+//! Scoring: turn eligible submissions into a single ordered aggregate.
+//!
+//! Per the team's decisions:
+//!   - Each ballot's item values are normalized to `[NORM_LO, NORM_HI]` = `[0.5, 1.0]`
+//!     by default, so being ranked at all is positive signal (floor 0.5) and
+//!     position scales up to 1.0.
+//!   - WEIGHTED ballots: min-max normalize the provided weights into the range.
+//!   - ORDINAL ballots: linear map by position (best = 1.0, worst = 0.5).
+//!   - Mixing ordinal + weighted in one block is fine — both land in the same range.
+//!
+//! Normalized contributions are summed per `(entity, space)` across ballots,
+//! sorted descending (tie-broken deterministically), and assigned integer
+//! positions. The summed `score` stays continuous (`f64`) — the integer
+//! projection for publishing happens later.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use crate::models::{Ranking, RankingItem};
+
+/// Default normalization floor: a ranked item always carries positive signal.
+pub const NORM_LO: f64 = 0.5;
+/// Default normalization ceiling: the top of a ballot.
+pub const NORM_HI: f64 = 1.0;
+
+/// A computed aggregate row (mirrors `ranks.ranking_scores`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoreRow {
+    pub entity_id: Uuid,
+    pub space_id: Uuid,
+    pub score: f64,
+    /// 1-based rank within the block.
+    pub position: i32,
+}
+
+fn is_weighted(rank_type: Option<&str>) -> bool {
+    matches!(rank_type, Some(t) if t.eq_ignore_ascii_case("WEIGHTED"))
+}
+
+/// Normalize one ballot's items to `[lo, hi]`, returning `(entity, space) -> value`.
+pub fn normalize_ballot(
+    ranking: &Ranking,
+    items: &[RankingItem],
+    lo: f64,
+    hi: f64,
+) -> Vec<((Uuid, Uuid), f64)> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+    if is_weighted(ranking.rank_type.as_deref()) {
+        normalize_weighted(items, lo, hi)
+    } else {
+        normalize_ordinal(items, lo, hi)
+    }
+}
+
+/// WEIGHTED: min-max the provided weights into `[lo, hi]`. Items without a
+/// weight can't be scored on a weighted ballot and are skipped. A degenerate
+/// range (single item / all-equal) maps everything to `hi`.
+fn normalize_weighted(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uuid), f64)> {
+    let weighted: Vec<&RankingItem> = items.iter().filter(|i| i.weight.is_some()).collect();
+    if weighted.is_empty() {
+        return Vec::new();
+    }
+    let min = weighted.iter().map(|i| i.weight.unwrap()).fold(f64::INFINITY, f64::min);
+    let max = weighted
+        .iter()
+        .map(|i| i.weight.unwrap())
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    weighted
+        .iter()
+        .map(|i| {
+            let w = i.weight.unwrap();
+            let norm = if max > min {
+                lo + (hi - lo) * (w - min) / (max - min)
+            } else {
+                hi
+            };
+            ((i.entity_id, i.space_id), norm)
+        })
+        .collect()
+}
+
+/// ORDINAL: order items by fractional index (ascending = best-first) and map
+/// linearly into `[lo, hi]` (best = hi, worst = lo). A single item maps to `hi`.
+fn normalize_ordinal(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uuid), f64)> {
+    let mut ordered: Vec<&RankingItem> = items.iter().collect();
+    // Sort by fractional index; items missing a position sort last (deterministic).
+    ordered.sort_by(|a, b| (a.position.is_none(), &a.position).cmp(&(b.position.is_none(), &b.position)));
+
+    let n = ordered.len();
+    ordered
+        .iter()
+        .enumerate()
+        .map(|(rank, item)| {
+            let value = if n > 1 {
+                hi - (hi - lo) * (rank as f64) / ((n - 1) as f64)
+            } else {
+                hi
+            };
+            ((item.entity_id, item.space_id), value)
+        })
+        .collect()
+}
+
+/// Aggregate eligible ballots into the block's ordered result.
+pub fn aggregate(
+    ballots: &[(&Ranking, Vec<RankingItem>)],
+    lo: f64,
+    hi: f64,
+) -> Vec<ScoreRow> {
+    let mut totals: HashMap<(Uuid, Uuid), f64> = HashMap::new();
+    for (ranking, items) in ballots {
+        for (key, value) in normalize_ballot(ranking, items, lo, hi) {
+            *totals.entry(key).or_insert(0.0) += value;
+        }
+    }
+
+    let mut rows: Vec<((Uuid, Uuid), f64)> = totals.into_iter().collect();
+    // Descending score; deterministic tie-break by (entity, space).
+    rows.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.0 .0.cmp(&b.0 .0))
+            .then_with(|| a.0 .1.cmp(&b.0 .1))
+    });
+
+    rows.into_iter()
+        .enumerate()
+        .map(|(i, ((entity_id, space_id), score))| ScoreRow {
+            entity_id,
+            space_id,
+            score,
+            position: (i as i32) + 1,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ranking(id: u128, rank_type: &str) -> Ranking {
+        Ranking {
+            id: Uuid::from_u128(id),
+            block_id: Some(Uuid::from_u128(1)),
+            space_id: Uuid::from_u128(900),
+            author_address: None,
+            rank_type: Some(rank_type.to_string()),
+            submitted_at: None,
+            updated_at_block: 0,
+            update_index: 0,
+        }
+    }
+
+    fn item(entity: u128, position: Option<&str>, weight: Option<f64>) -> RankingItem {
+        RankingItem {
+            ranking_id: Uuid::from_u128(0),
+            entity_id: Uuid::from_u128(entity),
+            space_id: Uuid::from_u128(500),
+            position: position.map(|s| s.to_string()),
+            weight,
+        }
+    }
+
+    fn value_for(out: &[((Uuid, Uuid), f64)], entity: u128) -> f64 {
+        out.iter()
+            .find(|((e, _), _)| *e == Uuid::from_u128(entity))
+            .map(|(_, v)| *v)
+            .expect("entity present")
+    }
+
+    #[test]
+    fn ordinal_maps_linearly_into_floor_to_ceiling() {
+        let r = ranking(1, "ORDINAL");
+        let items = vec![
+            item(10, Some("a0"), None),
+            item(11, Some("a1"), None),
+            item(12, Some("a2"), None),
+        ];
+        let out = normalize_ballot(&r, &items, NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0);
+        assert_eq!(value_for(&out, 11), 0.75);
+        assert_eq!(value_for(&out, 12), 0.5);
+    }
+
+    #[test]
+    fn weighted_min_max_into_floor_to_ceiling() {
+        let r = ranking(1, "WEIGHTED");
+        let items = vec![
+            item(10, Some("a0"), Some(90.0)),
+            item(11, Some("a1"), Some(65.0)),
+            item(12, Some("a2"), Some(50.0)),
+        ];
+        let out = normalize_ballot(&r, &items, NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0); // max -> hi
+        assert_eq!(value_for(&out, 12), 0.5); // min -> lo
+        // 65 is 15/40 of the way: 0.5 + 0.5*0.375 = 0.6875
+        assert!((value_for(&out, 11) - 0.6875).abs() < 1e-9);
+    }
+
+    #[test]
+    fn single_item_maps_to_ceiling() {
+        let ord = ranking(1, "ORDINAL");
+        let out = normalize_ballot(&ord, &[item(10, Some("a0"), None)], NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0);
+
+        let wtd = ranking(2, "WEIGHTED");
+        let out = normalize_ballot(&wtd, &[item(10, Some("a0"), Some(7.0))], NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0);
+    }
+
+    #[test]
+    fn all_equal_weights_map_to_ceiling() {
+        let r = ranking(1, "WEIGHTED");
+        let items = vec![item(10, None, Some(3.0)), item(11, None, Some(3.0))];
+        let out = normalize_ballot(&r, &items, NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0);
+        assert_eq!(value_for(&out, 11), 1.0);
+    }
+
+    #[test]
+    fn aggregate_sums_sorts_and_positions() {
+        // Two ordinal ballots agree A > B; a third ranks B first.
+        let r1 = ranking(1, "ORDINAL");
+        let b1 = vec![item(100, Some("a0"), None), item(200, Some("a1"), None)]; // A=1.0, B=0.5
+        let r2 = ranking(2, "ORDINAL");
+        let b2 = vec![item(100, Some("a0"), None), item(200, Some("a1"), None)]; // A=1.0, B=0.5
+        let r3 = ranking(3, "ORDINAL");
+        let b3 = vec![item(200, Some("a0"), None), item(100, Some("a1"), None)]; // B=1.0, A=0.5
+
+        let ballots = vec![(&r1, b1), (&r2, b2), (&r3, b3)];
+        let rows = aggregate(&ballots, NORM_LO, NORM_HI);
+
+        // A: 1.0 + 1.0 + 0.5 = 2.5 ; B: 0.5 + 0.5 + 1.0 = 2.0
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].entity_id, Uuid::from_u128(100));
+        assert_eq!(rows[0].position, 1);
+        assert!((rows[0].score - 2.5).abs() < 1e-9);
+        assert_eq!(rows[1].entity_id, Uuid::from_u128(200));
+        assert_eq!(rows[1].position, 2);
+        assert!((rows[1].score - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_keys_on_entity_and_space() {
+        // Same entity under two different space perspectives stays distinct.
+        let r = ranking(1, "ORDINAL");
+        let items = vec![
+            RankingItem {
+                ranking_id: Uuid::from_u128(1),
+                entity_id: Uuid::from_u128(100),
+                space_id: Uuid::from_u128(1),
+                position: Some("a0".into()),
+                weight: None,
+            },
+            RankingItem {
+                ranking_id: Uuid::from_u128(1),
+                entity_id: Uuid::from_u128(100),
+                space_id: Uuid::from_u128(2),
+                position: Some("a1".into()),
+                weight: None,
+            },
+        ];
+        let rows = aggregate(&[(&r, items)], NORM_LO, NORM_HI);
+        assert_eq!(rows.len(), 2); // two perspectives -> two rows
+    }
+}

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -5,10 +5,13 @@
 //! `sqlx::query` (not the compile-time macro) so the crate builds without a
 //! live database.
 
+use std::collections::HashSet;
+
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use uuid::Uuid;
 
+use crate::eligibility::SpaceKind;
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingBlock, RankingItem};
 
@@ -28,6 +31,37 @@ impl Storage {
 
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    /// Resolve a space's kind from `public.spaces.type` (`DAO` / `Personal`).
+    /// Returns `None` if the space isn't known yet; callers treat unknown
+    /// conservatively (as `Dao`, i.e. membership-restricted).
+    pub async fn space_kind(&self, space_id: Uuid) -> Result<Option<SpaceKind>, IndexerError> {
+        let row: Option<(String,)> = sqlx::query_as("SELECT type::text FROM spaces WHERE id = $1")
+            .bind(space_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|(t,)| match t.as_str() {
+            "Personal" => SpaceKind::Personal,
+            _ => SpaceKind::Dao,
+        }))
+    }
+
+    /// The set of personal-space ids that are members OR editors of `space_id`
+    /// — the eligible voters for a DAO-space block.
+    pub async fn member_and_editor_spaces(
+        &self,
+        space_id: Uuid,
+    ) -> Result<HashSet<Uuid>, IndexerError> {
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT member_space_id FROM members WHERE space_id = $1
+             UNION
+             SELECT member_space_id FROM editors WHERE space_id = $1",
+        )
+        .bind(space_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
     /// Upsert a Ranking Block.

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::eligibility::SpaceKind;
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingBlock, RankingItem};
+use crate::scoring::ScoreRow;
 
 #[derive(Clone)]
 pub struct Storage {
@@ -213,6 +214,52 @@ impl Storage {
             .bind(it.space_id)
             .bind(&it.position)
             .bind(it.weight)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Load the items of a set of rankings (the eligible submissions for a block).
+    pub async fn get_items_for_rankings(
+        &self,
+        ranking_ids: &[Uuid],
+    ) -> Result<Vec<RankingItem>, IndexerError> {
+        if ranking_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let rows = sqlx::query_as::<_, RankingItem>(
+            "SELECT ranking_id, entity_id, space_id, position, weight \
+             FROM ranks.ranking_items WHERE ranking_id = ANY($1)",
+        )
+        .bind(ranking_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Replace a block's computed aggregate wholesale (atomic full recompute).
+    pub async fn replace_ranking_scores(
+        &self,
+        block_id: Uuid,
+        rows: &[ScoreRow],
+    ) -> Result<(), IndexerError> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+            .bind(block_id)
+            .execute(&mut *tx)
+            .await?;
+        for r in rows {
+            sqlx::query(
+                "INSERT INTO ranks.ranking_scores (block_id, entity_id, space_id, score, position) \
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(block_id)
+            .bind(r.entity_id)
+            .bind(r.space_id)
+            .bind(r.score)
+            .bind(r.position)
             .execute(&mut *tx)
             .await?;
         }

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -64,6 +64,50 @@ impl Storage {
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
+    /// The block a rank is currently linked to (the link may have been set in an
+    /// earlier edit).
+    pub async fn block_id_for_ranking(
+        &self,
+        ranking_id: Uuid,
+    ) -> Result<Option<Uuid>, IndexerError> {
+        let row: Option<(Option<Uuid>,)> =
+            sqlx::query_as("SELECT block_id FROM ranks.rankings WHERE id = $1")
+                .bind(ranking_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.and_then(|(block_id,)| block_id))
+    }
+
+    /// Load a Ranking Block, if known.
+    pub async fn get_ranking_block(
+        &self,
+        block_id: Uuid,
+    ) -> Result<Option<RankingBlock>, IndexerError> {
+        let block = sqlx::query_as::<_, RankingBlock>(
+            "SELECT id, space_id, name, filter, start_date, end_date, restriction_id \
+             FROM ranks.ranking_blocks WHERE id = $1",
+        )
+        .bind(block_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(block)
+    }
+
+    /// Load all submissions currently linked to a block (pre-dedup).
+    pub async fn get_rankings_for_block(
+        &self,
+        block_id: Uuid,
+    ) -> Result<Vec<Ranking>, IndexerError> {
+        let rows = sqlx::query_as::<_, Ranking>(
+            "SELECT id, block_id, space_id, author_address, rank_type, submitted_at, \
+             updated_at_block, update_index FROM ranks.rankings WHERE block_id = $1",
+        )
+        .bind(block_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
     /// Upsert a Ranking Block.
     pub async fn upsert_ranking_block(&self, b: &RankingBlock) -> Result<(), IndexerError> {
         sqlx::query(

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -64,6 +64,12 @@ pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011
 pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
 pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
 pub const RANK_FILTER_PROPERTY_ID: &str = "14a46854-bfd1-4b18-8215-2785c2dab9f3";
+// The 8th ranking-block property in the canonical ontology: a Relation -> a
+// "Data source" entity describing how the block sources its candidate set
+// (query vs collection). V1 aggregation works off the submitted Rank entities
+// and the Filter string, so the indexer does not read this yet; defined for
+// completeness so the full block ontology is pinned in one place.
+pub const RANK_DATA_SOURCE_TYPE_PROPERTY_ID: &str = "1f69cc98-80d4-44ab-ad49-3df6a7b15ee4";
 
 // Indexer-owned ranking output IDs. System-minted (not SDK shapes), assigned as
 // a random v4 like SCORE_PROPERTY_ID. `RANK_POSITION` is the relation type the

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -63,6 +63,7 @@ pub const RANK_START_DATE_PROPERTY_ID: &str = "eed03a04-0acd-4a9e-81e0-8272ed70a
 pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011c";
 pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
 pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
+pub const RANK_FILTER_PROPERTY_ID: &str = "14a46854-bfd1-4b18-8215-2785c2dab9f3";
 
 // Indexer-owned ranking output IDs. System-minted (not SDK shapes), assigned as
 // a random v4 like SCORE_PROPERTY_ID. `RANK_POSITION` is the relation type the


### PR DESCRIPTION
## What

The ranking-indexer's **eligibility stage** plus the **per-block recompute orchestration** that drives it. Design §7, per the team's decisions in the design thread.

> **Stacked on #726** (the consumer scaffold). Base this PR there; retarget once #726 lands. Draft while the feature is in progress.

## Eligibility (`eligibility.rs`)
- **Restriction:** DAO-space block → submitter ∈ `members ∪ editors` of the block's space; personal-space block → **"All of Geo"** (admit all) for now, per Preston (narrows to verified users once verification ships).
- **Window:** submission timestamp within the block's optional `[start, end]` (absent bound = no limit).
- **Current-membership semantics:** revoked membership drops past votes on the next recompute — falls out naturally since eligibility resolves against current membership each run.
- Pure, unit-tested: `restriction_admits` / `window_admits` / `filter_eligible` (4 cases).

## Recompute orchestration (`recompute.rs`, wired into `main`)
- `affected_blocks()` — blocks whose settings changed, newly-linked blocks, and the current block of any touched rank/item (resolved from the working tables).
- `recompute_block()` — full per-block pipeline: **dedup → eligibility → [scoring stub] → [publish stub]**.
- Scoring and publish are clearly-marked stubs, gated on the open design questions (ballot normalization method; aggregate-weight property + atlas inclusion). When they land, steps 3–4 run in one transaction and the Kafka offset commit follows it.

## Storage / models
- New reads: `space_kind` (from `public.spaces.type`), `member_and_editor_spaces` (`public.members ∪ editors`), `block_id_for_ranking`, `get_ranking_block`, `get_rankings_for_block`.
- `FromRow` derived on the row models. Unknown space type → treated conservatively as DAO.

## Verification
`cargo build -p ranking-indexer` clean; `cargo test` → 8 pass (4 dedup + 4 eligibility).

## Notes
- The window check depends on `detect()` populating `submitted_at` (a TODO there); until then unknown timestamps are admitted rather than dropped.
- Full per-block recompute on every relevant edit (V1, always-correct); incremental recompute is a later optimization.
