### PR TITLE
feat(ranking-indexer): publish stage (RANK_POSITION projection)

### DIFF
--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! ranking-indexer: consumes `knowledge.edits`, maintains the private `ranks`
-//! working schema, and (future) projects aggregated `RANK_POSITION` relations
-//! back into the public graph.
+//! working schema, and projects aggregated `RANK_POSITION` relations back into
+//! the public graph.
 
 pub mod consumer;
 pub mod dedup;
@@ -8,6 +8,7 @@ pub mod detect;
 pub mod eligibility;
 pub mod error;
 pub mod models;
+pub mod publish;
 pub mod recompute;
 pub mod scoring;
 pub mod storage;

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -1,15 +1,9 @@
 //! ranking-indexer binary entrypoint.
 //!
-//! Consumes `knowledge.edits`, keeps the rank-relevant ops, and upserts them
-//! into the private `ranks` working schema. Per-edit processing (the design
-//! allows either per-edit or per-block batching, §10).
-//!
-//! NOT YET WIRED (follow-ups, gated on the design's open questions):
-//!   - `detect()` op extraction (the rank op-pattern matching)
-//!   - per-block recompute: dedup -> eligibility -> scoring
-//!   - projection of `RANK_POSITION` relations into `public.relations`
+//! Consumes `knowledge.edits`, keeps the rank-relevant ops, and runs the full
+//! pipeline per edit (decode -> detect -> upsert -> recompute -> publish). The
+//! design allows either per-edit or per-block batching (§10); this uses per-edit.
 
-use std::collections::HashMap;
 use std::env;
 
 use futures::StreamExt;
@@ -20,7 +14,6 @@ use uuid::Uuid;
 use ranking_indexer::consumer::{decode_grc20, parse_edit, KafkaConsumer};
 use ranking_indexer::detect::detect;
 use ranking_indexer::error::IndexerError;
-use ranking_indexer::models::RankingItem;
 use ranking_indexer::recompute;
 use ranking_indexer::storage::Storage;
 
@@ -93,41 +86,5 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         .map(|m| (m.block_number as i64, m.created_at as i64))
         .unwrap_or((0, 0));
     let detected = detect(&grc20_edit, space_id, block_number, block_timestamp);
-    if detected.is_empty() {
-        return Ok(());
-    }
-
-    for block in &detected.blocks {
-        storage.upsert_ranking_block(block).await?;
-    }
-    for ranking in &detected.rankings {
-        storage.upsert_ranking(ranking).await?;
-    }
-
-    // Re-submission rebuilds a rank's items, so replace per ranking. Clone into
-    // the per-ranking groups so `detected` stays intact for affected_blocks.
-    let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
-    for item in &detected.items {
-        items_by_ranking
-            .entry(item.ranking_id)
-            .or_default()
-            .push(item.clone());
-    }
-    for (ranking_id, items) in &items_by_ranking {
-        storage.replace_ranking_items(*ranking_id, items).await?;
-    }
-
-    for (ranking_id, block_id) in &detected.block_links {
-        // The RANK_BLOCK relation is authored in the ranking's space, so the
-        // edit's `space_id` is the rank row's space.
-        storage.set_ranking_block(*ranking_id, *block_id, space_id).await?;
-    }
-
-    // Recompute every block this edit may have affected
-    // (dedup -> eligibility -> [scoring/publish stubs]).
-    for block_id in recompute::affected_blocks(&detected, storage).await? {
-        recompute::recompute_block(block_id, storage).await?;
-    }
-
-    Ok(())
+    recompute::apply_detected_edit(&detected, space_id, storage).await
 }

