### PR TITLE
chore(search-indexer): production pull secret regcred → geo

### DIFF
--- a/search-indexer-deploy/k8s/production/search-indexer.yaml
+++ b/search-indexer-deploy/k8s/production/search-indexer.yaml
@@ -42,7 +42,10 @@ spec:
         app: search-indexer
     spec:
       imagePullSecrets:
-        - name: regcred
+        # Pull via the DigitalOcean-managed DOCR↔DOKS integration secret
+        # (`geo`, maintained by the DOSecret operator) instead of the manually
+        # stamped, per-person `regcred`. Validated on staging first (PR #732).
+        - name: geo
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## What

Switches the `search-indexer` **production** StatefulSet (`search` namespace) to pull images via the DigitalOcean-managed `geo` secret instead of `regcred`.

```diff
       imagePullSecrets:
-        - name: regcred
+        - name: geo
```

## Why

`regcred` is stamped with individual people's DO personal access tokens (`dop_v1_…`) that expire — the cause of the recent `proposal-executor` `ImagePullBackOff` outage. `geo` is DigitalOcean's managed DOCR↔DOKS integration credential (`digitalocean.com/dosecret-identifier: geo`, maintained by the DOSecret operator, org-level `doo_v1_` OAuth token), present in every namespace and not tied to any person.

## Validated on staging first

PR #732 made the identical change to **staging**. Result: the staging pod rolled (`search-indexer-0`, fresh) and **`Successfully pulled image … in 2.391s` via `geo`** — no 401, no `ImagePullBackOff`. Because the container is `imagePullPolicy: Always` and `geo` was the *sole* credential, the success is fully attributable to `geo`.

## Why this is safe

- Single workload; `imagePullPolicy: Always` so the rollout does a real registry pull/auth.
- `geo` is already proven: returns `200` against the DOCR auth endpoint and already pulls for many other workloads (incl. DO's own kube-system pods) — and now the search-indexer staging instance.
- Rollback is a one-line revert to `regcred`.

## Verify after merge

Production deploys on push to `main` (path `search-indexer-deploy/k8s/production/**`).

```bash
kubectl rollout status statefulset/search-indexer -n search --timeout=180s
kubectl get pod search-indexer-0 -n search -o jsonpath='{.spec.imagePullSecrets}'   # -> [{"name":"geo"}]
kubectl describe pod search-indexer-0 -n search | grep -iA1 "pulled\|failed"          # -> "Successfully pulled"
```

## Scope

Production search-indexer only. Follow-up (separate PRs) would migrate the remaining `regcred`-only workloads — `knowledge` stack, `scoring`, `api`, `notifications` — then retire `regcred`.