### PR TITLE
fix(api): handle POINT/RECT values in versioned proposal diff

### DIFF
--- a/api/src/versioned/__tests__/proposal-diff-point-value.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-point-value.test.ts
@@ -37,7 +37,10 @@ describe("propertyValueToVersionedValue — point/rect", () => {
 	})
 
 	it("includes altitude when present: 'lat,lon,alt'", () => {
-		const result = propertyValueToVersionedValue(pv({type: "point", lat: 37.7749, lon: -122.4194, alt: 10.5}), spaceId)
+		const result = propertyValueToVersionedValue(
+			pv({type: "point", lat: 37.7749, lon: -122.4194, alt: 10.5}),
+			spaceId,
+		)
 
 		expect(result.point).toBe("37.7749,-122.4194,10.5")
 	})

--- a/api/src/versioned/__tests__/proposal-diff-point-value.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-point-value.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression test for the versioned proposal-diff point/rect value handling.
+ *
+ * Bug: `/versioned/proposals/:id/diff` returned 500 for any edit containing a
+ * POINT value. `propertyValueToVersionedValue` read the coordinates from
+ * `value.value`, but GRC-20 decodes point/rect with their fields at the *top
+ * level* of the value ({type: "point", lat, lon, alt?}). `value.value` was
+ * therefore `undefined`, and accessing `.alt` on it threw a TypeError that
+ * surfaced as a 500.
+ *
+ * These are pure-function unit tests — no database required, so they always run
+ * (unlike the DB-gated proposal-diff-edit-flow integration suite, whose
+ * "all value types" fixture covered text/bool/int/float but not point).
+ */
+
+import type {PropertyValue} from "@geoprotocol/grc-20"
+import {describe, expect, it} from "vitest"
+import {propertyValueToVersionedValue} from "../proposal-diff"
+import {normalizeUuid} from "../../utils/uuid"
+
+const spaceId = normalizeUuid("20000000-0001-4000-8000-000000000001")
+const propertyId = "20000000-0004-4000-8000-000000000050"
+
+// `pv` is typed against the real SDK `PropertyValue`, so if a future grc-20
+// version moves point coords back under `value.value` the test stops compiling.
+function pv(value: PropertyValue["value"]): {property: any; value: PropertyValue["value"]} {
+	return {property: propertyId as any, value}
+}
+
+describe("propertyValueToVersionedValue — point/rect", () => {
+	it("does not throw and serializes a point value as 'lat,lon'", () => {
+		const result = propertyValueToVersionedValue(pv({type: "point", lat: 37.7749, lon: -122.4194}), spaceId)
+
+		// Matches the indexer's stored format (kg-indexer handlers/edits.rs):
+		// "lat,lon", so before/after compare equal instead of showing a spurious diff.
+		expect(result.point).toBe("37.7749,-122.4194")
+	})
+
+	it("includes altitude when present: 'lat,lon,alt'", () => {
+		const result = propertyValueToVersionedValue(pv({type: "point", lat: 37.7749, lon: -122.4194, alt: 10.5}), spaceId)
+
+		expect(result.point).toBe("37.7749,-122.4194,10.5")
+	})
+
+	it("does not throw and serializes a rect value as 'minLat,minLon,maxLat,maxLon'", () => {
+		const result = propertyValueToVersionedValue(
+			pv({type: "rect", minLat: 1, minLon: 2, maxLat: 3, maxLon: 4}),
+			spaceId,
+		)
+
+		expect(result.rect).toBe("1,2,3,4")
+	})
+})

--- a/api/src/versioned/__tests__/proposal-diff-point-value.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-point-value.test.ts
@@ -15,8 +15,8 @@
 
 import type {PropertyValue} from "@geoprotocol/grc-20"
 import {describe, expect, it} from "vitest"
-import {propertyValueToVersionedValue} from "../proposal-diff"
 import {normalizeUuid} from "../../utils/uuid"
+import {propertyValueToVersionedValue} from "../proposal-diff"
 
 const spaceId = normalizeUuid("20000000-0001-4000-8000-000000000001")
 const propertyId = "20000000-0004-4000-8000-000000000050"

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -618,7 +618,10 @@ function extractAffectedEntities(db: Database, ops: Op[]): Effect.Effect<Normali
  * GRC-20 v2 decoded values have the format: {type: "text", value: "..."}
  * We need to convert this to our VersionedValue format.
  */
