### PR TITLE
chore(k8s): switch all workloads (staging + prod) from regcred → geo pull secret

### DIFF
--- a/api/k8s/production/api.yaml
+++ b/api/k8s/production/api.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/api/k8s/staging/api.yaml
+++ b/api/k8s/staging/api.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/chain-tip-exporter/k8s/production/chain-tip-exporter.yaml
+++ b/chain-tip-exporter/k8s/production/chain-tip-exporter.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: chain-tip-exporter
           image: registry.digitalocean.com/geo/chain-tip-exporter:latest

--- a/chain-tip-exporter/k8s/staging/chain-tip-exporter.yaml
+++ b/chain-tip-exporter/k8s/staging/chain-tip-exporter.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: chain-tip-exporter
           image: registry.digitalocean.com/geo/chain-tip-exporter:latest

--- a/hermes-ipfs-cache/k8s/production/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/production/hermes-ipfs-cache.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/hermes-ipfs-cache/k8s/staging/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/staging/hermes-ipfs-cache.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/hermes/k8s/production/atlas.yaml
+++ b/hermes/k8s/production/atlas.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       restartPolicy: Always
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: atlas
           image: registry.digitalocean.com/geo/atlas:latest

--- a/hermes/k8s/production/hermes-pipeline.yaml
+++ b/hermes/k8s/production/hermes-pipeline.yaml
@@ -21,7 +21,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/hermes/k8s/staging/atlas.yaml
+++ b/hermes/k8s/staging/atlas.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       restartPolicy: Always
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: atlas
           image: registry.digitalocean.com/geo/atlas:latest

--- a/hermes/k8s/staging/hermes-pipeline.yaml
+++ b/hermes/k8s/staging/hermes-pipeline.yaml
@@ -23,7 +23,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/kg-indexer/k8s/production/kg-indexer.yaml
+++ b/kg-indexer/k8s/production/kg-indexer.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/kg-indexer/k8s/staging/kg-indexer.yaml
+++ b/kg-indexer/k8s/staging/kg-indexer.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/notification-service/deployment/production/delivery-worker.yaml
+++ b/notification-service/deployment/production/delivery-worker.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: delivery-worker
           image: registry.digitalocean.com/geo/delivery-worker:latest

--- a/notification-service/deployment/production/notification-indexer.yaml
+++ b/notification-service/deployment/production/notification-indexer.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: notification-indexer
           image: registry.digitalocean.com/geo/notification-indexer:latest

--- a/notification-service/deployment/staging/delivery-worker.yaml
+++ b/notification-service/deployment/staging/delivery-worker.yaml
@@ -27,7 +27,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: delivery-worker
           image: registry.digitalocean.com/geo/delivery-worker:latest

--- a/notification-service/deployment/staging/notification-indexer.yaml
+++ b/notification-service/deployment/staging/notification-indexer.yaml
@@ -27,7 +27,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: notification-indexer
           image: registry.digitalocean.com/geo/notification-indexer:latest

--- a/proposal-executor/deployment/production/cronjob.yaml
+++ b/proposal-executor/deployment/production/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1001
           imagePullSecrets:
-            - name: regcred
+            - name: geo
           volumes:
             - name: ssl-certs
               emptyDir: {}

--- a/proposal-executor/deployment/staging/cronjob.yaml
+++ b/proposal-executor/deployment/staging/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1001
           imagePullSecrets:
-            - name: regcred
+            - name: geo
           volumes:
             - name: ssl-certs
               emptyDir: {}

--- a/ranking-indexer/k8s/production/ranking-indexer.yaml
+++ b/ranking-indexer/k8s/production/ranking-indexer.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/ranking-indexer/k8s/staging/ranking-indexer.yaml
+++ b/ranking-indexer/k8s/staging/ranking-indexer.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       volumes:
         - name: ssl-certs
           emptyDir: {}

--- a/scoring-service/deployment/production/cronjob.yaml
+++ b/scoring-service/deployment/production/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           restartPolicy: OnFailure
           imagePullSecrets:
-            - name: regcred
+            - name: geo
           containers:
             - name: scoring-service
               image: registry.digitalocean.com/geo/scoring-service:latest

--- a/scoring-service/deployment/production/topology-indexer.yaml
+++ b/scoring-service/deployment/production/topology-indexer.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: topology-indexer
           image: registry.digitalocean.com/geo/topology-indexer:latest

--- a/scoring-service/deployment/production/vote-indexer.yaml
+++ b/scoring-service/deployment/production/vote-indexer.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: vote-indexer
           image: registry.digitalocean.com/geo/vote-indexer:latest

--- a/scoring-service/deployment/staging/cronjob.yaml
+++ b/scoring-service/deployment/staging/cronjob.yaml
@@ -17,7 +17,7 @@ spec:
         spec:
           restartPolicy: OnFailure
           imagePullSecrets:
-            - name: regcred
+            - name: geo
           containers:
             - name: scoring-service
               image: registry.digitalocean.com/geo/scoring-service:latest

--- a/scoring-service/deployment/staging/topology-indexer.yaml
+++ b/scoring-service/deployment/staging/topology-indexer.yaml
@@ -27,7 +27,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: topology-indexer
           image: registry.digitalocean.com/geo/topology-indexer:latest

--- a/scoring-service/deployment/staging/vote-indexer.yaml
+++ b/scoring-service/deployment/staging/vote-indexer.yaml
@@ -27,7 +27,7 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       containers:
         - name: vote-indexer
           image: registry.digitalocean.com/geo/vote-indexer:latest