--- a/ranking-indexer/src/publish.rs
+++ b/ranking-indexer/src/publish.rs
@@ -1,0 +1,119 @@
+//! Publish: project a block's computed aggregate into the public graph (design §8).
+//!
+//! Per ranked target we emit a `RANK_POSITION` relation (block -> ranked entity,
+//! in the ranked perspective, ordered by `position`) whose reified entity carries
+//! the integer rank-position value, plus an `Aggregated rankings` provenance
+//! relation (block -> each contributing submission). IDs are deterministic from
+//! `(block, entity, space)`, so re-aggregation upserts in place; the whole
+//! projection for a block is replaced atomically each recompute.
+
+use std::sync::LazyLock;
+
+use uuid::Uuid;
+
+use crate::scoring::ScoreRow;
+
+static NS: LazyLock<Uuid> = LazyLock::new(|| {
+    Uuid::parse_str(sdk::core::ids::GEO_SYSTEM_NAMESPACE).expect("valid GEO_SYSTEM_NAMESPACE")
+});
+
+fn derive(name: &str) -> Uuid {
+    Uuid::new_v5(&NS, name.as_bytes())
+}
+
+/// One `RANK_POSITION` projection row for a ranked `(entity, space)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankPositionRow {
+    pub entity_id: Uuid,
+    pub space_id: Uuid,
+    /// Published integer score (block-scoped 0–100, v1).
+    pub value: i64,
+    /// Lexicographically-ordered position key.
+    pub position: String,
+    pub relation_id: Uuid,
+    pub reified_entity_id: Uuid,
+    pub value_row_id: Uuid,
+}
+
+/// Build the public projection from a block's scored aggregate.
+///
+/// Integer value is block-scoped (v1): `round(100 * score / max_score)`, so the
+/// top entity is 100. Position is a fixed-width, lexicographically-ordered rank
+/// key (regenerated each full recompute — fine since the projection is replaced
+/// wholesale).
+pub fn build_projection(block_id: Uuid, scores: &[ScoreRow]) -> Vec<RankPositionRow> {
+    let max = scores.iter().map(|s| s.score).fold(0.0_f64, f64::max);
+    scores
+        .iter()
+        .map(|s| {
+            let value = if max > 0.0 {
+                (100.0 * s.score / max).round() as i64
+            } else {
+                0
+            };
+            let tag = |kind: &str| derive(&format!("{kind}:{block_id}:{}:{}", s.entity_id, s.space_id));
+            RankPositionRow {
+                entity_id: s.entity_id,
+                space_id: s.space_id,
+                value,
+                position: format!("{:010}", s.position),
+                relation_id: tag("rank_position"),
+                reified_entity_id: tag("rank_position_entity"),
+                value_row_id: tag("rank_position_value"),
+            }
+        })
+        .collect()
+}
+
+/// Deterministic `(relation_id, reified_entity_id)` for an `Aggregated rankings`
+/// provenance relation linking a block to one contributing submission.
+pub fn provenance_ids(block_id: Uuid, ranking_id: Uuid) -> (Uuid, Uuid) {
+    (
+        derive(&format!("aggregated_rankings:{block_id}:{ranking_id}")),
+        derive(&format!("aggregated_rankings_entity:{block_id}:{ranking_id}")),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn score(entity: u128, space: u128, score: f64, position: i32) -> ScoreRow {
+        ScoreRow {
+            entity_id: Uuid::from_u128(entity),
+            space_id: Uuid::from_u128(space),
+            score,
+            position,
+        }
+    }
+
+    #[test]
+    fn scales_top_to_100_and_orders_by_position() {
+        let block = Uuid::from_u128(1);
+        let scores = vec![score(10, 1, 2.5, 1), score(11, 1, 2.0, 2), score(12, 1, 1.0, 3)];
+        let proj = build_projection(block, &scores);
+        assert_eq!(proj.len(), 3);
+        assert_eq!(proj[0].value, 100); // 2.5/2.5
+        assert_eq!(proj[1].value, 80); // 2.0/2.5
+        assert_eq!(proj[2].value, 40); // 1.0/2.5
+        assert!(proj[0].position < proj[1].position);
+        assert!(proj[1].position < proj[2].position);
+    }
+
+    #[test]
+    fn ids_are_stable_and_distinct() {
+        let block = Uuid::from_u128(1);
+        let s = vec![score(10, 1, 1.0, 1)];
+        let a = build_projection(block, &s);
+        let b = build_projection(block, &s);
+        assert_eq!(a[0].relation_id, b[0].relation_id);
+        assert_ne!(a[0].relation_id, a[0].reified_entity_id);
+        assert_ne!(a[0].relation_id, a[0].value_row_id);
+        assert_ne!(a[0].reified_entity_id, a[0].value_row_id);
+    }
+
+    #[test]
+    fn empty_scores_yield_empty_projection() {
+        assert!(build_projection(Uuid::from_u128(1), &[]).is_empty());
+    }
+}

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -4,9 +4,7 @@
 //! (design §7): `dedup -> eligibility -> scoring -> publish`. A full recompute
 //! is always correct regardless of edit arrival order.
 //!
-//! Publish is still a stub, gated on the rank-position-value property ID
-//! (Preston) and projection details. Dedup, eligibility, and scoring are wired
-//! in and exercised.
+//! All four stages are wired: dedup -> eligibility -> scoring -> publish.
 
 use std::collections::{HashMap, HashSet};
 
@@ -17,7 +15,7 @@ use crate::detect::DetectedEdit;
 use crate::eligibility::{filter_eligible, SpaceKind};
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingItem};
-use crate::scoring;
+use crate::{publish, scoring};
 use crate::storage::Storage;
 
 /// Block ids whose aggregate may have changed as a result of this edit:
