### PR TITLE
ci: add gaia-v2 manual build/deploy workflows (GEO-664)

### DIFF
--- a/.github/workflows/build-v2-images.yml
+++ b/.github/workflows/build-v2-images.yml
@@ -1,0 +1,87 @@
+name: Build gaia-v2 images (manual)
+
+# Builds and pushes all images needed for the gaia-v2 (chain-migration) stack.
+# Build-and-push only — deploys stay manual per the GEO-664 runbook (Step 12:
+# sed the image tag into the k8s/v2 manifests and kubectl apply).
+#
+# Images are tagged with the full commit SHA and a short 8-char SHA; use either
+# in the manifests.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build-v2-images
+  cancel-in-progress: false
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: hermes-pipeline
+            dockerfile: hermes-pipeline/Dockerfile
+            context: .
+          - image: hermes-ipfs-cache
+            dockerfile: hermes-ipfs-cache/Dockerfile
+            context: .
+          - image: kg-indexer
+            dockerfile: kg-indexer/Dockerfile
+            context: .
+          - image: api
+            dockerfile: api/Dockerfile
+            context: ./api
+          - image: proposal-executor
+            dockerfile: proposal-executor/Dockerfile
+            context: proposal-executor
+          - image: atlas
+            dockerfile: atlas/Dockerfile
+            context: .
+          - image: search-indexer
+            dockerfile: search-indexer/Dockerfile
+            context: .
+          - image: vote-indexer
+            dockerfile: scoring-service/vote-indexer/Dockerfile
+            context: .
+          - image: topology-indexer
+            dockerfile: scoring-service/topology-indexer/Dockerfile
+            context: .
+          - image: scoring-service
+            dockerfile: scoring-service/cronjob/Dockerfile
+            context: scoring-service/cronjob
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:8}"
+          docker build -t ${{ env.REGISTRY }}/${{ matrix.image }}:${{ github.sha }} \
+                       -t ${{ env.REGISTRY }}/${{ matrix.image }}:$SHORT_SHA \
+                       -f ${{ matrix.dockerfile }} ${{ matrix.context }}
+          docker push ${{ env.REGISTRY }}/${{ matrix.image }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ matrix.image }}:$SHORT_SHA
+
+  summary:
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print image tags
+        run: |
+          echo "## gaia-v2 images" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tag for manifests: \`${GITHUB_SHA:0:8}\` (or full \`${GITHUB_SHA}\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Build result: ${{ needs.build.result }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -1,0 +1,114 @@
+name: Deploy gaia-v2 service (manual)
+
+# Deploys one gaia-v2 service: seds the image tag into its k8s/v2 manifest(s)
+# and applies them to the gaia-v2 namespace, then gates on rollout status.
+#
+# Companion to "Build gaia-v2 images (manual)" — build first, then deploy with
+# the tag the build run printed. Bring-up order and per-service health gates
+# live in the GEO-664 runbook (Step 12); this workflow deploys exactly one
+# service per run so that order stays under operator control.
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Service to deploy"
+        required: true
+        type: choice
+        options:
+          - hermes-ipfs-cache
+          - hermes-pipeline
+          - kg-indexer
+          - atlas
+          - api
+          - valkey
+          - search-indexer
+          - vote-indexer
+          - topology-indexer
+          - scoring-service
+          - proposal-executor
+      tag:
+        description: "Image tag to deploy (from the build workflow, e.g. short SHA). Ignored for valkey (pinned public image)."
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-v2-${{ inputs.service }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+  NAMESPACE: gaia-v2
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
+
+      - name: Configure kubectl for DigitalOcean
+        run: doctl kubernetes cluster kubeconfig save ${{ secrets.DIGITALOCEAN_CLUSTER_NAME }}
+
+      - name: Resolve service mapping
+        id: map
+        run: |
+          case "${{ inputs.service }}" in
+            hermes-ipfs-cache) manifests="hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml"; rollout="deployment/hermes-ipfs-cache" ;;
+            hermes-pipeline)   manifests="hermes/k8s/v2/hermes-pipeline.yaml";              rollout="deployment/hermes-pipeline" ;;
+            kg-indexer)        manifests="kg-indexer/k8s/v2/kg-indexer.yaml";               rollout="deployment/kg-indexer" ;;
+            atlas)             manifests="hermes/k8s/v2/atlas.yaml";                        rollout="deployment/atlas" ;;
+            api)               manifests="api/k8s/v2/api.yaml api/k8s/v2/hpa.yaml";         rollout="deployment/api" ;;
+            valkey)            manifests="api/k8s/v2/valkey.yaml";                          rollout="deployment/api-cache" ;;
+            search-indexer)    manifests="search-indexer-deploy/k8s/v2/search-indexer.yaml"; rollout="statefulset/search-indexer" ;;
+            vote-indexer)      manifests="scoring-service/deployment/v2/vote-indexer.yaml"; rollout="deployment/vote-indexer" ;;
+            topology-indexer)  manifests="scoring-service/deployment/v2/topology-indexer.yaml"; rollout="deployment/topology-indexer" ;;
+            scoring-service)   manifests="scoring-service/deployment/v2/cronjob.yaml";      rollout="" ;;
+            proposal-executor) manifests="proposal-executor/deployment/v2/cronjob.yaml";    rollout="" ;;
+            *) echo "unknown service"; exit 1 ;;
+          esac
+          echo "manifests=$manifests" >> "$GITHUB_OUTPUT"
+          echo "rollout=$rollout" >> "$GITHUB_OUTPUT"
+
+      - name: Verify image tag exists in registry
+        if: inputs.service != 'valkey'
+        run: |
+          doctl registry repository list-tags ${{ inputs.service }} --format Tag --no-header | \
+            grep -qx "${{ inputs.tag }}" || {
+              echo "::error::Tag ${{ inputs.tag }} not found in $REGISTRY/${{ inputs.service }} — run the build workflow first."
+              exit 1
+            }
+
+      - name: Ensure namespace exists
+        run: kubectl apply -f kg-indexer/k8s/v2/namespace.yaml
+
+      - name: Guard against unfilled placeholders
+        run: |
+          if grep -l "REPLACE_WITH" ${{ steps.map.outputs.manifests }}; then
+            echo "::error::Manifest still contains REPLACE_WITH_* placeholders — fill the chain-specific values before deploying."
+            exit 1
+          fi
+
+      - name: Apply manifests
+        run: |
+          for m in ${{ steps.map.outputs.manifests }}; do
+            sed "s|:latest|:${{ inputs.tag }}|g" "$m" | kubectl apply -f -
+          done
+
+      - name: Wait for rollout
+        if: steps.map.outputs.rollout != ''
+        run: kubectl rollout status ${{ steps.map.outputs.rollout }} -n $NAMESPACE --timeout=180s
+
+      - name: Show result
+        if: always()
+        run: |
+          echo "## Deploy ${{ inputs.service }} @ ${{ inputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          kubectl get pods -n $NAMESPACE -o wide | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

GitHub only lists `workflow_dispatch` workflows in the Actions UI when the workflow file exists on the **default branch**. These two power the gaia-v2 (chain-migration) bring-up, which deploys from the `staging` branch (snapshot of `defi-wonderland/gaia#feat/governance-v2-contract-migration`).

## What

- `build-v2-images.yml` — manual matrix build+push of the 10 gaia-v2 images to `registry.digitalocean.com/geo`, **SHA tags only, never `:latest`** — nothing running in prod can pull these
- `deploy-v2.yml` — manual single-service deploy, strictly scoped to the `gaia-v2` namespace, with two guards: the image tag must exist in the registry, and manifests containing unfilled `REPLACE_WITH_*` placeholders refuse to deploy

## Safety

- Dispatch-only: no `push`/`pull_request` triggers — merging this changes nothing by itself, and it doesn't match any existing prod workflow's path filters
- Reuses the existing `DIGITALOCEAN_ACCESS_TOKEN` / `DIGITALOCEAN_CLUSTER_NAME` secrets
- **When dispatching, select the `staging` branch as the ref** — the run uses that branch's code and `k8s/v2` manifests. Dispatched against `main` itself: the build produces unused SHA-tagged images, the deploy fails fast on missing `v2/` manifests

Part of GEO-664 — runbook: see the GEO-664 deploy doc (Steps 11–12).