### PR TITLE
chore(search-indexer): canary staging pull secret regcred → geo

### DIFF
--- a/search-indexer-deploy/k8s/staging/search-indexer.yaml
+++ b/search-indexer-deploy/k8s/staging/search-indexer.yaml
@@ -45,7 +45,10 @@ spec:
         environment: staging
     spec:
       imagePullSecrets:
-        - name: regcred
+        # Canary: pull via the DigitalOcean-managed DOCR↔DOKS integration secret
+        # (`geo`, maintained by the DOSecret operator) instead of the manually
+        # stamped, per-person `regcred`. Validates the migration off `regcred`.
+        - name: geo
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## What

Switches **only** the `search-indexer` **staging** StatefulSet (`search-staging` namespace) to pull images via the DigitalOcean-managed `geo` secret instead of the manually-stamped `regcred`.

```diff
       imagePullSecrets:
-        - name: regcred
+        - name: geo
```

## Why

`regcred` is stamped with individual people's DO personal access tokens (`dop_v1_…`), which expire — this is what caused the recent `proposal-executor` `ImagePullBackOff` outage. The `geo` secret is DigitalOcean's managed DOCR↔DOKS integration credential (`digitalocean.com/dosecret-identifier: geo`, maintained by the DOSecret operator, org-level `doo_v1_` OAuth token), present in every namespace and not tied to any person.

This is an isolated **canary** for migrating the fleet off `regcred`.

## Why this is a sound test

- **Isolated blast radius:** staging only, one StatefulSet, one namespace. If `geo` wiring is wrong, only `search-indexer-staging` goes `ImagePullBackOff`; revert is a one-line change.
- **Actually exercises the credential:** the container is `imagePullPolicy: Always`, so the rollout forces a fresh registry pull/auth — a success genuinely proves `geo` works, not a cached image.
- **`geo` is the sole credential:** we *replace* `regcred` rather than add `geo`, so a successful pull can only be attributed to `geo`.
- **Pre-validated:** `geo` already returns `200` against the DOCR auth endpoint and is already used to pull by other workloads (geo-analytics, kafka-ui, api-cache, and DO's own kube-system pods).

## How to verify after merge

Staging deploys on push to `dev` (path `search-indexer-deploy/k8s/staging/**`). After merge:

```bash
kubectl rollout status statefulset/search-indexer -n search-staging --timeout=120s
kubectl get pod search-indexer-0 -n search-staging -o jsonpath='{.spec.imagePullSecrets}'   # -> [{"name":"geo"}]
kubectl describe pod search-indexer-0 -n search-staging | grep -A1 -i "pulled\|failed"        # -> "Successfully pulled"
```

## Rollback

Revert this commit (flip `geo` back to `regcred`) and redeploy.

## Note / scope

This validates the **wiring** only. It does not change production or any other service. If the canary is healthy, the follow-up is to migrate the remaining `regcred`-only workloads (knowledge stack, scoring, api, notifications, search prod) — ideally by attaching `geo` to the ServiceAccount they run under, then retiring `regcred`.