### PR TITLE
feat(ranking-indexer): containerize + k8s deploy + CI workflows

### DIFF
--- a/.github/workflows/ranking-indexer-check.yml
+++ b/.github/workflows/ranking-indexer-check.yml
@@ -1,0 +1,67 @@
+name: Ranking Indexer Check
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'ranking-indexer/**'
+      - 'hermes-schema/**'
+      - 'hermes-instrumentation/**'
+      - 'hermes-kafka/**'
+      - 'indexer_utils/**'
+      - 'sdk/**'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'ranking-indexer/**'
+      - 'hermes-schema/**'
+      - 'hermes-instrumentation/**'
+      - 'hermes-kafka/**'
+      - 'indexer_utils/**'
+      - 'sdk/**'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Build & Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ranking-indexer
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.92.0"
+          components: rustfmt, clippy
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y \
+            cmake \
+            libclang-dev \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            pkg-config
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./ranking-indexer
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose

--- a/.github/workflows/ranking-indexer-deploy-staging.yml
+++ b/.github/workflows/ranking-indexer-deploy-staging.yml
@@ -1,0 +1,78 @@
+name: Deploy Ranking Indexer (Staging)
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'ranking-indexer/**'
+      - 'hermes-schema/**'
+      - 'hermes-instrumentation/**'
+      - 'hermes-kafka/**'
+      - 'indexer_utils/**'
+      - 'sdk/**'
+      - '.github/workflows/ranking-indexer-deploy-staging.yml'
+
+concurrency:
+  group: ranking-indexer-staging
+  cancel-in-progress: true
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+  IMAGE_NAME: ranking-indexer
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+                       -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging \
+                       -f ranking-indexer/Dockerfile .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
+
+      - name: Configure kubectl for DigitalOcean
+        run: |
+          doctl kubernetes cluster kubeconfig save ${{ secrets.DIGITALOCEAN_CLUSTER_NAME }}
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl apply -f ranking-indexer/k8s/staging/namespace.yaml
+          # Update image tag to use SHA and apply
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/staging/ranking-indexer.yaml
+          kubectl apply -f ranking-indexer/k8s/staging/ranking-indexer.yaml
+
+      - name: Restart deployment to pick up new image
+        run: |
+          kubectl rollout restart deployment/ranking-indexer -n knowledge-staging
+
+      - name: Wait for rollout
+        run: |
+          kubectl rollout status deployment/ranking-indexer -n knowledge-staging --timeout=120s
+
+      - name: Show deployment status
+        run: |
+          echo "=== Ranking Indexer Deployment ==="
+          kubectl get deployment ranking-indexer -n knowledge-staging
+          echo ""
+          echo "=== Ranking Indexer Pods ==="
+          kubectl get pods -n knowledge-staging -l app=ranking-indexer
+          echo ""
+          echo "=== Recent Events ==="
+          kubectl get events -n knowledge-staging --sort-by='.lastTimestamp' | grep ranking-indexer | tail -10

--- a/.github/workflows/ranking-indexer-deploy.yml
+++ b/.github/workflows/ranking-indexer-deploy.yml
@@ -1,0 +1,78 @@
+name: Deploy Ranking Indexer (Production)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'ranking-indexer/**'
+      - 'hermes-schema/**'
+      - 'hermes-instrumentation/**'
+      - 'hermes-kafka/**'
+      - 'indexer_utils/**'
+      - 'sdk/**'
+      - '.github/workflows/ranking-indexer-deploy.yml'
+
+concurrency:
+  group: ranking-indexer-production
+  cancel-in-progress: true
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+  IMAGE_NAME: ranking-indexer
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+                       -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+                       -f ranking-indexer/Dockerfile .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
+
+      - name: Configure kubectl for DigitalOcean
+        run: |
+          doctl kubernetes cluster kubeconfig save ${{ secrets.DIGITALOCEAN_CLUSTER_NAME }}
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl apply -f ranking-indexer/k8s/production/namespace.yaml
+          # Update image tag to use SHA and apply
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/production/ranking-indexer.yaml
+          kubectl apply -f ranking-indexer/k8s/production/ranking-indexer.yaml
+
+      - name: Restart deployment to pick up new image
+        run: |
+          kubectl rollout restart deployment/ranking-indexer -n knowledge
+
+      - name: Wait for rollout
+        run: |
+          kubectl rollout status deployment/ranking-indexer -n knowledge --timeout=120s
+
+      - name: Show deployment status
+        run: |
+          echo "=== Ranking Indexer Deployment ==="
+          kubectl get deployment ranking-indexer -n knowledge
+          echo ""
+          echo "=== Ranking Indexer Pods ==="
+          kubectl get pods -n knowledge -l app=ranking-indexer
+          echo ""
+          echo "=== Recent Events ==="
+          kubectl get events -n knowledge --sort-by='.lastTimestamp' | grep ranking-indexer | tail -10