@@ -90,20 +88,21 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
     let scores = scoring::aggregate(&ballots, scoring::NORM_LO, scoring::NORM_HI);
     storage.replace_ranking_scores(block_id, &scores).await?;
 
+    // 4. Publish: project RANK_POSITION relations (+ the integer rank-position
+    //    value on each reified entity) and Aggregated rankings provenance into
+    //    the public graph, replacing the prior projection atomically.
+    let projection = publish::build_projection(block_id, &scores);
+    let contributing: Vec<Uuid> = ballots.iter().map(|(r, _)| r.id).collect();
+    storage
+        .replace_rank_position_projection(block_id, block.space_id, &projection, &contributing)
+        .await?;
+
     tracing::debug!(
         block_id = %block_id,
         eligible_submissions = ballots.len(),
         ranked_entities = scores.len(),
-        "ranking-indexer recompute: scored (publish not yet wired)"
+        "ranking-indexer recompute: scored + published"
     );
-
-    // 4. TODO(publish): project RANK_POSITION relations (+ Aggregated rankings
-    //    provenance + the integer rank-position value on the reified relation
-    //    entity) into public.relations, atomically replacing the prior
-    //    projection. Gated on Preston minting the rank-position-value property.
-    //
-    // When publish lands, scoring + projection should run in one transaction and
-    // the Kafka offset commit (in main) should follow it.
 
     Ok(())
 }

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -106,3 +106,44 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
 
     Ok(())
 }
