### PR TITLE
feat(ranking-indexer): integration branch

### DIFF
--- a/.github/workflows/ranking-indexer-check.yml
+++ b/.github/workflows/ranking-indexer-check.yml
@@ -1,0 +1,67 @@
+name: Ranking Indexer Check
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'ranking-indexer/**'
+      - 'hermes-schema/**'
+      - 'hermes-instrumentation/**'
+      - 'hermes-kafka/**'
+      - 'indexer_utils/**'
+      - 'sdk/**'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'ranking-indexer/**'
+      - 'hermes-schema/**'
+      - 'hermes-instrumentation/**'
+      - 'hermes-kafka/**'
+      - 'indexer_utils/**'
+      - 'sdk/**'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Build & Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ranking-indexer
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.92.0"
+          components: rustfmt, clippy
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y \
+            cmake \
+            libclang-dev \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            pkg-config
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./ranking-indexer
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose

--- a/.github/workflows/ranking-indexer-deploy-staging.yml
+++ b/.github/workflows/ranking-indexer-deploy-staging.yml
@@ -1,0 +1,78 @@
+name: Deploy Ranking Indexer (Staging)
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'ranking-indexer/**'
+      - 'hermes-schema/**'
+      - 'hermes-instrumentation/**'
+      - 'hermes-kafka/**'
+      - 'indexer_utils/**'
+      - 'sdk/**'
+      - '.github/workflows/ranking-indexer-deploy-staging.yml'
+
+concurrency:
+  group: ranking-indexer-staging
+  cancel-in-progress: true
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+  IMAGE_NAME: ranking-indexer
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+                       -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging \
+                       -f ranking-indexer/Dockerfile .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
+
+      - name: Configure kubectl for DigitalOcean
+        run: |
+          doctl kubernetes cluster kubeconfig save ${{ secrets.DIGITALOCEAN_CLUSTER_NAME }}
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl apply -f ranking-indexer/k8s/staging/namespace.yaml
+          # Update image tag to use SHA and apply
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/staging/ranking-indexer.yaml
+          kubectl apply -f ranking-indexer/k8s/staging/ranking-indexer.yaml
+
+      - name: Restart deployment to pick up new image
+        run: |
+          kubectl rollout restart deployment/ranking-indexer -n knowledge-staging
+
+      - name: Wait for rollout
+        run: |
+          kubectl rollout status deployment/ranking-indexer -n knowledge-staging --timeout=120s
+
+      - name: Show deployment status
+        run: |
+          echo "=== Ranking Indexer Deployment ==="
+          kubectl get deployment ranking-indexer -n knowledge-staging
+          echo ""
+          echo "=== Ranking Indexer Pods ==="
+          kubectl get pods -n knowledge-staging -l app=ranking-indexer
+          echo ""
+          echo "=== Recent Events ==="
+          kubectl get events -n knowledge-staging --sort-by='.lastTimestamp' | grep ranking-indexer | tail -10

--- a/.github/workflows/ranking-indexer-deploy.yml
+++ b/.github/workflows/ranking-indexer-deploy.yml
@@ -1,0 +1,78 @@
+name: Deploy Ranking Indexer (Production)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'ranking-indexer/**'
+      - 'hermes-schema/**'
+      - 'hermes-instrumentation/**'
+      - 'hermes-kafka/**'
+      - 'indexer_utils/**'
+      - 'sdk/**'
+      - '.github/workflows/ranking-indexer-deploy.yml'
+
+concurrency:
+  group: ranking-indexer-production
+  cancel-in-progress: true
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+  IMAGE_NAME: ranking-indexer
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+                       -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+                       -f ranking-indexer/Dockerfile .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
+
+      - name: Configure kubectl for DigitalOcean
+        run: |
+          doctl kubernetes cluster kubeconfig save ${{ secrets.DIGITALOCEAN_CLUSTER_NAME }}
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl apply -f ranking-indexer/k8s/production/namespace.yaml
+          # Update image tag to use SHA and apply
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/production/ranking-indexer.yaml
+          kubectl apply -f ranking-indexer/k8s/production/ranking-indexer.yaml
+
+      - name: Restart deployment to pick up new image
+        run: |
+          kubectl rollout restart deployment/ranking-indexer -n knowledge
+
+      - name: Wait for rollout
+        run: |
+          kubectl rollout status deployment/ranking-indexer -n knowledge --timeout=120s
+
+      - name: Show deployment status
+        run: |
+          echo "=== Ranking Indexer Deployment ==="
+          kubectl get deployment ranking-indexer -n knowledge
+          echo ""
+          echo "=== Ranking Indexer Pods ==="
+          kubectl get pods -n knowledge -l app=ranking-indexer
+          echo ""
+          echo "=== Recent Events ==="
+          kubectl get events -n knowledge --sort-by='.lastTimestamp' | grep ranking-indexer | tail -10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5235,6 +5235,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ranking-indexer"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dotenv",
+ "futures 0.3.31",
+ "grc-20",
+ "hermes-instrumentation",
+ "hermes-kafka",
+ "hermes-schema",
+ "indexer_utils",
+ "prost 0.13.5",
+ "rdkafka 0.38.0",
+ "sdk",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "hermes-substream",
 
     "kg-indexer",
+    "ranking-indexer",
     "scoring-service/vote-indexer",
     "scoring-service/topology-indexer",
 

--- a/api/drizzle/0061_create_ranks_schema.sql
+++ b/api/drizzle/0061_create_ranks_schema.sql
@@ -1,76 +1,48 @@
--- ranking-indexer working schema (GEO ranking aggregation).
---
--- These tables are the ranking-indexer's PRIVATE working cache. They live in a
--- dedicated `ranks` schema (NOT `public`) on purpose: PostGraphile introspects
--- only `public`, so nothing here reaches the GraphQL API. Every value is
--- derivable from the `knowledge.edits` stream and can be rebuilt by replay —
--- this is a cache, not a source of truth. The indexer joins the public
--- `members`/`editors`/`spaces`/`entities` tables cross-schema during
--- aggregation, which is why these sit in the same database.
---
--- NOTE: some column shapes are inferred from the design doc (prose-level) and
--- may be refined once the decode path is built — e.g. the dedup "update
--- markers" on `rankings`, date storage, and the restriction representation.
--- Because the schema is a rebuildable cache, those are low-risk to adjust.
-
-CREATE SCHEMA IF NOT EXISTS ranks;
+CREATE SCHEMA "ranks";
 --> statement-breakpoint