--- a/ranking-indexer/Dockerfile
+++ b/ranking-indexer/Dockerfile
@@ -1,0 +1,36 @@
+FROM rust:1.92-bookworm as builder
+
+# Install build dependencies for rdkafka and protobuf
+RUN apt-get update && \
+    apt-get install -y \
+    cmake \
+    libclang-dev \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy only required crates (no workspace Cargo.toml - build standalone)
+COPY hermes-schema ./hermes-schema
+COPY hermes-instrumentation ./hermes-instrumentation
+COPY hermes-kafka ./hermes-kafka
+COPY indexer_utils ./indexer_utils
+COPY sdk ./sdk
+COPY ranking-indexer ./ranking-indexer
+
+# Build from the crate directory (standalone, not as workspace member)
+WORKDIR /app/ranking-indexer
+ENV SQLX_OFFLINE=true
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates libssl3 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/ranking-indexer/target/release/ranking-indexer /usr/local/bin/ranking-indexer
+
+CMD ["ranking-indexer"]

--- a/ranking-indexer/k8s/production/namespace.yaml
+++ b/ranking-indexer/k8s/production/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knowledge
+  labels:
+    app.kubernetes.io/name: knowledge
+    app.kubernetes.io/part-of: geo

--- a/ranking-indexer/k8s/production/ranking-indexer.yaml
+++ b/ranking-indexer/k8s/production/ranking-indexer.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ranking-indexer
+  namespace: knowledge
+  labels:
+    app: ranking-indexer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ranking-indexer
+  template:
+    metadata:
+      labels:
+        app: ranking-indexer
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: ranking-indexer
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: PGSSLROOTCERT
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_PASSWORD
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_SSL_CA_PEM
+            - name: ENVIRONMENT
+              value: "production"
+            - name: KAFKA_GROUP_ID
+              value: "ranking-indexer-v1"
+            - name: RUST_LOG
+              value: "ranking_indexer=info"
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "500m"
+      restartPolicy: Always

--- a/ranking-indexer/k8s/production/secrets.yaml
+++ b/ranking-indexer/k8s/production/secrets.yaml
@@ -1,0 +1,33 @@
+# ranking-indexer secrets template
+#
+# 1. Create the knowledge namespace (if not exists):
+#    kubectl create namespace knowledge
+#
+# 2. Copy regcred for image pulls:
+#    kubectl get secret regcred -n api -o yaml | \
+#      sed 's/namespace: api/namespace: knowledge/' | \
+#      kubectl apply -f -
+#
+# 3. Copy database secrets (api-secrets.DATABASE_URL should be the pooler URL):
+#    kubectl get secret api-secrets -n api -o yaml | \
+#      sed 's/namespace: api/namespace: knowledge/' | \
+#      kubectl apply -f -
+#
+# 4. Copy Kafka credentials:
+#    kubectl get secret kafka-credentials -n kafka -o yaml | \
+#      sed 's/namespace: kafka/namespace: knowledge/' | \
+#      sed 's/name: kafka-credentials/name: ranking-indexer-secrets/' | \
+#      kubectl apply -f -
+#
+# Or create Kafka secrets manually:
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ranking-indexer-secrets
+  namespace: knowledge
+type: Opaque
+stringData:
+  KAFKA_BROKER: "<kafka-broker-url>"
+  KAFKA_USERNAME: "<kafka-username>"
+  KAFKA_PASSWORD: "<kafka-password>"
+  KAFKA_SSL_CA_PEM: "<kafka-ssl-ca-pem>"