+
+/// Apply a detected edit end to end: upsert its rank ops into the working
+/// tables, then recompute every block it may have affected. Shared by the main
+/// consumer loop and integration tests.
+pub async fn apply_detected_edit(
+    detected: &DetectedEdit,
+    storage: &Storage,
+) -> Result<(), IndexerError> {
+    if detected.is_empty() {
+        return Ok(());
+    }
+
+    for block in &detected.blocks {
+        storage.upsert_ranking_block(block).await?;
+    }
+    for ranking in &detected.rankings {
+        storage.upsert_ranking(ranking).await?;
+    }
+
+    // Re-submission rebuilds a rank's items, so replace per ranking.
+    let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
+    for item in &detected.items {
+        items_by_ranking
+            .entry(item.ranking_id)
+            .or_default()
+            .push(item.clone());
+    }
+    for (ranking_id, items) in &items_by_ranking {
+        storage.replace_ranking_items(*ranking_id, items).await?;
+    }
+
+    for (ranking_id, block_id) in &detected.block_links {
+        storage.set_ranking_block(*ranking_id, *block_id).await?;
+    }
+
+    for block_id in affected_blocks(detected, storage).await? {
+        recompute_block(block_id, storage).await?;
+    }
+
+    Ok(())
+}

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -112,6 +112,7 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
 /// consumer loop and integration tests.
 pub async fn apply_detected_edit(
     detected: &DetectedEdit,
+    space_id: Uuid,
     storage: &Storage,
 ) -> Result<(), IndexerError> {
     if detected.is_empty() {
@@ -138,7 +139,9 @@ pub async fn apply_detected_edit(
     }
 
     for (ranking_id, block_id) in &detected.block_links {
-        storage.set_ranking_block(*ranking_id, *block_id).await?;
+        // The RANK_BLOCK relation is authored in the ranking's space, so the
+        // edit's `space_id` is the rank row's space.
+        storage.set_ranking_block(*ranking_id, *block_id, space_id).await?;
     }
 
     for block_id in affected_blocks(detected, storage).await? {

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::eligibility::SpaceKind;
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingBlock, RankingItem};
+use crate::publish::{provenance_ids, RankPositionRow};
 use crate::scoring::ScoreRow;
 
 #[derive(Clone)]
@@ -263,6 +264,100 @@ impl Storage {
             .execute(&mut *tx)
             .await?;
         }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Replace a block's public `RANK_POSITION` projection atomically:
+    /// the ordered relations (with the integer rank-position value on each
+    /// reified entity) and the `Aggregated rankings` provenance relations.
+    pub async fn replace_rank_position_projection(
+        &self,
+        block_id: Uuid,
+        block_space_id: Uuid,
+        rows: &[RankPositionRow],
+        contributing_rankings: &[Uuid],
+    ) -> Result<(), IndexerError> {
+        use sdk::core::ids::{
+            AGGREGATED_RANKINGS_RELATION_TYPE_ID, RANK_POSITION_RELATION_TYPE_ID,
+            RANK_POSITION_VALUE_PROPERTY_ID,
+        };
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+        let rank_position = pid(RANK_POSITION_RELATION_TYPE_ID);
+        let aggregated = pid(AGGREGATED_RANKINGS_RELATION_TYPE_ID);
+        let value_prop = pid(RANK_POSITION_VALUE_PROPERTY_ID);
+
+        let mut tx = self.pool.begin().await?;
+
+        // 1. Drop prior value rows on this block's reified RANK_POSITION entities
+        //    (before the relations they hang off are deleted).
+        sqlx::query(
+            "DELETE FROM values WHERE property_id = $1 AND entity_id IN \
+             (SELECT entity_id FROM relations WHERE type_id = $2 AND from_entity_id = $3)",
+        )
+        .bind(value_prop)
+        .bind(rank_position)
+        .bind(block_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // 2. Drop prior projection relations (RANK_POSITION + Aggregated rankings).
+        sqlx::query("DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2)")
+            .bind(block_id)
+            .bind(&[rank_position, aggregated][..])
+            .execute(&mut *tx)
+            .await?;
+
+        // 3. Insert the ordered RANK_POSITION relations + their value rows.
+        for r in rows {
+            sqlx::query(
+                "INSERT INTO relations \
+                 (id, entity_id, type_id, from_entity_id, to_entity_id, to_space_id, space_id, position) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            )
+            .bind(r.relation_id)
+            .bind(r.reified_entity_id)
+            .bind(rank_position)
+            .bind(block_id)
+            .bind(r.entity_id)
+            .bind(r.space_id)
+            .bind(block_space_id)
+            .bind(&r.position)
+            .execute(&mut *tx)
+            .await?;
+
+            // `values.id` is a text column — serialize the UUID at the bind boundary.
+            sqlx::query(
+                "INSERT INTO values (id, entity_id, space_id, property_id, integer) \
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(r.value_row_id.to_string())
+            .bind(r.reified_entity_id)
+            .bind(block_space_id)
+            .bind(value_prop)
+            .bind(r.value)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        // 4. Insert Aggregated rankings provenance relations (block -> submission).
+        for ranking_id in contributing_rankings {
+            let (relation_id, reified) = provenance_ids(block_id, *ranking_id);
+            sqlx::query(
+                "INSERT INTO relations \
+                 (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+                 VALUES ($1, $2, $3, $4, $5, $6)",
+            )
+            .bind(relation_id)
+            .bind(reified)
+            .bind(aggregated)
+            .bind(block_id)
+            .bind(ranking_id)
+            .bind(block_space_id)
+            .execute(&mut *tx)
+            .await?;
+        }
+
         tx.commit().await?;
         Ok(())
     }

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -290,23 +290,30 @@ impl Storage {
         let mut tx = self.pool.begin().await?;
 
         // 1. Drop prior value rows on this block's reified RANK_POSITION entities
-        //    (before the relations they hang off are deleted).
+        //    (before the relations they hang off are deleted). Scoped to this
+        //    block's space so a same-id block perspectived into another space
+        //    keeps its own projection.
         sqlx::query(
-            "DELETE FROM values WHERE property_id = $1 AND entity_id IN \
-             (SELECT entity_id FROM relations WHERE type_id = $2 AND from_entity_id = $3)",
+            "DELETE FROM values WHERE property_id = $1 AND space_id = $4 AND entity_id IN \
+             (SELECT entity_id FROM relations \
+              WHERE type_id = $2 AND from_entity_id = $3 AND space_id = $4)",
         )
         .bind(value_prop)
         .bind(rank_position)
         .bind(block_id)
+        .bind(block_space_id)
         .execute(&mut *tx)
         .await?;
 
         // 2. Drop prior projection relations (RANK_POSITION + Aggregated rankings).
-        sqlx::query("DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2)")
-            .bind(block_id)
-            .bind(&[rank_position, aggregated][..])
-            .execute(&mut *tx)
-            .await?;
+        sqlx::query(
+            "DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2) AND space_id = $3",
+        )
+        .bind(block_id)
+        .bind(&[rank_position, aggregated][..])
+        .bind(block_space_id)
+        .execute(&mut *tx)
+        .await?;
 
         // 3. Insert the ordered RANK_POSITION relations + their value rows.
         for r in rows {

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -1,0 +1,199 @@
+//! End-to-end integration test for the full ranking-indexer pipeline.
+//!
+//! Runs real edits through `detect -> apply_detected_edit` (upsert -> dedup ->
+//! eligibility -> scoring -> publish) against a live Postgres and asserts the
+//! public `RANK_POSITION` projection. Requires a DB with the public schema + the
+//! private `ranks` schema. Opt-in: set `RANKING_INDEXER_E2E_DATABASE_URL` to the
+//! connection string. Skips (passes) if unset, so it never runs on a generic
+//! CI `DATABASE_URL` that lacks the `ranks` schema.
+
+use grc_20::model::builder::EditBuilder;
+use sdk::core::ids::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+use ranking_indexer::detect::detect;
+use ranking_indexer::recompute::apply_detected_edit;
+use ranking_indexer::storage::Storage;
+
+fn gid(n: u128) -> [u8; 16] {
+    *Uuid::from_u128(n).as_bytes()
+}
+fn sid(s: &str) -> [u8; 16] {
+    *Uuid::parse_str(s).unwrap().as_bytes()
+}
+fn u(n: u128) -> Uuid {
+    Uuid::from_u128(n)
+}
+
+// Scenario UUIDs (high values, unlikely to collide with real data).
+const BLOCK_SPACE: u128 = 0xE2E5_0000_0001;
+const MEMBER1: u128 = 0xE2E5_0000_0011;
+const MEMBER2: u128 = 0xE2E5_0000_0012;
+const NONMEMBER: u128 = 0xE2E5_0000_0013;
+const BLOCK: u128 = 0xE2E5_0000_0021;
+const ENTITY_A: u128 = 0xE2E5_0000_0031;
+const ENTITY_B: u128 = 0xE2E5_0000_0032;
+const RANK1: u128 = 0xE2E5_0000_0041;
+const RANK2: u128 = 0xE2E5_0000_0042;
+const RANK3: u128 = 0xE2E5_0000_0043;
+
+#[tokio::test]
+async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+    ] {
+        sqlx::query(sql).bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = ANY($1)")
+        .bind(&[u(RANK1), u(RANK2), u(RANK3)][..])
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = ANY($1)")
+        .bind(&[u(RANK1), u(RANK2), u(RANK3)][..])
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1").bind(u(BLOCK)).execute(pool).await.unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1").bind(u(BLOCK)).execute(pool).await.unwrap();
+    sqlx::query("DELETE FROM members WHERE space_id = $1").bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id = $1").bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
+
+    // --- seed public prerequisites -----------------------------------------
+    // The block lives in a DAO space; member1/member2 are members, nonmember isn't.
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e')")
+        .bind(u(BLOCK_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    for m in [MEMBER1, MEMBER2] {
+        sqlx::query("INSERT INTO members (member_space_id, space_id) VALUES ($1, $2)")
+            .bind(u(m))
+            .bind(u(BLOCK_SPACE))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    // --- edit 1: create the ranking block ----------------------------------
+    let block_edit = EditBuilder::new(gid(1))
+        .create_relation(|r| {
+            r.id(gid(0x100))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(BLOCK))
+                .to(sid(RANKING_BLOCK_TYPE_ID))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x101))
+                .relation_type(sid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+                .from(gid(BLOCK))
+                .to(sid(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID))
+        })
+        .create_entity(gid(BLOCK), |e| e.text(sid(NAME_PROPERTY_ID), "Top Films", None))
+        .build();
+    apply_detected_edit(&detect(&block_edit, u(BLOCK_SPACE), 1, 0), &storage)
+        .await
+        .unwrap();
+
+    // --- ordinal submission helper (rank -> [first, second]) ----------------
+    // Two members rank A above B; the non-member ranks B above A.
+    let submit = |rank: u128, rel_base: u128, first: u128, second: u128| {
+        EditBuilder::new(gid(rank ^ 0xED17))
+            .create_relation(|r| {
+                r.id(gid(rel_base))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(sid(RANK_TYPE_ID))
+            })
+            .create_entity(gid(rank), |e| e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None))
+            .create_relation(|r| {
+                r.id(gid(rel_base + 1))
+                    .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(BLOCK))
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 2))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(first))
+                    .to_space(gid(BLOCK_SPACE))
+                    .position("a0")
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 3))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(second))
+                    .to_space(gid(BLOCK_SPACE))
+                    .position("a1")
+            })
+            .build()
+    };
+
+    apply_detected_edit(&detect(&submit(RANK1, 0x200, ENTITY_A, ENTITY_B), u(MEMBER1), 2, 0), &storage)
+        .await
+        .unwrap();
+    apply_detected_edit(&detect(&submit(RANK2, 0x210, ENTITY_A, ENTITY_B), u(MEMBER2), 3, 0), &storage)
+        .await
+        .unwrap();
+    // non-member ranks B above A — must be filtered out
+    apply_detected_edit(&detect(&submit(RANK3, 0x220, ENTITY_B, ENTITY_A), u(NONMEMBER), 4, 0), &storage)
+        .await
+        .unwrap();
+
+    // --- assert the published RANK_POSITION projection ----------------------
+    let rank_position = u(Uuid::parse_str(RANK_POSITION_RELATION_TYPE_ID).unwrap().as_u128());
+    let value_prop = Uuid::parse_str(RANK_POSITION_VALUE_PROPERTY_ID).unwrap();
+
+    let rows = sqlx::query(
+        "SELECT r.to_entity_id AS entity, r.to_space_id AS space, v.integer AS value, r.position AS position \
+         FROM relations r \
+         JOIN values v ON v.entity_id = r.entity_id AND v.property_id = $3 \
+         WHERE r.from_entity_id = $1 AND r.type_id = $2 \
+         ORDER BY r.position",
+    )
+    .bind(u(BLOCK))
+    .bind(rank_position)
+    .bind(value_prop)
+    .fetch_all(pool)
+    .await
+    .unwrap();
+
+    // Only members counted (both ranked A>B), so A is #1 and B is #2.
+    assert_eq!(rows.len(), 2, "expected two ranked entities");
+
+    let e0: Uuid = rows[0].get("entity");
+    let v0: i64 = rows[0].get("value");
+    let s0: Uuid = rows[0].get("space");
+    assert_eq!(e0, u(ENTITY_A), "top-ranked entity should be A");
+    assert_eq!(v0, 100, "top entity scaled to 100");
+    assert_eq!(s0, u(BLOCK_SPACE), "ranked perspective carried on to_space_id");
+
+    let e1: Uuid = rows[1].get("entity");
+    let v1: i64 = rows[1].get("value");
+    assert_eq!(e1, u(ENTITY_B), "second entity should be B");
+    assert_eq!(v1, 50, "B is half of A (1.0 vs 2.0 summed)");
+
+    // provenance: one Aggregated rankings relation per *eligible* submission (2).
+    let aggregated = Uuid::parse_str(AGGREGATED_RANKINGS_RELATION_TYPE_ID).unwrap();
+    let prov: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM relations WHERE from_entity_id = $1 AND type_id = $2",
+    )
+    .bind(u(BLOCK))
+    .bind(aggregated)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(prov, 2, "non-member submission must be excluded from provenance");
+}

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -101,7 +101,7 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
         })
         .create_entity(gid(BLOCK), |e| e.text(sid(NAME_PROPERTY_ID), "Top Films", None))
         .build();
