### PR TITLE
fix(docker): pin Rust builds to the workspace Cargo.lock

### DIFF
--- a/atlas/Dockerfile
+++ b/atlas/Dockerfile
@@ -22,6 +22,11 @@ COPY hermes-substream ./hermes-substream
 COPY stream ./stream
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./atlas/Cargo.lock
+
 WORKDIR /app/atlas
 RUN cargo build --release
 

--- a/chain-tip-exporter/Dockerfile
+++ b/chain-tip-exporter/Dockerfile
@@ -12,6 +12,11 @@ WORKDIR /app
 COPY hermes-instrumentation ./hermes-instrumentation
 COPY chain-tip-exporter ./chain-tip-exporter
 
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./chain-tip-exporter/Cargo.lock
+
 WORKDIR /app/chain-tip-exporter
 RUN cargo build --release
 

--- a/hermes-ipfs-cache/Dockerfile
+++ b/hermes-ipfs-cache/Dockerfile
@@ -20,6 +20,11 @@ COPY stream ./stream
 COPY ipfs ./ipfs
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./hermes-ipfs-cache/Cargo.lock
+
 WORKDIR /app/hermes-ipfs-cache
 RUN cargo build --release
 

--- a/hermes-pipeline/Dockerfile
+++ b/hermes-pipeline/Dockerfile
@@ -22,6 +22,11 @@ COPY hermes-substream ./hermes-substream
 COPY stream ./stream
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./hermes-pipeline/Cargo.lock
+
 WORKDIR /app/hermes-pipeline
 RUN cargo build --release
 

--- a/kg-indexer/Dockerfile
+++ b/kg-indexer/Dockerfile
@@ -21,6 +21,11 @@ COPY sdk ./sdk
 COPY kg-indexer ./kg-indexer
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./kg-indexer/Cargo.lock
+
 WORKDIR /app/kg-indexer
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/notification-service/delivery-worker/Dockerfile
+++ b/notification-service/delivery-worker/Dockerfile
@@ -17,6 +17,11 @@ COPY hermes-instrumentation ./hermes-instrumentation
 COPY notification-service/delivery-worker ./notification-service/delivery-worker
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./notification-service/delivery-worker/Cargo.lock
+
 WORKDIR /app/notification-service/delivery-worker
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/notification-service/notification-indexer/Dockerfile
+++ b/notification-service/notification-indexer/Dockerfile
@@ -21,6 +21,11 @@ COPY sdk ./sdk
 COPY notification-service/notification-indexer ./notification-service/notification-indexer
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./notification-service/notification-indexer/Cargo.lock
+
 WORKDIR /app/notification-service/notification-indexer
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/ranking-indexer/Dockerfile
+++ b/ranking-indexer/Dockerfile
@@ -21,6 +21,11 @@ COPY sdk ./sdk
 COPY ranking-indexer ./ranking-indexer
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./ranking-indexer/Cargo.lock
+
 WORKDIR /app/ranking-indexer
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/scoring-service/topology-indexer/Dockerfile
+++ b/scoring-service/topology-indexer/Dockerfile
@@ -19,6 +19,11 @@ COPY hermes-kafka ./hermes-kafka
 COPY scoring-service/topology-indexer ./scoring-service/topology-indexer
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./scoring-service/topology-indexer/Cargo.lock
+
 WORKDIR /app/scoring-service/topology-indexer
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/scoring-service/vote-indexer/Dockerfile
+++ b/scoring-service/vote-indexer/Dockerfile
@@ -20,6 +20,11 @@ COPY sdk ./sdk
 COPY scoring-service/vote-indexer ./scoring-service/vote-indexer
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./scoring-service/vote-indexer/Cargo.lock
+
 WORKDIR /app/scoring-service/vote-indexer
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/search-indexer/Dockerfile
+++ b/search-indexer/Dockerfile
@@ -28,6 +28,11 @@ COPY sdk ./sdk
 # Build from the crate directory (standalone, not as workspace member)
 # Note: auto_index_creation feature is disabled by default (production-safe)
 # For local dev, pass --build-arg CARGO_FEATURES="--features search-indexer-repository/auto_index_creation"
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time 0.3.48 broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./search-indexer/Cargo.lock
+
 WORKDIR /app/search-indexer
 RUN cargo build --release ${CARGO_FEATURES}
 