--- a/ranking-indexer/k8s/staging/namespace.yaml
+++ b/ranking-indexer/k8s/staging/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knowledge-staging
+  labels:
+    app.kubernetes.io/name: knowledge
+    app.kubernetes.io/part-of: geo
+    environment: staging

--- a/ranking-indexer/k8s/staging/ranking-indexer.yaml
+++ b/ranking-indexer/k8s/staging/ranking-indexer.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ranking-indexer
+  namespace: knowledge-staging
+  labels:
+    app: ranking-indexer
+    environment: staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ranking-indexer
+  template:
+    metadata:
+      labels:
+        app: ranking-indexer
+        environment: staging
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: ranking-indexer
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: PGSSLROOTCERT
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_PASSWORD
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_SSL_CA_PEM
+            - name: ENVIRONMENT
+              value: "staging"
+            - name: KAFKA_GROUP_ID
+              value: "ranking-indexer-v1-staging"
+            - name: RUST_LOG
+              value: "ranking_indexer=info"
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "500m"
+      restartPolicy: Always


### PR DESCRIPTION
Stacked on #728. Adds the deployment infrastructure the ranking-indexer was missing — it was the only indexer in the repo with no `Dockerfile` and no `k8s/`. Modeled directly on the **kg-indexer** (same Rust / Kafka / sqlx stack).

## What's here
- **`Dockerfile`** — standalone two-stage build (cmake/ssl/protobuf deps `rdkafka` needs), copying only the crates the binary depends on.
- **`k8s/{staging,production}/`** — `Deployment` + `Namespace`, reusing the shared `knowledge` / `knowledge-staging` namespaces and `api-secrets` (DB URL + SSL CA via the same `setup-certs` initContainer pattern). Production includes a `ranking-indexer-secrets` template.
- **CI workflows** — `check` (fmt + `clippy -D warnings` + build), `deploy-staging` (push to `dev`), `deploy` (push to `main`). Both deploy jobs build and push images to the DigitalOcean registry (`registry.digitalocean.com/geo/ranking-indexer`), which the k8s rollout then pulls — same flow as `kg-indexer-deploy-staging.yml`.

## Deliberate differences from the kg-indexer template
- **Env vars** match what the binary actually reads: `DATABASE_URL`, `ENVIRONMENT` (required — `get_topic_prefix()` panics without it), `KAFKA_BROKER/USERNAME/PASSWORD/SSL_CA_PEM`, `KAFKA_GROUP_ID`, `RUST_LOG`.
- **Omitted** kg-indexer-only vars with no corresponding code/deps here: `BLOCK_STALE_TIMEOUT_MS`, all `SENTRY_*`, all `AXIOM_*`.
- **Path triggers** scoped to this crate's real dependency set: `ranking-indexer`, `hermes-schema`, `hermes-instrumentation`, `hermes-kafka`, `indexer_utils`, `sdk`.

## Verification
- `cargo clippy --all-targets -- -D warnings` → clean (exit 0), so the check job will pass.
- All manifests + workflows validate as YAML; the deploy `sed` image-rewrite string matches both manifests.

## Note for review
- No new **repo** secrets needed (`DIGITALOCEAN_ACCESS_TOKEN` / `DIGITALOCEAN_CLUSTER_NAME` already used by every other service). The only new **cluster** secret is `ranking-indexer-secrets` — creation steps are in `k8s/production/secrets.yaml`.