-    apply_detected_edit(&detect(&block_edit, u(BLOCK_SPACE), 1, 0), &storage)
+    apply_detected_edit(&detect(&block_edit, u(BLOCK_SPACE), 1, 0), u(BLOCK_SPACE), &storage)
         .await
         .unwrap();
 
@@ -141,14 +141,14 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
             .build()
     };
 
-    apply_detected_edit(&detect(&submit(RANK1, 0x200, ENTITY_A, ENTITY_B), u(MEMBER1), 2, 0), &storage)
+    apply_detected_edit(&detect(&submit(RANK1, 0x200, ENTITY_A, ENTITY_B), u(MEMBER1), 2, 0), u(MEMBER1), &storage)
         .await
         .unwrap();
-    apply_detected_edit(&detect(&submit(RANK2, 0x210, ENTITY_A, ENTITY_B), u(MEMBER2), 3, 0), &storage)
+    apply_detected_edit(&detect(&submit(RANK2, 0x210, ENTITY_A, ENTITY_B), u(MEMBER2), 3, 0), u(MEMBER2), &storage)
         .await
         .unwrap();
     // non-member ranks B above A — must be filtered out
-    apply_detected_edit(&detect(&submit(RANK3, 0x220, ENTITY_B, ENTITY_A), u(NONMEMBER), 4, 0), &storage)
+    apply_detected_edit(&detect(&submit(RANK3, 0x220, ENTITY_B, ENTITY_A), u(NONMEMBER), 4, 0), u(NONMEMBER), &storage)
         .await
         .unwrap();
 


