### PR TITLE
fix(ranking-indexer): recover unregistered blocks from the KG (#738)

### DIFF
--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -54,9 +54,23 @@ pub async fn affected_blocks(
 
 /// Recompute a single block's aggregate end to end.
 pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), IndexerError> {
-    let Some(block) = storage.get_ranking_block(block_id).await? else {
-        // A rank may link to a block we haven't indexed yet; nothing to do.
-        return Ok(());
+    let block = match storage.get_ranking_block(block_id).await? {
+        Some(block) => block,
+        None => {
+            // The block's `TYPES -> Ranking Block` relation and its config can
+            // arrive in separate edits, so detect() never registered it and the
+            // rank would be silently never scored (issue #738). Recover the
+            // block from the indexed graph and register it. If the entity isn't
+            // a Ranking Block there (e.g. a rank linking to a not-yet-indexed
+            // block), there is genuinely nothing to recompute yet.
+            match storage.get_block_config_from_kg(block_id).await? {
+                Some(block) => {
+                    storage.upsert_ranking_block(&block).await?;
+                    block
+                }
+                None => return Ok(()),
+            }
+        }
     };
 
     // 1. Dedup: keep the latest submission per (block, personal space).

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashSet;
 
+use chrono::{DateTime, Utc};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -93,6 +94,84 @@ impl Storage {
         .fetch_optional(&self.pool)
         .await?;
         Ok(block)
+    }
+
+    /// Reconstruct a Ranking Block's config from the indexed public graph.
+    ///
+    /// `detect()` only registers a block when its `TYPES -> Ranking Block`
+    /// relation and its config (Name/Filter/dates/restriction) arrive in the
+    /// *same* edit, because it resolves an entity's types from the current edit
+    /// alone. Real clients emit the type and the config across separate edits,
+    /// so the block is never registered and every rank linked to it is silently
+    /// never scored (issue #738). When a rank links to a block we never
+    /// registered, recover it from the graph here. Returns `None` if the entity
+    /// is not (yet) typed as a Ranking Block in `public.relations`.
+    pub async fn get_block_config_from_kg(
+        &self,
+        block_id: Uuid,
+    ) -> Result<Option<RankingBlock>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+
+        // Must be typed as a Ranking Block in the graph; the type relation also
+        // tells us the block's home space.
+        let typed: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT space_id FROM relations \
+             WHERE from_entity_id = $1 AND type_id = $2 AND to_entity_id = $3 \
+             LIMIT 1",
+        )
+        .bind(block_id)
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANKING_BLOCK_TYPE_ID))
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some((space_id,)) = typed else {
+            return Ok(None);
+        };
+
+        // Config properties: Name/Filter as text, Start/End as datetime. One row
+        // is always returned (aggregates over zero matching values yield NULLs).
+        type ConfigRow = (
+            Option<String>,
+            Option<String>,
+            Option<DateTime<Utc>>,
+            Option<DateTime<Utc>>,
+        );
+        let (name, filter, start_date, end_date): ConfigRow = sqlx::query_as(
+            "SELECT \
+               max(text)         FILTER (WHERE property_id = $2) AS name, \
+               max(text)         FILTER (WHERE property_id = $3) AS filter, \
+               max(datetime_utc) FILTER (WHERE property_id = $4) AS start_date, \
+               max(datetime_utc) FILTER (WHERE property_id = $5) AS end_date \
+             FROM values WHERE entity_id = $1",
+        )
+        .bind(block_id)
+        .bind(pid(ids::NAME_PROPERTY_ID))
+        .bind(pid(ids::RANK_FILTER_PROPERTY_ID))
+        .bind(pid(ids::RANK_START_DATE_PROPERTY_ID))
+        .bind(pid(ids::RANK_END_DATE_PROPERTY_ID))
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Aggregation restriction is a relation (as detect() collects it).
+        let restriction: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT to_entity_id FROM relations \
+             WHERE from_entity_id = $1 AND type_id = $2 LIMIT 1",
+        )
+        .bind(block_id)
+        .bind(pid(ids::RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(Some(RankingBlock {
+            id: block_id,
+            space_id,
+            name,
+            filter,
+            start_date,
+            end_date,
+            restriction_id: restriction.map(|(r,)| r),
+        }))
     }
 
     /// Load all submissions currently linked to a block (pre-dedup).

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -137,29 +137,34 @@ impl Storage {
             Option<DateTime<Utc>>,
             Option<DateTime<Utc>>,
         );
+        // Scope to the block's home space: the same entity may be perspectived
+        // into other spaces with different config, keyed on (id, space_id).
         let (name, filter, start_date, end_date): ConfigRow = sqlx::query_as(
             "SELECT \
                max(text)         FILTER (WHERE property_id = $2) AS name, \
                max(text)         FILTER (WHERE property_id = $3) AS filter, \
                max(datetime_utc) FILTER (WHERE property_id = $4) AS start_date, \
                max(datetime_utc) FILTER (WHERE property_id = $5) AS end_date \
-             FROM values WHERE entity_id = $1",
+             FROM values WHERE entity_id = $1 AND space_id = $6",
         )
         .bind(block_id)
         .bind(pid(ids::NAME_PROPERTY_ID))
         .bind(pid(ids::RANK_FILTER_PROPERTY_ID))
         .bind(pid(ids::RANK_START_DATE_PROPERTY_ID))
         .bind(pid(ids::RANK_END_DATE_PROPERTY_ID))
+        .bind(space_id)
         .fetch_one(&self.pool)
         .await?;
 
-        // Aggregation restriction is a relation (as detect() collects it).
+        // Aggregation restriction is a relation (as detect() collects it),
+        // likewise scoped to the block's home space.
         let restriction: Option<(Uuid,)> = sqlx::query_as(
             "SELECT to_entity_id FROM relations \
-             WHERE from_entity_id = $1 AND type_id = $2 LIMIT 1",
+             WHERE from_entity_id = $1 AND type_id = $2 AND space_id = $3 LIMIT 1",
         )
         .bind(block_id)
         .bind(pid(ids::RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+        .bind(space_id)
         .fetch_optional(&self.pool)
         .await?;
 

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -251,3 +251,185 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
         "non-member submission must be excluded from provenance"
     );
 }
+
+/// Regression for #738: a block whose `TYPES -> Ranking Block` relation and its
+/// config arrive in *separate* edits is never registered by `detect()` (which
+/// resolves types from the current edit alone), so its rankings were silently
+/// never scored. `recompute_block()` must recover the block from the indexed
+/// graph and score it once a rank links to it.
+#[tokio::test]
+async fn cross_edit_block_is_recovered_from_kg_and_scored() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    // Distinct scenario ids so this can share a DB with the other e2e test.
+    const SPACE: u128 = 0xE2E5_0000_2001;
+    const MEMBER: u128 = 0xE2E5_0000_2011;
+    const BLOCK: u128 = 0xE2E5_0000_2021;
+    const TYPE_REL: u128 = 0xE2E5_0000_2022;
+    const NAME_VAL: u128 = 0xE2E5_0000_2023;
+    const ENT_A: u128 = 0xE2E5_0000_2031;
+    const ENT_B: u128 = 0xE2E5_0000_2032;
+    const RANK: u128 = 0xE2E5_0000_2041;
+
+    let su = |s: &str| Uuid::parse_str(s).unwrap();
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+    ] {
+        sqlx::query(sql).bind(u(SPACE)).execute(pool).await.unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM members WHERE space_id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed public prerequisites -----------------------------------------
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e2')")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO members (member_space_id, space_id) VALUES ($1, $2)")
+        .bind(u(MEMBER))
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // Seed the KG as kg-indexer would: the block's `TYPES -> Ranking Block`
+    // relation and its Name, but WITHOUT registering it in `ranks` — i.e. the
+    // exact state where detect() never saw the type and config in one edit.
+    sqlx::query(
+        "INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(u(TYPE_REL).to_string())
+    .bind(u(TYPE_REL))
+    .bind(su(TYPE_RELATION_TYPE_ID))
+    .bind(u(BLOCK))
+    .bind(su(RANKING_BLOCK_TYPE_ID))
+    .bind(u(SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, text) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(NAME_VAL).to_string())
+    .bind(u(BLOCK))
+    .bind(u(SPACE))
+    .bind(su(NAME_PROPERTY_ID))
+    .bind("Recovered Block")
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Precondition: the block is NOT registered in the ranks schema.
+    assert!(
+        storage.get_ranking_block(u(BLOCK)).await.unwrap().is_none(),
+        "precondition: block must be unregistered before the rank arrives"
+    );
+
+    // --- a member submits a rank linked to the (unregistered) block --------
+    let rank_edit = EditBuilder::new(gid(RANK ^ 0xED17))
+        .create_relation(|r| {
+            r.id(gid(0x300))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(sid(RANK_TYPE_ID))
+        })
+        .create_entity(gid(RANK), |e| {
+            e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+        })
+        .create_relation(|r| {
+            r.id(gid(0x301))
+                .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(BLOCK))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x302))
+                .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(ENT_A))
+                .to_space(gid(SPACE))
+                .position("a0")
+        })
+        .create_relation(|r| {
+            r.id(gid(0x303))
+                .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(ENT_B))
+                .to_space(gid(SPACE))
+                .position("a1")
+        })
+        .build();
+    apply_detected_edit(&detect(&rank_edit, u(MEMBER), 2, 0), u(MEMBER), &storage)
+        .await
+        .unwrap();
+
+    // --- the block is recovered from the KG, registered, and scored --------
+    let registered: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM ranks.ranking_blocks WHERE id = $1")
+            .bind(u(BLOCK))
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(registered, 1, "block must be recovered from the KG");
+
+    let name: Option<String> =
+        sqlx::query_scalar("SELECT name FROM ranks.ranking_blocks WHERE id = $1")
+            .bind(u(BLOCK))
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        name.as_deref(),
+        Some("Recovered Block"),
+        "recovered block carries its KG name/config"
+    );
+
+    let scores: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM ranks.ranking_scores WHERE block_id = $1")
+            .bind(u(BLOCK))
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        scores, 2,
+        "both ranked entities scored once the block is recovered"
+    );
+}