--- a/search-indexer-deploy/k8s/production/jobs/backfill-name-raw-job.yaml
+++ b/search-indexer-deploy/k8s/production/jobs/backfill-name-raw-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: production
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/production/jobs/create-index-job.yaml
+++ b/search-indexer-deploy/k8s/production/jobs/create-index-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: production
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/production/jobs/delete-index-job.yaml
+++ b/search-indexer-deploy/k8s/production/jobs/delete-index-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: production
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/production/jobs/full-migration-job.yaml
+++ b/search-indexer-deploy/k8s/production/jobs/full-migration-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: production
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       # Use ServiceAccount with permissions to manage deployments
       serviceAccountName: search-admin
       restartPolicy: Never

--- a/search-indexer-deploy/k8s/production/jobs/list-indices-job.yaml
+++ b/search-indexer-deploy/k8s/production/jobs/list-indices-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: production
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/production/jobs/reindex-job.yaml
+++ b/search-indexer-deploy/k8s/production/jobs/reindex-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: production
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/production/jobs/update-alias-job.yaml
+++ b/search-indexer-deploy/k8s/production/jobs/update-alias-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: production
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/production/search-indexer.yaml
+++ b/search-indexer-deploy/k8s/production/search-indexer.yaml
@@ -42,7 +42,7 @@ spec:
         app: search-indexer
     spec:
       imagePullSecrets:
-        - name: regcred
+        - name: geo
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/search-indexer-deploy/k8s/staging/jobs/backfill-name-raw-job.yaml
+++ b/search-indexer-deploy/k8s/staging/jobs/backfill-name-raw-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: staging
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/staging/jobs/create-index-job.yaml
+++ b/search-indexer-deploy/k8s/staging/jobs/create-index-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: staging
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/staging/jobs/delete-index-job.yaml
+++ b/search-indexer-deploy/k8s/staging/jobs/delete-index-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: staging
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/staging/jobs/full-migration-job.yaml
+++ b/search-indexer-deploy/k8s/staging/jobs/full-migration-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: staging
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       # Use ServiceAccount with permissions to manage deployments
       serviceAccountName: search-admin
       restartPolicy: Never

--- a/search-indexer-deploy/k8s/staging/jobs/list-indices-job.yaml
+++ b/search-indexer-deploy/k8s/staging/jobs/list-indices-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: staging
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/staging/jobs/reindex-job.yaml
+++ b/search-indexer-deploy/k8s/staging/jobs/reindex-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: staging
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/search-indexer-deploy/k8s/staging/jobs/update-alias-job.yaml
+++ b/search-indexer-deploy/k8s/staging/jobs/update-alias-job.yaml
@@ -19,7 +19,7 @@ spec:
         environment: staging
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: geo
       restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## What

Migrates **every** Kubernetes manifest — **staging and production** — off the manually-stamped, per-person `regcred` image pull secret onto the DigitalOcean-managed `geo` secret. One-line change per file (`imagePullSecrets: regcred → geo`), **39 files**, no `regcred` reference left anywhere in the repo.

## Why

`regcred` is stamped with individual people's DO personal access tokens (`dop_v1_…`) that expire — the root cause of the recent `proposal-executor` `ImagePullBackOff` outage. `geo` is DigitalOcean's managed DOCR↔DOKS integration credential (`digitalocean.com/dosecret-identifier: geo`, maintained by the DOSecret operator, org-level `doo_v1_` OAuth token), injected into every namespace and **not tied to any person**.

## "Where it makes sense" — verified

`geo` only carries auth for `registry.digitalocean.com`. I confirmed **every** affected manifest pulls exclusively from `registry.digitalocean.com/geo` (no Docker Hub / ghcr / other registries), so `geo` is a valid pull secret in all 39 cases — no manifest was left on `regcred`.

## Already validated end-to-end

Identical change proven on `search-indexer`:
- **staging** #732 → pod rolled, `Successfully pulled image … via geo in 2.4s`, no 401
- **production** #733 → pod rolled, pulled via `geo` in 1.1s, `1/1 Running`

`geo` is also already the pull secret for many other workloads (geo-analytics, kafka-ui, api-cache, DO's own kube-system pods).

## Scope (services × envs)

| Service | Staging | Production |
|---|---|---|
| api | ✅ | ✅ |
| chain-tip-exporter | ✅ | ✅ |
| hermes-ipfs-cache | ✅ | ✅ |
| hermes (atlas + pipeline) | ✅ | ✅ |
| kg-indexer | ✅ | ✅ |
| notifications (delivery-worker + indexer) | ✅ | ✅ |
| proposal-executor | ✅ | ✅ |
| scoring (cronjob + topology + vote) | ✅ | ✅ |
| search-indexer (deployment + 7 jobs) | ✅* | ✅ |

\* search-indexer staging main manifest already migrated in #732; its staging jobs are included here.

## ⚠️ Deploy behavior — note for the merger

This PR targets `dev`. On merge, the **staging** deploy workflows fire (push-to-`dev`, path-filtered) and roll the staging workloads onto `geo`.

The **production** manifest changes ride on `dev` until the next `dev → main` promotion, at which point the production deploy workflows fire and migrate prod. So **production migrates when `dev` is promoted to `main`, not on this merge.** (search-indexer prod was already migrated directly via #733; re-applying `geo` there is a no-op.) If you'd prefer production to go via its own dedicated `main` PR instead of riding the promotion, say so and I'll split it back out.

All target workloads use `imagePullPolicy: Always`, so every rollout does a real registry pull/auth against `geo`.

## Rollback

Revert the commit (flips `geo` back to `regcred`) and redeploy. Per-service blast radius is one workload per env.