### PR DESCRIPTION
## What

The ranking-indexer's **publish stage** (design §8) — projects a block's scored aggregate into the public graph. This **completes the V1 pipeline**: `consume → decode → detect → upsert → recompute(dedup → eligibility → scoring → publish)`.

> **Stacked on #727.** Draft while the stack is in review. The stack was rebased onto the latest #724, so this branch carries the full ID set (incl. `RANK_POSITION_VALUE_PROPERTY_ID`).

## What it writes (per block, replaced atomically each recompute)
- **`RANK_POSITION` relations** — one per ranked target: `from` = block, `to` = ranked entity, `to_space_id` = the ranked perspective, ordered by a lexicographic `position` key.
- **Integer rank-position value** on each relation's reified entity (`RANK_POSITION_VALUE_PROPERTY`), block-scoped **0–100** for v1 (`round(100 * score / max_score)`).
- **`Aggregated rankings` provenance relations** — block → each contributing submission.

## Design points
- **Deterministic IDs** from `(block, entity, space)` (UUIDv5) so re-aggregation upserts in place; dropped targets are removed (the whole projection is delete-then-insert in one transaction).
- `values.id` is a text column, so the value-row UUID is serialized at the bind boundary (matches the SCORE mirror).
- Reified entities aren't inserted into `entities` (FKs are NOT VALID; readers join `block → RANK_POSITION → to_entity` and read the value by reified id) — can revisit if needed.

## Verification
`cargo build -p ranking-indexer` clean; `cargo test` → 23 pass (3 new `publish` tests: 0–100 scaling, position ordering, stable/distinct IDs).

## Notes / v2
- Integer is block-scoped (v1). Cross-ranking comparability would mean switching the aggregate measure from **sum** to a count-normalized mean — a product call, deferred.
- Position is a fixed-width lexicographic key (fine under full-replace); could swap to true fractional indexing if needed.
- Per the team: no atlas changes; cross-consumer consistency is V1 self-healing.
