### PR TITLE
feat(proposal-executor): add membership vote constants + ABIs

### DIFF
--- a/docs/protocol/dao-space.md
+++ b/docs/protocol/dao-space.md
@@ -27,9 +27,9 @@ enum VotingMode {
 ```solidity
 enum VoteOption {
     None,    // 0 - Invalid/not voted
-    Abstain, // 1
-    Yes,     // 2
-    No       // 3
+    Yes,     // 1
+    No,      // 2
+    Abstain  // 3
 }
 ```
 

--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -47,6 +47,13 @@ export const SpaceRegistryAbi = [
 		type: "function",
 	},
 	{
+		inputs: [{internalType: "bytes16", name: "_spaceId", type: "bytes16"}],
+		name: "spaceIdToAddress",
+		outputs: [{internalType: "address", name: "_account", type: "address"}],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
 		inputs: [
 			{internalType: "bytes16", name: "_fromSpaceId", type: "bytes16"},
 			{internalType: "bytes16", name: "_toSpaceId", type: "bytes16"},
@@ -58,6 +65,63 @@ export const SpaceRegistryAbi = [
 		name: "enter",
 		outputs: [],
 		stateMutability: "nonpayable",
+		type: "function",
+	},
+] as const
+
+// ---------------------------------------------------------------------------
+// DAOSpace ABI — minimal subset (only getLatestProposalInformation)
+// Source: geo-contracts-foundry/src/interfaces/IDAOSpace.sol
+//
+// The vote-tally getters live on the per-space DAOSpace contract (resolved via
+// SpaceRegistry.spaceIdToAddress), NOT on the SpaceRegistry. The membership
+// path reads this for the stage-2 authoritative "untouched" check.
+// ---------------------------------------------------------------------------
+
+export const DAOSpaceAbi = [
+	{
+		inputs: [{internalType: "bytes16", name: "_proposalId", type: "bytes16"}],
+		name: "getLatestProposalInformation",
+		outputs: [
+			{internalType: "bool", name: "_executed", type: "bool"},
+			{internalType: "bytes16", name: "_creator", type: "bytes16"},
+			{
+				components: [
+					{internalType: "uint8", name: "votingMode", type: "uint8"},
+					{internalType: "uint256", name: "partialPercentageSupportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "universalPercentageSupportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "flatSupportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "quorum", type: "uint256"},
+					{internalType: "uint256", name: "startDate", type: "uint256"},
+					{internalType: "uint256", name: "lastDate", type: "uint256"},
+					{internalType: "uint256", name: "executeBy", type: "uint256"},
+				],
+				internalType: "struct IDAOSpace.ProposalParameters",
+				name: "_parameters",
+				type: "tuple",
+			},
+			{
+				components: [
+					{internalType: "uint256", name: "yes", type: "uint256"},
+					{internalType: "uint256", name: "no", type: "uint256"},
+					{internalType: "uint256", name: "abstain", type: "uint256"},
+				],
+				internalType: "struct IDAOSpace.Tally",
+				name: "_tally",
+				type: "tuple",
+			},
+			{
+				components: [
+					{internalType: "address", name: "to", type: "address"},
+					{internalType: "uint256", name: "value", type: "uint256"},
+					{internalType: "bytes", name: "data", type: "bytes"},
+				],
+				internalType: "struct IDAOSpace.Action[]",
+				name: "_actions",
+				type: "tuple[]",
+			},
+		],
+		stateMutability: "view",
 		type: "function",
 	},
 ] as const
@@ -117,6 +181,15 @@ export const TESTNET_SAFE_ADDRESSES = {
 
 /** keccak256('GOVERNANCE.PROPOSAL_EXECUTED') — action hash for enter() */
 export const PROPOSAL_EXECUTED_ACTION = "0x62a60c0a9681612871e0dafa0f24bb0c83cbdde8be5a6299979c88d382369e96" as Hex
+
+/** keccak256('GOVERNANCE.PROPOSAL_VOTED') — action hash for casting a vote via enter() */
+export const PROPOSAL_VOTED_ACTION = "0x4ebf5f29676cedf7e2e4d346a8433289278f95a9fda73691dc1ce24574d5819e" as Hex
+
+/**
+ * IDAOSpace.VoteOption.Yes — the on-chain enum value for a YES vote.
+ * Authoritative enum (geo-contracts-foundry IDAOSpace): None=0, Yes=1, No=2, Abstain=3.
+ */
+export const VOTE_YES = 1
 
 /** Empty signature — ignored when msg.sender == _fromSpace */
 export const EMPTY_SIGNATURE = "0x" as Hex

--- a/proposal-executor/tests/contracts.test.ts
+++ b/proposal-executor/tests/contracts.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for contracts.ts — membership vote constants and the DAOSpace /
+ * SpaceRegistry ABI view subsets used by the membership-accept path.
+ *
+ * These pin the on-chain encoding (VoteOption.Yes = 1) and the action hash
+ * against the authoritative source (geo-contracts-foundry IDAOSpace), and
+ * verify the ABI subsets expose the view names the membership path calls.
+ */
+
+import {describe, expect, test} from "bun:test"
+import {DAOSpaceAbi, PROPOSAL_VOTED_ACTION, SpaceRegistryAbi, VOTE_YES} from "../src/contracts.js"
+
+// ---------------------------------------------------------------------------
+// VOTE_YES — guards the documented enum discrepancy
+// ---------------------------------------------------------------------------
+
+describe("VOTE_YES constant", () => {
+	test("is 1 (IDAOSpace.VoteOption.Yes: None=0, Yes=1, No=2, Abstain=3)", () => {
+		// Source of truth: geo-contracts-foundry/src/interfaces/IDAOSpace.sol
+		expect(VOTE_YES).toBe(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// PROPOSAL_VOTED_ACTION — keccak256('GOVERNANCE.PROPOSAL_VOTED')
+// ---------------------------------------------------------------------------
+
+describe("PROPOSAL_VOTED_ACTION constant", () => {
+	test("matches the action hash from hermes-substream", () => {
+		expect(PROPOSAL_VOTED_ACTION).toBe("0x4ebf5f29676cedf7e2e4d346a8433289278f95a9fda73691dc1ce24574d5819e")
+	})
+
+	test("is a 32-byte hex string (0x + 64 hex chars)", () => {
+		expect(PROPOSAL_VOTED_ACTION.length).toBe(66)
+		expect(PROPOSAL_VOTED_ACTION).toMatch(/^0x[0-9a-f]{64}$/)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// DAOSpaceAbi — getLatestProposalInformation view (stage-2 tally read)
+// ---------------------------------------------------------------------------
+
+describe("DAOSpaceAbi", () => {
+	const getInfo = DAOSpaceAbi.find(
+		(entry) => entry.type === "function" && entry.name === "getLatestProposalInformation",
+	)
+
+	test("exposes getLatestProposalInformation", () => {
+		expect(getInfo).toBeDefined()
+	})
+
+	test("takes a single bytes16 proposalId input", () => {
+		expect(getInfo?.inputs).toHaveLength(1)
+		expect(getInfo?.inputs[0]?.type).toBe("bytes16")
+	})
+
+	test("returns the (executed, creator, parameters, tally, actions) tuple", () => {
+		const outputs = getInfo?.outputs ?? []
+		expect(outputs.map((o) => o.type)).toEqual(["bool", "bytes16", "tuple", "tuple", "tuple[]"])
+	})
+
+	test("decodes the Tally tuple as (yes, no, abstain) uint256 components", () => {
+		const tally = getInfo?.outputs?.[3]
+		expect(tally?.type).toBe("tuple")
+		expect(tally?.components?.map((c) => c.name)).toEqual(["yes", "no", "abstain"])
+		expect(tally?.components?.every((c) => c.type === "uint256")).toBe(true)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// SpaceRegistryAbi — spaceIdToAddress view (DAOSpace address resolution)
+// ---------------------------------------------------------------------------
+
+describe("SpaceRegistryAbi", () => {
+	test("exposes spaceIdToAddress(bytes16) → address", () => {
+		const fn = SpaceRegistryAbi.find((entry) => entry.type === "function" && entry.name === "spaceIdToAddress")
+		expect(fn).toBeDefined()
+		expect(fn?.inputs[0]?.type).toBe("bytes16")
+		expect(fn?.outputs[0]?.type).toBe("address")
+	})
+
+	test("still exposes the pre-existing enter and addressToSpaceId views", () => {
+		const names = SpaceRegistryAbi.map((entry) => entry.name)
+		expect(names).toContain("enter")
+		expect(names).toContain("addressToSpaceId")
+	})
+})


### PR DESCRIPTION
PR-A of the `auto-accept-membership` feature. Adds the on-chain primitives the membership-accept path needs, with no behavior change:

- PROPOSAL_VOTED_ACTION + VOTE_YES (IDAOSpace.VoteOption.Yes = 1) constants
- DAOSpaceAbi subset: getLatestProposalInformation (stage-2 tally read)
- SpaceRegistryAbi += spaceIdToAddress (DAOSpace address resolution)
- contracts.test.ts pinning the encodings and view names
- Fix VoteOption enum in docs/protocol/dao-space.md (None=0, Yes=1, No=2, Abstain=3)