-
--- One row per Ranking Block entity.
-CREATE TABLE IF NOT EXISTS ranks.ranking_blocks (
-	"id" uuid NOT NULL,                            -- Ranking Block entity id
-	"space_id" uuid NOT NULL,                      -- space the block lives in (an entity can be perspectived across spaces)
+CREATE TABLE "ranks"."ranking_blocks" (
+	"id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
 	"name" text,
-	"filter" text,                                 -- query-data-block filter string (optional)
-	"start_date" timestamp with time zone,         -- optional submission window (inclusive)
+	"filter" text,
+	"start_date" timestamp with time zone,
 	"end_date" timestamp with time zone,
-	"restriction_id" uuid,                         -- aggregation restriction value entity; NULL => default "Members and editors"
+	"restriction_id" uuid,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	-- Composite key: the same block id can be perspectived under multiple spaces.
-	CONSTRAINT "ranking_blocks_pkey" PRIMARY KEY ("id", "space_id")
+	CONSTRAINT "ranking_blocks_id_space_id_pk" PRIMARY KEY("id","space_id")
 );
 --> statement-breakpoint
-
--- One row per Rank submission entity.
-CREATE TABLE IF NOT EXISTS ranks.rankings (
-	"id" uuid NOT NULL,                            -- Rank entity id
-	"block_id" uuid,                               -- nullable until the RANK_BLOCK link arrives (partial-state model)
-	"space_id" uuid NOT NULL,                      -- submitter's personal space (a rank can be perspectived across spaces)
-	"author_address" text,                         -- submitter address resolved from the personal space
-	"rank_type" text,                              -- 'ORDINAL' | 'WEIGHTED'
-	"submitted_at" timestamp with time zone,       -- submission timestamp used for the window check
-	"updated_at_block" bigint DEFAULT 0 NOT NULL,  -- update markers for dedup: most-recently-updated rank per (block, space) wins
-	"update_index" bigint DEFAULT 0 NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	-- Composite key: the same rank id can be perspectived under multiple spaces.
-	CONSTRAINT "rankings_pkey" PRIMARY KEY ("id", "space_id")
-);
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "rankings_block_id_idx" ON ranks.rankings ("block_id");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "rankings_block_space_idx" ON ranks.rankings ("block_id","space_id");
---> statement-breakpoint
-
--- Decoded items of each submission, keyed on (ranking, entity, space) so a user
--- can rank competing perspectives of the same subject.
-CREATE TABLE IF NOT EXISTS ranks.ranking_items (
+CREATE TABLE "ranks"."ranking_items" (
 	"ranking_id" uuid NOT NULL,
-	"entity_id" uuid NOT NULL,                     -- ranked entity
-	"space_id" uuid NOT NULL,                      -- to_space_id (perspective of the ranked entity)
-	"position" text,                               -- fractional index (ordinal ordering)
-	"weight" double precision,                     -- weighted value (NULL for ordinal ranks)
-	CONSTRAINT "ranking_items_pkey" PRIMARY KEY ("ranking_id","entity_id","space_id")
+	"entity_id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
+	"position" text,
+	"weight" double precision,
+	CONSTRAINT "ranking_items_ranking_id_entity_id_space_id_pk" PRIMARY KEY("ranking_id","entity_id","space_id")
 );
 --> statement-breakpoint
-
--- Computed aggregate, keyed on (block, entity, space).
-CREATE TABLE IF NOT EXISTS ranks.ranking_scores (
+CREATE TABLE "ranks"."ranking_scores" (
 	"block_id" uuid NOT NULL,
 	"entity_id" uuid NOT NULL,
 	"space_id" uuid NOT NULL,
-	"score" double precision NOT NULL,             -- summed contribution across eligible submissions
-	"position" integer NOT NULL,                   -- final integer rank within the block
-	CONSTRAINT "ranking_scores_pkey" PRIMARY KEY ("block_id","entity_id","space_id")
+	"score" double precision NOT NULL,
+	"position" integer NOT NULL,
+	CONSTRAINT "ranking_scores_block_id_entity_id_space_id_pk" PRIMARY KEY("block_id","entity_id","space_id")
 );
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "ranking_scores_block_position_idx" ON ranks.ranking_scores ("block_id","position");
+CREATE TABLE "ranks"."rankings" (
+	"id" uuid NOT NULL,
+	"block_id" uuid,
+	"space_id" uuid NOT NULL,
+	"author_address" text,
+	"rank_type" text,
+	"submitted_at" timestamp with time zone,
+	"updated_at_block" bigint DEFAULT 0 NOT NULL,
+	"update_index" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "rankings_id_space_id_pk" PRIMARY KEY("id","space_id")
+);
+--> statement-breakpoint
+CREATE INDEX "ranking_scores_block_position_idx" ON "ranks"."ranking_scores" USING btree ("block_id","position");--> statement-breakpoint
+CREATE INDEX "rankings_block_id_idx" ON "ranks"."rankings" USING btree ("block_id");--> statement-breakpoint
+CREATE INDEX "rankings_block_space_idx" ON "ranks"."rankings" USING btree ("block_id","space_id");

--- a/api/drizzle/0061_create_ranks_schema.sql
+++ b/api/drizzle/0061_create_ranks_schema.sql
@@ -18,28 +18,32 @@ CREATE SCHEMA IF NOT EXISTS ranks;
 
 -- One row per Ranking Block entity.
 CREATE TABLE IF NOT EXISTS ranks.ranking_blocks (
-	"id" uuid PRIMARY KEY NOT NULL,                -- Ranking Block entity id
-	"space_id" uuid NOT NULL,                      -- space the block lives in
+	"id" uuid NOT NULL,                            -- Ranking Block entity id
+	"space_id" uuid NOT NULL,                      -- space the block lives in (an entity can be perspectived across spaces)
 	"name" text,
 	"filter" text,                                 -- query-data-block filter string (optional)
 	"start_date" timestamp with time zone,         -- optional submission window (inclusive)
 	"end_date" timestamp with time zone,
 	"restriction_id" uuid,                         -- aggregation restriction value entity; NULL => default "Members and editors"
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	-- Composite key: the same block id can be perspectived under multiple spaces.
+	CONSTRAINT "ranking_blocks_pkey" PRIMARY KEY ("id", "space_id")
 );
 --> statement-breakpoint
 
 -- One row per Rank submission entity.
 CREATE TABLE IF NOT EXISTS ranks.rankings (
-	"id" uuid PRIMARY KEY NOT NULL,                -- Rank entity id
+	"id" uuid NOT NULL,                            -- Rank entity id
 	"block_id" uuid,                               -- nullable until the RANK_BLOCK link arrives (partial-state model)
-	"space_id" uuid NOT NULL,                      -- submitter's personal space
+	"space_id" uuid NOT NULL,                      -- submitter's personal space (a rank can be perspectived across spaces)
 	"author_address" text,                         -- submitter address resolved from the personal space
 	"rank_type" text,                              -- 'ORDINAL' | 'WEIGHTED'
 	"submitted_at" timestamp with time zone,       -- submission timestamp used for the window check
 	"updated_at_block" bigint DEFAULT 0 NOT NULL,  -- update markers for dedup: most-recently-updated rank per (block, space) wins
 	"update_index" bigint DEFAULT 0 NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	-- Composite key: the same rank id can be perspectived under multiple spaces.
+	CONSTRAINT "rankings_pkey" PRIMARY KEY ("id", "space_id")
 );
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "rankings_block_id_idx" ON ranks.rankings ("block_id");

--- a/api/drizzle/0061_create_ranks_schema.sql
+++ b/api/drizzle/0061_create_ranks_schema.sql
@@ -1,0 +1,72 @@
+-- ranking-indexer working schema (GEO ranking aggregation).
+--
+-- These tables are the ranking-indexer's PRIVATE working cache. They live in a
+-- dedicated `ranks` schema (NOT `public`) on purpose: PostGraphile introspects
+-- only `public`, so nothing here reaches the GraphQL API. Every value is
+-- derivable from the `knowledge.edits` stream and can be rebuilt by replay —
+-- this is a cache, not a source of truth. The indexer joins the public
+-- `members`/`editors`/`spaces`/`entities` tables cross-schema during
+-- aggregation, which is why these sit in the same database.
+--
+-- NOTE: some column shapes are inferred from the design doc (prose-level) and
+-- may be refined once the decode path is built — e.g. the dedup "update
+-- markers" on `rankings`, date storage, and the restriction representation.
+-- Because the schema is a rebuildable cache, those are low-risk to adjust.
+
+CREATE SCHEMA IF NOT EXISTS ranks;
+--> statement-breakpoint
+
+-- One row per Ranking Block entity.
+CREATE TABLE IF NOT EXISTS ranks.ranking_blocks (
+	"id" uuid PRIMARY KEY NOT NULL,                -- Ranking Block entity id
+	"space_id" uuid NOT NULL,                      -- space the block lives in
+	"name" text,
+	"filter" text,                                 -- query-data-block filter string (optional)
+	"start_date" timestamp with time zone,         -- optional submission window (inclusive)
+	"end_date" timestamp with time zone,
+	"restriction_id" uuid,                         -- aggregation restriction value entity; NULL => default "Members and editors"
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+-- One row per Rank submission entity.
+CREATE TABLE IF NOT EXISTS ranks.rankings (
+	"id" uuid PRIMARY KEY NOT NULL,                -- Rank entity id
+	"block_id" uuid,                               -- nullable until the RANK_BLOCK link arrives (partial-state model)
+	"space_id" uuid NOT NULL,                      -- submitter's personal space
+	"author_address" text,                         -- submitter address resolved from the personal space
+	"rank_type" text,                              -- 'ORDINAL' | 'WEIGHTED'
+	"submitted_at" timestamp with time zone,       -- submission timestamp used for the window check
+	"updated_at_block" bigint DEFAULT 0 NOT NULL,  -- update markers for dedup: most-recently-updated rank per (block, space) wins
+	"update_index" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rankings_block_id_idx" ON ranks.rankings ("block_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rankings_block_space_idx" ON ranks.rankings ("block_id","space_id");
+--> statement-breakpoint
+
+-- Decoded items of each submission, keyed on (ranking, entity, space) so a user
+-- can rank competing perspectives of the same subject.
+CREATE TABLE IF NOT EXISTS ranks.ranking_items (
+	"ranking_id" uuid NOT NULL,
+	"entity_id" uuid NOT NULL,                     -- ranked entity
+	"space_id" uuid NOT NULL,                      -- to_space_id (perspective of the ranked entity)
+	"position" text,                               -- fractional index (ordinal ordering)
+	"weight" double precision,                     -- weighted value (NULL for ordinal ranks)
+	CONSTRAINT "ranking_items_pkey" PRIMARY KEY ("ranking_id","entity_id","space_id")
+);
+--> statement-breakpoint
+
+-- Computed aggregate, keyed on (block, entity, space).
+CREATE TABLE IF NOT EXISTS ranks.ranking_scores (
+	"block_id" uuid NOT NULL,
+	"entity_id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
+	"score" double precision NOT NULL,             -- summed contribution across eligible submissions
+	"position" integer NOT NULL,                   -- final integer rank within the block
+	CONSTRAINT "ranking_scores_pkey" PRIMARY KEY ("block_id","entity_id","space_id")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ranking_scores_block_position_idx" ON ranks.ranking_scores ("block_id","position");

--- a/api/drizzle/meta/0061_snapshot.json
+++ b/api/drizzle/meta/0061_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "1d5de818-469a-4f69-a4d5-af57ca863559",
+  "id": "66ae6367-a3a0-4a26-9998-a7e9914df646",
   "prevId": "31f65a89-695c-4176-a730-40c09d30c2d3",
   "version": "7",
   "dialect": "postgresql",
@@ -54,10 +54,10 @@
       "uniqueConstraints": {
         "app_webhooks_app_name_unique": {
           "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "app_name"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -197,9 +197,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -207,11 +207,11 @@
       "uniqueConstraints": {
         "edit_versions_block_sequence_unique": {
           "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "block_number",
             "sequence"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -247,9 +247,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -314,9 +314,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "entities_updated_at_id_idx": {
           "name": "entities_updated_at_id_idx",
@@ -335,9 +335,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "entities_created_at_id_idx": {
           "name": "entities_created_at_id_idx",
@@ -356,9 +356,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -453,10 +453,10 @@
       "uniqueConstraints": {
         "ipfs_cache_uri_unique": {
           "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "uri"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -504,9 +504,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "idx_local_scores_entity_id": {
           "name": "idx_local_scores_entity_id",
@@ -519,9 +519,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "idx_local_scores_space_score": {
           "name": "idx_local_scores_space_score",
@@ -540,9 +540,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -589,9 +589,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -729,48 +729,48 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "notification_deliveries_outbox_id_notification_outbox_id_fk": {
           "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
           "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
           "columnsFrom": [
             "outbox_id"
           ],
-          "tableTo": "notification_outbox",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "notification_deliveries_webhook_id_app_webhooks_id_fk": {
           "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
           "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
           "columnsFrom": [
             "webhook_id"
           ],
-          "tableTo": "app_webhooks",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "notification_deliveries_outbox_id_webhook_id_unique": {
           "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "outbox_id",
             "webhook_id"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -827,10 +827,10 @@
       "uniqueConstraints": {
         "notification_outbox_idempotency_key_unique": {
           "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "idempotency_key"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -959,9 +959,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_actions_action_type_idx": {
           "name": "proposal_actions_action_type_idx",
@@ -974,9 +974,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_actions_proposal_action_target_idx": {
           "name": "proposal_actions_proposal_action_target_idx",
@@ -1001,24 +1001,24 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "proposal_actions_proposal_id_proposals_id_fk": {
           "name": "proposal_actions_proposal_id_proposals_id_fk",
           "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
           "columnsFrom": [
             "proposal_id"
           ],
-          "tableTo": "proposals",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -1050,15 +1050,15 @@
         "proposal_tally_queue_proposal_id_proposals_id_fk": {
           "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
           "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
           "columnsFrom": [
             "proposal_id"
           ],
-          "tableTo": "proposals",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -1121,9 +1121,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_votes_voter_id_idx": {
           "name": "proposal_votes_voter_id_idx",
@@ -1136,9 +1136,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_votes_vote_idx": {
           "name": "proposal_votes_vote_idx",
@@ -1151,37 +1151,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "proposal_votes_proposal_id_proposals_id_fk": {
           "name": "proposal_votes_proposal_id_proposals_id_fk",
           "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
           "columnsFrom": [
             "proposal_id"
           ],
-          "tableTo": "proposals",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "proposal_votes_space_id_spaces_id_fk": {
           "name": "proposal_votes_space_id_spaces_id_fk",
           "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
           "columnsFrom": [
             "space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
@@ -1309,9 +1309,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_proposed_by_idx": {
           "name": "proposals_proposed_by_idx",
@@ -1324,9 +1324,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_created_at_idx": {
           "name": "proposals_created_at_idx",
@@ -1339,9 +1339,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_space_created_at_idx": {
           "name": "proposals_space_created_at_idx",
@@ -1360,9 +1360,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_space_end_time_idx": {
           "name": "proposals_space_end_time_idx",
@@ -1381,9 +1381,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposals_space_start_time_idx": {
           "name": "proposals_space_start_time_idx",
@@ -1402,27 +1402,338 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "proposals_space_id_spaces_id_fk": {
           "name": "proposals_space_id_spaces_id_fk",
           "tableFrom": "proposals",
+          "tableTo": "spaces",
           "columnsFrom": [
             "space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_blocks": {
+      "name": "ranking_blocks",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restriction_id": {
+          "name": "restriction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_blocks_id_space_id_pk": {
+          "name": "ranking_blocks_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_items": {
+      "name": "ranking_items",
+      "schema": "ranks",
+      "columns": {
+        "ranking_id": {
+          "name": "ranking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_items_ranking_id_entity_id_space_id_pk": {
+          "name": "ranking_items_ranking_id_entity_id_space_id_pk",
+          "columns": [
+            "ranking_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_scores": {
+      "name": "ranking_scores",
+      "schema": "ranks",
+      "columns": {
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranking_scores_block_position_idx": {
+          "name": "ranking_scores_block_position_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_scores_block_id_entity_id_space_id_pk": {
+          "name": "ranking_scores_block_id_entity_id_space_id_pk",
+          "columns": [
+            "block_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.rankings": {
+      "name": "rankings",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank_type": {
+          "name": "rank_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "update_index": {
+          "name": "update_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rankings_block_id_idx": {
+          "name": "rankings_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rankings_block_space_idx": {
+          "name": "rankings_block_space_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rankings_id_space_id_pk": {
+          "name": "rankings_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
@@ -1535,9 +1846,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relation_versions_entity_idx": {
           "name": "relation_versions_entity_idx",
@@ -1550,9 +1861,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relation_versions_open_idx": {
           "name": "relation_versions_open_idx",
@@ -1565,10 +1876,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "relation_versions_range_idx": {
           "name": "relation_versions_range_idx",
@@ -1587,9 +1898,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relation_versions_from_entity_type_idx": {
           "name": "relation_versions_from_entity_type_idx",
@@ -1614,9 +1925,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relation_versions_from_entity_valid_to_idx": {
           "name": "relation_versions_from_entity_valid_to_idx",
@@ -1635,10 +1946,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -1744,9 +2055,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_type_id_idx": {
           "name": "relations_type_id_idx",
@@ -1759,9 +2070,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_from_entity_id_idx": {
           "name": "relations_from_entity_id_idx",
@@ -1774,9 +2085,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_to_entity_id_idx": {
           "name": "relations_to_entity_id_idx",
@@ -1789,9 +2100,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_space_id_idx": {
           "name": "relations_space_id_idx",
@@ -1804,9 +2115,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_space_from_to_idx": {
           "name": "relations_space_from_to_idx",
@@ -1831,9 +2142,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_space_type_idx": {
           "name": "relations_space_type_idx",
@@ -1852,9 +2163,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_to_entity_space_idx": {
           "name": "relations_to_entity_space_idx",
@@ -1873,9 +2184,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_from_entity_space_idx": {
           "name": "relations_from_entity_space_idx",
@@ -1894,9 +2205,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_entity_type_space_idx": {
           "name": "relations_entity_type_space_idx",
@@ -1921,9 +2232,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "relations_type_from_to_idx": {
           "name": "relations_type_from_to_idx",
@@ -1948,9 +2259,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -2033,24 +2344,24 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "spaces_topic_id_entities_id_fk": {
           "name": "spaces_topic_id_entities_id_fk",
           "tableFrom": "spaces",
+          "tableTo": "entities",
           "columnsFrom": [
             "topic_id"
           ],
-          "tableTo": "entities",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2088,9 +2399,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "subspace_topics_topic_id_idx": {
           "name": "subspace_topics_topic_id_idx",
@@ -2103,37 +2414,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "subspace_topics_space_id_spaces_id_fk": {
           "name": "subspace_topics_space_id_spaces_id_fk",
           "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
           "columnsFrom": [
             "space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "subspace_topics_topic_id_entities_id_fk": {
           "name": "subspace_topics_topic_id_entities_id_fk",
           "tableFrom": "subspace_topics",
+          "tableTo": "entities",
           "columnsFrom": [
             "topic_id"
           ],
-          "tableTo": "entities",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
@@ -2187,9 +2498,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "subspaces_child_space_id_idx": {
           "name": "subspaces_child_space_id_idx",
@@ -2202,37 +2513,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "subspaces_parent_space_id_spaces_id_fk": {
           "name": "subspaces_parent_space_id_spaces_id_fk",
           "tableFrom": "subspaces",
+          "tableTo": "spaces",
           "columnsFrom": [
             "parent_space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "subspaces_child_space_id_spaces_id_fk": {
           "name": "subspaces_child_space_id_spaces_id_fk",
           "tableFrom": "subspaces",
+          "tableTo": "spaces",
           "columnsFrom": [
             "child_space_id"
           ],
-          "tableTo": "spaces",
           "columnsTo": [
             "id"
           ],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
@@ -2315,9 +2626,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -2325,13 +2636,13 @@
       "uniqueConstraints": {
         "user_votes_user_id_object_id_object_type_space_id_unique": {
           "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "user_id",
             "object_id",
             "object_type",
             "space_id"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -2505,9 +2816,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "value_versions_lookup_idx": {
           "name": "value_versions_lookup_idx",
@@ -2532,9 +2843,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "value_versions_open_idx": {
           "name": "value_versions_open_idx",
@@ -2559,10 +2870,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"value_versions\".\"valid_to_key\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "value_versions_range_idx": {
           "name": "value_versions_range_idx",
@@ -2581,9 +2892,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "value_versions_entity_space_valid_to_idx": {
           "name": "value_versions_entity_space_valid_to_idx",
@@ -2608,10 +2919,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -2764,9 +3075,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_entity_id_idx": {
           "name": "values_entity_id_idx",
@@ -2779,9 +3090,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_space_id_idx": {
           "name": "values_space_id_idx",
@@ -2794,9 +3105,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_boolean_idx": {
           "name": "values_boolean_idx",
@@ -2809,9 +3120,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_integer_idx": {
           "name": "values_integer_idx",
@@ -2824,9 +3135,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_float_idx": {
           "name": "values_float_idx",
@@ -2839,9 +3150,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_decimal_idx": {
           "name": "values_decimal_idx",
@@ -2854,9 +3165,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_text_idx": {
           "name": "values_text_idx",
@@ -2869,10 +3180,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "length(\"values\".\"text\") <= 2000",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "values_date_idx": {
           "name": "values_date_idx",
@@ -2885,9 +3196,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_time_idx": {
           "name": "values_time_idx",
@@ -2900,9 +3211,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_datetime_idx": {
           "name": "values_datetime_idx",
@@ -2915,9 +3226,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_point_idx": {
           "name": "values_point_idx",
@@ -2930,9 +3241,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_rect_idx": {
           "name": "values_rect_idx",
@@ -2945,9 +3256,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_entity_property_idx": {
           "name": "values_entity_property_idx",
@@ -2966,9 +3277,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_entity_space_idx": {
           "name": "values_entity_space_idx",
@@ -2987,9 +3298,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_property_space_idx": {
           "name": "values_property_space_idx",
@@ -3008,9 +3319,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_entity_property_space_idx": {
           "name": "values_entity_property_space_idx",
@@ -3035,9 +3346,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_language_idx": {
           "name": "values_language_idx",
@@ -3050,9 +3361,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_unit_idx": {
           "name": "values_unit_idx",
@@ -3065,9 +3376,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_time_utc_idx": {
           "name": "values_time_utc_idx",
@@ -3080,9 +3391,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "values_datetime_utc_idx": {
           "name": "values_datetime_utc_idx",
@@ -3095,9 +3406,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -3179,9 +3490,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "idx_votes_object_type_object_id_space_id": {
           "name": "idx_votes_object_type_object_id_space_id",
@@ -3206,9 +3517,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -3286,10 +3597,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "object_type = 0",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -3297,12 +3608,12 @@
       "uniqueConstraints": {
         "votes_count_object_id_object_type_space_id_unique": {
           "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "object_id",
             "object_type",
             "space_id"
-          ],
-          "nullsNotDistinct": false
+          ]
         }
       },
       "policies": {},
@@ -3369,11 +3680,13 @@
       ]
     }
   },
-  "schemas": {},
-  "views": {},
+  "schemas": {
+    "ranks": "ranks"
+  },
   "sequences": {},
   "roles": {},
   "policies": {},
+  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},

--- a/api/drizzle/meta/0061_snapshot.json
+++ b/api/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,3382 @@
+{
+  "id": "1d5de818-469a-4f69-a4d5-af57ca863559",
+  "prevId": "31f65a89-695c-4176-a730-40c09d30c2d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "columns": [
+            "app_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "columns": [
+            "block_number",
+            "sequence"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "columns": [
+            "uri"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "tableTo": "notification_outbox",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "tableTo": "app_webhooks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_poll_cursors": {
+      "name": "notification_poll_cursors",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor_updated_at": {
+          "name": "cursor_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "tableTo": "entities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "tableTo": "entities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_count_updated_at": {
+          "name": "idx_votes_count_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "object_type = 0",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -432,7 +432,7 @@
     {
       "idx": 61,
       "version": "7",
-      "when": 1780963771035,
+      "when": 1781041240657,
       "tag": "0061_create_ranks_schema",
       "breakpoints": true
     }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1780679566128,
       "tag": "0060_optimize-entities-ordered-by-property",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1780963771035,
+      "tag": "0061_create_ranks_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -6,8 +6,10 @@ import {
 	decimal,
 	doublePrecision,
 	index,
+	integer,
 	jsonb,
 	pgEnum,
+	pgSchema,
 	pgTable,
 	primaryKey,
 	serial,
@@ -980,5 +982,81 @@ export const notificationDeliveries = pgTable(
 	(table) => [
 		unique().on(table.outboxId, table.webhookId),
 		index("idx_deliveries_pending").on(table.status, table.nextRetryAt),
+	],
+)
+
+/**
+ * Private `ranks` schema — the ranking-indexer's working cache.
+ *
+ * Lives outside `public` on purpose: PostGraphile introspects only `public`, so
+ * nothing here reaches the GraphQL API. Defined here (rather than as a hand-
+ * written migration) so drizzle-kit owns the migration. Every value is
+ * derivable from the `knowledge.edits` stream and rebuildable by replay.
+ */
+export const ranks = pgSchema("ranks")
+
+/** One row per Ranking Block entity, keyed on (id, space) for perspectives. */
+export const rankingBlocks = ranks.table(
+	"ranking_blocks",
+	{
+		id: uuid().notNull(),
+		spaceId: uuid("space_id").notNull(),
+		name: text(),
+		filter: text(),
+		startDate: timestamp("start_date", {withTimezone: true, mode: "date"}),
+		endDate: timestamp("end_date", {withTimezone: true, mode: "date"}),
+		restrictionId: uuid("restriction_id"),
+		updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull().defaultNow(),
+	},
+	(table) => [primaryKey({columns: [table.id, table.spaceId]})],
+)
+
+/** One row per Rank submission entity, keyed on (id, space) for perspectives. */
+export const rankings = ranks.table(
+	"rankings",
+	{
+		id: uuid().notNull(),
+		blockId: uuid("block_id"),
+		spaceId: uuid("space_id").notNull(),
+		authorAddress: text("author_address"),
+		rankType: text("rank_type"),
+		submittedAt: timestamp("submitted_at", {withTimezone: true, mode: "date"}),
+		updatedAtBlock: bigint("updated_at_block", {mode: "number"}).notNull().default(0),
+		updateIndex: bigint("update_index", {mode: "number"}).notNull().default(0),
+		updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull().defaultNow(),
+	},
+	(table) => [
+		primaryKey({columns: [table.id, table.spaceId]}),
+		index("rankings_block_id_idx").on(table.blockId),
+		index("rankings_block_space_idx").on(table.blockId, table.spaceId),
+	],
+)
+
+/** Decoded items of each submission, keyed on (ranking, entity, space). */
+export const rankingItems = ranks.table(
+	"ranking_items",
+	{
+		rankingId: uuid("ranking_id").notNull(),
+		entityId: uuid("entity_id").notNull(),
+		spaceId: uuid("space_id").notNull(),
+		position: text(),
+		weight: doublePrecision(),
+	},
+	(table) => [primaryKey({columns: [table.rankingId, table.entityId, table.spaceId]})],
+)
+
+/** Computed aggregate, keyed on (block, entity, space). */
+export const rankingScores = ranks.table(
+	"ranking_scores",
+	{
+		blockId: uuid("block_id").notNull(),
+		entityId: uuid("entity_id").notNull(),
+		spaceId: uuid("space_id").notNull(),
+		score: doublePrecision().notNull(),
+		position: integer().notNull(),
+	},
+	(table) => [
+		primaryKey({columns: [table.blockId, table.entityId, table.spaceId]}),
+		index("ranking_scores_block_position_idx").on(table.blockId, table.position),
 	],
 )

--- a/ranking-indexer/Cargo.toml
+++ b/ranking-indexer/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ranking-indexer"
+version = "0.1.0"
+edition = "2021"
+description = "Aggregates GEO rank submissions into ranking results and projects them back into the knowledge graph"
+
+[[bin]]
+name = "ranking-indexer"
+path = "src/main.rs"
+
+[dependencies]
+hermes-schema = { path = "../hermes-schema" }
+hermes-instrumentation = { path = "../hermes-instrumentation" }
+hermes-kafka = { path = "../hermes-kafka" }
+indexer_utils = { path = "../indexer_utils" }
+sdk = { path = "../sdk" }
+# GRC-20 v2 binary format (same decoder the kg-indexer uses)
+grc-20 = "0.4.1"
+rdkafka = { version = "0.38.0", features = ["cmake-build", "ssl", "zstd"] }
+tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
+futures = "0.3.31"
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "uuid", "chrono", "tls-rustls"] }
+prost = "0.13.5"
+thiserror = "2.0.12"
+chrono = "0.4.41"
+uuid = { version = "1.17.0", features = ["v4", "v5"] }
+dotenv = "0.15.0"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }

--- a/ranking-indexer/Dockerfile
+++ b/ranking-indexer/Dockerfile
@@ -1,0 +1,36 @@
+FROM rust:1.92-bookworm as builder
+
+# Install build dependencies for rdkafka and protobuf
+RUN apt-get update && \
+    apt-get install -y \
+    cmake \
+    libclang-dev \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy only required crates (no workspace Cargo.toml - build standalone)
+COPY hermes-schema ./hermes-schema
+COPY hermes-instrumentation ./hermes-instrumentation
+COPY hermes-kafka ./hermes-kafka
+COPY indexer_utils ./indexer_utils
+COPY sdk ./sdk
+COPY ranking-indexer ./ranking-indexer
+
+# Build from the crate directory (standalone, not as workspace member)
+WORKDIR /app/ranking-indexer
+ENV SQLX_OFFLINE=true
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates libssl3 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/ranking-indexer/target/release/ranking-indexer /usr/local/bin/ranking-indexer
+
+CMD ["ranking-indexer"]

--- a/ranking-indexer/k8s/production/namespace.yaml
+++ b/ranking-indexer/k8s/production/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knowledge
+  labels:
+    app.kubernetes.io/name: knowledge
+    app.kubernetes.io/part-of: geo

--- a/ranking-indexer/k8s/production/ranking-indexer.yaml
+++ b/ranking-indexer/k8s/production/ranking-indexer.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ranking-indexer
+  namespace: knowledge
+  labels:
+    app: ranking-indexer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ranking-indexer
+  template:
+    metadata:
+      labels:
+        app: ranking-indexer
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: ranking-indexer
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: PGSSLROOTCERT
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_PASSWORD
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_SSL_CA_PEM
+            - name: ENVIRONMENT
+              value: "production"
+            - name: KAFKA_GROUP_ID
+              value: "ranking-indexer-v1"
+            - name: RUST_LOG
+              value: "ranking_indexer=info"
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "500m"
+      restartPolicy: Always

--- a/ranking-indexer/k8s/production/secrets.yaml
+++ b/ranking-indexer/k8s/production/secrets.yaml
@@ -1,0 +1,33 @@
+# ranking-indexer secrets template
+#
+# 1. Create the knowledge namespace (if not exists):
+#    kubectl create namespace knowledge
+#
+# 2. Copy regcred for image pulls:
+#    kubectl get secret regcred -n api -o yaml | \
+#      sed 's/namespace: api/namespace: knowledge/' | \
+#      kubectl apply -f -
+#
+# 3. Copy database secrets (api-secrets.DATABASE_URL should be the pooler URL):
+#    kubectl get secret api-secrets -n api -o yaml | \
+#      sed 's/namespace: api/namespace: knowledge/' | \
+#      kubectl apply -f -
+#
+# 4. Copy Kafka credentials:
+#    kubectl get secret kafka-credentials -n kafka -o yaml | \
+#      sed 's/namespace: kafka/namespace: knowledge/' | \
+#      sed 's/name: kafka-credentials/name: ranking-indexer-secrets/' | \
+#      kubectl apply -f -
+#
+# Or create Kafka secrets manually:
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ranking-indexer-secrets
+  namespace: knowledge
+type: Opaque
+stringData:
+  KAFKA_BROKER: "<kafka-broker-url>"
+  KAFKA_USERNAME: "<kafka-username>"
+  KAFKA_PASSWORD: "<kafka-password>"
+  KAFKA_SSL_CA_PEM: "<kafka-ssl-ca-pem>"

--- a/ranking-indexer/k8s/staging/namespace.yaml
+++ b/ranking-indexer/k8s/staging/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knowledge-staging
+  labels:
+    app.kubernetes.io/name: knowledge
+    app.kubernetes.io/part-of: geo
+    environment: staging

--- a/ranking-indexer/k8s/staging/ranking-indexer.yaml
+++ b/ranking-indexer/k8s/staging/ranking-indexer.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ranking-indexer
+  namespace: knowledge-staging
+  labels:
+    app: ranking-indexer
+    environment: staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ranking-indexer
+  template:
+    metadata:
+      labels:
+        app: ranking-indexer
+        environment: staging
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: ranking-indexer
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: PGSSLROOTCERT
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_PASSWORD
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: ranking-indexer-secrets
+                  key: KAFKA_SSL_CA_PEM
+            - name: ENVIRONMENT
+              value: "staging"
+            - name: KAFKA_GROUP_ID
+              value: "ranking-indexer-v1-staging"
+            - name: RUST_LOG
+              value: "ranking_indexer=info"
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "500m"
+      restartPolicy: Always

--- a/ranking-indexer/src/consumer.rs
+++ b/ranking-indexer/src/consumer.rs
@@ -95,7 +95,9 @@ impl KafkaConsumer {
 }
 
 /// Decode the `HermesEdit` envelope from a Kafka payload.
-pub fn parse_edit(payload: &[u8]) -> Result<hermes_schema::pb::knowledge::HermesEdit, IndexerError> {
+pub fn parse_edit(
+    payload: &[u8],
+) -> Result<hermes_schema::pb::knowledge::HermesEdit, IndexerError> {
     Ok(hermes_schema::pb::knowledge::HermesEdit::decode(payload)?)
 }
 

--- a/ranking-indexer/src/consumer.rs
+++ b/ranking-indexer/src/consumer.rs
@@ -1,0 +1,106 @@
+//! Kafka consumer for the `knowledge.edits` topic.
+//!
+//! Mirrors the vote-indexer consumer: a manual-commit `StreamConsumer` with the
+//! environment topic prefix applied. Edits are decoded in two steps —
+//! `HermesEdit` (prost) then the raw GRC2/GRC2Z payload via the `grc-20` crate,
+//! the same decoder the kg-indexer uses.
+
+use hermes_kafka::get_topic_prefix;
+use prost::Message;
+use rdkafka::{
+    config::ClientConfig,
+    consumer::{Consumer, DefaultConsumerContext, StreamConsumer},
+    TopicPartitionList,
+};
+use std::env;
+use tracing::{debug, info};
+
+use crate::error::IndexerError;
+
+/// Base topic for knowledge edits.
+const EDITS_TOPIC: &str = "knowledge.edits";
+
+/// Kafka consumer for knowledge edits.
+pub struct KafkaConsumer {
+    consumer: StreamConsumer<DefaultConsumerContext>,
+    topic: String,
+}
+
+impl KafkaConsumer {
+    pub fn new(brokers: &str, group_id: &str) -> Result<Self, IndexerError> {
+        let mut config = ClientConfig::new();
+        config
+            .set("bootstrap.servers", brokers)
+            .set("group.id", group_id)
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .set("session.timeout.ms", "6000");
+
+        if let Ok(username) = env::var("KAFKA_USERNAME") {
+            config.set("security.protocol", "SASL_SSL");
+            config.set("sasl.mechanisms", "PLAIN");
+            config.set("sasl.username", &username);
+
+            let password = env::var("KAFKA_PASSWORD").map_err(|_| {
+                IndexerError::Config(
+                    "KAFKA_PASSWORD must be set when KAFKA_USERNAME is configured".into(),
+                )
+            })?;
+            config.set("sasl.password", &password);
+        }
+
+        if let Ok(ca_pem) = env::var("KAFKA_SSL_CA_PEM") {
+            config.set("ssl.ca.pem", &ca_pem);
+        }
+
+        let consumer: StreamConsumer = config.create()?;
+
+        let prefix = get_topic_prefix();
+        let topic = format!("{}{}", prefix, EDITS_TOPIC);
+
+        info!(
+            brokers = %brokers,
+            group_id = %group_id,
+            topic_prefix = %prefix,
+            topic = %topic,
+            "Created Kafka consumer"
+        );
+
+        Ok(Self { consumer, topic })
+    }
+
+    pub fn subscribe(&self) -> Result<(), IndexerError> {
+        self.consumer.subscribe(&[&self.topic])?;
+        info!(topic = %self.topic, "Subscribed to Kafka topic");
+        Ok(())
+    }
+
+    pub fn stream(&self) -> rdkafka::consumer::MessageStream<'_, DefaultConsumerContext> {
+        self.consumer.stream()
+    }
+
+    pub fn commit_message(
+        &self,
+        topic: &str,
+        partition: i32,
+        offset: i64,
+    ) -> Result<(), IndexerError> {
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition_offset(topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+        self.consumer
+            .commit(&tpl, rdkafka::consumer::CommitMode::Async)?;
+        debug!(topic = %topic, partition = partition, offset = offset, "Committed offset");
+        Ok(())
+    }
+}
+
+/// Decode the `HermesEdit` envelope from a Kafka payload.
+pub fn parse_edit(payload: &[u8]) -> Result<hermes_schema::pb::knowledge::HermesEdit, IndexerError> {
+    Ok(hermes_schema::pb::knowledge::HermesEdit::decode(payload)?)
+}
+
+/// Decode the raw GRC2/GRC2Z payload bytes into a `grc_20::Edit` (handles both
+/// compressed and uncompressed forms, same as the kg-indexer).
+pub fn decode_grc20(payload: &[u8]) -> Result<grc_20::Edit<'_>, IndexerError> {
+    grc_20::decode_edit(payload).map_err(|e| IndexerError::decode(format!("grc20: {e}")))
+}

--- a/ranking-indexer/src/dedup.rs
+++ b/ranking-indexer/src/dedup.rs
@@ -19,8 +19,7 @@ pub fn dedup_latest(rankings: Vec<Ranking>) -> Vec<Ranking> {
         let key = (block_id, r.space_id);
         let incoming = (r.updated_at_block, r.update_index);
         match latest.get(&key) {
-            Some(existing)
-                if (existing.updated_at_block, existing.update_index) >= incoming => {}
+            Some(existing) if (existing.updated_at_block, existing.update_index) >= incoming => {}
             _ => {
                 latest.insert(key, r);
             }

--- a/ranking-indexer/src/dedup.rs
+++ b/ranking-indexer/src/dedup.rs
@@ -1,0 +1,82 @@
+//! Deduplication: keep only the most-recently-updated submission per
+//! (block, personal space). A user who submits twice to the same block counts
+//! once, with the later submission superseding the earlier (design §7).
+
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::models::Ranking;
+
+/// Reduce a set of submissions to the latest per (block_id, space_id).
+///
+/// "Latest" is ordered by the update markers `(updated_at_block, update_index)`.
+/// Submissions whose `block_id` is still null contribute to no block and are
+/// dropped here (they're held until their link arrives).
+pub fn dedup_latest(rankings: Vec<Ranking>) -> Vec<Ranking> {
+    let mut latest: HashMap<(Uuid, Uuid), Ranking> = HashMap::new();
+    for r in rankings {
+        let Some(block_id) = r.block_id else { continue };
+        let key = (block_id, r.space_id);
+        let incoming = (r.updated_at_block, r.update_index);
+        match latest.get(&key) {
+            Some(existing)
+                if (existing.updated_at_block, existing.update_index) >= incoming => {}
+            _ => {
+                latest.insert(key, r);
+            }
+        }
+    }
+    latest.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn ranking(id: u128, block: Option<u128>, space: u128, blk: i64, idx: i64) -> Ranking {
+        Ranking {
+            id: Uuid::from_u128(id),
+            block_id: block.map(Uuid::from_u128),
+            space_id: Uuid::from_u128(space),
+            author_address: None,
+            rank_type: None,
+            submitted_at: Some(Utc::now()),
+            updated_at_block: blk,
+            update_index: idx,
+        }
+    }
+
+    #[test]
+    fn keeps_latest_per_block_and_space() {
+        let earlier = ranking(1, Some(100), 200, 10, 0);
+        let later = ranking(2, Some(100), 200, 20, 0);
+        let out = dedup_latest(vec![earlier, later]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, Uuid::from_u128(2));
+    }
+
+    #[test]
+    fn tie_breaks_on_update_index() {
+        let a = ranking(1, Some(100), 200, 20, 1);
+        let b = ranking(2, Some(100), 200, 20, 5);
+        let out = dedup_latest(vec![a, b]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, Uuid::from_u128(2));
+    }
+
+    #[test]
+    fn different_spaces_both_kept() {
+        let a = ranking(1, Some(100), 200, 10, 0);
+        let b = ranking(2, Some(100), 201, 10, 0);
+        let out = dedup_latest(vec![a, b]);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn unlinked_rankings_dropped() {
+        let unlinked = ranking(1, None, 200, 10, 0);
+        let out = dedup_latest(vec![unlinked]);
+        assert!(out.is_empty());
+    }
+}

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -30,6 +30,10 @@ struct DetectIds {
     rank_votes_relation: Uuid,
     rank_block_relation: Uuid,
     vote_weighted_value_property: Uuid,
+    filter_property: Uuid,
+    start_date_property: Uuid,
+    end_date_property: Uuid,
+    aggregation_restriction_relation: Uuid,
 }
 
 static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
@@ -44,6 +48,10 @@ static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
         rank_votes_relation: uid(RANK_VOTES_RELATION_TYPE_ID),
         rank_block_relation: uid(RANK_BLOCK_RELATION_TYPE_ID),
         vote_weighted_value_property: uid(VOTE_WEIGHTED_VALUE_PROPERTY_ID),
+        filter_property: uid(RANK_FILTER_PROPERTY_ID),
+        start_date_property: uid(RANK_START_DATE_PROPERTY_ID),
+        end_date_property: uid(RANK_END_DATE_PROPERTY_ID),
+        aggregation_restriction_relation: uid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID),
     }
 });
 
@@ -73,6 +81,35 @@ fn float_value(values: &[PropertyValue], property: Uuid) -> Option<f64> {
             _ => None,
         }
     })
+}
+
+/// Read a `Date`/`Datetime` property and parse it to a UTC instant.
+fn date_value(values: &[PropertyValue], property: Uuid) -> Option<DateTime<Utc>> {
+    let raw = values.iter().find_map(|pv| {
+        if id_to_uuid(&pv.property) != property {
+            return None;
+        }
+        match &pv.value {
+            Grc20Value::Date(v) | Grc20Value::Datetime(v) => Some(v.to_string()),
+            _ => None,
+        }
+    })?;
+    parse_date(&raw)
+}
+
+/// Parse a date/datetime string defensively: RFC3339 first, then a bare
+/// `YYYY-MM-DD` date (taken as midnight UTC). Unparseable values yield `None`
+/// rather than a wrong bound (so the window check just doesn't constrain).
+fn parse_date(s: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(d) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return d
+            .and_hms_opt(0, 0, 0)
+            .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
+    }
+    None
 }
 
 /// The rank-relevant ops extracted from a single edit.
@@ -115,6 +152,8 @@ pub fn detect(
     // collect the rank relations (votes + block links).
     let mut entity_values: HashMap<Uuid, &[PropertyValue]> = HashMap::new();
     let mut types_of: HashMap<Uuid, HashSet<Uuid>> = HashMap::new();
+    // block -> aggregation-restriction value entity (e.g. "Members and editors").
+    let mut restriction_of: HashMap<Uuid, Uuid> = HashMap::new();
 
     for op in &edit.ops {
         match op {
@@ -128,6 +167,8 @@ pub fn detect(
                         .entry(id_to_uuid(&relation.from))
                         .or_default()
                         .insert(id_to_uuid(&relation.to));
+                } else if type_id == ids.aggregation_restriction_relation {
+                    restriction_of.insert(id_to_uuid(&relation.from), id_to_uuid(&relation.to));
                 }
             }
             _ => {}
@@ -157,19 +198,16 @@ pub fn detect(
                         update_index: op_index as i64,
                     });
                 } else if is_block {
-                    // NOTE: only id/space_id/name are confidently extractable today.
-                    // The block's window dates, filter, and aggregation restriction
-                    // emission shapes aren't in the merged SDK yet (geo-sdk#89 adds
-                    // the IDs; block creation lands separately). Left as TODO so we
-                    // don't guess the wrong op shape.
+                    // Block config (Name/Filter/Start/End as properties; the
+                    // aggregation restriction as a relation collected in pass 1).
                     out.blocks.push(RankingBlock {
                         id: entity_id,
                         space_id,
                         name: text_value(&entity.values, ids.name_property),
-                        filter: None,
-                        start_date: None,
-                        end_date: None,
-                        restriction_id: None,
+                        filter: text_value(&entity.values, ids.filter_property),
+                        start_date: date_value(&entity.values, ids.start_date_property),
+                        end_date: date_value(&entity.values, ids.end_date_property),
+                        restriction_id: restriction_of.get(&entity_id).copied(),
                     });
                 }
             }
@@ -314,6 +352,44 @@ mod tests {
         assert_eq!(detected.blocks[0].id, Uuid::from_u128(BLOCK));
         assert_eq!(detected.blocks[0].name.as_deref(), Some("Top Films"));
         assert!(detected.rankings.is_empty());
+    }
+
+    #[test]
+    fn detects_full_block_config() {
+        use chrono::TimeZone;
+        let edit = EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(50))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(BLOCK))
+                    .to(sid(RANKING_BLOCK_TYPE_ID))
+            })
+            // aggregation restriction relation -> "Members and editors"
+            .create_relation(|r| {
+                r.id(gid(51))
+                    .relation_type(sid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+                    .from(gid(BLOCK))
+                    .to(sid(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID))
+            })
+            .create_entity(gid(BLOCK), |e| {
+                e.text(sid(NAME_PROPERTY_ID), "Top Films", None)
+                    .text(sid(RANK_FILTER_PROPERTY_ID), "types: Movie", None)
+                    .value(sid(RANK_START_DATE_PROPERTY_ID), Grc20Value::Date("2026-06-01".into()))
+                    .value(sid(RANK_END_DATE_PROPERTY_ID), Grc20Value::Date("2026-06-30".into()))
+            })
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert_eq!(detected.blocks.len(), 1);
+        let b = &detected.blocks[0];
+        assert_eq!(b.name.as_deref(), Some("Top Films"));
+        assert_eq!(b.filter.as_deref(), Some("types: Movie"));
+        assert_eq!(b.start_date, Some(Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap()));
+        assert_eq!(b.end_date, Some(Utc.with_ymd_and_hms(2026, 6, 30, 0, 0, 0).unwrap()));
+        assert_eq!(
+            b.restriction_id,
+            Some(Uuid::parse_str(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID).unwrap())
+        );
     }
 
     #[test]

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -2,19 +2,77 @@
 //!
 //! The indexer keeps only the four op patterns from the design (§5) and
 //! discards everything else:
+//!   - `CreateEntity` typed `Rank`           -> a [`Ranking`]
 //!   - `CreateEntity` typed `Ranking Block`  -> a [`RankingBlock`]
-//!   - `CreateEntity` typed `Rank`           -> a [`Ranking`] (+ its items)
 //!   - `RANK_VOTES` relations                -> [`RankingItem`] rows
 //!   - `CreateRelation` of type `RANK_BLOCK`  -> a rank -> block link
 //!
-//! Type membership is read from the `TYPES` relation, matching how the rest of
-//! gaia resolves entity types. The relevant system IDs live in
-//! [`sdk::core::ids`] (`RANK_TYPE_ID`, `RANKING_BLOCK_TYPE_ID`,
-//! `RANK_VOTES_RELATION_TYPE_ID`, `RANK_BLOCK_RELATION_TYPE_ID`, …).
+//! Type membership is read from the `TYPES` relation (a `CreateRelation` of
+//! type `TYPE_RELATION_TYPE_ID` whose `to` is the type entity), matching how
+//! the rest of gaia resolves entity types.
 
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use grc_20::{Id as Grc20Id, Op as Grc20Op, PropertyValue, Value as Grc20Value};
 use uuid::Uuid;
 
 use crate::models::{Ranking, RankingBlock, RankingItem};
+
+/// System IDs we match against, parsed once from their string constants.
+struct DetectIds {
+    type_relation: Uuid,
+    name_property: Uuid,
+    rank_type: Uuid,
+    ranking_block_type: Uuid,
+    rank_type_property: Uuid,
+    rank_votes_relation: Uuid,
+    rank_block_relation: Uuid,
+    vote_weighted_value_property: Uuid,
+}
+
+static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
+    use sdk::core::ids::*;
+    let uid = |s: &str| Uuid::parse_str(s).expect("invalid system ID constant");
+    DetectIds {
+        type_relation: uid(TYPE_RELATION_TYPE_ID),
+        name_property: uid(NAME_PROPERTY_ID),
+        rank_type: uid(RANK_TYPE_ID),
+        ranking_block_type: uid(RANKING_BLOCK_TYPE_ID),
+        rank_type_property: uid(RANK_TYPE_PROPERTY_ID),
+        rank_votes_relation: uid(RANK_VOTES_RELATION_TYPE_ID),
+        rank_block_relation: uid(RANK_BLOCK_RELATION_TYPE_ID),
+        vote_weighted_value_property: uid(VOTE_WEIGHTED_VALUE_PROPERTY_ID),
+    }
+});
+
+fn id_to_uuid(id: &Grc20Id) -> Uuid {
+    Uuid::from_bytes(*id)
+}
+
+fn text_value(values: &[PropertyValue], property: Uuid) -> Option<String> {
+    values.iter().find_map(|pv| {
+        if id_to_uuid(&pv.property) != property {
+            return None;
+        }
+        match &pv.value {
+            Grc20Value::Text { value, .. } => Some(value.to_string()),
+            _ => None,
+        }
+    })
+}
+
+fn float_value(values: &[PropertyValue], property: Uuid) -> Option<f64> {
+    values.iter().find_map(|pv| {
+        if id_to_uuid(&pv.property) != property {
+            return None;
+        }
+        match &pv.value {
+            Grc20Value::Float { value, .. } => Some(*value),
+            _ => None,
+        }
+    })
+}
 
 /// The rank-relevant ops extracted from a single edit.
 #[derive(Debug, Default)]
@@ -37,16 +95,101 @@ impl DetectedEdit {
 
 /// Extract the rank-relevant ops from a decoded GRC-20 edit.
 ///
-/// TODO(ranking-indexer): implement the op-pattern matching against
-/// `grc_20::Op` variants, mirroring the kg-indexer's `extract_entities` /
-/// `extract_values` / `extract_relations` (kg-indexer/src/handlers/edits.rs).
-/// This is the focused next step: it needs the grc_20 op API and the
-/// `TYPES`-relation type-resolution pattern. Returning an empty result keeps
-/// the pipeline correct (a no-op) until the matching lands.
-pub fn detect(edit: &grc_20::Edit, _space_id: Uuid) -> DetectedEdit {
-    tracing::debug!(
-        op_count = edit.ops.len(),
-        "ranking-indexer: detect() not yet wired — skipping rank op extraction"
-    );
-    DetectedEdit::default()
+/// `space_id` is the edit's space (a Rank/Ranking Block lives in it).
+/// `block_number` seeds the dedup update markers ("most recently updated rank
+/// per (block, space) wins"); `update_index` is the op position within the edit.
+pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> DetectedEdit {
+    let ids = &*IDS;
+    let mut out = DetectedEdit::default();
+
+    // Pass 1: index entity property-values and resolve TYPES membership, and
+    // collect the rank relations (votes + block links).
+    let mut entity_values: HashMap<Uuid, &[PropertyValue]> = HashMap::new();
+    let mut types_of: HashMap<Uuid, HashSet<Uuid>> = HashMap::new();
+
+    for op in &edit.ops {
+        match op {
+            Grc20Op::CreateEntity(entity) => {
+                entity_values.insert(id_to_uuid(&entity.id), entity.values.as_slice());
+            }
+            Grc20Op::CreateRelation(relation) => {
+                let type_id = id_to_uuid(&relation.relation_type);
+                if type_id == ids.type_relation {
+                    types_of
+                        .entry(id_to_uuid(&relation.from))
+                        .or_default()
+                        .insert(id_to_uuid(&relation.to));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Pass 2: classify ops using the resolved types.
+    for (op_index, op) in edit.ops.iter().enumerate() {
+        match op {
+            Grc20Op::CreateEntity(entity) => {
+                let entity_id = id_to_uuid(&entity.id);
+                let entity_types = types_of.get(&entity_id);
+
+                let is_rank = entity_types.is_some_and(|t| t.contains(&ids.rank_type));
+                let is_block =
+                    entity_types.is_some_and(|t| t.contains(&ids.ranking_block_type));
+
+                if is_rank {
+                    out.rankings.push(Ranking {
+                        id: entity_id,
+                        block_id: None, // set when the RANK_BLOCK link is seen (here or later)
+                        space_id,
+                        author_address: None, // resolved from the personal space during aggregation
+                        rank_type: text_value(&entity.values, ids.rank_type_property),
+                        submitted_at: None, // TODO: derive from edit/block timestamp
+                        updated_at_block: block_number,
+                        update_index: op_index as i64,
+                    });
+                } else if is_block {
+                    // NOTE: only id/space_id/name are confidently extractable today.
+                    // The block's window dates, filter, and aggregation restriction
+                    // emission shapes aren't in the merged SDK yet (geo-sdk#89 adds
+                    // the IDs; block creation lands separately). Left as TODO so we
+                    // don't guess the wrong op shape.
+                    out.blocks.push(RankingBlock {
+                        id: entity_id,
+                        space_id,
+                        name: text_value(&entity.values, ids.name_property),
+                        filter: None,
+                        start_date: None,
+                        end_date: None,
+                        restriction_id: None,
+                    });
+                }
+            }
+            Grc20Op::CreateRelation(relation) => {
+                let type_id = id_to_uuid(&relation.relation_type);
+                let from = id_to_uuid(&relation.from);
+
+                if type_id == ids.rank_votes_relation {
+                    // A ranked item: position is the fractional index, to_space the
+                    // perspective, and the weighted value lives on the reified vote
+                    // entity (ordinal ranks carry only the fractional index).
+                    let reified = id_to_uuid(&relation.entity_id());
+                    let weight = entity_values
+                        .get(&reified)
+                        .and_then(|vals| float_value(vals, ids.vote_weighted_value_property));
+                    out.items.push(RankingItem {
+                        ranking_id: from,
+                        entity_id: id_to_uuid(&relation.to),
+                        space_id: relation.to_space.map(|id| id_to_uuid(&id)).unwrap_or(space_id),
+                        position: relation.position.as_ref().map(|p| p.to_string()),
+                        weight,
+                    });
+                } else if type_id == ids.rank_block_relation {
+                    out.block_links.push((from, id_to_uuid(&relation.to)));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    out
 }

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -172,6 +172,23 @@ pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> Detecte
                     // A ranked item: position is the fractional index, to_space the
                     // perspective, and the weighted value lives on the reified vote
                     // entity (ordinal ranks carry only the fractional index).
+                    //
+                    // `to_space` is the ranked entity's perspective and is required:
+                    // the SDK sets it on every vote (buildVoteOps keys uniqueness on
+                    // (entityId, spaceId)), and both aggregation and the published
+                    // projection key on it. It is normally *not* the ranking's own
+                    // (personal) space — it's wherever the ranked entity lives. A
+                    // missing one is a malformed vote we can't place in a perspective,
+                    // so skip the item rather than mis-bucketing it into the ranking's
+                    // space (which would create an aggregate row readers can't resolve).
+                    let Some(item_space) = relation.to_space.map(|id| id_to_uuid(&id)) else {
+                        tracing::warn!(
+                            ranking = %from,
+                            entity = %id_to_uuid(&relation.to),
+                            "RANK_VOTES relation missing to_space; skipping item"
+                        );
+                        continue;
+                    };
                     let reified = id_to_uuid(&relation.entity_id());
                     let weight = entity_values
                         .get(&reified)
@@ -179,7 +196,7 @@ pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> Detecte
                     out.items.push(RankingItem {
                         ranking_id: from,
                         entity_id: id_to_uuid(&relation.to),
-                        space_id: relation.to_space.map(|id| id_to_uuid(&id)).unwrap_or(space_id),
+                        space_id: item_space,
                         position: relation.position.as_ref().map(|p| p.to_string()),
                         weight,
                     });

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -14,6 +14,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
+use chrono::{DateTime, Utc};
 use grc_20::{Id as Grc20Id, Op as Grc20Op, PropertyValue, Value as Grc20Value};
 use uuid::Uuid;
 
@@ -98,8 +99,16 @@ impl DetectedEdit {
 /// `space_id` is the edit's space (a Rank/Ranking Block lives in it).
 /// `block_number` seeds the dedup update markers ("most recently updated rank
 /// per (block, space) wins"); `update_index` is the op position within the edit.
-pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> DetectedEdit {
+/// `block_timestamp` is the edit's on-chain time (Unix seconds), recorded as the
+/// submission timestamp for the window check.
+pub fn detect(
+    edit: &grc_20::Edit,
+    space_id: Uuid,
+    block_number: i64,
+    block_timestamp: i64,
+) -> DetectedEdit {
     let ids = &*IDS;
+    let submitted_at = DateTime::<Utc>::from_timestamp(block_timestamp, 0);
     let mut out = DetectedEdit::default();
 
     // Pass 1: index entity property-values and resolve TYPES membership, and
@@ -143,7 +152,7 @@ pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> Detecte
                         space_id,
                         author_address: None, // resolved from the personal space during aggregation
                         rank_type: text_value(&entity.values, ids.rank_type_property),
-                        submitted_at: None, // TODO: derive from edit/block timestamp
+                        submitted_at,
                         updated_at_block: block_number,
                         update_index: op_index as i64,
                     });
@@ -209,4 +218,142 @@ pub fn detect(edit: &grc_20::Edit, space_id: Uuid, block_number: i64) -> Detecte
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use grc_20::model::builder::EditBuilder;
+    use sdk::core::ids::*;
+
+    /// grc_20 Id ([u8; 16]) from an arbitrary u128.
+    fn gid(n: u128) -> [u8; 16] {
+        *Uuid::from_u128(n).as_bytes()
+    }
+    /// grc_20 Id from a system-ID string constant.
+    fn sid(s: &str) -> [u8; 16] {
+        *Uuid::parse_str(s).unwrap().as_bytes()
+    }
+
+    const SPACE: u128 = 7000;
+    const RANK: u128 = 1;
+    const BLOCK: u128 = 2;
+    const RANKED_ENTITY: u128 = 3;
+    const VOTE_ENTITY: u128 = 4;
+    const PERSPECTIVE: u128 = 8000;
+
+    fn space_uuid() -> Uuid {
+        Uuid::from_u128(SPACE)
+    }
+
+    #[test]
+    fn detects_weighted_rank_with_item_and_submitted_at() {
+        let edit = EditBuilder::new(gid(0))
+            // entity RANK is typed `Rank` via a TYPES relation
+            .create_relation(|r| {
+                r.id(gid(10))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(sid(RANK_TYPE_ID))
+            })
+            .create_entity(gid(RANK), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "WEIGHTED", None)
+            })
+            // a RANK_VOTES item: rank -> ranked entity, with perspective + position
+            // and an explicit reified vote entity
+            .create_relation(|r| {
+                r.id(gid(11))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(gid(RANKED_ENTITY))
+                    .to_space(gid(PERSPECTIVE))
+                    .position("a0")
+                    .entity(gid(VOTE_ENTITY))
+            })
+            // the reified vote entity carries the weighted value
+            .create_entity(gid(VOTE_ENTITY), |e| {
+                e.float(sid(VOTE_WEIGHTED_VALUE_PROPERTY_ID), 0.9, None)
+            })
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 1_700_000_000);
+
+        assert_eq!(detected.rankings.len(), 1);
+        let r = &detected.rankings[0];
+        assert_eq!(r.id, Uuid::from_u128(RANK));
+        assert_eq!(r.rank_type.as_deref(), Some("WEIGHTED"));
+        assert_eq!(r.space_id, space_uuid());
+        assert_eq!(
+            r.submitted_at,
+            DateTime::<Utc>::from_timestamp(1_700_000_000, 0)
+        );
+
+        assert_eq!(detected.items.len(), 1);
+        let it = &detected.items[0];
+        assert_eq!(it.ranking_id, Uuid::from_u128(RANK));
+        assert_eq!(it.entity_id, Uuid::from_u128(RANKED_ENTITY));
+        assert_eq!(it.space_id, Uuid::from_u128(PERSPECTIVE));
+        assert_eq!(it.position.as_deref(), Some("a0"));
+        assert_eq!(it.weight, Some(0.9));
+    }
+
+    #[test]
+    fn detects_ranking_block() {
+        let edit = EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(20))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(BLOCK))
+                    .to(sid(RANKING_BLOCK_TYPE_ID))
+            })
+            .create_entity(gid(BLOCK), |e| e.text(sid(NAME_PROPERTY_ID), "Top Films", None))
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert_eq!(detected.blocks.len(), 1);
+        assert_eq!(detected.blocks[0].id, Uuid::from_u128(BLOCK));
+        assert_eq!(detected.blocks[0].name.as_deref(), Some("Top Films"));
+        assert!(detected.rankings.is_empty());
+    }
+
+    #[test]
+    fn detects_rank_block_link() {
+        let edit = EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(30))
+                    .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(gid(BLOCK))
+            })
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert_eq!(
+            detected.block_links,
+            vec![(Uuid::from_u128(RANK), Uuid::from_u128(BLOCK))]
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_ops() {
+        let edit = EditBuilder::new(gid(0))
+            .create_entity(gid(999), |e| {
+                e.text(sid(NAME_PROPERTY_ID), "Just an entity", None)
+            })
+            .build();
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert!(detected.is_empty());
+    }
+
+    #[test]
+    fn untyped_rank_entity_is_not_detected() {
+        // A Rank-shaped entity WITHOUT the TYPES relation isn't classified as a rank.
+        let edit = EditBuilder::new(gid(0))
+            .create_entity(gid(RANK), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+            })
+            .build();
+        let detected = detect(&edit, space_uuid(), 100, 0);
+        assert!(detected.rankings.is_empty());
+    }
 }

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -336,6 +336,40 @@ mod tests {
     }
 
     #[test]
+    fn rank_vote_without_to_space_is_skipped() {
+        // A RANK_VOTES relation with no `to_space` can't be placed in a
+        // perspective, so detect() drops the item rather than defaulting it to
+        // the ranking's own space (which would mis-bucket the aggregate).
+        let edit = EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(10))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(sid(RANK_TYPE_ID))
+            })
+            .create_entity(gid(RANK), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+            })
+            // RANK_VOTES item with position but NO to_space
+            .create_relation(|r| {
+                r.id(gid(11))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(RANK))
+                    .to(gid(RANKED_ENTITY))
+                    .position("a0")
+                    .entity(gid(VOTE_ENTITY))
+            })
+            .build();
+
+        let detected = detect(&edit, space_uuid(), 100, 0);
+
+        // the ranking itself is still detected...
+        assert_eq!(detected.rankings.len(), 1);
+        // ...but the perspective-less item is dropped (not bucketed into SPACE).
+        assert!(detected.items.is_empty());
+    }
+
+    #[test]
     fn detects_ranking_block() {
         let edit = EditBuilder::new(gid(0))
             .create_relation(|r| {

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -1,0 +1,52 @@
+//! Detection of rank-relevant operations within a decoded GRC-20 edit.
+//!
+//! The indexer keeps only the four op patterns from the design (§5) and
+//! discards everything else:
+//!   - `CreateEntity` typed `Ranking Block`  -> a [`RankingBlock`]
+//!   - `CreateEntity` typed `Rank`           -> a [`Ranking`] (+ its items)
+//!   - `RANK_VOTES` relations                -> [`RankingItem`] rows
+//!   - `CreateRelation` of type `RANK_BLOCK`  -> a rank -> block link
+//!
+//! Type membership is read from the `TYPES` relation, matching how the rest of
+//! gaia resolves entity types. The relevant system IDs live in
+//! [`sdk::core::ids`] (`RANK_TYPE_ID`, `RANKING_BLOCK_TYPE_ID`,
+//! `RANK_VOTES_RELATION_TYPE_ID`, `RANK_BLOCK_RELATION_TYPE_ID`, …).
+
+use uuid::Uuid;
+
+use crate::models::{Ranking, RankingBlock, RankingItem};
+
+/// The rank-relevant ops extracted from a single edit.
+#[derive(Debug, Default)]
+pub struct DetectedEdit {
+    pub blocks: Vec<RankingBlock>,
+    pub rankings: Vec<Ranking>,
+    pub items: Vec<RankingItem>,
+    /// `(ranking_id, block_id)` links from `RANK_BLOCK` relations.
+    pub block_links: Vec<(Uuid, Uuid)>,
+}
+
+impl DetectedEdit {
+    pub fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+            && self.rankings.is_empty()
+            && self.items.is_empty()
+            && self.block_links.is_empty()
+    }
+}
+
+/// Extract the rank-relevant ops from a decoded GRC-20 edit.
+///
+/// TODO(ranking-indexer): implement the op-pattern matching against
+/// `grc_20::Op` variants, mirroring the kg-indexer's `extract_entities` /
+/// `extract_values` / `extract_relations` (kg-indexer/src/handlers/edits.rs).
+/// This is the focused next step: it needs the grc_20 op API and the
+/// `TYPES`-relation type-resolution pattern. Returning an empty result keeps
+/// the pipeline correct (a no-op) until the matching lands.
+pub fn detect(edit: &grc_20::Edit, _space_id: Uuid) -> DetectedEdit {
+    tracing::debug!(
+        op_count = edit.ops.len(),
+        "ranking-indexer: detect() not yet wired — skipping rank op extraction"
+    );
+    DetectedEdit::default()
+}

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -183,8 +183,7 @@ pub fn detect(
                 let entity_types = types_of.get(&entity_id);
 
                 let is_rank = entity_types.is_some_and(|t| t.contains(&ids.rank_type));
-                let is_block =
-                    entity_types.is_some_and(|t| t.contains(&ids.ranking_block_type));
+                let is_block = entity_types.is_some_and(|t| t.contains(&ids.ranking_block_type));
 
                 if is_rank {
                     out.rankings.push(Ranking {
@@ -378,7 +377,9 @@ mod tests {
                     .from(gid(BLOCK))
                     .to(sid(RANKING_BLOCK_TYPE_ID))
             })
-            .create_entity(gid(BLOCK), |e| e.text(sid(NAME_PROPERTY_ID), "Top Films", None))
+            .create_entity(gid(BLOCK), |e| {
+                e.text(sid(NAME_PROPERTY_ID), "Top Films", None)
+            })
             .build();
 
         let detected = detect(&edit, space_uuid(), 100, 0);
@@ -408,8 +409,14 @@ mod tests {
             .create_entity(gid(BLOCK), |e| {
                 e.text(sid(NAME_PROPERTY_ID), "Top Films", None)
                     .text(sid(RANK_FILTER_PROPERTY_ID), "types: Movie", None)
-                    .value(sid(RANK_START_DATE_PROPERTY_ID), Grc20Value::Date("2026-06-01".into()))
-                    .value(sid(RANK_END_DATE_PROPERTY_ID), Grc20Value::Date("2026-06-30".into()))
+                    .value(
+                        sid(RANK_START_DATE_PROPERTY_ID),
+                        Grc20Value::Date("2026-06-01".into()),
+                    )
+                    .value(
+                        sid(RANK_END_DATE_PROPERTY_ID),
+                        Grc20Value::Date("2026-06-30".into()),
+                    )
             })
             .build();
 
@@ -418,8 +425,14 @@ mod tests {
         let b = &detected.blocks[0];
         assert_eq!(b.name.as_deref(), Some("Top Films"));
         assert_eq!(b.filter.as_deref(), Some("types: Movie"));
-        assert_eq!(b.start_date, Some(Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap()));
-        assert_eq!(b.end_date, Some(Utc.with_ymd_and_hms(2026, 6, 30, 0, 0, 0).unwrap()));
+        assert_eq!(
+            b.start_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap())
+        );
+        assert_eq!(
+            b.end_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 30, 0, 0, 0).unwrap())
+        );
         assert_eq!(
             b.restriction_id,
             Some(Uuid::parse_str(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID).unwrap())

--- a/ranking-indexer/src/eligibility.rs
+++ b/ranking-indexer/src/eligibility.rs
@@ -124,8 +124,16 @@ mod tests {
     fn dao_block_admits_only_members_or_editors() {
         let mut members = HashSet::new();
         members.insert(Uuid::from_u128(42));
-        assert!(restriction_admits(SpaceKind::Dao, Uuid::from_u128(42), &members));
-        assert!(!restriction_admits(SpaceKind::Dao, Uuid::from_u128(99), &members));
+        assert!(restriction_admits(
+            SpaceKind::Dao,
+            Uuid::from_u128(42),
+            &members
+        ));
+        assert!(!restriction_admits(
+            SpaceKind::Dao,
+            Uuid::from_u128(99),
+            &members
+        ));
     }
 
     #[test]

--- a/ranking-indexer/src/eligibility.rs
+++ b/ranking-indexer/src/eligibility.rs
@@ -1,0 +1,162 @@
+//! Eligibility resolution for ranking aggregation (design §7).
+//!
+//! A submission counts toward a block only if it passes both a *restriction*
+//! check and a *window* check.
+//!
+//! Restriction (per the team decision):
+//!   - DAO-space block: the submitter must be a member or editor of the block's
+//!     space.
+//!   - Personal-space block: "All of Geo" for now — admit every submitter. (This
+//!     will narrow to verified users once verification ships.)
+//!
+//! Window: the submission timestamp must fall within the block's optional
+//! `[start, end]` bounds; an absent bound imposes no limit.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::models::{Ranking, RankingBlock};
+
+/// The kind of space a block lives in, which sets its default restriction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpaceKind {
+    /// Governed space — restrict to members/editors.
+    Dao,
+    /// Personal space — "All of Geo" for now.
+    Personal,
+}
+
+/// Does the block's restriction admit a submission from `submitter_space`?
+pub fn restriction_admits(
+    space_kind: SpaceKind,
+    submitter_space: Uuid,
+    eligible_member_spaces: &HashSet<Uuid>,
+) -> bool {
+    match space_kind {
+        // "All of Geo" for now; narrows to verified users post-verification.
+        SpaceKind::Personal => true,
+        SpaceKind::Dao => eligible_member_spaces.contains(&submitter_space),
+    }
+}
+
+/// Does the submission fall within the block's optional window?
+///
+/// An absent bound imposes no limit. If the submission time is unknown the
+/// window cannot reject it — populating `submitted_at` in `detect()` is a
+/// follow-up, so we admit rather than silently drop.
+pub fn window_admits(
+    submitted_at: Option<DateTime<Utc>>,
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+) -> bool {
+    let after_start = match (start, submitted_at) {
+        (Some(s), Some(t)) => t >= s,
+        _ => true,
+    };
+    let before_end = match (end, submitted_at) {
+        (Some(e), Some(t)) => t <= e,
+        _ => true,
+    };
+    after_start && before_end
+}
+
+/// Filter deduped submissions to those eligible for `block`.
+///
+/// `eligible_member_spaces` is the set of member/editor space ids of the
+/// block's space (ignored for personal-space blocks).
+pub fn filter_eligible(
+    block: &RankingBlock,
+    space_kind: SpaceKind,
+    eligible_member_spaces: &HashSet<Uuid>,
+    submissions: Vec<Ranking>,
+) -> Vec<Ranking> {
+    submissions
+        .into_iter()
+        .filter(|s| {
+            restriction_admits(space_kind, s.space_id, eligible_member_spaces)
+                && window_admits(s.submitted_at, block.start_date, block.end_date)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block(start: Option<DateTime<Utc>>, end: Option<DateTime<Utc>>) -> RankingBlock {
+        RankingBlock {
+            id: Uuid::from_u128(1),
+            space_id: Uuid::from_u128(900),
+            name: None,
+            filter: None,
+            start_date: start,
+            end_date: end,
+            restriction_id: None,
+        }
+    }
+
+    fn submission(space: u128, at: Option<DateTime<Utc>>) -> Ranking {
+        Ranking {
+            id: Uuid::from_u128(space + 1000),
+            block_id: Some(Uuid::from_u128(1)),
+            space_id: Uuid::from_u128(space),
+            author_address: None,
+            rank_type: None,
+            submitted_at: at,
+            updated_at_block: 0,
+            update_index: 0,
+        }
+    }
+
+    #[test]
+    fn personal_block_admits_any_submitter() {
+        let members = HashSet::new(); // none
+        assert!(restriction_admits(
+            SpaceKind::Personal,
+            Uuid::from_u128(42),
+            &members
+        ));
+    }
+
+    #[test]
+    fn dao_block_admits_only_members_or_editors() {
+        let mut members = HashSet::new();
+        members.insert(Uuid::from_u128(42));
+        assert!(restriction_admits(SpaceKind::Dao, Uuid::from_u128(42), &members));
+        assert!(!restriction_admits(SpaceKind::Dao, Uuid::from_u128(99), &members));
+    }
+
+    #[test]
+    fn window_bounds() {
+        let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0);
+        // within
+        assert!(window_admits(t(50), t(0), t(100)));
+        // before start / after end
+        assert!(!window_admits(t(50), t(60), t(100)));
+        assert!(!window_admits(t(50), t(0), t(40)));
+        // absent bounds impose no limit
+        assert!(window_admits(t(50), None, None));
+        // unknown submission time can't be rejected
+        assert!(window_admits(None, t(0), t(100)));
+    }
+
+    #[test]
+    fn filter_eligible_combines_both_checks() {
+        let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0);
+        let b = block(t(0), t(100));
+        let mut members = HashSet::new();
+        members.insert(Uuid::from_u128(1)); // space 1 is a member
+
+        let subs = vec![
+            submission(1, t(50)),  // member, in window -> keep
+            submission(2, t(50)),  // non-member -> drop
+            submission(1, t(200)), // member, out of window -> drop
+        ];
+        let kept = filter_eligible(&b, SpaceKind::Dao, &members, subs);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].space_id, Uuid::from_u128(1));
+        assert_eq!(kept[0].submitted_at, t(50));
+    }
+}

--- a/ranking-indexer/src/error.rs
+++ b/ranking-indexer/src/error.rs
@@ -1,0 +1,28 @@
+//! Error types for the ranking-indexer.
+
+#[derive(Debug, thiserror::Error)]
+pub enum IndexerError {
+    #[error("config error: {0}")]
+    Config(String),
+
+    #[error("kafka error: {0}")]
+    Kafka(#[from] rdkafka::error::KafkaError),
+
+    #[error("decode error: {0}")]
+    Decode(String),
+
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+impl IndexerError {
+    pub fn decode(msg: impl Into<String>) -> Self {
+        Self::Decode(msg.into())
+    }
+}
+
+impl From<prost::DecodeError> for IndexerError {
+    fn from(e: prost::DecodeError) -> Self {
+        Self::Decode(format!("prost: {e}"))
+    }
+}

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod consumer;
 pub mod dedup;
 pub mod detect;
+pub mod eligibility;
 pub mod error;
 pub mod models;
 pub mod storage;

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -9,4 +9,5 @@ pub mod eligibility;
 pub mod error;
 pub mod models;
 pub mod recompute;
+pub mod scoring;
 pub mod storage;

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -1,0 +1,10 @@
+//! ranking-indexer: consumes `knowledge.edits`, maintains the private `ranks`
+//! working schema, and (future) projects aggregated `RANK_POSITION` relations
+//! back into the public graph.
+
+pub mod consumer;
+pub mod dedup;
+pub mod detect;
+pub mod error;
+pub mod models;
+pub mod storage;

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -8,4 +8,5 @@ pub mod detect;
 pub mod eligibility;
 pub mod error;
 pub mod models;
+pub mod recompute;
 pub mod storage;

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! ranking-indexer: consumes `knowledge.edits`, maintains the private `ranks`
-//! working schema, and (future) projects aggregated `RANK_POSITION` relations
-//! back into the public graph.
+//! working schema, and projects aggregated `RANK_POSITION` relations back into
+//! the public graph.
 
 pub mod consumer;
 pub mod dedup;
@@ -8,6 +8,7 @@ pub mod detect;
 pub mod eligibility;
 pub mod error;
 pub mod models;
+pub mod publish;
 pub mod recompute;
 pub mod scoring;
 pub mod storage;

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -112,7 +112,9 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
     }
 
     for (ranking_id, block_id) in detected.block_links {
-        storage.set_ranking_block(ranking_id, block_id).await?;
+        // The RANK_BLOCK relation is authored in the ranking's space, so the
+        // edit's `space_id` is the rank row's space.
+        storage.set_ranking_block(ranking_id, block_id, space_id).await?;
     }
 
     // TODO(ranking-indexer): recompute affected blocks (dedup -> eligibility ->

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -1,0 +1,119 @@
+//! ranking-indexer binary entrypoint.
+//!
+//! Consumes `knowledge.edits`, keeps the rank-relevant ops, and upserts them
+//! into the private `ranks` working schema. Per-edit processing (the design
+//! allows either per-edit or per-block batching, §10).
+//!
+//! NOT YET WIRED (follow-ups, gated on the design's open questions):
+//!   - `detect()` op extraction (the rank op-pattern matching)
+//!   - per-block recompute: dedup -> eligibility -> scoring
+//!   - projection of `RANK_POSITION` relations into `public.relations`
+
+use std::collections::HashMap;
+use std::env;
+
+use futures::StreamExt;
+use rdkafka::Message;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use ranking_indexer::consumer::{decode_grc20, parse_edit, KafkaConsumer};
+use ranking_indexer::detect::detect;
+use ranking_indexer::error::IndexerError;
+use ranking_indexer::storage::Storage;
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let brokers = env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".into());
+    let group_id = env::var("KAFKA_GROUP_ID").unwrap_or_else(|_| "ranking-indexer".into());
+
+    let storage = Storage::new(&database_url).await?;
+    let consumer = KafkaConsumer::new(&brokers, &group_id)?;
+    consumer.subscribe()?;
+
+    info!("ranking-indexer started");
+
+    let mut stream = consumer.stream();
+    while let Some(result) = stream.next().await {
+        let msg = match result {
+            Ok(m) => m,
+            Err(e) => {
+                error!(error = %e, "Kafka receive error");
+                continue;
+            }
+        };
+
+        let topic = msg.topic().to_string();
+        let partition = msg.partition();
+        let offset = msg.offset();
+
+        let Some(payload) = msg.payload() else {
+            // Tombstone / empty payload — nothing to do, advance past it.
+            let _ = consumer.commit_message(&topic, partition, offset);
+            continue;
+        };
+
+        match process_edit(payload, &storage).await {
+            Ok(()) => {
+                if let Err(e) = consumer.commit_message(&topic, partition, offset) {
+                    error!(error = %e, "Failed to commit offset");
+                }
+            }
+            Err(e) => {
+                // A malformed edit is logged and skipped rather than stalling the
+                // partition (design §10). The offset is still advanced.
+                warn!(error = %e, offset = offset, "Skipping unprocessable edit");
+                let _ = consumer.commit_message(&topic, partition, offset);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Decode one edit and upsert its rank-relevant ops into the `ranks` schema.
+async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerError> {
+    let edit = parse_edit(payload)?;
+    let space_id = Uuid::from_slice(&edit.space_id)
+        .map_err(|e| IndexerError::decode(format!("space_id: {e}")))?;
+
+    let grc20_edit = decode_grc20(&edit.payload)?;
+    let detected = detect(&grc20_edit, space_id);
+    if detected.is_empty() {
+        return Ok(());
+    }
+
+    for block in &detected.blocks {
+        storage.upsert_ranking_block(block).await?;
+    }
+    for ranking in &detected.rankings {
+        storage.upsert_ranking(ranking).await?;
+    }
+
+    // Re-submission rebuilds a rank's items, so replace per ranking.
+    let mut items_by_ranking: HashMap<Uuid, Vec<_>> = HashMap::new();
+    for item in detected.items {
+        items_by_ranking.entry(item.ranking_id).or_default().push(item);
+    }
+    for (ranking_id, items) in items_by_ranking {
+        storage.replace_ranking_items(ranking_id, &items).await?;
+    }
+
+    for (ranking_id, block_id) in detected.block_links {
+        storage.set_ranking_block(ranking_id, block_id).await?;
+    }
+
+    // TODO(ranking-indexer): recompute affected blocks (dedup -> eligibility ->
+    // scoring) and project RANK_POSITION relations. Gated on the design's open
+    // questions (eligibility for personal spaces, scoring normalization, the
+    // public-projection / atlas coordination).
+
+    Ok(())
+}

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -1,15 +1,9 @@
 //! ranking-indexer binary entrypoint.
 //!
-//! Consumes `knowledge.edits`, keeps the rank-relevant ops, and upserts them
-//! into the private `ranks` working schema. Per-edit processing (the design
-//! allows either per-edit or per-block batching, §10).
-//!
-//! NOT YET WIRED (follow-ups, gated on the design's open questions):
-//!   - `detect()` op extraction (the rank op-pattern matching)
-//!   - per-block recompute: dedup -> eligibility -> scoring
-//!   - projection of `RANK_POSITION` relations into `public.relations`
+//! Consumes `knowledge.edits`, keeps the rank-relevant ops, and runs the full
+//! pipeline per edit (decode -> detect -> upsert -> recompute -> publish). The
+//! design allows either per-edit or per-block batching (§10); this uses per-edit.
 
-use std::collections::HashMap;
 use std::env;
 
 use futures::StreamExt;
@@ -20,7 +14,6 @@ use uuid::Uuid;
 use ranking_indexer::consumer::{decode_grc20, parse_edit, KafkaConsumer};
 use ranking_indexer::detect::detect;
 use ranking_indexer::error::IndexerError;
-use ranking_indexer::models::RankingItem;
 use ranking_indexer::recompute;
 use ranking_indexer::storage::Storage;
 
@@ -93,41 +86,5 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         .map(|m| (m.block_number as i64, m.created_at as i64))
         .unwrap_or((0, 0));
     let detected = detect(&grc20_edit, space_id, block_number, block_timestamp);
-    if detected.is_empty() {
-        return Ok(());
-    }
-
-    for block in &detected.blocks {
-        storage.upsert_ranking_block(block).await?;
-    }
-    for ranking in &detected.rankings {
-        storage.upsert_ranking(ranking).await?;
-    }
-
-    // Re-submission rebuilds a rank's items, so replace per ranking. Clone into
-    // the per-ranking groups so `detected` stays intact for affected_blocks.
-    let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
-    for item in &detected.items {
-        items_by_ranking
-            .entry(item.ranking_id)
-            .or_default()
-            .push(item.clone());
-    }
-    for (ranking_id, items) in &items_by_ranking {
-        storage.replace_ranking_items(*ranking_id, items).await?;
-    }
-
-    for (ranking_id, block_id) in &detected.block_links {
-        // The RANK_BLOCK relation is authored in the ranking's space, so the
-        // edit's `space_id` is the rank row's space.
-        storage.set_ranking_block(*ranking_id, *block_id, space_id).await?;
-    }
-
-    // Recompute every block this edit may have affected
-    // (dedup -> eligibility -> [scoring/publish stubs]).
-    for block_id in recompute::affected_blocks(&detected, storage).await? {
-        recompute::recompute_block(block_id, storage).await?;
-    }
-
-    Ok(())
+    recompute::apply_detected_edit(&detected, space_id, storage).await
 }

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -20,6 +20,8 @@ use uuid::Uuid;
 use ranking_indexer::consumer::{decode_grc20, parse_edit, KafkaConsumer};
 use ranking_indexer::detect::detect;
 use ranking_indexer::error::IndexerError;
+use ranking_indexer::models::RankingItem;
+use ranking_indexer::recompute;
 use ranking_indexer::storage::Storage;
 
 #[tokio::main]
@@ -102,25 +104,30 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         storage.upsert_ranking(ranking).await?;
     }
 
-    // Re-submission rebuilds a rank's items, so replace per ranking.
-    let mut items_by_ranking: HashMap<Uuid, Vec<_>> = HashMap::new();
-    for item in detected.items {
-        items_by_ranking.entry(item.ranking_id).or_default().push(item);
+    // Re-submission rebuilds a rank's items, so replace per ranking. Clone into
+    // the per-ranking groups so `detected` stays intact for affected_blocks.
+    let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
+    for item in &detected.items {
+        items_by_ranking
+            .entry(item.ranking_id)
+            .or_default()
+            .push(item.clone());
     }
-    for (ranking_id, items) in items_by_ranking {
-        storage.replace_ranking_items(ranking_id, &items).await?;
+    for (ranking_id, items) in &items_by_ranking {
+        storage.replace_ranking_items(*ranking_id, items).await?;
     }
 
-    for (ranking_id, block_id) in detected.block_links {
+    for (ranking_id, block_id) in &detected.block_links {
         // The RANK_BLOCK relation is authored in the ranking's space, so the
         // edit's `space_id` is the rank row's space.
-        storage.set_ranking_block(ranking_id, block_id, space_id).await?;
+        storage.set_ranking_block(*ranking_id, *block_id, space_id).await?;
     }
 
-    // TODO(ranking-indexer): recompute affected blocks (dedup -> eligibility ->
-    // scoring) and project RANK_POSITION relations. Gated on the design's open
-    // questions (eligibility for personal spaces, scoring normalization, the
-    // public-projection / atlas coordination).
+    // Recompute every block this edit may have affected
+    // (dedup -> eligibility -> [scoring/publish stubs]).
+    for block_id in recompute::affected_blocks(&detected, storage).await? {
+        recompute::recompute_block(block_id, storage).await?;
+    }
 
     Ok(())
 }

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -87,12 +87,12 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         .map_err(|e| IndexerError::decode(format!("space_id: {e}")))?;
 
     let grc20_edit = decode_grc20(&edit.payload)?;
-    let block_number = edit
+    let (block_number, block_timestamp) = edit
         .meta
         .as_ref()
-        .map(|m| m.block_number as i64)
-        .unwrap_or(0);
-    let detected = detect(&grc20_edit, space_id, block_number);
+        .map(|m| (m.block_number as i64, m.created_at as i64))
+        .unwrap_or((0, 0));
+    let detected = detect(&grc20_edit, space_id, block_number, block_timestamp);
     if detected.is_empty() {
         return Ok(());
     }

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -85,7 +85,12 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         .map_err(|e| IndexerError::decode(format!("space_id: {e}")))?;
 
     let grc20_edit = decode_grc20(&edit.payload)?;
-    let detected = detect(&grc20_edit, space_id);
+    let block_number = edit
+        .meta
+        .as_ref()
+        .map(|m| m.block_number as i64)
+        .unwrap_or(0);
+    let detected = detect(&grc20_edit, space_id, block_number);
     if detected.is_empty() {
         return Ok(());
     }

--- a/ranking-indexer/src/models.rs
+++ b/ranking-indexer/src/models.rs
@@ -1,0 +1,45 @@
+//! Row models mirroring the private `ranks` working schema.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+/// A `ranks.ranking_blocks` row — one per Ranking Block entity.
+#[derive(Debug, Clone)]
+pub struct RankingBlock {
+    pub id: Uuid,
+    pub space_id: Uuid,
+    pub name: Option<String>,
+    pub filter: Option<String>,
+    pub start_date: Option<DateTime<Utc>>,
+    pub end_date: Option<DateTime<Utc>>,
+    /// Aggregation restriction value entity; `None` => default "Members and editors".
+    pub restriction_id: Option<Uuid>,
+}
+
+/// A `ranks.rankings` row — one per Rank submission.
+#[derive(Debug, Clone)]
+pub struct Ranking {
+    pub id: Uuid,
+    /// `None` until the `RANK_BLOCK` link arrives (partial-state model).
+    pub block_id: Option<Uuid>,
+    pub space_id: Uuid,
+    pub author_address: Option<String>,
+    /// "ORDINAL" | "WEIGHTED".
+    pub rank_type: Option<String>,
+    pub submitted_at: Option<DateTime<Utc>>,
+    /// Update markers for dedup: most-recently-updated rank per (block, space) wins.
+    pub updated_at_block: i64,
+    pub update_index: i64,
+}
+
+/// A `ranks.ranking_items` row — keyed on (ranking, entity, space).
+#[derive(Debug, Clone)]
+pub struct RankingItem {
+    pub ranking_id: Uuid,
+    pub entity_id: Uuid,
+    pub space_id: Uuid,
+    /// Fractional index for ordinal ordering.
+    pub position: Option<String>,
+    /// Weighted value (`None` for ordinal ranks).
+    pub weight: Option<f64>,
+}

--- a/ranking-indexer/src/models.rs
+++ b/ranking-indexer/src/models.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 /// A `ranks.ranking_blocks` row — one per Ranking Block entity.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RankingBlock {
     pub id: Uuid,
     pub space_id: Uuid,
@@ -17,7 +17,7 @@ pub struct RankingBlock {
 }
 
 /// A `ranks.rankings` row — one per Rank submission.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Ranking {
     pub id: Uuid,
     /// `None` until the `RANK_BLOCK` link arrives (partial-state model).
@@ -33,7 +33,7 @@ pub struct Ranking {
 }
 
 /// A `ranks.ranking_items` row — keyed on (ranking, entity, space).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RankingItem {
     pub ranking_id: Uuid,
     pub entity_id: Uuid,

--- a/ranking-indexer/src/publish.rs
+++ b/ranking-indexer/src/publish.rs
@@ -51,7 +51,8 @@ pub fn build_projection(block_id: Uuid, scores: &[ScoreRow]) -> Vec<RankPosition
             } else {
                 0
             };
-            let tag = |kind: &str| derive(&format!("{kind}:{block_id}:{}:{}", s.entity_id, s.space_id));
+            let tag =
+                |kind: &str| derive(&format!("{kind}:{block_id}:{}:{}", s.entity_id, s.space_id));
             RankPositionRow {
                 entity_id: s.entity_id,
                 space_id: s.space_id,
@@ -70,7 +71,9 @@ pub fn build_projection(block_id: Uuid, scores: &[ScoreRow]) -> Vec<RankPosition
 pub fn provenance_ids(block_id: Uuid, ranking_id: Uuid) -> (Uuid, Uuid) {
     (
         derive(&format!("aggregated_rankings:{block_id}:{ranking_id}")),
-        derive(&format!("aggregated_rankings_entity:{block_id}:{ranking_id}")),
+        derive(&format!(
+            "aggregated_rankings_entity:{block_id}:{ranking_id}"
+        )),
     )
 }
 
@@ -90,7 +93,11 @@ mod tests {
     #[test]
     fn scales_top_to_100_and_orders_by_position() {
         let block = Uuid::from_u128(1);
-        let scores = vec![score(10, 1, 2.5, 1), score(11, 1, 2.0, 2), score(12, 1, 1.0, 3)];
+        let scores = vec![
+            score(10, 1, 2.5, 1),
+            score(11, 1, 2.0, 2),
+            score(12, 1, 1.0, 3),
+        ];
         let proj = build_projection(block, &scores);
         assert_eq!(proj.len(), 3);
         assert_eq!(proj[0].value, 100); // 2.5/2.5

--- a/ranking-indexer/src/publish.rs
+++ b/ranking-indexer/src/publish.rs
@@ -1,0 +1,119 @@
+//! Publish: project a block's computed aggregate into the public graph (design §8).
+//!
+//! Per ranked target we emit a `RANK_POSITION` relation (block -> ranked entity,
+//! in the ranked perspective, ordered by `position`) whose reified entity carries
+//! the integer rank-position value, plus an `Aggregated rankings` provenance
+//! relation (block -> each contributing submission). IDs are deterministic from
+//! `(block, entity, space)`, so re-aggregation upserts in place; the whole
+//! projection for a block is replaced atomically each recompute.
+
+use std::sync::LazyLock;
+
+use uuid::Uuid;
+
+use crate::scoring::ScoreRow;
+
+static NS: LazyLock<Uuid> = LazyLock::new(|| {
+    Uuid::parse_str(sdk::core::ids::GEO_SYSTEM_NAMESPACE).expect("valid GEO_SYSTEM_NAMESPACE")
+});
+
+fn derive(name: &str) -> Uuid {
+    Uuid::new_v5(&NS, name.as_bytes())
+}
+
+/// One `RANK_POSITION` projection row for a ranked `(entity, space)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankPositionRow {
+    pub entity_id: Uuid,
+    pub space_id: Uuid,
+    /// Published integer score (block-scoped 0–100, v1).
+    pub value: i64,
+    /// Lexicographically-ordered position key.
+    pub position: String,
+    pub relation_id: Uuid,
+    pub reified_entity_id: Uuid,
+    pub value_row_id: Uuid,
+}
+
+/// Build the public projection from a block's scored aggregate.
+///
+/// Integer value is block-scoped (v1): `round(100 * score / max_score)`, so the
+/// top entity is 100. Position is a fixed-width, lexicographically-ordered rank
+/// key (regenerated each full recompute — fine since the projection is replaced
+/// wholesale).
+pub fn build_projection(block_id: Uuid, scores: &[ScoreRow]) -> Vec<RankPositionRow> {
+    let max = scores.iter().map(|s| s.score).fold(0.0_f64, f64::max);
+    scores
+        .iter()
+        .map(|s| {
+            let value = if max > 0.0 {
+                (100.0 * s.score / max).round() as i64
+            } else {
+                0
+            };
+            let tag = |kind: &str| derive(&format!("{kind}:{block_id}:{}:{}", s.entity_id, s.space_id));
+            RankPositionRow {
+                entity_id: s.entity_id,
+                space_id: s.space_id,
+                value,
+                position: format!("{:010}", s.position),
+                relation_id: tag("rank_position"),
+                reified_entity_id: tag("rank_position_entity"),
+                value_row_id: tag("rank_position_value"),
+            }
+        })
+        .collect()
+}
+
+/// Deterministic `(relation_id, reified_entity_id)` for an `Aggregated rankings`
+/// provenance relation linking a block to one contributing submission.
+pub fn provenance_ids(block_id: Uuid, ranking_id: Uuid) -> (Uuid, Uuid) {
+    (
+        derive(&format!("aggregated_rankings:{block_id}:{ranking_id}")),
+        derive(&format!("aggregated_rankings_entity:{block_id}:{ranking_id}")),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn score(entity: u128, space: u128, score: f64, position: i32) -> ScoreRow {
+        ScoreRow {
+            entity_id: Uuid::from_u128(entity),
+            space_id: Uuid::from_u128(space),
+            score,
+            position,
+        }
+    }
+
+    #[test]
+    fn scales_top_to_100_and_orders_by_position() {
+        let block = Uuid::from_u128(1);
+        let scores = vec![score(10, 1, 2.5, 1), score(11, 1, 2.0, 2), score(12, 1, 1.0, 3)];
+        let proj = build_projection(block, &scores);
+        assert_eq!(proj.len(), 3);
+        assert_eq!(proj[0].value, 100); // 2.5/2.5
+        assert_eq!(proj[1].value, 80); // 2.0/2.5
+        assert_eq!(proj[2].value, 40); // 1.0/2.5
+        assert!(proj[0].position < proj[1].position);
+        assert!(proj[1].position < proj[2].position);
+    }
+
+    #[test]
+    fn ids_are_stable_and_distinct() {
+        let block = Uuid::from_u128(1);
+        let s = vec![score(10, 1, 1.0, 1)];
+        let a = build_projection(block, &s);
+        let b = build_projection(block, &s);
+        assert_eq!(a[0].relation_id, b[0].relation_id);
+        assert_ne!(a[0].relation_id, a[0].reified_entity_id);
+        assert_ne!(a[0].relation_id, a[0].value_row_id);
+        assert_ne!(a[0].reified_entity_id, a[0].value_row_id);
+    }
+
+    #[test]
+    fn empty_scores_yield_empty_projection() {
+        assert!(build_projection(Uuid::from_u128(1), &[]).is_empty());
+    }
+}

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -4,9 +4,7 @@
 //! (design §7): `dedup -> eligibility -> scoring -> publish`. A full recompute
 //! is always correct regardless of edit arrival order.
 //!
-//! Publish is still a stub, gated on the rank-position-value property ID
-//! (Preston) and projection details. Dedup, eligibility, and scoring are wired
-//! in and exercised.
+//! All four stages are wired: dedup -> eligibility -> scoring -> publish.
 
 use std::collections::{HashMap, HashSet};
 
@@ -17,7 +15,7 @@ use crate::detect::DetectedEdit;
 use crate::eligibility::{filter_eligible, SpaceKind};
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingItem};
-use crate::scoring;
+use crate::{publish, scoring};
 use crate::storage::Storage;
 
 /// Block ids whose aggregate may have changed as a result of this edit:
@@ -90,20 +88,21 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
     let scores = scoring::aggregate(&ballots, scoring::NORM_LO, scoring::NORM_HI);
     storage.replace_ranking_scores(block_id, &scores).await?;
 
+    // 4. Publish: project RANK_POSITION relations (+ the integer rank-position
+    //    value on each reified entity) and Aggregated rankings provenance into
+    //    the public graph, replacing the prior projection atomically.
+    let projection = publish::build_projection(block_id, &scores);
+    let contributing: Vec<Uuid> = ballots.iter().map(|(r, _)| r.id).collect();
+    storage
+        .replace_rank_position_projection(block_id, block.space_id, &projection, &contributing)
+        .await?;
+
     tracing::debug!(
         block_id = %block_id,
         eligible_submissions = ballots.len(),
         ranked_entities = scores.len(),
-        "ranking-indexer recompute: scored (publish not yet wired)"
+        "ranking-indexer recompute: scored + published"
     );
-
-    // 4. TODO(publish): project RANK_POSITION relations (+ Aggregated rankings
-    //    provenance + the integer rank-position value on the reified relation
-    //    entity) into public.relations, atomically replacing the prior
-    //    projection. Gated on Preston minting the rank-position-value property.
-    //
-    // When publish lands, scoring + projection should run in one transaction and
-    // the Kafka offset commit (in main) should follow it.
 
     Ok(())
 }

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -1,0 +1,95 @@
+//! Per-block recompute orchestration.
+//!
+//! For each block an edit may have affected, recompute its aggregate in full
+//! (design §7): `dedup -> eligibility -> scoring -> publish`. A full recompute
+//! is always correct regardless of edit arrival order.
+//!
+//! Scoring and publish are stubs pending the open design questions (the ballot
+//! normalization method, and the aggregate-weight property + atlas inclusion
+//! for the projection). Dedup and eligibility are wired in and exercised.
+
+use std::collections::HashSet;
+
+use uuid::Uuid;
+
+use crate::dedup::dedup_latest;
+use crate::detect::DetectedEdit;
+use crate::eligibility::{filter_eligible, SpaceKind};
+use crate::error::IndexerError;
+use crate::storage::Storage;
+
+/// Block ids whose aggregate may have changed as a result of this edit:
+/// blocks whose own settings changed, blocks newly linked from a rank, and the
+/// (possibly previously-linked) block of any rank/item touched here.
+pub async fn affected_blocks(
+    detected: &DetectedEdit,
+    storage: &Storage,
+) -> Result<HashSet<Uuid>, IndexerError> {
+    let mut blocks: HashSet<Uuid> = HashSet::new();
+
+    for b in &detected.blocks {
+        blocks.insert(b.id);
+    }
+    for (_ranking_id, block_id) in &detected.block_links {
+        blocks.insert(*block_id);
+    }
+
+    // Rankings/items touched here may already be linked to a block from a prior
+    // edit — resolve their current block_id from the working tables.
+    let mut ranking_ids: HashSet<Uuid> = HashSet::new();
+    for r in &detected.rankings {
+        ranking_ids.insert(r.id);
+    }
+    for it in &detected.items {
+        ranking_ids.insert(it.ranking_id);
+    }
+    for ranking_id in ranking_ids {
+        if let Some(block_id) = storage.block_id_for_ranking(ranking_id).await? {
+            blocks.insert(block_id);
+        }
+    }
+
+    Ok(blocks)
+}
+
+/// Recompute a single block's aggregate end to end.
+pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), IndexerError> {
+    let Some(block) = storage.get_ranking_block(block_id).await? else {
+        // A rank may link to a block we haven't indexed yet; nothing to do.
+        return Ok(());
+    };
+
+    // 1. Dedup: keep the latest submission per (block, personal space).
+    let submissions = storage.get_rankings_for_block(block_id).await?;
+    let deduped = dedup_latest(submissions);
+
+    // 2. Eligibility: resolve the block's space kind + member/editor set.
+    let space_kind = storage
+        .space_kind(block.space_id)
+        .await?
+        .unwrap_or(SpaceKind::Dao); // unknown space -> conservative (membership-restricted)
+    let eligible_member_spaces = match space_kind {
+        SpaceKind::Dao => storage.member_and_editor_spaces(block.space_id).await?,
+        SpaceKind::Personal => HashSet::new(), // unused under "All of Geo"
+    };
+    let eligible = filter_eligible(&block, space_kind, &eligible_member_spaces, deduped);
+
+    tracing::debug!(
+        block_id = %block_id,
+        eligible_submissions = eligible.len(),
+        "ranking-indexer recompute: dedup + eligibility done (scoring/publish not yet wired)"
+    );
+
+    // 3. TODO(scoring): load each eligible submission's items, convert to
+    //    per-(entity, space) contributions with per-ballot normalization
+    //    (method pending Jagger), sum, sort, and upsert ranks.ranking_scores.
+    // 4. TODO(publish): project RANK_POSITION relations (+ Aggregated rankings
+    //    provenance + the aggregate weight on the reified relation entity) into
+    //    public.relations, atomically replacing the prior projection. Gated on
+    //    the weight-property and atlas-inclusion decisions.
+    //
+    // When scoring/publish land, steps 3–4 should run in a single transaction
+    // and the Kafka offset commit (in main) should follow that transaction.
+
+    Ok(())
+}

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -4,11 +4,11 @@
 //! (design §7): `dedup -> eligibility -> scoring -> publish`. A full recompute
 //! is always correct regardless of edit arrival order.
 //!
-//! Scoring and publish are stubs pending the open design questions (the ballot
-//! normalization method, and the aggregate-weight property + atlas inclusion
-//! for the projection). Dedup and eligibility are wired in and exercised.
+//! Publish is still a stub, gated on the rank-position-value property ID
+//! (Preston) and projection details. Dedup, eligibility, and scoring are wired
+//! in and exercised.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use uuid::Uuid;
 
@@ -16,6 +16,8 @@ use crate::dedup::dedup_latest;
 use crate::detect::DetectedEdit;
 use crate::eligibility::{filter_eligible, SpaceKind};
 use crate::error::IndexerError;
+use crate::models::{Ranking, RankingItem};
+use crate::scoring;
 use crate::storage::Storage;
 
 /// Block ids whose aggregate may have changed as a result of this edit:
@@ -74,22 +76,34 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
     };
     let eligible = filter_eligible(&block, space_kind, &eligible_member_spaces, deduped);
 
+    // 3. Scoring: normalize each ballot to [0.5, 1] and aggregate per (entity, space).
+    let eligible_ids: Vec<Uuid> = eligible.iter().map(|r| r.id).collect();
+    let items = storage.get_items_for_rankings(&eligible_ids).await?;
+    let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
+    for item in items {
+        items_by_ranking.entry(item.ranking_id).or_default().push(item);
+    }
+    let ballots: Vec<(&Ranking, Vec<RankingItem>)> = eligible
+        .iter()
+        .map(|r| (r, items_by_ranking.remove(&r.id).unwrap_or_default()))
+        .collect();
+    let scores = scoring::aggregate(&ballots, scoring::NORM_LO, scoring::NORM_HI);
+    storage.replace_ranking_scores(block_id, &scores).await?;
+
     tracing::debug!(
         block_id = %block_id,
-        eligible_submissions = eligible.len(),
-        "ranking-indexer recompute: dedup + eligibility done (scoring/publish not yet wired)"
+        eligible_submissions = ballots.len(),
+        ranked_entities = scores.len(),
+        "ranking-indexer recompute: scored (publish not yet wired)"
     );
 
-    // 3. TODO(scoring): load each eligible submission's items, convert to
-    //    per-(entity, space) contributions with per-ballot normalization
-    //    (method pending Jagger), sum, sort, and upsert ranks.ranking_scores.
     // 4. TODO(publish): project RANK_POSITION relations (+ Aggregated rankings
-    //    provenance + the aggregate weight on the reified relation entity) into
-    //    public.relations, atomically replacing the prior projection. Gated on
-    //    the weight-property and atlas-inclusion decisions.
+    //    provenance + the integer rank-position value on the reified relation
+    //    entity) into public.relations, atomically replacing the prior
+    //    projection. Gated on Preston minting the rank-position-value property.
     //
-    // When scoring/publish land, steps 3–4 should run in a single transaction
-    // and the Kafka offset commit (in main) should follow that transaction.
+    // When publish lands, scoring + projection should run in one transaction and
+    // the Kafka offset commit (in main) should follow it.
 
     Ok(())
 }

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -106,3 +106,44 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
 
     Ok(())
 }
+
+/// Apply a detected edit end to end: upsert its rank ops into the working
+/// tables, then recompute every block it may have affected. Shared by the main
+/// consumer loop and integration tests.
+pub async fn apply_detected_edit(
+    detected: &DetectedEdit,
+    storage: &Storage,
+) -> Result<(), IndexerError> {
+    if detected.is_empty() {
+        return Ok(());
+    }
+
+    for block in &detected.blocks {
+        storage.upsert_ranking_block(block).await?;
+    }
+    for ranking in &detected.rankings {
+        storage.upsert_ranking(ranking).await?;
+    }
+
+    // Re-submission rebuilds a rank's items, so replace per ranking.
+    let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
+    for item in &detected.items {
+        items_by_ranking
+            .entry(item.ranking_id)
+            .or_default()
+            .push(item.clone());
+    }
+    for (ranking_id, items) in &items_by_ranking {
+        storage.replace_ranking_items(*ranking_id, items).await?;
+    }
+
+    for (ranking_id, block_id) in &detected.block_links {
+        storage.set_ranking_block(*ranking_id, *block_id).await?;
+    }
+
+    for block_id in affected_blocks(detected, storage).await? {
+        recompute_block(block_id, storage).await?;
+    }
+
+    Ok(())
+}

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -112,6 +112,7 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
 /// consumer loop and integration tests.
 pub async fn apply_detected_edit(
     detected: &DetectedEdit,
+    space_id: Uuid,
     storage: &Storage,
 ) -> Result<(), IndexerError> {
     if detected.is_empty() {
@@ -138,7 +139,9 @@ pub async fn apply_detected_edit(
     }
 
     for (ranking_id, block_id) in &detected.block_links {
-        storage.set_ranking_block(*ranking_id, *block_id).await?;
+        // The RANK_BLOCK relation is authored in the ranking's space, so the
+        // edit's `space_id` is the rank row's space.
+        storage.set_ranking_block(*ranking_id, *block_id, space_id).await?;
     }
 
     for block_id in affected_blocks(detected, storage).await? {

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -15,8 +15,8 @@ use crate::detect::DetectedEdit;
 use crate::eligibility::{filter_eligible, SpaceKind};
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingItem};
-use crate::{publish, scoring};
 use crate::storage::Storage;
+use crate::{publish, scoring};
 
 /// Block ids whose aggregate may have changed as a result of this edit:
 /// blocks whose own settings changed, blocks newly linked from a rank, and the
@@ -79,7 +79,10 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
     let items = storage.get_items_for_rankings(&eligible_ids).await?;
     let mut items_by_ranking: HashMap<Uuid, Vec<RankingItem>> = HashMap::new();
     for item in items {
-        items_by_ranking.entry(item.ranking_id).or_default().push(item);
+        items_by_ranking
+            .entry(item.ranking_id)
+            .or_default()
+            .push(item);
     }
     let ballots: Vec<(&Ranking, Vec<RankingItem>)> = eligible
         .iter()
@@ -141,7 +144,9 @@ pub async fn apply_detected_edit(
     for (ranking_id, block_id) in &detected.block_links {
         // The RANK_BLOCK relation is authored in the ranking's space, so the
         // edit's `space_id` is the rank row's space.
-        storage.set_ranking_block(*ranking_id, *block_id, space_id).await?;
+        storage
+            .set_ranking_block(*ranking_id, *block_id, space_id)
+            .await?;
     }
 
     for block_id in affected_blocks(detected, storage).await? {

--- a/ranking-indexer/src/scoring.rs
+++ b/ranking-indexer/src/scoring.rs
@@ -1,0 +1,271 @@
+//! Scoring: turn eligible submissions into a single ordered aggregate.
+//!
+//! Per the team's decisions:
+//!   - Each ballot's item values are normalized to `[NORM_LO, NORM_HI]` = `[0.5, 1.0]`
+//!     by default, so being ranked at all is positive signal (floor 0.5) and
+//!     position scales up to 1.0.
+//!   - WEIGHTED ballots: min-max normalize the provided weights into the range.
+//!   - ORDINAL ballots: linear map by position (best = 1.0, worst = 0.5).
+//!   - Mixing ordinal + weighted in one block is fine — both land in the same range.
+//!
+//! Normalized contributions are summed per `(entity, space)` across ballots,
+//! sorted descending (tie-broken deterministically), and assigned integer
+//! positions. The summed `score` stays continuous (`f64`) — the integer
+//! projection for publishing happens later.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use crate::models::{Ranking, RankingItem};
+
+/// Default normalization floor: a ranked item always carries positive signal.
+pub const NORM_LO: f64 = 0.5;
+/// Default normalization ceiling: the top of a ballot.
+pub const NORM_HI: f64 = 1.0;
+
+/// A computed aggregate row (mirrors `ranks.ranking_scores`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoreRow {
+    pub entity_id: Uuid,
+    pub space_id: Uuid,
+    pub score: f64,
+    /// 1-based rank within the block.
+    pub position: i32,
+}
+
+fn is_weighted(rank_type: Option<&str>) -> bool {
+    matches!(rank_type, Some(t) if t.eq_ignore_ascii_case("WEIGHTED"))
+}
+
+/// Normalize one ballot's items to `[lo, hi]`, returning `(entity, space) -> value`.
+pub fn normalize_ballot(
+    ranking: &Ranking,
+    items: &[RankingItem],
+    lo: f64,
+    hi: f64,
+) -> Vec<((Uuid, Uuid), f64)> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+    if is_weighted(ranking.rank_type.as_deref()) {
+        normalize_weighted(items, lo, hi)
+    } else {
+        normalize_ordinal(items, lo, hi)
+    }
+}
+
+/// WEIGHTED: min-max the provided weights into `[lo, hi]`. Items without a
+/// weight can't be scored on a weighted ballot and are skipped. A degenerate
+/// range (single item / all-equal) maps everything to `hi`.
+fn normalize_weighted(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uuid), f64)> {
+    let weighted: Vec<&RankingItem> = items.iter().filter(|i| i.weight.is_some()).collect();
+    if weighted.is_empty() {
+        return Vec::new();
+    }
+    let min = weighted.iter().map(|i| i.weight.unwrap()).fold(f64::INFINITY, f64::min);
+    let max = weighted
+        .iter()
+        .map(|i| i.weight.unwrap())
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    weighted
+        .iter()
+        .map(|i| {
+            let w = i.weight.unwrap();
+            let norm = if max > min {
+                lo + (hi - lo) * (w - min) / (max - min)
+            } else {
+                hi
+            };
+            ((i.entity_id, i.space_id), norm)
+        })
+        .collect()
+}
+
+/// ORDINAL: order items by fractional index (ascending = best-first) and map
+/// linearly into `[lo, hi]` (best = hi, worst = lo). A single item maps to `hi`.
+fn normalize_ordinal(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uuid), f64)> {
+    let mut ordered: Vec<&RankingItem> = items.iter().collect();
+    // Sort by fractional index; items missing a position sort last (deterministic).
+    ordered.sort_by(|a, b| (a.position.is_none(), &a.position).cmp(&(b.position.is_none(), &b.position)));
+
+    let n = ordered.len();
+    ordered
+        .iter()
+        .enumerate()
+        .map(|(rank, item)| {
+            let value = if n > 1 {
+                hi - (hi - lo) * (rank as f64) / ((n - 1) as f64)
+            } else {
+                hi
+            };
+            ((item.entity_id, item.space_id), value)
+        })
+        .collect()
+}
+
+/// Aggregate eligible ballots into the block's ordered result.
+pub fn aggregate(
+    ballots: &[(&Ranking, Vec<RankingItem>)],
+    lo: f64,
+    hi: f64,
+) -> Vec<ScoreRow> {
+    let mut totals: HashMap<(Uuid, Uuid), f64> = HashMap::new();
+    for (ranking, items) in ballots {
+        for (key, value) in normalize_ballot(ranking, items, lo, hi) {
+            *totals.entry(key).or_insert(0.0) += value;
+        }
+    }
+
+    let mut rows: Vec<((Uuid, Uuid), f64)> = totals.into_iter().collect();
+    // Descending score; deterministic tie-break by (entity, space).
+    rows.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.0 .0.cmp(&b.0 .0))
+            .then_with(|| a.0 .1.cmp(&b.0 .1))
+    });
+
+    rows.into_iter()
+        .enumerate()
+        .map(|(i, ((entity_id, space_id), score))| ScoreRow {
+            entity_id,
+            space_id,
+            score,
+            position: (i as i32) + 1,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ranking(id: u128, rank_type: &str) -> Ranking {
+        Ranking {
+            id: Uuid::from_u128(id),
+            block_id: Some(Uuid::from_u128(1)),
+            space_id: Uuid::from_u128(900),
+            author_address: None,
+            rank_type: Some(rank_type.to_string()),
+            submitted_at: None,
+            updated_at_block: 0,
+            update_index: 0,
+        }
+    }
+
+    fn item(entity: u128, position: Option<&str>, weight: Option<f64>) -> RankingItem {
+        RankingItem {
+            ranking_id: Uuid::from_u128(0),
+            entity_id: Uuid::from_u128(entity),
+            space_id: Uuid::from_u128(500),
+            position: position.map(|s| s.to_string()),
+            weight,
+        }
+    }
+
+    fn value_for(out: &[((Uuid, Uuid), f64)], entity: u128) -> f64 {
+        out.iter()
+            .find(|((e, _), _)| *e == Uuid::from_u128(entity))
+            .map(|(_, v)| *v)
+            .expect("entity present")
+    }
+
+    #[test]
+    fn ordinal_maps_linearly_into_floor_to_ceiling() {
+        let r = ranking(1, "ORDINAL");
+        let items = vec![
+            item(10, Some("a0"), None),
+            item(11, Some("a1"), None),
+            item(12, Some("a2"), None),
+        ];
+        let out = normalize_ballot(&r, &items, NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0);
+        assert_eq!(value_for(&out, 11), 0.75);
+        assert_eq!(value_for(&out, 12), 0.5);
+    }
+
+    #[test]
+    fn weighted_min_max_into_floor_to_ceiling() {
+        let r = ranking(1, "WEIGHTED");
+        let items = vec![
+            item(10, Some("a0"), Some(90.0)),
+            item(11, Some("a1"), Some(65.0)),
+            item(12, Some("a2"), Some(50.0)),
+        ];
+        let out = normalize_ballot(&r, &items, NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0); // max -> hi
+        assert_eq!(value_for(&out, 12), 0.5); // min -> lo
+        // 65 is 15/40 of the way: 0.5 + 0.5*0.375 = 0.6875
+        assert!((value_for(&out, 11) - 0.6875).abs() < 1e-9);
+    }
+
+    #[test]
+    fn single_item_maps_to_ceiling() {
+        let ord = ranking(1, "ORDINAL");
+        let out = normalize_ballot(&ord, &[item(10, Some("a0"), None)], NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0);
+
+        let wtd = ranking(2, "WEIGHTED");
+        let out = normalize_ballot(&wtd, &[item(10, Some("a0"), Some(7.0))], NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0);
+    }
+
+    #[test]
+    fn all_equal_weights_map_to_ceiling() {
+        let r = ranking(1, "WEIGHTED");
+        let items = vec![item(10, None, Some(3.0)), item(11, None, Some(3.0))];
+        let out = normalize_ballot(&r, &items, NORM_LO, NORM_HI);
+        assert_eq!(value_for(&out, 10), 1.0);
+        assert_eq!(value_for(&out, 11), 1.0);
+    }
+
+    #[test]
+    fn aggregate_sums_sorts_and_positions() {
+        // Two ordinal ballots agree A > B; a third ranks B first.
+        let r1 = ranking(1, "ORDINAL");
+        let b1 = vec![item(100, Some("a0"), None), item(200, Some("a1"), None)]; // A=1.0, B=0.5
+        let r2 = ranking(2, "ORDINAL");
+        let b2 = vec![item(100, Some("a0"), None), item(200, Some("a1"), None)]; // A=1.0, B=0.5
+        let r3 = ranking(3, "ORDINAL");
+        let b3 = vec![item(200, Some("a0"), None), item(100, Some("a1"), None)]; // B=1.0, A=0.5
+
+        let ballots = vec![(&r1, b1), (&r2, b2), (&r3, b3)];
+        let rows = aggregate(&ballots, NORM_LO, NORM_HI);
+
+        // A: 1.0 + 1.0 + 0.5 = 2.5 ; B: 0.5 + 0.5 + 1.0 = 2.0
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].entity_id, Uuid::from_u128(100));
+        assert_eq!(rows[0].position, 1);
+        assert!((rows[0].score - 2.5).abs() < 1e-9);
+        assert_eq!(rows[1].entity_id, Uuid::from_u128(200));
+        assert_eq!(rows[1].position, 2);
+        assert!((rows[1].score - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_keys_on_entity_and_space() {
+        // Same entity under two different space perspectives stays distinct.
+        let r = ranking(1, "ORDINAL");
+        let items = vec![
+            RankingItem {
+                ranking_id: Uuid::from_u128(1),
+                entity_id: Uuid::from_u128(100),
+                space_id: Uuid::from_u128(1),
+                position: Some("a0".into()),
+                weight: None,
+            },
+            RankingItem {
+                ranking_id: Uuid::from_u128(1),
+                entity_id: Uuid::from_u128(100),
+                space_id: Uuid::from_u128(2),
+                position: Some("a1".into()),
+                weight: None,
+            },
+        ];
+        let rows = aggregate(&[(&r, items)], NORM_LO, NORM_HI);
+        assert_eq!(rows.len(), 2); // two perspectives -> two rows
+    }
+}

--- a/ranking-indexer/src/scoring.rs
+++ b/ranking-indexer/src/scoring.rs
@@ -64,7 +64,10 @@ fn normalize_weighted(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uu
     if weighted.is_empty() {
         return Vec::new();
     }
-    let min = weighted.iter().map(|i| i.weight.unwrap()).fold(f64::INFINITY, f64::min);
+    let min = weighted
+        .iter()
+        .map(|i| i.weight.unwrap())
+        .fold(f64::INFINITY, f64::min);
     let max = weighted
         .iter()
         .map(|i| i.weight.unwrap())
@@ -89,7 +92,9 @@ fn normalize_weighted(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uu
 fn normalize_ordinal(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uuid), f64)> {
     let mut ordered: Vec<&RankingItem> = items.iter().collect();
     // Sort by fractional index; items missing a position sort last (deterministic).
-    ordered.sort_by(|a, b| (a.position.is_none(), &a.position).cmp(&(b.position.is_none(), &b.position)));
+    ordered.sort_by(|a, b| {
+        (a.position.is_none(), &a.position).cmp(&(b.position.is_none(), &b.position))
+    });
 
     let n = ordered.len();
     ordered
@@ -107,11 +112,7 @@ fn normalize_ordinal(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uui
 }
 
 /// Aggregate eligible ballots into the block's ordered result.
-pub fn aggregate(
-    ballots: &[(&Ranking, Vec<RankingItem>)],
-    lo: f64,
-    hi: f64,
-) -> Vec<ScoreRow> {
+pub fn aggregate(ballots: &[(&Ranking, Vec<RankingItem>)], lo: f64, hi: f64) -> Vec<ScoreRow> {
     let mut totals: HashMap<(Uuid, Uuid), f64> = HashMap::new();
     for (ranking, items) in ballots {
         for (key, value) in normalize_ballot(ranking, items, lo, hi) {
@@ -198,7 +199,7 @@ mod tests {
         let out = normalize_ballot(&r, &items, NORM_LO, NORM_HI);
         assert_eq!(value_for(&out, 10), 1.0); // max -> hi
         assert_eq!(value_for(&out, 12), 0.5); // min -> lo
-        // 65 is 15/40 of the way: 0.5 + 0.5*0.375 = 0.6875
+                                              // 65 is 15/40 of the way: 0.5 + 0.5*0.375 = 0.6875
         assert!((value_for(&out, 11) - 0.6875).abs() < 1e-9);
     }
 

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -1,0 +1,138 @@
+//! PostgreSQL persistence for the private `ranks` working schema.
+//!
+//! All writes are upserts keyed deterministically so reprocessing an edit
+//! converges on the same state (idempotency, design §10). Uses runtime
+//! `sqlx::query` (not the compile-time macro) so the crate builds without a
+//! live database.
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::error::IndexerError;
+use crate::models::{Ranking, RankingBlock, RankingItem};
+
+#[derive(Clone)]
+pub struct Storage {
+    pool: PgPool,
+}
+
+impl Storage {
+    pub async fn new(database_url: &str) -> Result<Self, IndexerError> {
+        let pool = PgPoolOptions::new()
+            .max_connections(10)
+            .connect(database_url)
+            .await?;
+        Ok(Self { pool })
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Upsert a Ranking Block.
+    pub async fn upsert_ranking_block(&self, b: &RankingBlock) -> Result<(), IndexerError> {
+        sqlx::query(
+            r#"
+            INSERT INTO ranks.ranking_blocks
+                (id, space_id, name, filter, start_date, end_date, restriction_id, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+            ON CONFLICT (id) DO UPDATE SET
+                space_id = EXCLUDED.space_id,
+                name = EXCLUDED.name,
+                filter = EXCLUDED.filter,
+                start_date = EXCLUDED.start_date,
+                end_date = EXCLUDED.end_date,
+                restriction_id = EXCLUDED.restriction_id,
+                updated_at = now()
+            "#,
+        )
+        .bind(b.id)
+        .bind(b.space_id)
+        .bind(&b.name)
+        .bind(&b.filter)
+        .bind(b.start_date)
+        .bind(b.end_date)
+        .bind(b.restriction_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Upsert a Rank submission. A null incoming `block_id` never clobbers an
+    /// already-known link (the link may have arrived in an earlier edit).
+    pub async fn upsert_ranking(&self, r: &Ranking) -> Result<(), IndexerError> {
+        sqlx::query(
+            r#"
+            INSERT INTO ranks.rankings
+                (id, block_id, space_id, author_address, rank_type, submitted_at,
+                 updated_at_block, update_index, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+            ON CONFLICT (id) DO UPDATE SET
+                block_id = COALESCE(EXCLUDED.block_id, ranks.rankings.block_id),
+                space_id = EXCLUDED.space_id,
+                author_address = EXCLUDED.author_address,
+                rank_type = EXCLUDED.rank_type,
+                submitted_at = EXCLUDED.submitted_at,
+                updated_at_block = EXCLUDED.updated_at_block,
+                update_index = EXCLUDED.update_index,
+                updated_at = now()
+            "#,
+        )
+        .bind(r.id)
+        .bind(r.block_id)
+        .bind(r.space_id)
+        .bind(&r.author_address)
+        .bind(&r.rank_type)
+        .bind(r.submitted_at)
+        .bind(r.updated_at_block)
+        .bind(r.update_index)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Set a rank's block link (the `RANK_BLOCK` relation may land in a later edit).
+    pub async fn set_ranking_block(
+        &self,
+        ranking_id: Uuid,
+        block_id: Uuid,
+    ) -> Result<(), IndexerError> {
+        sqlx::query("UPDATE ranks.rankings SET block_id = $2, updated_at = now() WHERE id = $1")
+            .bind(ranking_id)
+            .bind(block_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Replace a submission's items wholesale (re-submission rebuilds them).
+    pub async fn replace_ranking_items(
+        &self,
+        ranking_id: Uuid,
+        items: &[RankingItem],
+    ) -> Result<(), IndexerError> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+            .bind(ranking_id)
+            .execute(&mut *tx)
+            .await?;
+        for it in items {
+            sqlx::query(
+                r#"
+                INSERT INTO ranks.ranking_items (ranking_id, entity_id, space_id, position, weight)
+                VALUES ($1, $2, $3, $4, $5)
+                "#,
+            )
+            .bind(it.ranking_id)
+            .bind(it.entity_id)
+            .bind(it.space_id)
+            .bind(&it.position)
+            .bind(it.weight)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+}

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -91,16 +91,24 @@ impl Storage {
     }
 
     /// Set a rank's block link (the `RANK_BLOCK` relation may land in a later edit).
+    /// `ranks.rankings` is keyed on `(id, space_id)`, so the update is scoped to
+    /// the rank's space — a same-id rank perspectived into another space is left
+    /// untouched.
     pub async fn set_ranking_block(
         &self,
         ranking_id: Uuid,
         block_id: Uuid,
+        space_id: Uuid,
     ) -> Result<(), IndexerError> {
-        sqlx::query("UPDATE ranks.rankings SET block_id = $2, updated_at = now() WHERE id = $1")
-            .bind(ranking_id)
-            .bind(block_id)
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(
+            "UPDATE ranks.rankings SET block_id = $2, updated_at = now() \
+             WHERE id = $1 AND space_id = $3",
+        )
+        .bind(ranking_id)
+        .bind(block_id)
+        .bind(space_id)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -5,10 +5,13 @@
 //! `sqlx::query` (not the compile-time macro) so the crate builds without a
 //! live database.
 
+use std::collections::HashSet;
+
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use uuid::Uuid;
 
+use crate::eligibility::SpaceKind;
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingBlock, RankingItem};
 
@@ -28,6 +31,37 @@ impl Storage {
 
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    /// Resolve a space's kind from `public.spaces.type` (`DAO` / `Personal`).
+    /// Returns `None` if the space isn't known yet; callers treat unknown
+    /// conservatively (as `Dao`, i.e. membership-restricted).
+    pub async fn space_kind(&self, space_id: Uuid) -> Result<Option<SpaceKind>, IndexerError> {
+        let row: Option<(String,)> = sqlx::query_as("SELECT type::text FROM spaces WHERE id = $1")
+            .bind(space_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|(t,)| match t.as_str() {
+            "Personal" => SpaceKind::Personal,
+            _ => SpaceKind::Dao,
+        }))
+    }
+
+    /// The set of personal-space ids that are members OR editors of `space_id`
+    /// — the eligible voters for a DAO-space block.
+    pub async fn member_and_editor_spaces(
+        &self,
+        space_id: Uuid,
+    ) -> Result<HashSet<Uuid>, IndexerError> {
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT member_space_id FROM members WHERE space_id = $1
+             UNION
+             SELECT member_space_id FROM editors WHERE space_id = $1",
+        )
+        .bind(space_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
     /// Upsert a Ranking Block.

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::eligibility::SpaceKind;
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingBlock, RankingItem};
+use crate::publish::{provenance_ids, RankPositionRow};
 use crate::scoring::ScoreRow;
 
 #[derive(Clone)]
@@ -263,6 +264,100 @@ impl Storage {
             .execute(&mut *tx)
             .await?;
         }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Replace a block's public `RANK_POSITION` projection atomically:
+    /// the ordered relations (with the integer rank-position value on each
+    /// reified entity) and the `Aggregated rankings` provenance relations.
+    pub async fn replace_rank_position_projection(
+        &self,
+        block_id: Uuid,
+        block_space_id: Uuid,
+        rows: &[RankPositionRow],
+        contributing_rankings: &[Uuid],
+    ) -> Result<(), IndexerError> {
+        use sdk::core::ids::{
+            AGGREGATED_RANKINGS_RELATION_TYPE_ID, RANK_POSITION_RELATION_TYPE_ID,
+            RANK_POSITION_VALUE_PROPERTY_ID,
+        };
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+        let rank_position = pid(RANK_POSITION_RELATION_TYPE_ID);
+        let aggregated = pid(AGGREGATED_RANKINGS_RELATION_TYPE_ID);
+        let value_prop = pid(RANK_POSITION_VALUE_PROPERTY_ID);
+
+        let mut tx = self.pool.begin().await?;
+
+        // 1. Drop prior value rows on this block's reified RANK_POSITION entities
+        //    (before the relations they hang off are deleted).
+        sqlx::query(
+            "DELETE FROM values WHERE property_id = $1 AND entity_id IN \
+             (SELECT entity_id FROM relations WHERE type_id = $2 AND from_entity_id = $3)",
+        )
+        .bind(value_prop)
+        .bind(rank_position)
+        .bind(block_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // 2. Drop prior projection relations (RANK_POSITION + Aggregated rankings).
+        sqlx::query("DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2)")
+            .bind(block_id)
+            .bind(&[rank_position, aggregated][..])
+            .execute(&mut *tx)
+            .await?;
+
+        // 3. Insert the ordered RANK_POSITION relations + their value rows.
+        for r in rows {
+            sqlx::query(
+                "INSERT INTO relations \
+                 (id, entity_id, type_id, from_entity_id, to_entity_id, to_space_id, space_id, position) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            )
+            .bind(r.relation_id)
+            .bind(r.reified_entity_id)
+            .bind(rank_position)
+            .bind(block_id)
+            .bind(r.entity_id)
+            .bind(r.space_id)
+            .bind(block_space_id)
+            .bind(&r.position)
+            .execute(&mut *tx)
+            .await?;
+
+            // `values.id` is a text column — serialize the UUID at the bind boundary.
+            sqlx::query(
+                "INSERT INTO values (id, entity_id, space_id, property_id, integer) \
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(r.value_row_id.to_string())
+            .bind(r.reified_entity_id)
+            .bind(block_space_id)
+            .bind(value_prop)
+            .bind(r.value)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        // 4. Insert Aggregated rankings provenance relations (block -> submission).
+        for ranking_id in contributing_rankings {
+            let (relation_id, reified) = provenance_ids(block_id, *ranking_id);
+            sqlx::query(
+                "INSERT INTO relations \
+                 (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+                 VALUES ($1, $2, $3, $4, $5, $6)",
+            )
+            .bind(relation_id)
+            .bind(reified)
+            .bind(aggregated)
+            .bind(block_id)
+            .bind(ranking_id)
+            .bind(block_space_id)
+            .execute(&mut *tx)
+            .await?;
+        }
+
         tx.commit().await?;
         Ok(())
     }

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::eligibility::SpaceKind;
 use crate::error::IndexerError;
 use crate::models::{Ranking, RankingBlock, RankingItem};
+use crate::scoring::ScoreRow;
 
 #[derive(Clone)]
 pub struct Storage {
@@ -213,6 +214,52 @@ impl Storage {
             .bind(it.space_id)
             .bind(&it.position)
             .bind(it.weight)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Load the items of a set of rankings (the eligible submissions for a block).
+    pub async fn get_items_for_rankings(
+        &self,
+        ranking_ids: &[Uuid],
+    ) -> Result<Vec<RankingItem>, IndexerError> {
+        if ranking_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let rows = sqlx::query_as::<_, RankingItem>(
+            "SELECT ranking_id, entity_id, space_id, position, weight \
+             FROM ranks.ranking_items WHERE ranking_id = ANY($1)",
+        )
+        .bind(ranking_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Replace a block's computed aggregate wholesale (atomic full recompute).
+    pub async fn replace_ranking_scores(
+        &self,
+        block_id: Uuid,
+        rows: &[ScoreRow],
+    ) -> Result<(), IndexerError> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+            .bind(block_id)
+            .execute(&mut *tx)
+            .await?;
+        for r in rows {
+            sqlx::query(
+                "INSERT INTO ranks.ranking_scores (block_id, entity_id, space_id, score, position) \
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(block_id)
+            .bind(r.entity_id)
+            .bind(r.space_id)
+            .bind(r.score)
+            .bind(r.position)
             .execute(&mut *tx)
             .await?;
         }

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -64,6 +64,50 @@ impl Storage {
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
+    /// The block a rank is currently linked to (the link may have been set in an
+    /// earlier edit).
+    pub async fn block_id_for_ranking(
+        &self,
+        ranking_id: Uuid,
+    ) -> Result<Option<Uuid>, IndexerError> {
+        let row: Option<(Option<Uuid>,)> =
+            sqlx::query_as("SELECT block_id FROM ranks.rankings WHERE id = $1")
+                .bind(ranking_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.and_then(|(block_id,)| block_id))
+    }
+
+    /// Load a Ranking Block, if known.
+    pub async fn get_ranking_block(
+        &self,
+        block_id: Uuid,
+    ) -> Result<Option<RankingBlock>, IndexerError> {
+        let block = sqlx::query_as::<_, RankingBlock>(
+            "SELECT id, space_id, name, filter, start_date, end_date, restriction_id \
+             FROM ranks.ranking_blocks WHERE id = $1",
+        )
+        .bind(block_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(block)
+    }
+
+    /// Load all submissions currently linked to a block (pre-dedup).
+    pub async fn get_rankings_for_block(
+        &self,
+        block_id: Uuid,
+    ) -> Result<Vec<Ranking>, IndexerError> {
+        let rows = sqlx::query_as::<_, Ranking>(
+            "SELECT id, block_id, space_id, author_address, rank_type, submitted_at, \
+             updated_at_block, update_index FROM ranks.rankings WHERE block_id = $1",
+        )
+        .bind(block_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
     /// Upsert a Ranking Block.
     pub async fn upsert_ranking_block(&self, b: &RankingBlock) -> Result<(), IndexerError> {
         sqlx::query(

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -37,8 +37,7 @@ impl Storage {
             INSERT INTO ranks.ranking_blocks
                 (id, space_id, name, filter, start_date, end_date, restriction_id, updated_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, now())
-            ON CONFLICT (id) DO UPDATE SET
-                space_id = EXCLUDED.space_id,
+            ON CONFLICT (id, space_id) DO UPDATE SET
                 name = EXCLUDED.name,
                 filter = EXCLUDED.filter,
                 start_date = EXCLUDED.start_date,
@@ -68,9 +67,8 @@ impl Storage {
                 (id, block_id, space_id, author_address, rank_type, submitted_at,
                  updated_at_block, update_index, updated_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
-            ON CONFLICT (id) DO UPDATE SET
+            ON CONFLICT (id, space_id) DO UPDATE SET
                 block_id = COALESCE(EXCLUDED.block_id, ranks.rankings.block_id),
-                space_id = EXCLUDED.space_id,
                 author_address = EXCLUDED.author_address,
                 rank_type = EXCLUDED.rank_type,
                 submitted_at = EXCLUDED.submitted_at,

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -290,23 +290,30 @@ impl Storage {
         let mut tx = self.pool.begin().await?;
 
         // 1. Drop prior value rows on this block's reified RANK_POSITION entities
-        //    (before the relations they hang off are deleted).
+        //    (before the relations they hang off are deleted). Scoped to this
+        //    block's space so a same-id block perspectived into another space
+        //    keeps its own projection.
         sqlx::query(
-            "DELETE FROM values WHERE property_id = $1 AND entity_id IN \
-             (SELECT entity_id FROM relations WHERE type_id = $2 AND from_entity_id = $3)",
+            "DELETE FROM values WHERE property_id = $1 AND space_id = $4 AND entity_id IN \
+             (SELECT entity_id FROM relations \
+              WHERE type_id = $2 AND from_entity_id = $3 AND space_id = $4)",
         )
         .bind(value_prop)
         .bind(rank_position)
         .bind(block_id)
+        .bind(block_space_id)
         .execute(&mut *tx)
         .await?;
 
         // 2. Drop prior projection relations (RANK_POSITION + Aggregated rankings).
-        sqlx::query("DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2)")
-            .bind(block_id)
-            .bind(&[rank_position, aggregated][..])
-            .execute(&mut *tx)
-            .await?;
+        sqlx::query(
+            "DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2) AND space_id = $3",
+        )
+        .bind(block_id)
+        .bind(&[rank_position, aggregated][..])
+        .bind(block_space_id)
+        .execute(&mut *tx)
+        .await?;
 
         // 3. Insert the ordered RANK_POSITION relations + their value rows.
         for r in rows {

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -52,7 +52,11 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
         "DELETE FROM relations WHERE space_id = $1",
         "DELETE FROM values WHERE space_id = $1",
     ] {
-        sqlx::query(sql).bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
+        sqlx::query(sql)
+            .bind(u(BLOCK_SPACE))
+            .execute(pool)
+            .await
+            .unwrap();
     }
     sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = ANY($1)")
         .bind(&[u(RANK1), u(RANK2), u(RANK3)][..])
@@ -64,10 +68,26 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
         .execute(pool)
         .await
         .unwrap();
-    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1").bind(u(BLOCK)).execute(pool).await.unwrap();
-    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1").bind(u(BLOCK)).execute(pool).await.unwrap();
-    sqlx::query("DELETE FROM members WHERE space_id = $1").bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
-    sqlx::query("DELETE FROM spaces WHERE id = $1").bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM members WHERE space_id = $1")
+        .bind(u(BLOCK_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id = $1")
+        .bind(u(BLOCK_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
 
     // --- seed public prerequisites -----------------------------------------
     // The block lives in a DAO space; member1/member2 are members, nonmember isn't.
@@ -99,11 +119,17 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
                 .from(gid(BLOCK))
                 .to(sid(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID))
         })
-        .create_entity(gid(BLOCK), |e| e.text(sid(NAME_PROPERTY_ID), "Top Films", None))
+        .create_entity(gid(BLOCK), |e| {
+            e.text(sid(NAME_PROPERTY_ID), "Top Films", None)
+        })
         .build();
-    apply_detected_edit(&detect(&block_edit, u(BLOCK_SPACE), 1, 0), u(BLOCK_SPACE), &storage)
-        .await
-        .unwrap();
+    apply_detected_edit(
+        &detect(&block_edit, u(BLOCK_SPACE), 1, 0),
+        u(BLOCK_SPACE),
+        &storage,
+    )
+    .await
+    .unwrap();
 
     // --- ordinal submission helper (rank -> [first, second]) ----------------
     // Two members rank A above B; the non-member ranks B above A.
@@ -115,7 +141,9 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
                     .from(gid(rank))
                     .to(sid(RANK_TYPE_ID))
             })
-            .create_entity(gid(rank), |e| e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None))
+            .create_entity(gid(rank), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+            })
             .create_relation(|r| {
                 r.id(gid(rel_base + 1))
                     .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
@@ -141,19 +169,38 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
             .build()
     };
 
-    apply_detected_edit(&detect(&submit(RANK1, 0x200, ENTITY_A, ENTITY_B), u(MEMBER1), 2, 0), u(MEMBER1), &storage)
-        .await
-        .unwrap();
-    apply_detected_edit(&detect(&submit(RANK2, 0x210, ENTITY_A, ENTITY_B), u(MEMBER2), 3, 0), u(MEMBER2), &storage)
-        .await
-        .unwrap();
+    apply_detected_edit(
+        &detect(&submit(RANK1, 0x200, ENTITY_A, ENTITY_B), u(MEMBER1), 2, 0),
+        u(MEMBER1),
+        &storage,
+    )
+    .await
+    .unwrap();
+    apply_detected_edit(
+        &detect(&submit(RANK2, 0x210, ENTITY_A, ENTITY_B), u(MEMBER2), 3, 0),
+        u(MEMBER2),
+        &storage,
+    )
+    .await
+    .unwrap();
     // non-member ranks B above A — must be filtered out
-    apply_detected_edit(&detect(&submit(RANK3, 0x220, ENTITY_B, ENTITY_A), u(NONMEMBER), 4, 0), u(NONMEMBER), &storage)
-        .await
-        .unwrap();
+    apply_detected_edit(
+        &detect(
+            &submit(RANK3, 0x220, ENTITY_B, ENTITY_A),
+            u(NONMEMBER),
+            4,
+            0,
+        ),
+        u(NONMEMBER),
+        &storage,
+    )
+    .await
+    .unwrap();
 
     // --- assert the published RANK_POSITION projection ----------------------
-    let rank_position = u(Uuid::parse_str(RANK_POSITION_RELATION_TYPE_ID).unwrap().as_u128());
+    let rank_position = u(Uuid::parse_str(RANK_POSITION_RELATION_TYPE_ID)
+        .unwrap()
+        .as_u128());
     let value_prop = Uuid::parse_str(RANK_POSITION_VALUE_PROPERTY_ID).unwrap();
 
     let rows = sqlx::query(
@@ -178,7 +225,11 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
     let s0: Uuid = rows[0].get("space");
     assert_eq!(e0, u(ENTITY_A), "top-ranked entity should be A");
     assert_eq!(v0, 100, "top entity scaled to 100");
-    assert_eq!(s0, u(BLOCK_SPACE), "ranked perspective carried on to_space_id");
+    assert_eq!(
+        s0,
+        u(BLOCK_SPACE),
+        "ranked perspective carried on to_space_id"
+    );
 
     let e1: Uuid = rows[1].get("entity");
     let v1: i64 = rows[1].get("value");
@@ -195,5 +246,8 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
     .fetch_one(pool)
     .await
     .unwrap();
-    assert_eq!(prov, 2, "non-member submission must be excluded from provenance");
+    assert_eq!(
+        prov, 2,
+        "non-member submission must be excluded from provenance"
+    );
 }

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -1,0 +1,199 @@
+//! End-to-end integration test for the full ranking-indexer pipeline.
+//!
+//! Runs real edits through `detect -> apply_detected_edit` (upsert -> dedup ->
+//! eligibility -> scoring -> publish) against a live Postgres and asserts the
+//! public `RANK_POSITION` projection. Requires a DB with the public schema + the
+//! private `ranks` schema. Opt-in: set `RANKING_INDEXER_E2E_DATABASE_URL` to the
+//! connection string. Skips (passes) if unset, so it never runs on a generic
+//! CI `DATABASE_URL` that lacks the `ranks` schema.
+
+use grc_20::model::builder::EditBuilder;
+use sdk::core::ids::*;
+use sqlx::Row;
+use uuid::Uuid;
+
+use ranking_indexer::detect::detect;
+use ranking_indexer::recompute::apply_detected_edit;
+use ranking_indexer::storage::Storage;
+
+fn gid(n: u128) -> [u8; 16] {
+    *Uuid::from_u128(n).as_bytes()
+}
+fn sid(s: &str) -> [u8; 16] {
+    *Uuid::parse_str(s).unwrap().as_bytes()
+}
+fn u(n: u128) -> Uuid {
+    Uuid::from_u128(n)
+}
+
+// Scenario UUIDs (high values, unlikely to collide with real data).
+const BLOCK_SPACE: u128 = 0xE2E5_0000_0001;
+const MEMBER1: u128 = 0xE2E5_0000_0011;
+const MEMBER2: u128 = 0xE2E5_0000_0012;
+const NONMEMBER: u128 = 0xE2E5_0000_0013;
+const BLOCK: u128 = 0xE2E5_0000_0021;
+const ENTITY_A: u128 = 0xE2E5_0000_0031;
+const ENTITY_B: u128 = 0xE2E5_0000_0032;
+const RANK1: u128 = 0xE2E5_0000_0041;
+const RANK2: u128 = 0xE2E5_0000_0042;
+const RANK3: u128 = 0xE2E5_0000_0043;
+
+#[tokio::test]
+async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+    ] {
+        sqlx::query(sql).bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = ANY($1)")
+        .bind(&[u(RANK1), u(RANK2), u(RANK3)][..])
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = ANY($1)")
+        .bind(&[u(RANK1), u(RANK2), u(RANK3)][..])
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1").bind(u(BLOCK)).execute(pool).await.unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1").bind(u(BLOCK)).execute(pool).await.unwrap();
+    sqlx::query("DELETE FROM members WHERE space_id = $1").bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id = $1").bind(u(BLOCK_SPACE)).execute(pool).await.unwrap();
+
+    // --- seed public prerequisites -----------------------------------------
+    // The block lives in a DAO space; member1/member2 are members, nonmember isn't.
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e')")
+        .bind(u(BLOCK_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    for m in [MEMBER1, MEMBER2] {
+        sqlx::query("INSERT INTO members (member_space_id, space_id) VALUES ($1, $2)")
+            .bind(u(m))
+            .bind(u(BLOCK_SPACE))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    // --- edit 1: create the ranking block ----------------------------------
+    let block_edit = EditBuilder::new(gid(1))
+        .create_relation(|r| {
+            r.id(gid(0x100))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(BLOCK))
+                .to(sid(RANKING_BLOCK_TYPE_ID))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x101))
+                .relation_type(sid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+                .from(gid(BLOCK))
+                .to(sid(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID))
+        })
+        .create_entity(gid(BLOCK), |e| e.text(sid(NAME_PROPERTY_ID), "Top Films", None))
+        .build();
+    apply_detected_edit(&detect(&block_edit, u(BLOCK_SPACE), 1, 0), &storage)
+        .await
+        .unwrap();
+
+    // --- ordinal submission helper (rank -> [first, second]) ----------------
+    // Two members rank A above B; the non-member ranks B above A.
+    let submit = |rank: u128, rel_base: u128, first: u128, second: u128| {
+        EditBuilder::new(gid(rank ^ 0xED17))
+            .create_relation(|r| {
+                r.id(gid(rel_base))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(sid(RANK_TYPE_ID))
+            })
+            .create_entity(gid(rank), |e| e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None))
+            .create_relation(|r| {
+                r.id(gid(rel_base + 1))
+                    .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(BLOCK))
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 2))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(first))
+                    .to_space(gid(BLOCK_SPACE))
+                    .position("a0")
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 3))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(second))
+                    .to_space(gid(BLOCK_SPACE))
+                    .position("a1")
+            })
+            .build()
+    };
+
+    apply_detected_edit(&detect(&submit(RANK1, 0x200, ENTITY_A, ENTITY_B), u(MEMBER1), 2, 0), &storage)
+        .await
+        .unwrap();
+    apply_detected_edit(&detect(&submit(RANK2, 0x210, ENTITY_A, ENTITY_B), u(MEMBER2), 3, 0), &storage)
+        .await
+        .unwrap();
+    // non-member ranks B above A — must be filtered out
+    apply_detected_edit(&detect(&submit(RANK3, 0x220, ENTITY_B, ENTITY_A), u(NONMEMBER), 4, 0), &storage)
+        .await
+        .unwrap();
+
+    // --- assert the published RANK_POSITION projection ----------------------
+    let rank_position = u(Uuid::parse_str(RANK_POSITION_RELATION_TYPE_ID).unwrap().as_u128());
+    let value_prop = Uuid::parse_str(RANK_POSITION_VALUE_PROPERTY_ID).unwrap();
+
+    let rows = sqlx::query(
+        "SELECT r.to_entity_id AS entity, r.to_space_id AS space, v.integer AS value, r.position AS position \
+         FROM relations r \
+         JOIN values v ON v.entity_id = r.entity_id AND v.property_id = $3 \
+         WHERE r.from_entity_id = $1 AND r.type_id = $2 \
+         ORDER BY r.position",
+    )
+    .bind(u(BLOCK))
+    .bind(rank_position)
+    .bind(value_prop)
+    .fetch_all(pool)
+    .await
+    .unwrap();
+
+    // Only members counted (both ranked A>B), so A is #1 and B is #2.
+    assert_eq!(rows.len(), 2, "expected two ranked entities");
+
+    let e0: Uuid = rows[0].get("entity");
+    let v0: i64 = rows[0].get("value");
+    let s0: Uuid = rows[0].get("space");
+    assert_eq!(e0, u(ENTITY_A), "top-ranked entity should be A");
+    assert_eq!(v0, 100, "top entity scaled to 100");
+    assert_eq!(s0, u(BLOCK_SPACE), "ranked perspective carried on to_space_id");
+
+    let e1: Uuid = rows[1].get("entity");
+    let v1: i64 = rows[1].get("value");
+    assert_eq!(e1, u(ENTITY_B), "second entity should be B");
+    assert_eq!(v1, 50, "B is half of A (1.0 vs 2.0 summed)");
+
+    // provenance: one Aggregated rankings relation per *eligible* submission (2).
+    let aggregated = Uuid::parse_str(AGGREGATED_RANKINGS_RELATION_TYPE_ID).unwrap();
+    let prov: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM relations WHERE from_entity_id = $1 AND type_id = $2",
+    )
+    .bind(u(BLOCK))
+    .bind(aggregated)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(prov, 2, "non-member submission must be excluded from provenance");
+}

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -101,7 +101,7 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
         })
         .create_entity(gid(BLOCK), |e| e.text(sid(NAME_PROPERTY_ID), "Top Films", None))
         .build();
-    apply_detected_edit(&detect(&block_edit, u(BLOCK_SPACE), 1, 0), &storage)
+    apply_detected_edit(&detect(&block_edit, u(BLOCK_SPACE), 1, 0), u(BLOCK_SPACE), &storage)
         .await
         .unwrap();
 
@@ -141,14 +141,14 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
             .build()
     };
 
-    apply_detected_edit(&detect(&submit(RANK1, 0x200, ENTITY_A, ENTITY_B), u(MEMBER1), 2, 0), &storage)
+    apply_detected_edit(&detect(&submit(RANK1, 0x200, ENTITY_A, ENTITY_B), u(MEMBER1), 2, 0), u(MEMBER1), &storage)
         .await
         .unwrap();
-    apply_detected_edit(&detect(&submit(RANK2, 0x210, ENTITY_A, ENTITY_B), u(MEMBER2), 3, 0), &storage)
+    apply_detected_edit(&detect(&submit(RANK2, 0x210, ENTITY_A, ENTITY_B), u(MEMBER2), 3, 0), u(MEMBER2), &storage)
         .await
         .unwrap();
     // non-member ranks B above A — must be filtered out
-    apply_detected_edit(&detect(&submit(RANK3, 0x220, ENTITY_B, ENTITY_A), u(NONMEMBER), 4, 0), &storage)
+    apply_detected_edit(&detect(&submit(RANK3, 0x220, ENTITY_B, ENTITY_A), u(NONMEMBER), 4, 0), u(NONMEMBER), &storage)
         .await
         .unwrap();
 

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -64,6 +64,12 @@ pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011
 pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
 pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
 pub const RANK_FILTER_PROPERTY_ID: &str = "14a46854-bfd1-4b18-8215-2785c2dab9f3";
+// The 8th ranking-block property in the canonical ontology: a Relation -> a
+// "Data source" entity describing how the block sources its candidate set
+// (query vs collection). V1 aggregation works off the submitted Rank entities
+// and the Filter string, so the indexer does not read this yet; defined for
+// completeness so the full block ontology is pinned in one place.
+pub const RANK_DATA_SOURCE_TYPE_PROPERTY_ID: &str = "1f69cc98-80d4-44ab-ad49-3df6a7b15ee4";
 
 // Indexer-owned ranking output IDs. System-minted (not SDK shapes), assigned as
 // a random v4 like SCORE_PROPERTY_ID. `RANK_POSITION` is the relation type the

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -43,10 +43,9 @@ pub const SCORE_PROPERTY_ID: &str = "85a4668a-42fa-4f48-8969-c0a9de0c294b";
 // (`@graphprotocol/grc-20` core/ids/system) — these are the user-authored
 // shapes the ranking-indexer detects on the `knowledge.edits` stream.
 //
-// NOTE: the indexer-owned output relation type (`RANK_POSITION`) is
-// intentionally NOT defined here yet — it is not part of the SDK and needs a
-// canonical system-ID assignment before it can be added to
-// `PROTECTED_RELATION_TYPE_IDS`.
+// The indexer-owned output IDs (`RANK_POSITION` etc.) are defined below: they
+// are system-minted (not SDK shapes), assigned as a random v4 like
+// `SCORE_PROPERTY_ID` rather than derived.
 pub const RANK_TYPE_ID: &str = "5c74731d-fabb-4dc8-b5c5-3346521c639a";
 pub const RANK_TYPE_PROPERTY_ID: &str = "48e01bc8-324e-48c2-a6c9-cab3f49290c6";
 pub const RANK_VOTES_RELATION_TYPE_ID: &str = "19a4cfff-45f2-4150-abf2-af0f43eb2eec";
@@ -64,6 +63,16 @@ pub const RANK_START_DATE_PROPERTY_ID: &str = "eed03a04-0acd-4a9e-81e0-8272ed70a
 pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011c";
 pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
 pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
+
+// Indexer-owned ranking output IDs. System-minted (not SDK shapes), assigned as
+// a random v4 like SCORE_PROPERTY_ID. `RANK_POSITION` is the relation type the
+// ranking-indexer publishes per ranked target — no user edit may author it, so
+// it is reserved in `PROTECTED_RELATION_TYPE_IDS` below.
+pub const RANK_POSITION_RELATION_TYPE_ID: &str = "890deffb-3843-49fa-8269-74000e3dcef6";
+// Aggregated-rankings property — canonical id captured, but its exact role in
+// the (still-gated) publish stage vs the RANK_POSITION relation is pending
+// confirmation, so it is intentionally NOT yet added to PROTECTED_PROPERTY_IDS.
+pub const AGGREGATED_RANKINGS_PROPERTY_ID: &str = "67651da6-11a9-4246-9ff4-039aafbe9e43";
 
 /// Onchain-derived ID of the "root" space whose editors are authorized to
 /// publish edits that mutate the system property-definition entities — i.e.
@@ -89,7 +98,8 @@ pub const PROTECTED_PROPERTY_IDS: &[&str] = &[
     SCORE_PROPERTY_ID,
 ];
 
-pub const PROTECTED_RELATION_TYPE_IDS: &[&str] = &[SYSTEM_TYPES_RELATION_TYPE_ID];
+pub const PROTECTED_RELATION_TYPE_IDS: &[&str] =
+    &[SYSTEM_TYPES_RELATION_TYPE_ID, RANK_POSITION_RELATION_TYPE_ID];
 
 #[cfg(test)]
 mod tests {
@@ -170,7 +180,8 @@ mod tests {
 
     #[test]
     fn protected_relation_type_ids_contains_system_types() {
-        assert_eq!(PROTECTED_RELATION_TYPE_IDS.len(), 1);
+        assert_eq!(PROTECTED_RELATION_TYPE_IDS.len(), 2);
         assert!(PROTECTED_RELATION_TYPE_IDS.contains(&SYSTEM_TYPES_RELATION_TYPE_ID));
+        assert!(PROTECTED_RELATION_TYPE_IDS.contains(&RANK_POSITION_RELATION_TYPE_ID));
     }
 }

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -63,6 +63,7 @@ pub const RANK_START_DATE_PROPERTY_ID: &str = "eed03a04-0acd-4a9e-81e0-8272ed70a
 pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011c";
 pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
 pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
+pub const RANK_FILTER_PROPERTY_ID: &str = "14a46854-bfd1-4b18-8215-2785c2dab9f3";
 
 // Indexer-owned ranking output IDs. System-minted (not SDK shapes), assigned as
 // a random v4 like SCORE_PROPERTY_ID. `RANK_POSITION` is the relation type the

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -74,6 +74,10 @@ pub const RANK_POSITION_RELATION_TYPE_ID: &str = "890deffb-3843-49fa-8269-74000e
 // aggregated to produce its ordering (provenance). Reserved below so user edits
 // can't forge it.
 pub const AGGREGATED_RANKINGS_RELATION_TYPE_ID: &str = "67651da6-11a9-4246-9ff4-039aafbe9e43";
+// `Rank position value` is the indexer-owned integer property carrying an
+// entity's aggregated score within a ranking block (surfaced on the published
+// RANK_POSITION relation's reified entity). Reserved in PROTECTED_PROPERTY_IDS.
+pub const RANK_POSITION_VALUE_PROPERTY_ID: &str = "e1ffac9f-beb4-4654-8a50-00e1d6c662fb";
 
 /// Onchain-derived ID of the "root" space whose editors are authorized to
 /// publish edits that mutate the system property-definition entities — i.e.
@@ -97,6 +101,7 @@ pub const PROTECTED_PROPERTY_IDS: &[&str] = &[
     SPACE_ID_PROPERTY_ID,
     CREATED_AT_BLOCK_PROPERTY_ID,
     SCORE_PROPERTY_ID,
+    RANK_POSITION_VALUE_PROPERTY_ID,
 ];
 
 pub const PROTECTED_RELATION_TYPE_IDS: &[&str] = &[
@@ -171,6 +176,7 @@ mod tests {
             SPACE_ID_PROPERTY_ID,
             CREATED_AT_BLOCK_PROPERTY_ID,
             SCORE_PROPERTY_ID,
+            RANK_POSITION_VALUE_PROPERTY_ID,
         ];
         assert_eq!(PROTECTED_PROPERTY_IDS.len(), expected.len());
         for id in &expected {

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -39,6 +39,32 @@ pub const SPACE_ID_PROPERTY_ID: &str = "712adc1f-e950-5d14-bbd8-bf2166fe59c1";
 pub const CREATED_AT_BLOCK_PROPERTY_ID: &str = "da2952fb-17d6-53f3-b521-52e254106e0b";
 pub const SCORE_PROPERTY_ID: &str = "85a4668a-42fa-4f48-8969-c0a9de0c294b";
 
+// Rank submission IDs. Canonical values mirrored from the grc-20 SDK
+// (`@graphprotocol/grc-20` core/ids/system) — these are the user-authored
+// shapes the ranking-indexer detects on the `knowledge.edits` stream.
+//
+// NOTE: the indexer-owned output relation type (`RANK_POSITION`) is
+// intentionally NOT defined here yet — it is not part of the SDK and needs a
+// canonical system-ID assignment before it can be added to
+// `PROTECTED_RELATION_TYPE_IDS`.
+pub const RANK_TYPE_ID: &str = "5c74731d-fabb-4dc8-b5c5-3346521c639a";
+pub const RANK_TYPE_PROPERTY_ID: &str = "48e01bc8-324e-48c2-a6c9-cab3f49290c6";
+pub const RANK_VOTES_RELATION_TYPE_ID: &str = "19a4cfff-45f2-4150-abf2-af0f43eb2eec";
+pub const VOTE_ORDINAL_VALUE_PROPERTY_ID: &str = "49ee1b89-1820-4e75-a1ae-38a2dcaad4a5";
+pub const VOTE_WEIGHTED_VALUE_PROPERTY_ID: &str = "103701dd-cabe-4a8e-835b-10345327b647";
+
+// Ranking-block IDs. PROVISIONAL — sourced from geo-sdk#89
+// (feat/ranks-create-update), which is not yet merged; pin to the released
+// values once it lands. These are the user-authored ranking-block shapes the
+// indexer detects (block type, rank→block link, submission window, and the
+// aggregation restriction with its default "Members and editors" value).
+pub const RANKING_BLOCK_TYPE_ID: &str = "150db6de-fe23-44f0-805a-fa57502e2c32";
+pub const RANK_BLOCK_RELATION_TYPE_ID: &str = "09c219c1-03d1-4d2a-a5c7-8edbf2d0182a";
+pub const RANK_START_DATE_PROPERTY_ID: &str = "eed03a04-0acd-4a9e-81e0-8272ed70a817";
+pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011c";
+pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
+pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
+
 /// Onchain-derived ID of the "root" space whose editors are authorized to
 /// publish edits that mutate the system property-definition entities — i.e.
 /// relations whose `from` or `to` is in `PROTECTED_PROPERTY_IDS`. Edits from

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -69,10 +69,11 @@ pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-80
 // ranking-indexer publishes per ranked target — no user edit may author it, so
 // it is reserved in `PROTECTED_RELATION_TYPE_IDS` below.
 pub const RANK_POSITION_RELATION_TYPE_ID: &str = "890deffb-3843-49fa-8269-74000e3dcef6";
-// Aggregated-rankings property — canonical id captured, but its exact role in
-// the (still-gated) publish stage vs the RANK_POSITION relation is pending
-// confirmation, so it is intentionally NOT yet added to PROTECTED_PROPERTY_IDS.
-pub const AGGREGATED_RANKINGS_PROPERTY_ID: &str = "67651da6-11a9-4246-9ff4-039aafbe9e43";
+// `Aggregated rankings` is an indexer-owned relation type: from a published
+// RANK_POSITION result back to the individual Rank submissions that were
+// aggregated to produce its ordering (provenance). Reserved below so user edits
+// can't forge it.
+pub const AGGREGATED_RANKINGS_RELATION_TYPE_ID: &str = "67651da6-11a9-4246-9ff4-039aafbe9e43";
 
 /// Onchain-derived ID of the "root" space whose editors are authorized to
 /// publish edits that mutate the system property-definition entities — i.e.
@@ -98,8 +99,11 @@ pub const PROTECTED_PROPERTY_IDS: &[&str] = &[
     SCORE_PROPERTY_ID,
 ];
 
-pub const PROTECTED_RELATION_TYPE_IDS: &[&str] =
-    &[SYSTEM_TYPES_RELATION_TYPE_ID, RANK_POSITION_RELATION_TYPE_ID];
+pub const PROTECTED_RELATION_TYPE_IDS: &[&str] = &[
+    SYSTEM_TYPES_RELATION_TYPE_ID,
+    RANK_POSITION_RELATION_TYPE_ID,
+    AGGREGATED_RANKINGS_RELATION_TYPE_ID,
+];
 
 #[cfg(test)]
 mod tests {
@@ -180,8 +184,9 @@ mod tests {
 
     #[test]
     fn protected_relation_type_ids_contains_system_types() {
-        assert_eq!(PROTECTED_RELATION_TYPE_IDS.len(), 2);
+        assert_eq!(PROTECTED_RELATION_TYPE_IDS.len(), 3);
         assert!(PROTECTED_RELATION_TYPE_IDS.contains(&SYSTEM_TYPES_RELATION_TYPE_ID));
         assert!(PROTECTED_RELATION_TYPE_IDS.contains(&RANK_POSITION_RELATION_TYPE_ID));
+        assert!(PROTECTED_RELATION_TYPE_IDS.contains(&AGGREGATED_RANKINGS_RELATION_TYPE_ID));
     }
 }


### PR DESCRIPTION
Integration branch consolidating the full ranking-indexer feature for a single merge into `dev`, per Jagger's suggestion — instead of landing the stacked chain PR-by-PR.

## What's folded in (6 PRs)
The linear stack and the schema branch, merged into one branch off `dev`:

- #724 — `feat(sdk)`: rank + ranking-block system IDs
- #725 — `feat(api)`: private `ranks` schema
- #726 — `feat(ranking-indexer)`: scaffold the rank-aggregation consumer
- #727 — `feat(ranking-indexer)`: eligibility + recompute orchestration
- #728 — `feat(ranking-indexer)`: publish stage (RANK_POSITION projection)
- #729 — `feat(ranking-indexer)`: containerize + k8s deploy + CI workflows

Because #724→#726→#727→#728→#729 are a linear stack, this was two merges: the `feat/ranking-indexer-deploy` tip (covers the whole chain) plus `feat/ranks-schema` (#725). Both merged cleanly, no conflicts.

## Scope (vs `dev`)
30 files: `ranking-indexer/` (crate + Dockerfile + k8s + 3 CI workflows), the `api/` drizzle `ranks` schema migration, `sdk/ids.rs`, and `Cargo.{toml,lock}`. No unrelated changes — the standalone scoring PRs (#715–#719) are intentionally **not** included; they merge to `main` on their own.

## Note
The feature branches were originally based on `main` (1 commit ahead of `dev`), so merging here also brings `dev` up to that commit. Once this lands, the six stacked PRs above can be closed.