-export function propertyValueToVersionedValue(pv: {property: Id; value: unknown}, spaceId: NormalizedUuid): VersionedValue {
+export function propertyValueToVersionedValue(
+	pv: {property: Id; value: unknown},
+	spaceId: NormalizedUuid,
+): VersionedValue {
 	const propertyId = idToUuid(pv.property)
 	const value = pv.value as {type: string; value: unknown}
 

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -618,7 +618,7 @@ function extractAffectedEntities(db: Database, ops: Op[]): Effect.Effect<Normali
  * GRC-20 v2 decoded values have the format: {type: "text", value: "..."}
  * We need to convert this to our VersionedValue format.
  */
-function propertyValueToVersionedValue(pv: {property: Id; value: unknown}, spaceId: NormalizedUuid): VersionedValue {
+export function propertyValueToVersionedValue(pv: {property: Id; value: unknown}, spaceId: NormalizedUuid): VersionedValue {
 	const propertyId = idToUuid(pv.property)
 	const value = pv.value as {type: string; value: unknown}
 
@@ -677,13 +677,20 @@ function propertyValueToVersionedValue(pv: {property: Id; value: unknown}, space
 			result.schedule = value.value
 			break
 		case "point": {
-			const pt = value.value as {lon: number; lat: number; alt?: number}
+			// GRC-20 decodes point coordinates at the top level of the value
+			// ({type: "point", lat, lon, alt?}), NOT nested under `value.value`.
+			// Reading `value.value` yielded `undefined` and threw on `.alt`,
+			// 500-ing the diff endpoint for any edit containing a point value.
+			// Serialize as "lat,lon[,alt]" to match the indexer's stored format.
+			const pt = value as unknown as {lon: number; lat: number; alt?: number}
 			result.point = pt.alt !== undefined ? `${pt.lat},${pt.lon},${pt.alt}` : `${pt.lat},${pt.lon}`
 			break
 		}
 		case "rect": {
-			const rect = value.value as {minLon: number; minLat: number; maxLon: number; maxLat: number}
-			result.rect = `${rect.minLon},${rect.minLat},${rect.maxLon},${rect.maxLat}`
+			// Same top-level shape as point ({type: "rect", minLat, minLon, ...}).
+			// Serialize as "minLat,minLon,maxLat,maxLon" to match the indexer.
+			const rect = value as unknown as {minLon: number; minLat: number; maxLon: number; maxLat: number}
+			result.rect = `${rect.minLat},${rect.minLon},${rect.maxLat},${rect.maxLon}`
 			break
 		}
 		case "embedding":


### PR DESCRIPTION
## Problem

`/versioned/proposals/{id}/diff` returns **500** whenever the edit contains a **point** value.

Example: https://www.geobrowser.io/space/84a679ce188f061ac9a92380bac2bab5/governance?proposalId=1e801da239414969824685e650421ec3

## Root cause

In `api/src/versioned/proposal-diff.ts`, `propertyValueToVersionedValue` read point/rect coordinates from `value.value`:

```ts
const pt = value.value as {lon, lat, alt?}
result.point = pt.alt !== undefined ? ... : ...   // TypeError: Cannot read properties of undefined (reading 'alt')
```

But GRC-20 (`@geoprotocol/grc-20`) decodes point/rect with their fields at the **top level** of the value — `{type: "point", lat, lon, alt?}`, not nested under `value.value`. So `value.value` was `undefined`, and accessing `.alt` threw a `TypeError` that surfaced as a 500. The adjacent `decimal` case already reads top-level fields correctly; `point`/`rect` were just never updated to the decoded shape.

`rect` had the same latent crash **plus** a wrong field order (it emitted `lon,lat` while the indexer stores `lat,lon`), so it's fixed too.

## Fix

Read coordinates from the top level and serialize to match the indexer's stored format (`kg-indexer/src/handlers/edits.rs`): `"lat,lon[,alt]"` for point, `"minLat,minLon,maxLat,maxLon"` for rect. This keeps before/after comparisons equal instead of showing a spurious diff.

## Test

Adds `api/src/versioned/__tests__/proposal-diff-point-value.test.ts` — a fast, DB-free unit test covering point (with/without altitude) and rect.

- With the buggy `value.value` read restored → fails with `TypeError: Cannot read properties of undefined (reading 'alt')` (the 500).
- With the fix → passes. Typecheck clean.

The existing DB-gated `proposal-diff-edit-flow` integration suite only exercised text/bool/int/float, which is why this slipped through.

## Notes

- Scoped to the bug only — **no SDK bump**. Installed `@geoprotocol/grc-20@0.3.0`; 0.4.x has the same point/lat/lon shape (so a bump wouldn't fix this) but renames the value tags (`bool→boolean`, `int64→integer`, `float64→float`), which would need separate switch updates. That's deliberately out of scope here.