### PR DESCRIPTION
## TL;DR

**Every Rust image build on `main` is currently broken** — not by any commit of ours, but by a crates.io release this morning. This PR pins all 11 Rust Dockerfiles to the workspace `Cargo.lock` so image builds resolve the same dependency versions the repo tests against.

## The problem

The Rust Dockerfiles intentionally build each crate **standalone**: they copy the member crates into the image but not the workspace `Cargo.toml` — and they never copy `Cargo.lock`. Inside the container there is no workspace and no lockfile, so `cargo build` re-resolves every dependency from **latest compatible on crates.io at build time**. The images we run in prod were never built from the dependency graph pinned in the repo — they were built from whatever crates.io served that day.

## Why now

| Date | Event |
|---|---|
| 2026-01/02 | `sentry-types 0.46.2` + `time 0.3.47` published — a compatible pair |
| 2026-06-03 | Last prod Rust deploys (atlas, kg-indexer, hermes-pipeline) — unpinned resolution still compiled |
| **2026-06-12** | **`time 0.3.48` published.** Its new internal `From` impls collide with `sentry-types 0.46.2`'s blanket `impl<T> From<T>` → `error[E0119]` |

Since this morning, any fresh build resolves `sentry-types 0.46.2` + `time 0.3.48` and fails. First observed building the gaia-v2 images ([failed run](https://github.com/geobrowser/gaia/actions/runs/27422939898): all 7 Rust matrix jobs failed identically; the bun/python images — whose deps *are* lockfile-pinned — passed). The repo's `Cargo.lock` pins the compiling pair (`sentry-types 0.46.1` / `time 0.3.46`) — it just never reached the Docker builds.

## The fix

`COPY Cargo.lock ./<crate>/Cargo.lock` into each crate's build directory (the build context is the repo root, so the source is the single workspace lockfile; the copy exists only inside the image). A standalone package reads `./Cargo.lock` next to its manifest, so cargo adopts the workspace pins for the subset of deps it uses and silently prunes the rest. Deliberately **no `--locked`**: the pruning counts as a lockfile change, which `--locked` would reject.

Covers all 11 Rust images: hermes-pipeline, hermes-ipfs-cache, kg-indexer, atlas, search-indexer, ranking-indexer, chain-tip-exporter, delivery-worker, notification-indexer, vote-indexer, topology-indexer.

## Local verification (A/B)

Same machine, same image (topology-indexer — smallest Rust build), only variable is the lockfile COPY:

| Build | Resolved | Result |
|---|---|---|
| `origin/main` (unpinned), `--no-cache` | `time 0.3.48` + `sentry-types 0.46.2` | ❌ `E0119 ×2 → could not compile sentry-types` |
| this branch | `time 0.3.46` + `sentry-types 0.46.1` | ✅ image builds |

Also verified the resolution mechanism in isolation: replicating the container layout (member crates + workspace lock placed in the crate dir, no workspace manifest), `cargo metadata` resolves `sentry-types 0.46.1`; without the lock, `0.46.2`.

## Replicate it yourself

```bash
# broken (main):
git checkout main
docker build --no-cache -f scoring-service/topology-indexer/Dockerfile .
# → 'Compiling time v0.3.48' … 'Compiling sentry-types v0.46.2' … error[E0119]

# fixed (this branch):
git checkout fix/pin-cargo-lock-in-docker-main
docker build --no-cache -f scoring-service/topology-indexer/Dockerfile .
# → 'Compiling sentry-types v0.46.1' … 'Compiling time v0.3.46' … success
```

## Side benefits

- Image builds become **reproducible**: same commit → same dependency graph, instead of a function of build date.
- Dependency upgrades now happen where they're visible — `cargo update` + lockfile diff in a PR — rather than silently inside CI image builds.