### PR DESCRIPTION
Draft fix for #738. Targets `main` because the ranking-indexer only exists on `main` right now (#730 was merged there, not `dev`) — **please retarget if you'd rather land it via `dev`.**

## Problem
`detect()` resolves an entity's types from the **current edit alone**, so a Ranking Block is only registered when its `TYPES → Ranking Block` relation and its config (Name/Filter/dates/restriction) arrive in the **same edit**. Real clients emit them across separate edits, so blocks were never registered — and `recompute_block()` short-circuits on a missing block, so every linked rank was **silently never scored**. In prod this was total: **0 blocks registered, 0 scores published** across 3 blocks / 18 rankings.

## Fix
When a rank links to a block that isn't in `ranks.ranking_blocks`, recover the block's config from the **indexed public graph** (`Storage::get_block_config_from_kg`) and register it before scoring. `recompute_block()` now backfills instead of bailing. Self-heals as soon as any rank for the block is processed.

- `storage.rs`: `get_block_config_from_kg()` — confirms the entity is typed `Ranking Block` in `public.relations` (also yields its home space), then reads Name/Filter/Start/End from `public.values` and the aggregation-restriction relation.
- `recompute.rs`: backfill-and-register on cache miss instead of early return.
- `tests/e2e.rs`: opt-in regression test reproducing the cross-edit scenario (type+config seeded in the KG, block unregistered, a rank arrives → block recovered + scored).

## Reviewer notes / caveats
- **Trigger is a rank edit**, not a block re-save. A pure block-config edit still produces no detected block/rank, so it won't trigger recompute. If we also want block edits to trigger it, `detect()`/`affected_blocks` would need to recognize block entities via the indexed graph (follow-up).
- **Existing backlog won't auto-reprocess**: the 3 stuck blocks' rank edits are already consumed (committed offsets). They'll heal when any *new* rank touches them; otherwise we need a one-off replay / offset reset of `ranking-indexer-v1`. (Noted on #738.)
- **Dates** are read from `values.datetime_utc`; confirm that's where kg-indexer writes the Start/End date properties (they're optional and were unset on the blocks I inspected).
- The e2e test is opt-in (`RANKING_INDEXER_E2E_DATABASE_URL`), like the existing one — it won't run on generic CI. Verified `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean locally; couldn't run the e2e itself here (no `ranks`-schema DB).