### PR TITLE
feat(ranking-indexer): recompute aggregates on space membership events

### DIFF
--- a/api/drizzle/0062_ranks_members_editors.sql
+++ b/api/drizzle/0062_ranks_members_editors.sql
@@ -12,6 +12,7 @@ CREATE TABLE "ranks"."members" (
 --> statement-breakpoint
 CREATE INDEX "ranks_editors_space_id_idx" ON "ranks"."editors" USING btree ("space_id");--> statement-breakpoint
 CREATE INDEX "ranks_members_space_id_idx" ON "ranks"."members" USING btree ("space_id");--> statement-breakpoint
+CREATE INDEX "rankings_space_id_idx" ON "ranks"."rankings" USING btree ("space_id");--> statement-breakpoint
 -- Seed the ranking-indexer's membership view from the kg-indexer-maintained
 -- public tables. Eligibility reads the public tables until this migration runs,
 -- so the copy makes the switch-over a semantic no-op; only events consumed

--- a/api/drizzle/0062_ranks_members_editors.sql
+++ b/api/drizzle/0062_ranks_members_editors.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "ranks"."editors" (
+	"member_space_id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
+	CONSTRAINT "editors_member_space_id_space_id_pk" PRIMARY KEY("member_space_id","space_id")
+);
+--> statement-breakpoint
+CREATE TABLE "ranks"."members" (
+	"member_space_id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
+	CONSTRAINT "members_member_space_id_space_id_pk" PRIMARY KEY("member_space_id","space_id")
+);
+--> statement-breakpoint
+CREATE INDEX "ranks_editors_space_id_idx" ON "ranks"."editors" USING btree ("space_id");--> statement-breakpoint
+CREATE INDEX "ranks_members_space_id_idx" ON "ranks"."members" USING btree ("space_id");--> statement-breakpoint
+-- Seed the ranking-indexer's membership view from the kg-indexer-maintained
+-- public tables. Eligibility reads the public tables until this migration runs,
+-- so the copy makes the switch-over a semantic no-op; only events consumed
+-- after deploy diverge.
+INSERT INTO "ranks"."members" ("member_space_id", "space_id")
+SELECT "member_space_id", "space_id" FROM "public"."members"
+ON CONFLICT DO NOTHING;--> statement-breakpoint
+INSERT INTO "ranks"."editors" ("member_space_id", "space_id")
+SELECT "member_space_id", "space_id" FROM "public"."editors"
+ON CONFLICT DO NOTHING;

--- a/api/drizzle/meta/0062_snapshot.json
+++ b/api/drizzle/meta/0062_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "9acc6507-6328-4fbe-85bb-f62567a4b6be",
+  "id": "1e70dfc8-9e9e-4392-83b1-cb0798aa1f53",
   "prevId": "66ae6367-a3a0-4a26-9998-a7e9914df646",
   "version": "7",
   "dialect": "postgresql",
@@ -1711,6 +1711,21 @@
               "asc": true,
               "nulls": "last"
             },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rankings_space_id_idx": {
+          "name": "rankings_space_id_idx",
+          "columns": [
             {
               "expression": "space_id",
               "isExpression": false,

--- a/api/drizzle/meta/0062_snapshot.json
+++ b/api/drizzle/meta/0062_snapshot.json
@@ -1,0 +1,3793 @@
+{
+  "id": "9acc6507-6328-4fbe-85bb-f62567a4b6be",
+  "prevId": "66ae6367-a3a0-4a26-9998-a7e9914df646",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_poll_cursors": {
+      "name": "notification_poll_cursors",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor_updated_at": {
+          "name": "cursor_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_blocks": {
+      "name": "ranking_blocks",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restriction_id": {
+          "name": "restriction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_blocks_id_space_id_pk": {
+          "name": "ranking_blocks_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_items": {
+      "name": "ranking_items",
+      "schema": "ranks",
+      "columns": {
+        "ranking_id": {
+          "name": "ranking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_items_ranking_id_entity_id_space_id_pk": {
+          "name": "ranking_items_ranking_id_entity_id_space_id_pk",
+          "columns": [
+            "ranking_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_scores": {
+      "name": "ranking_scores",
+      "schema": "ranks",
+      "columns": {
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranking_scores_block_position_idx": {
+          "name": "ranking_scores_block_position_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_scores_block_id_entity_id_space_id_pk": {
+          "name": "ranking_scores_block_id_entity_id_space_id_pk",
+          "columns": [
+            "block_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.rankings": {
+      "name": "rankings",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank_type": {
+          "name": "rank_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "update_index": {
+          "name": "update_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rankings_block_id_idx": {
+          "name": "rankings_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rankings_block_space_idx": {
+          "name": "rankings_block_space_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rankings_id_space_id_pk": {
+          "name": "rankings_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.editors": {
+      "name": "editors",
+      "schema": "ranks",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranks_editors_space_id_idx": {
+          "name": "ranks_editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.members": {
+      "name": "members",
+      "schema": "ranks",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranks_members_space_id_idx": {
+          "name": "ranks_members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_count_updated_at": {
+          "name": "idx_votes_count_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "object_type = 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {
+    "ranks": "ranks"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -439,7 +439,7 @@
     {
       "idx": 62,
       "version": "7",
-      "when": 1781289096597,
+      "when": 1781295117937,
       "tag": "0062_ranks_members_editors",
       "breakpoints": true
     }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1781041240657,
       "tag": "0061_create_ranks_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1781289096597,
+      "tag": "0062_ranks_members_editors",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -1029,6 +1029,7 @@ export const rankings = ranks.table(
 		primaryKey({columns: [table.id, table.spaceId]}),
 		index("rankings_block_id_idx").on(table.blockId),
 		index("rankings_block_space_idx").on(table.blockId, table.spaceId),
+		index("rankings_space_id_idx").on(table.spaceId),
 	],
 )
 

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -1045,6 +1045,36 @@ export const rankingItems = ranks.table(
 	(table) => [primaryKey({columns: [table.rankingId, table.entityId, table.spaceId]})],
 )
 
+/**
+ * The ranking-indexer's own view of space membership, mirroring the public
+ * `members` / `editors` tables but fed directly from the `space.membership`
+ * Kafka topic. Eligibility reads this view instead of the public tables so a
+ * recompute never races the kg-indexer's consumer group.
+ */
+export const ranksMembers = ranks.table(
+	"members",
+	{
+		memberSpaceId: uuid("member_space_id").notNull(),
+		spaceId: uuid("space_id").notNull(),
+	},
+	(table) => [
+		primaryKey({columns: [table.memberSpaceId, table.spaceId]}),
+		index("ranks_members_space_id_idx").on(table.spaceId),
+	],
+)
+
+export const ranksEditors = ranks.table(
+	"editors",
+	{
+		memberSpaceId: uuid("member_space_id").notNull(),
+		spaceId: uuid("space_id").notNull(),
+	},
+	(table) => [
+		primaryKey({columns: [table.memberSpaceId, table.spaceId]}),
+		index("ranks_editors_space_id_idx").on(table.spaceId),
+	],
+)
+
 /** Computed aggregate, keyed on (block, entity, space). */
 export const rankingScores = ranks.table(
 	"ranking_scores",

--- a/ranking-indexer/src/consumer.rs
+++ b/ranking-indexer/src/consumer.rs
@@ -9,12 +9,16 @@
 use hermes_kafka::get_topic_prefix;
 use prost::Message;
 use rdkafka::{
+    client::ClientContext,
     config::ClientConfig,
-    consumer::{Consumer, DefaultConsumerContext, StreamConsumer},
-    TopicPartitionList,
+    consumer::{BaseConsumer, Consumer, ConsumerContext, RebalanceProtocol, StreamConsumer},
+    error::RDKafkaErrorCode,
+    types::RDKafkaRespErr,
+    Offset, TopicPartitionList,
 };
 use std::env;
-use tracing::{debug, info};
+use std::time::Duration;
+use tracing::{debug, error, info, warn};
 
 use crate::error::IndexerError;
 use crate::membership::MembershipEvent;
@@ -32,9 +36,135 @@ pub enum TopicKind {
     Membership,
 }
 
+/// Consumer context that starts *fresh* membership partitions at the latest
+/// offset instead of replaying the topic's history.
+///
+/// The membership view (`ranks.members` / `ranks.editors`) is seeded by
+/// migration 0062 from the kg-indexer-maintained public tables, so on the
+/// first deploy — when the group has committed offsets for `knowledge.edits`
+/// but none for `space.membership` — `auto.offset.reset=earliest` would
+/// replay the membership topic's entire retained history, recomputing and
+/// *republishing* aggregates through every historical membership state along
+/// the way. Starting at the high watermark is correct because the seed
+/// already reflects everything up to migration time; events produced after
+/// the consumer joins are consumed normally. Edits partitions are untouched.
+///
+/// Caveat: if the group's committed offsets expire (group inactive longer
+/// than the broker's `offsets.retention.minutes`), membership resumes at
+/// latest and the outage window's events are skipped — re-run the 0062 seed
+/// inserts to reconcile the view before restarting.
+pub struct RankingConsumerContext {
+    membership_topic: String,
+}
+
+impl RankingConsumerContext {
+    /// For each membership partition in the assignment with no committed
+    /// offset, override the start position to the high watermark. Leaves
+    /// every other partition untouched (committed offset, or
+    /// `auto.offset.reset` if none). On lookup failure the assignment is left
+    /// as-is, falling back to `earliest` — a full replay converges (it only
+    /// flaps published aggregates), whereas wrongly skipping ahead would
+    /// silently lose events.
+    fn start_fresh_membership_partitions_at_latest(
+        &self,
+        consumer: &BaseConsumer<Self>,
+        assignment: &mut TopicPartitionList,
+    ) {
+        let partitions: Vec<i32> = assignment
+            .elements_for_topic(&self.membership_topic)
+            .iter()
+            .map(|e| e.partition())
+            .collect();
+        if partitions.is_empty() {
+            return;
+        }
+
+        let mut query = TopicPartitionList::new();
+        for partition in &partitions {
+            query.add_partition(&self.membership_topic, *partition);
+        }
+        let committed = match consumer.committed_offsets(query, Duration::from_secs(10)) {
+            Ok(committed) => committed,
+            Err(e) => {
+                error!(
+                    error = %e,
+                    topic = %self.membership_topic,
+                    "Failed to fetch committed membership offsets — falling back to \
+                     auto.offset.reset (full replay)"
+                );
+                return;
+            }
+        };
+
+        for elem in committed.elements() {
+            if elem.offset() != Offset::Invalid {
+                continue;
+            }
+            if let Some(mut assigned) =
+                assignment.find_partition(&self.membership_topic, elem.partition())
+            {
+                if let Err(e) = assigned.set_offset(Offset::End) {
+                    error!(error = %e, partition = elem.partition(), "Failed to set start offset");
+                    continue;
+                }
+                info!(
+                    topic = %self.membership_topic,
+                    partition = elem.partition(),
+                    "No committed offset for membership partition — starting at latest \
+                     (view is seeded by migration 0062)"
+                );
+            }
+        }
+    }
+}
+
+impl ClientContext for RankingConsumerContext {}
+
+impl ConsumerContext for RankingConsumerContext {
+    // Full override of the default rebalance flow (the default body can't be
+    // called from an override): identical assign/unassign behavior via the
+    // public API, plus the fresh-membership-partition offset override before
+    // partitions are assigned.
+    fn rebalance(
+        &self,
+        base_consumer: &BaseConsumer<Self>,
+        err: RDKafkaRespErr,
+        tpl: &mut TopicPartitionList,
+    ) {
+        match err {
+            RDKafkaRespErr::RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS => {
+                self.start_fresh_membership_partitions_at_latest(base_consumer, tpl);
+                let result = match base_consumer.rebalance_protocol() {
+                    RebalanceProtocol::Cooperative => base_consumer.incremental_assign(tpl),
+                    _ => base_consumer.assign(tpl),
+                };
+                if let Err(e) = result {
+                    error!(error = %e, "Failed to assign partitions during rebalance");
+                }
+            }
+            RDKafkaRespErr::RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS => {
+                let result = match base_consumer.rebalance_protocol() {
+                    RebalanceProtocol::Cooperative => base_consumer.incremental_unassign(tpl),
+                    _ => base_consumer.unassign(),
+                };
+                if let Err(e) = result {
+                    error!(error = %e, "Failed to unassign partitions during rebalance");
+                }
+            }
+            _ => {
+                let code: RDKafkaErrorCode = err.into();
+                error!(error = %code, "Kafka rebalance error");
+                if let Err(e) = base_consumer.unassign() {
+                    warn!(error = %e, "Failed to unassign partitions after rebalance error");
+                }
+            }
+        }
+    }
+}
+
 /// Kafka consumer for knowledge edits + membership events.
 pub struct KafkaConsumer {
-    consumer: StreamConsumer<DefaultConsumerContext>,
+    consumer: StreamConsumer<RankingConsumerContext>,
     edits_topic: String,
     membership_topic: String,
 }
@@ -66,11 +196,15 @@ impl KafkaConsumer {
             config.set("ssl.ca.pem", &ca_pem);
         }
 
-        let consumer: StreamConsumer = config.create()?;
-
         let prefix = get_topic_prefix();
         let edits_topic = format!("{}{}", prefix, EDITS_TOPIC);
         let membership_topic = format!("{}{}", prefix, MEMBERSHIP_TOPIC);
+
+        let context = RankingConsumerContext {
+            membership_topic: membership_topic.clone(),
+        };
+        let consumer: StreamConsumer<RankingConsumerContext> =
+            config.create_with_context(context)?;
 
         info!(
             brokers = %brokers,
@@ -110,7 +244,7 @@ impl KafkaConsumer {
         }
     }
 
-    pub fn stream(&self) -> rdkafka::consumer::MessageStream<'_, DefaultConsumerContext> {
+    pub fn stream(&self) -> rdkafka::consumer::MessageStream<'_, RankingConsumerContext> {
         self.consumer.stream()
     }
 
@@ -159,19 +293,26 @@ pub fn get_event_type(headers: Option<&rdkafka::message::BorrowedHeaders>) -> Op
 }
 
 /// Decode a `space.membership` message, dispatching on the `event-type` header.
+///
+/// `Ok(None)` means a known event type this indexer intentionally ignores —
+/// distinguished from unknown types (an error) so an expected event never
+/// logs at warn level.
 pub fn parse_membership_event(
     payload: &[u8],
     event_type: Option<&str>,
-) -> Result<MembershipEvent, IndexerError> {
+) -> Result<Option<MembershipEvent>, IndexerError> {
     match event_type {
-        Some("ROLE_GRANTED") => Ok(MembershipEvent::RoleGranted(
+        Some("ROLE_GRANTED") => Ok(Some(MembershipEvent::RoleGranted(
             hermes_schema::pb::membership::HermesRoleGranted::decode(payload)
                 .map_err(|e| IndexerError::decode(format!("HermesRoleGranted: {e}")))?,
-        )),
-        Some("ROLE_REVOKED") => Ok(MembershipEvent::RoleRevoked(
+        ))),
+        Some("ROLE_REVOKED") => Ok(Some(MembershipEvent::RoleRevoked(
             hermes_schema::pb::membership::HermesRoleRevoked::decode(payload)
                 .map_err(|e| IndexerError::decode(format!("HermesRoleRevoked: {e}")))?,
-        )),
+        ))),
+        // Emitted by the pipeline but intentionally unhandled, for parity with
+        // the kg-indexer (which also ignores it).
+        Some("SPACE_LEFT") => Ok(None),
         other => Err(IndexerError::decode(format!(
             "unknown membership event type: {other:?}"
         ))),
@@ -196,11 +337,16 @@ mod tests {
 
         assert!(matches!(
             parse_membership_event(&payload, Some("ROLE_GRANTED")),
-            Ok(MembershipEvent::RoleGranted(_))
+            Ok(Some(MembershipEvent::RoleGranted(_)))
         ));
         assert!(matches!(
             parse_membership_event(&payload, Some("ROLE_REVOKED")),
-            Ok(MembershipEvent::RoleRevoked(_))
+            Ok(Some(MembershipEvent::RoleRevoked(_)))
+        ));
+        // known-but-unhandled event type -> ignored, not an error
+        assert!(matches!(
+            parse_membership_event(&payload, Some("SPACE_LEFT")),
+            Ok(None)
         ));
         // missing or unknown header -> decode error, not a crash
         assert!(parse_membership_event(&payload, None).is_err());

--- a/ranking-indexer/src/consumer.rs
+++ b/ranking-indexer/src/consumer.rs
@@ -1,9 +1,10 @@
-//! Kafka consumer for the `knowledge.edits` topic.
+//! Kafka consumer for the `knowledge.edits` and `space.membership` topics.
 //!
 //! Mirrors the vote-indexer consumer: a manual-commit `StreamConsumer` with the
 //! environment topic prefix applied. Edits are decoded in two steps —
 //! `HermesEdit` (prost) then the raw GRC2/GRC2Z payload via the `grc-20` crate,
-//! the same decoder the kg-indexer uses.
+//! the same decoder the kg-indexer uses. Membership messages are dispatched on
+//! the `event-type` Kafka header, same as the kg-indexer.
 
 use hermes_kafka::get_topic_prefix;
 use prost::Message;
@@ -16,14 +17,26 @@ use std::env;
 use tracing::{debug, info};
 
 use crate::error::IndexerError;
+use crate::membership::MembershipEvent;
 
 /// Base topic for knowledge edits.
 const EDITS_TOPIC: &str = "knowledge.edits";
 
-/// Kafka consumer for knowledge edits.
+/// Base topic for membership events (role granted/revoked, space left).
+const MEMBERSHIP_TOPIC: &str = "space.membership";
+
+/// Which subscribed topic a message arrived on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopicKind {
+    Edits,
+    Membership,
+}
+
+/// Kafka consumer for knowledge edits + membership events.
 pub struct KafkaConsumer {
     consumer: StreamConsumer<DefaultConsumerContext>,
-    topic: String,
+    edits_topic: String,
+    membership_topic: String,
 }
 
 impl KafkaConsumer {
@@ -56,23 +69,45 @@ impl KafkaConsumer {
         let consumer: StreamConsumer = config.create()?;
 
         let prefix = get_topic_prefix();
-        let topic = format!("{}{}", prefix, EDITS_TOPIC);
+        let edits_topic = format!("{}{}", prefix, EDITS_TOPIC);
+        let membership_topic = format!("{}{}", prefix, MEMBERSHIP_TOPIC);
 
         info!(
             brokers = %brokers,
             group_id = %group_id,
             topic_prefix = %prefix,
-            topic = %topic,
+            edits_topic = %edits_topic,
+            membership_topic = %membership_topic,
             "Created Kafka consumer"
         );
 
-        Ok(Self { consumer, topic })
+        Ok(Self {
+            consumer,
+            edits_topic,
+            membership_topic,
+        })
     }
 
     pub fn subscribe(&self) -> Result<(), IndexerError> {
-        self.consumer.subscribe(&[&self.topic])?;
-        info!(topic = %self.topic, "Subscribed to Kafka topic");
+        self.consumer
+            .subscribe(&[&self.edits_topic, &self.membership_topic])?;
+        info!(
+            edits_topic = %self.edits_topic,
+            membership_topic = %self.membership_topic,
+            "Subscribed to Kafka topics"
+        );
         Ok(())
+    }
+
+    /// Which of the subscribed topics a message's topic is.
+    pub fn topic_kind(&self, topic: &str) -> Option<TopicKind> {
+        if topic == self.edits_topic {
+            Some(TopicKind::Edits)
+        } else if topic == self.membership_topic {
+            Some(TopicKind::Membership)
+        } else {
+            None
+        }
     }
 
     pub fn stream(&self) -> rdkafka::consumer::MessageStream<'_, DefaultConsumerContext> {
@@ -105,4 +140,74 @@ pub fn parse_edit(
 /// compressed and uncompressed forms, same as the kg-indexer).
 pub fn decode_grc20(payload: &[u8]) -> Result<grc_20::Edit<'_>, IndexerError> {
     grc_20::decode_edit(payload).map_err(|e| IndexerError::decode(format!("grc20: {e}")))
+}
+
+/// The `event-type` Kafka header, which selects the protobuf message type on
+/// the membership topic (same convention as the kg-indexer).
+pub fn get_event_type(headers: Option<&rdkafka::message::BorrowedHeaders>) -> Option<String> {
+    use rdkafka::message::Headers;
+    headers.and_then(|h| {
+        for header in h.iter() {
+            if header.key == "event-type" {
+                if let Some(value) = header.value {
+                    return String::from_utf8(value.to_vec()).ok();
+                }
+            }
+        }
+        None
+    })
+}
+
+/// Decode a `space.membership` message, dispatching on the `event-type` header.
+pub fn parse_membership_event(
+    payload: &[u8],
+    event_type: Option<&str>,
+) -> Result<MembershipEvent, IndexerError> {
+    match event_type {
+        Some("ROLE_GRANTED") => Ok(MembershipEvent::RoleGranted(
+            hermes_schema::pb::membership::HermesRoleGranted::decode(payload)
+                .map_err(|e| IndexerError::decode(format!("HermesRoleGranted: {e}")))?,
+        )),
+        Some("ROLE_REVOKED") => Ok(MembershipEvent::RoleRevoked(
+            hermes_schema::pb::membership::HermesRoleRevoked::decode(payload)
+                .map_err(|e| IndexerError::decode(format!("HermesRoleRevoked: {e}")))?,
+        )),
+        Some("SPACE_LEFT") => Ok(MembershipEvent::SpaceLeft(
+            hermes_schema::pb::membership::HermesSpaceLeft::decode(payload)
+                .map_err(|e| IndexerError::decode(format!("HermesSpaceLeft: {e}")))?,
+        )),
+        other => Err(IndexerError::decode(format!(
+            "unknown membership event type: {other:?}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hermes_schema::pb::membership::{HermesRoleGranted, MembershipRole};
+    use uuid::Uuid;
+
+    #[test]
+    fn membership_dispatches_on_event_type_header() {
+        let granted = HermesRoleGranted {
+            space_id: Uuid::from_u128(1).as_bytes().to_vec(),
+            member_space_id: Uuid::from_u128(2).as_bytes().to_vec(),
+            role: MembershipRole::Member as i32,
+            meta: None,
+        };
+        let payload = granted.encode_to_vec();
+
+        assert!(matches!(
+            parse_membership_event(&payload, Some("ROLE_GRANTED")),
+            Ok(MembershipEvent::RoleGranted(_))
+        ));
+        assert!(matches!(
+            parse_membership_event(&payload, Some("ROLE_REVOKED")),
+            Ok(MembershipEvent::RoleRevoked(_))
+        ));
+        // missing or unknown header -> decode error, not a crash
+        assert!(parse_membership_event(&payload, None).is_err());
+        assert!(parse_membership_event(&payload, Some("BOGUS")).is_err());
+    }
 }

--- a/ranking-indexer/src/consumer.rs
+++ b/ranking-indexer/src/consumer.rs
@@ -172,10 +172,6 @@ pub fn parse_membership_event(
             hermes_schema::pb::membership::HermesRoleRevoked::decode(payload)
                 .map_err(|e| IndexerError::decode(format!("HermesRoleRevoked: {e}")))?,
         )),
-        Some("SPACE_LEFT") => Ok(MembershipEvent::SpaceLeft(
-            hermes_schema::pb::membership::HermesSpaceLeft::decode(payload)
-                .map_err(|e| IndexerError::decode(format!("HermesSpaceLeft: {e}")))?,
-        )),
         other => Err(IndexerError::decode(format!(
             "unknown membership event type: {other:?}"
         ))),

--- a/ranking-indexer/src/error.rs
+++ b/ranking-indexer/src/error.rs
@@ -19,6 +19,14 @@ impl IndexerError {
     pub fn decode(msg: impl Into<String>) -> Self {
         Self::Decode(msg.into())
     }
+
+    /// True when retrying the same input can never succeed (malformed
+    /// message). Everything else — database, Kafka — is treated as transient:
+    /// retried, and never skipped past, since the writes are idempotent and
+    /// redelivery converges.
+    pub fn is_poison(&self) -> bool {
+        matches!(self, Self::Decode(_))
+    }
 }
 
 impl From<prost::DecodeError> for IndexerError {

--- a/ranking-indexer/src/lib.rs
+++ b/ranking-indexer/src/lib.rs
@@ -1,12 +1,14 @@
-//! ranking-indexer: consumes `knowledge.edits`, maintains the private `ranks`
-//! working schema, and projects aggregated `RANK_POSITION` relations back into
-//! the public graph.
+//! ranking-indexer: consumes `knowledge.edits` and `space.membership`,
+//! maintains the private `ranks` working schema (including its own view of
+//! space membership), and projects aggregated `RANK_POSITION` relations back
+//! into the public graph.
 
 pub mod consumer;
 pub mod dedup;
 pub mod detect;
 pub mod eligibility;
 pub mod error;
+pub mod membership;
 pub mod models;
 pub mod publish;
 pub mod recompute;

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -3,6 +3,10 @@
 //! Consumes `knowledge.edits`, keeps the rank-relevant ops, and runs the full
 //! pipeline per edit (decode -> detect -> upsert -> recompute -> publish). The
 //! design allows either per-edit or per-block batching (§10); this uses per-edit.
+//!
+//! Also consumes `space.membership` to maintain the indexer's own view of the
+//! space registry (`ranks.members` / `ranks.editors`) and recompute the blocks
+//! a role grant/revoke affects (GEO-688).
 
 use std::env;
 
@@ -11,9 +15,12 @@ use rdkafka::Message;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use ranking_indexer::consumer::{decode_grc20, parse_edit, KafkaConsumer};
+use ranking_indexer::consumer::{
+    decode_grc20, get_event_type, parse_edit, parse_membership_event, KafkaConsumer, TopicKind,
+};
 use ranking_indexer::detect::detect;
 use ranking_indexer::error::IndexerError;
+use ranking_indexer::membership::apply_membership_event;
 use ranking_indexer::recompute;
 use ranking_indexer::storage::Storage;
 
@@ -55,16 +62,31 @@ async fn main() -> Result<(), IndexerError> {
             continue;
         };
 
-        match process_edit(payload, &storage).await {
-            Ok(()) => {
+        match consumer.topic_kind(&topic) {
+            Some(TopicKind::Edits) => {
+                match process_edit(payload, &storage).await {
+                    Ok(()) => {
+                        if let Err(e) = consumer.commit_message(&topic, partition, offset) {
+                            error!(error = %e, "Failed to commit offset");
+                        }
+                    }
+                    Err(e) => {
+                        // A malformed edit is logged and skipped rather than stalling the
+                        // partition (design §10). The offset is still advanced.
+                        warn!(error = %e, offset = offset, "Skipping unprocessable edit");
+                        let _ = consumer.commit_message(&topic, partition, offset);
+                    }
+                }
+            }
+            Some(TopicKind::Membership) => {
+                let event_type = get_event_type(msg.headers());
+                process_membership(payload, event_type.as_deref(), &storage, offset).await;
                 if let Err(e) = consumer.commit_message(&topic, partition, offset) {
                     error!(error = %e, "Failed to commit offset");
                 }
             }
-            Err(e) => {
-                // A malformed edit is logged and skipped rather than stalling the
-                // partition (design §10). The offset is still advanced.
-                warn!(error = %e, offset = offset, "Skipping unprocessable edit");
+            None => {
+                warn!(topic = %topic, "Message on unexpected topic — skipping");
                 let _ = consumer.commit_message(&topic, partition, offset);
             }
         }
@@ -87,4 +109,28 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         .unwrap_or((0, 0));
     let detected = detect(&grc20_edit, space_id, block_number, block_timestamp);
     recompute::apply_detected_edit(&detected, space_id, storage).await
+}
+
+/// Apply one membership event. Errors are logged and the message dropped —
+/// same policy as edits, so one bad message can never stall the partition. A
+/// dropped view update (e.g. a ROLE_GRANTED lost to a transient DB error)
+/// stays divergent until the affected member's next membership event or a
+/// reseed from the public tables.
+async fn process_membership(
+    payload: &[u8],
+    event_type: Option<&str>,
+    storage: &Storage,
+    offset: i64,
+) {
+    let event = match parse_membership_event(payload, event_type) {
+        Ok(event) => event,
+        Err(e) => {
+            warn!(error = %e, offset = offset, "Skipping undecodable membership event");
+            return;
+        }
+    };
+
+    if let Err(e) = apply_membership_event(&event, storage).await {
+        warn!(error = %e, offset = offset, "Skipping unprocessable membership event");
+    }
 }

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -6,7 +6,7 @@
 //!
 //! Also consumes `space.membership` to maintain the indexer's own view of the
 //! space registry (`ranks.members` / `ranks.editors`) and recompute the blocks
-//! a role grant/revoke affects (GEO-688).
+//! a role grant/revoke affects.
 
 use std::env;
 

--- a/ranking-indexer/src/main.rs
+++ b/ranking-indexer/src/main.rs
@@ -7,12 +7,21 @@
 //! Also consumes `space.membership` to maintain the indexer's own view of the
 //! space registry (`ranks.members` / `ranks.editors`) and recompute the blocks
 //! a role grant/revoke affects.
+//!
+//! Error policy: poison messages (malformed input — retrying can never
+//! succeed) are logged, skipped, and committed past, so one bad message never
+//! stalls the partition. Transient errors (database, Kafka) are retried with
+//! backoff; if they persist the process exits *without* committing, so Kafka
+//! redelivers from the last committed offset on restart and the idempotent
+//! writes converge. Transient failures are never skipped past — that would
+//! silently lose an edit, or worse, a role revocation.
 
 use std::env;
+use std::time::Duration;
 
 use futures::StreamExt;
 use rdkafka::Message;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use ranking_indexer::consumer::{
@@ -23,6 +32,13 @@ use ranking_indexer::error::IndexerError;
 use ranking_indexer::membership::apply_membership_event;
 use ranking_indexer::recompute;
 use ranking_indexer::storage::Storage;
+
+/// Attempts per message for transient failures before the process exits to
+/// force redelivery from the last committed offset.
+const MAX_TRANSIENT_ATTEMPTS: u32 = 4;
+
+/// First retry delay; doubles per attempt (1s, 2s, 4s).
+const BACKOFF_BASE_MS: u64 = 1000;
 
 #[tokio::main]
 async fn main() -> Result<(), IndexerError> {
@@ -37,6 +53,7 @@ async fn main() -> Result<(), IndexerError> {
     let group_id = env::var("KAFKA_GROUP_ID").unwrap_or_else(|_| "ranking-indexer".into());
 
     let storage = Storage::new(&database_url).await?;
+    storage.check_membership_view().await?;
     let consumer = KafkaConsumer::new(&brokers, &group_id)?;
     consumer.subscribe()?;
 
@@ -64,23 +81,39 @@ async fn main() -> Result<(), IndexerError> {
 
         match consumer.topic_kind(&topic) {
             Some(TopicKind::Edits) => {
-                match process_edit(payload, &storage).await {
-                    Ok(()) => {
-                        if let Err(e) = consumer.commit_message(&topic, partition, offset) {
-                            error!(error = %e, "Failed to commit offset");
-                        }
-                    }
-                    Err(e) => {
-                        // A malformed edit is logged and skipped rather than stalling the
-                        // partition (design §10). The offset is still advanced.
-                        warn!(error = %e, offset = offset, "Skipping unprocessable edit");
-                        let _ = consumer.commit_message(&topic, partition, offset);
-                    }
+                if let Err(e) =
+                    with_transient_retry("edit", offset, || process_edit(payload, &storage)).await
+                {
+                    // Poison: a malformed edit is logged and skipped rather
+                    // than stalling the partition (design §10).
+                    warn!(error = %e, offset = offset, "Skipping unprocessable edit");
+                }
+                if let Err(e) = consumer.commit_message(&topic, partition, offset) {
+                    error!(error = %e, "Failed to commit offset");
                 }
             }
             Some(TopicKind::Membership) => {
                 let event_type = get_event_type(msg.headers());
-                process_membership(payload, event_type.as_deref(), &storage, offset).await;
+                match parse_membership_event(payload, event_type.as_deref()) {
+                    Ok(Some(event)) => {
+                        if let Err(e) = with_transient_retry("membership event", offset, || {
+                            apply_membership_event(&event, &storage)
+                        })
+                        .await
+                        {
+                            // Poison: unknown role or malformed ids.
+                            warn!(error = %e, offset = offset, "Skipping unprocessable membership event");
+                        }
+                    }
+                    // Known event type this indexer intentionally ignores
+                    // (SPACE_LEFT, kg-indexer parity) — not warn-worthy.
+                    Ok(None) => {
+                        debug!(offset = offset, "Ignoring unhandled membership event type")
+                    }
+                    Err(e) => {
+                        warn!(error = %e, offset = offset, "Skipping undecodable membership event");
+                    }
+                }
                 if let Err(e) = consumer.commit_message(&topic, partition, offset) {
                     error!(error = %e, "Failed to commit offset");
                 }
@@ -93,6 +126,56 @@ async fn main() -> Result<(), IndexerError> {
     }
 
     Ok(())
+}
+
+/// Run one message's processing, retrying transient errors with capped
+/// exponential backoff.
+///
+/// `Ok(())` means processing succeeded; `Err(e)` means the error is poison
+/// (retrying can never succeed) and the caller should skip + commit. A
+/// transient error that survives every attempt exits the process instead:
+/// the offset is never committed, so Kafka redelivers the message on restart
+/// and the idempotent writes converge.
+async fn with_transient_retry<F, Fut>(
+    kind: &str,
+    offset: i64,
+    mut op: F,
+) -> Result<(), IndexerError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), IndexerError>>,
+{
+    let mut attempt: u32 = 1;
+    loop {
+        match op().await {
+            Ok(()) => return Ok(()),
+            Err(e) if e.is_poison() => return Err(e),
+            Err(e) if attempt < MAX_TRANSIENT_ATTEMPTS => {
+                let delay_ms = BACKOFF_BASE_MS << (attempt - 1);
+                warn!(
+                    error = %e,
+                    kind = kind,
+                    offset = offset,
+                    attempt = attempt,
+                    delay_ms = delay_ms,
+                    "Transient error — retrying"
+                );
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                attempt += 1;
+            }
+            Err(e) => {
+                error!(
+                    error = %e,
+                    kind = kind,
+                    offset = offset,
+                    attempts = attempt,
+                    "Transient error persisted — exiting so Kafka redelivers from the last \
+                     committed offset"
+                );
+                std::process::exit(1);
+            }
+        }
+    }
 }
 
 /// Decode one edit and upsert its rank-relevant ops into the `ranks` schema.
@@ -109,28 +192,4 @@ async fn process_edit(payload: &[u8], storage: &Storage) -> Result<(), IndexerEr
         .unwrap_or((0, 0));
     let detected = detect(&grc20_edit, space_id, block_number, block_timestamp);
     recompute::apply_detected_edit(&detected, space_id, storage).await
-}
-
-/// Apply one membership event. Errors are logged and the message dropped —
-/// same policy as edits, so one bad message can never stall the partition. A
-/// dropped view update (e.g. a ROLE_GRANTED lost to a transient DB error)
-/// stays divergent until the affected member's next membership event or a
-/// reseed from the public tables.
-async fn process_membership(
-    payload: &[u8],
-    event_type: Option<&str>,
-    storage: &Storage,
-    offset: i64,
-) {
-    let event = match parse_membership_event(payload, event_type) {
-        Ok(event) => event,
-        Err(e) => {
-            warn!(error = %e, offset = offset, "Skipping undecodable membership event");
-            return;
-        }
-    };
-
-    if let Err(e) = apply_membership_event(&event, storage).await {
-        warn!(error = %e, offset = offset, "Skipping unprocessable membership event");
-    }
 }

--- a/ranking-indexer/src/membership.rs
+++ b/ranking-indexer/src/membership.rs
@@ -1,4 +1,4 @@
-//! Membership event handling (GEO-688).
+//! Membership event handling.
 //!
 //! The indexer maintains its own minimal view of the space registry
 //! (`ranks.members` / `ranks.editors`), fed from the `space.membership` topic,

--- a/ranking-indexer/src/membership.rs
+++ b/ranking-indexer/src/membership.rs
@@ -6,9 +6,7 @@
 //! event recomputes the blocks where the change can matter: blocks in the
 //! affected space that hold a submission from the member's personal space.
 
-use hermes_schema::pb::membership::{
-    HermesRoleGranted, HermesRoleRevoked, HermesSpaceLeft, MembershipRole,
-};
+use hermes_schema::pb::membership::{HermesRoleGranted, HermesRoleRevoked, MembershipRole};
 use uuid::Uuid;
 
 use crate::error::IndexerError;
@@ -20,7 +18,6 @@ use crate::storage::Storage;
 pub enum MembershipEvent {
     RoleGranted(HermesRoleGranted),
     RoleRevoked(HermesRoleRevoked),
-    SpaceLeft(HermesSpaceLeft),
 }
 
 /// What an event does to the membership view.
@@ -30,9 +27,6 @@ pub enum ChangeKind {
     AddEditor,
     RemoveMember,
     RemoveEditor,
-    /// `SPACE_LEFT` carries no role — the member left voluntarily, so both
-    /// roles are dropped.
-    Left,
 }
 
 /// A membership event reduced to ids + effect.
@@ -80,14 +74,6 @@ pub fn change_for(event: &MembershipEvent) -> Result<MembershipChange, IndexerEr
                 kind,
             })
         }
-        MembershipEvent::SpaceLeft(e) => {
-            let (space_id, member_space_id) = ids(&e.space_id, &e.member_id)?;
-            Ok(MembershipChange {
-                space_id,
-                member_space_id,
-                kind: ChangeKind::Left,
-            })
-        }
     }
 }
 
@@ -120,11 +106,6 @@ pub async fn apply_membership_event(
         ChangeKind::RemoveEditor => {
             storage
                 .remove_editor(change.space_id, change.member_space_id)
-                .await?
-        }
-        ChangeKind::Left => {
-            storage
-                .remove_member_and_editor(change.space_id, change.member_space_id)
                 .await?
         }
     }
@@ -188,19 +169,6 @@ mod tests {
             });
             assert_eq!(change_for(&event).unwrap().kind, kind);
         }
-    }
-
-    #[test]
-    fn space_left_drops_both_roles() {
-        let event = MembershipEvent::SpaceLeft(HermesSpaceLeft {
-            member_id: b(2),
-            space_id: b(1),
-            meta: None,
-        });
-        let change = change_for(&event).unwrap();
-        assert_eq!(change.space_id, Uuid::from_u128(1));
-        assert_eq!(change.member_space_id, Uuid::from_u128(2));
-        assert_eq!(change.kind, ChangeKind::Left);
     }
 
     #[test]

--- a/ranking-indexer/src/membership.rs
+++ b/ranking-indexer/src/membership.rs
@@ -1,0 +1,227 @@
+//! Membership event handling (GEO-688).
+//!
+//! The indexer maintains its own minimal view of the space registry
+//! (`ranks.members` / `ranks.editors`), fed from the `space.membership` topic,
+//! so eligibility never races the kg-indexer's consumer group. Each applied
+//! event recomputes the blocks where the change can matter: blocks in the
+//! affected space that hold a submission from the member's personal space.
+
+use hermes_schema::pb::membership::{
+    HermesRoleGranted, HermesRoleRevoked, HermesSpaceLeft, MembershipRole,
+};
+use uuid::Uuid;
+
+use crate::error::IndexerError;
+use crate::recompute::recompute_block;
+use crate::storage::Storage;
+
+/// A decoded `space.membership` message (dispatched on the `event-type` header).
+#[derive(Debug)]
+pub enum MembershipEvent {
+    RoleGranted(HermesRoleGranted),
+    RoleRevoked(HermesRoleRevoked),
+    SpaceLeft(HermesSpaceLeft),
+}
+
+/// What an event does to the membership view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeKind {
+    AddMember,
+    AddEditor,
+    RemoveMember,
+    RemoveEditor,
+    /// `SPACE_LEFT` carries no role — the member left voluntarily, so both
+    /// roles are dropped.
+    Left,
+}
+
+/// A membership event reduced to ids + effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MembershipChange {
+    pub space_id: Uuid,
+    pub member_space_id: Uuid,
+    pub kind: ChangeKind,
+}
+
+fn ids(space_id: &[u8], member_space_id: &[u8]) -> Result<(Uuid, Uuid), IndexerError> {
+    let space =
+        Uuid::from_slice(space_id).map_err(|e| IndexerError::decode(format!("space_id: {e}")))?;
+    let member = Uuid::from_slice(member_space_id)
+        .map_err(|e| IndexerError::decode(format!("member_space_id: {e}")))?;
+    Ok((space, member))
+}
+
+/// Reduce a decoded event to the change it makes to the view.
+pub fn change_for(event: &MembershipEvent) -> Result<MembershipChange, IndexerError> {
+    match event {
+        MembershipEvent::RoleGranted(e) => {
+            let (space_id, member_space_id) = ids(&e.space_id, &e.member_space_id)?;
+            let kind = match MembershipRole::try_from(e.role) {
+                Ok(MembershipRole::Editor) => ChangeKind::AddEditor,
+                Ok(MembershipRole::Member) => ChangeKind::AddMember,
+                Err(_) => return Err(IndexerError::decode(format!("unknown role: {}", e.role))),
+            };
+            Ok(MembershipChange {
+                space_id,
+                member_space_id,
+                kind,
+            })
+        }
+        MembershipEvent::RoleRevoked(e) => {
+            let (space_id, member_space_id) = ids(&e.space_id, &e.member_space_id)?;
+            let kind = match MembershipRole::try_from(e.role) {
+                Ok(MembershipRole::Editor) => ChangeKind::RemoveEditor,
+                Ok(MembershipRole::Member) => ChangeKind::RemoveMember,
+                Err(_) => return Err(IndexerError::decode(format!("unknown role: {}", e.role))),
+            };
+            Ok(MembershipChange {
+                space_id,
+                member_space_id,
+                kind,
+            })
+        }
+        MembershipEvent::SpaceLeft(e) => {
+            let (space_id, member_space_id) = ids(&e.space_id, &e.member_id)?;
+            Ok(MembershipChange {
+                space_id,
+                member_space_id,
+                kind: ChangeKind::Left,
+            })
+        }
+    }
+}
+
+/// Apply a membership event end to end: update the view, then recompute every
+/// block in the affected space holding a submission from that member's
+/// personal space. The recompute reads the just-updated view, so a late join
+/// integrates the member's existing ranks and a removal drops them.
+pub async fn apply_membership_event(
+    event: &MembershipEvent,
+    storage: &Storage,
+) -> Result<(), IndexerError> {
+    let change = change_for(event)?;
+
+    match change.kind {
+        ChangeKind::AddMember => {
+            storage
+                .add_member(change.space_id, change.member_space_id)
+                .await?
+        }
+        ChangeKind::AddEditor => {
+            storage
+                .add_editor(change.space_id, change.member_space_id)
+                .await?
+        }
+        ChangeKind::RemoveMember => {
+            storage
+                .remove_member(change.space_id, change.member_space_id)
+                .await?
+        }
+        ChangeKind::RemoveEditor => {
+            storage
+                .remove_editor(change.space_id, change.member_space_id)
+                .await?
+        }
+        ChangeKind::Left => {
+            storage
+                .remove_member_and_editor(change.space_id, change.member_space_id)
+                .await?
+        }
+    }
+
+    let blocks = storage
+        .blocks_with_rankings_from(change.space_id, change.member_space_id)
+        .await?;
+    for block_id in &blocks {
+        recompute_block(*block_id, storage).await?;
+    }
+
+    tracing::debug!(
+        space_id = %change.space_id,
+        member_space_id = %change.member_space_id,
+        kind = ?change.kind,
+        recomputed_blocks = blocks.len(),
+        "ranking-indexer membership: view updated + affected blocks recomputed"
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b(n: u128) -> Vec<u8> {
+        Uuid::from_u128(n).as_bytes().to_vec()
+    }
+
+    #[test]
+    fn role_granted_maps_to_add() {
+        for (role, kind) in [
+            (MembershipRole::Member, ChangeKind::AddMember),
+            (MembershipRole::Editor, ChangeKind::AddEditor),
+        ] {
+            let event = MembershipEvent::RoleGranted(HermesRoleGranted {
+                space_id: b(1),
+                member_space_id: b(2),
+                role: role as i32,
+                meta: None,
+            });
+            let change = change_for(&event).unwrap();
+            assert_eq!(change.space_id, Uuid::from_u128(1));
+            assert_eq!(change.member_space_id, Uuid::from_u128(2));
+            assert_eq!(change.kind, kind);
+        }
+    }
+
+    #[test]
+    fn role_revoked_maps_to_remove() {
+        for (role, kind) in [
+            (MembershipRole::Member, ChangeKind::RemoveMember),
+            (MembershipRole::Editor, ChangeKind::RemoveEditor),
+        ] {
+            let event = MembershipEvent::RoleRevoked(HermesRoleRevoked {
+                space_id: b(1),
+                member_space_id: b(2),
+                role: role as i32,
+                meta: None,
+            });
+            assert_eq!(change_for(&event).unwrap().kind, kind);
+        }
+    }
+
+    #[test]
+    fn space_left_drops_both_roles() {
+        let event = MembershipEvent::SpaceLeft(HermesSpaceLeft {
+            member_id: b(2),
+            space_id: b(1),
+            meta: None,
+        });
+        let change = change_for(&event).unwrap();
+        assert_eq!(change.space_id, Uuid::from_u128(1));
+        assert_eq!(change.member_space_id, Uuid::from_u128(2));
+        assert_eq!(change.kind, ChangeKind::Left);
+    }
+
+    #[test]
+    fn unknown_role_is_a_decode_error() {
+        let event = MembershipEvent::RoleGranted(HermesRoleGranted {
+            space_id: b(1),
+            member_space_id: b(2),
+            role: 99,
+            meta: None,
+        });
+        assert!(matches!(change_for(&event), Err(IndexerError::Decode(_))));
+    }
+
+    #[test]
+    fn malformed_ids_are_decode_errors() {
+        let event = MembershipEvent::RoleGranted(HermesRoleGranted {
+            space_id: vec![1, 2, 3],
+            member_space_id: b(2),
+            role: MembershipRole::Member as i32,
+            meta: None,
+        });
+        assert!(matches!(change_for(&event), Err(IndexerError::Decode(_))));
+    }
+}

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -132,26 +132,6 @@ impl Storage {
         Ok(())
     }
 
-    /// Drop both roles at once (`SPACE_LEFT` carries no role).
-    pub async fn remove_member_and_editor(
-        &self,
-        space_id: Uuid,
-        member_space_id: Uuid,
-    ) -> Result<(), IndexerError> {
-        let mut tx = self.pool.begin().await?;
-        for table in ["ranks.members", "ranks.editors"] {
-            sqlx::query(&format!(
-                "DELETE FROM {table} WHERE member_space_id = $1 AND space_id = $2"
-            ))
-            .bind(member_space_id)
-            .bind(space_id)
-            .execute(&mut *tx)
-            .await?;
-        }
-        tx.commit().await?;
-        Ok(())
-    }
-
     /// Blocks whose aggregate a membership change for `(space_id,
     /// member_space_id)` can affect: blocks in the affected space holding a
     /// submission from that member's personal space.

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -51,17 +51,123 @@ impl Storage {
     }
 
     /// The set of personal-space ids that are members OR editors of `space_id`
-    /// — the eligible voters for a DAO-space block.
+    /// — the eligible voters for a DAO-space block. Reads the indexer's own
+    /// view (`ranks.members` / `ranks.editors`, fed from `space.membership`)
+    /// rather than the kg-indexer-maintained public tables, so a recompute
+    /// never races the kg-indexer's consumer group.
     pub async fn member_and_editor_spaces(
         &self,
         space_id: Uuid,
     ) -> Result<HashSet<Uuid>, IndexerError> {
         let rows: Vec<(Uuid,)> = sqlx::query_as(
-            "SELECT member_space_id FROM members WHERE space_id = $1
+            "SELECT member_space_id FROM ranks.members WHERE space_id = $1
              UNION
-             SELECT member_space_id FROM editors WHERE space_id = $1",
+             SELECT member_space_id FROM ranks.editors WHERE space_id = $1",
         )
         .bind(space_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Record `member_space_id` as a member of `space_id` in the view.
+    pub async fn add_member(
+        &self,
+        space_id: Uuid,
+        member_space_id: Uuid,
+    ) -> Result<(), IndexerError> {
+        sqlx::query(
+            "INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(member_space_id)
+        .bind(space_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Drop `member_space_id` as a member of `space_id` from the view.
+    pub async fn remove_member(
+        &self,
+        space_id: Uuid,
+        member_space_id: Uuid,
+    ) -> Result<(), IndexerError> {
+        sqlx::query("DELETE FROM ranks.members WHERE member_space_id = $1 AND space_id = $2")
+            .bind(member_space_id)
+            .bind(space_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Record `member_space_id` as an editor of `space_id` in the view.
+    pub async fn add_editor(
+        &self,
+        space_id: Uuid,
+        member_space_id: Uuid,
+    ) -> Result<(), IndexerError> {
+        sqlx::query(
+            "INSERT INTO ranks.editors (member_space_id, space_id) VALUES ($1, $2)
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(member_space_id)
+        .bind(space_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Drop `member_space_id` as an editor of `space_id` from the view.
+    pub async fn remove_editor(
+        &self,
+        space_id: Uuid,
+        member_space_id: Uuid,
+    ) -> Result<(), IndexerError> {
+        sqlx::query("DELETE FROM ranks.editors WHERE member_space_id = $1 AND space_id = $2")
+            .bind(member_space_id)
+            .bind(space_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Drop both roles at once (`SPACE_LEFT` carries no role).
+    pub async fn remove_member_and_editor(
+        &self,
+        space_id: Uuid,
+        member_space_id: Uuid,
+    ) -> Result<(), IndexerError> {
+        let mut tx = self.pool.begin().await?;
+        for table in ["ranks.members", "ranks.editors"] {
+            sqlx::query(&format!(
+                "DELETE FROM {table} WHERE member_space_id = $1 AND space_id = $2"
+            ))
+            .bind(member_space_id)
+            .bind(space_id)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Blocks whose aggregate a membership change for `(space_id,
+    /// member_space_id)` can affect: blocks in the affected space holding a
+    /// submission from that member's personal space.
+    pub async fn blocks_with_rankings_from(
+        &self,
+        space_id: Uuid,
+        member_space_id: Uuid,
+    ) -> Result<Vec<Uuid>, IndexerError> {
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT DISTINCT r.block_id
+             FROM ranks.rankings r
+             JOIN ranks.ranking_blocks b ON b.id = r.block_id AND b.space_id = $1
+             WHERE r.space_id = $2 AND r.block_id IS NOT NULL",
+        )
+        .bind(space_id)
+        .bind(member_space_id)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.into_iter().map(|(id,)| id).collect())

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -36,6 +36,26 @@ impl Storage {
         &self.pool
     }
 
+    /// Fail-fast startup check that the membership view exists (migration
+    /// `0062_ranks_members_editors`). Without it the missing tables would only
+    /// surface sporadically — on the first DAO-space recompute — instead of
+    /// deterministically at boot with an explicit error. Deploy order matters:
+    /// the migration must be applied before this indexer version starts.
+    pub async fn check_membership_view(&self) -> Result<(), IndexerError> {
+        for table in ["ranks.members", "ranks.editors"] {
+            sqlx::query(&format!("SELECT 1 FROM {table} LIMIT 1"))
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| {
+                    IndexerError::Config(format!(
+                        "{table} not readable — has migration 0062_ranks_members_editors \
+                         been applied? ({e})"
+                    ))
+                })?;
+        }
+        Ok(())
+    }
+
     /// Resolve a space's kind from `public.spaces.type` (`DAO` / `Personal`).
     /// Returns `None` if the space isn't known yet; callers treat unknown
     /// conservatively (as `Dao`, i.e. membership-restricted).

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -8,11 +8,15 @@
 //! CI `DATABASE_URL` that lacks the `ranks` schema.
 
 use grc_20::model::builder::EditBuilder;
+use hermes_schema::pb::membership::{
+    HermesRoleGranted, HermesRoleRevoked, HermesSpaceLeft, MembershipRole,
+};
 use sdk::core::ids::*;
 use sqlx::Row;
 use uuid::Uuid;
 
 use ranking_indexer::detect::detect;
+use ranking_indexer::membership::{apply_membership_event, MembershipEvent};
 use ranking_indexer::recompute::apply_detected_edit;
 use ranking_indexer::storage::Storage;
 
@@ -78,7 +82,7 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
         .execute(pool)
         .await
         .unwrap();
-    sqlx::query("DELETE FROM members WHERE space_id = $1")
+    sqlx::query("DELETE FROM ranks.members WHERE space_id = $1")
         .bind(u(BLOCK_SPACE))
         .execute(pool)
         .await
@@ -89,15 +93,16 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
         .await
         .unwrap();
 
-    // --- seed public prerequisites -----------------------------------------
-    // The block lives in a DAO space; member1/member2 are members, nonmember isn't.
+    // --- seed prerequisites --------------------------------------------------
+    // The block lives in a DAO space; member1/member2 are members, nonmember
+    // isn't. Membership lives in the indexer's own view (`ranks.members`).
     sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e')")
         .bind(u(BLOCK_SPACE))
         .execute(pool)
         .await
         .unwrap();
     for m in [MEMBER1, MEMBER2] {
-        sqlx::query("INSERT INTO members (member_space_id, space_id) VALUES ($1, $2)")
+        sqlx::query("INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)")
             .bind(u(m))
             .bind(u(BLOCK_SPACE))
             .execute(pool)
@@ -305,7 +310,7 @@ async fn cross_edit_block_is_recovered_from_kg_and_scored() {
         .execute(pool)
         .await
         .unwrap();
-    sqlx::query("DELETE FROM members WHERE space_id = $1")
+    sqlx::query("DELETE FROM ranks.members WHERE space_id = $1")
         .bind(u(SPACE))
         .execute(pool)
         .await
@@ -316,13 +321,13 @@ async fn cross_edit_block_is_recovered_from_kg_and_scored() {
         .await
         .unwrap();
 
-    // --- seed public prerequisites -----------------------------------------
+    // --- seed prerequisites --------------------------------------------------
     sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e2')")
         .bind(u(SPACE))
         .execute(pool)
         .await
         .unwrap();
-    sqlx::query("INSERT INTO members (member_space_id, space_id) VALUES ($1, $2)")
+    sqlx::query("INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)")
         .bind(u(MEMBER))
         .bind(u(SPACE))
         .execute(pool)
@@ -336,7 +341,7 @@ async fn cross_edit_block_is_recovered_from_kg_and_scored() {
         "INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
          VALUES ($1, $2, $3, $4, $5, $6)",
     )
-    .bind(u(TYPE_REL).to_string())
+    .bind(u(TYPE_REL))
     .bind(u(TYPE_REL))
     .bind(su(TYPE_RELATION_TYPE_ID))
     .bind(u(BLOCK))
@@ -432,4 +437,255 @@ async fn cross_edit_block_is_recovered_from_kg_and_scored() {
         scores, 2,
         "both ranked entities scored once the block is recovered"
     );
+}
+// Membership-lifecycle scenario UUIDs (distinct namespace so both e2e tests
+// can run against the same database, even concurrently).
+const M_SPACE: u128 = 0xE2E6_0000_0001;
+const M_MEMBER: u128 = 0xE2E6_0000_0011;
+const M_LATE: u128 = 0xE2E6_0000_0012;
+const M_BLOCK: u128 = 0xE2E6_0000_0021;
+const M_ENTITY_A: u128 = 0xE2E6_0000_0031;
+const M_ENTITY_B: u128 = 0xE2E6_0000_0032;
+const M_RANK1: u128 = 0xE2E6_0000_0041;
+const M_RANK2: u128 = 0xE2E6_0000_0042;
+
+/// GEO-688: a rank submitted by a non-member must be integrated when they
+/// become a member (or editor), and dropped again when the role is revoked or
+/// they leave the space.
+#[tokio::test]
+async fn membership_events_integrate_and_drop_rankings() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+        "DELETE FROM ranks.members WHERE space_id = $1",
+        "DELETE FROM ranks.editors WHERE space_id = $1",
+        "DELETE FROM spaces WHERE id = $1",
+    ] {
+        sqlx::query(sql)
+            .bind(u(M_SPACE))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = ANY($1)")
+        .bind(&[u(M_RANK1), u(M_RANK2)][..])
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = ANY($1)")
+        .bind(&[u(M_RANK1), u(M_RANK2)][..])
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(M_BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(M_BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed: DAO space with one founding member ---------------------------
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e6')")
+        .bind(u(M_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)")
+        .bind(u(M_MEMBER))
+        .bind(u(M_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- create the block + two submissions ---------------------------------
+    let block_edit = EditBuilder::new(gid(0xE2E6_0001))
+        .create_relation(|r| {
+            r.id(gid(0xE2E6_0100))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(M_BLOCK))
+                .to(sid(RANKING_BLOCK_TYPE_ID))
+        })
+        .create_relation(|r| {
+            r.id(gid(0xE2E6_0101))
+                .relation_type(sid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+                .from(gid(M_BLOCK))
+                .to(sid(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID))
+        })
+        .create_entity(gid(M_BLOCK), |e| {
+            e.text(sid(NAME_PROPERTY_ID), "Top Tokens", None)
+        })
+        .build();
+    apply_detected_edit(&detect(&block_edit, u(M_SPACE), 1, 0), u(M_SPACE), &storage)
+        .await
+        .unwrap();
+
+    let submit = |rank: u128, rel_base: u128, first: u128, second: u128| {
+        EditBuilder::new(gid(rank ^ 0xED17))
+            .create_relation(|r| {
+                r.id(gid(rel_base))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(sid(RANK_TYPE_ID))
+            })
+            .create_entity(gid(rank), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 1))
+                    .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(M_BLOCK))
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 2))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(first))
+                    .to_space(gid(M_SPACE))
+                    .position("a0")
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 3))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(second))
+                    .to_space(gid(M_SPACE))
+                    .position("a1")
+            })
+            .build()
+    };
+
+    apply_detected_edit(
+        &detect(
+            &submit(M_RANK1, 0xE2E6_0200, M_ENTITY_A, M_ENTITY_B),
+            u(M_MEMBER),
+            2,
+            0,
+        ),
+        u(M_MEMBER),
+        &storage,
+    )
+    .await
+    .unwrap();
+    // The latecomer submits while NOT yet a member — must be excluded.
+    apply_detected_edit(
+        &detect(
+            &submit(M_RANK2, 0xE2E6_0210, M_ENTITY_A, M_ENTITY_B),
+            u(M_LATE),
+            3,
+            0,
+        ),
+        u(M_LATE),
+        &storage,
+    )
+    .await
+    .unwrap();
+
+    let aggregated = Uuid::parse_str(AGGREGATED_RANKINGS_RELATION_TYPE_ID).unwrap();
+    let contributing = |pool: &sqlx::PgPool| {
+        let pool = pool.clone();
+        async move {
+            let rows: Vec<(Uuid,)> = sqlx::query_as(
+                "SELECT to_entity_id FROM relations WHERE from_entity_id = $1 AND type_id = $2",
+            )
+            .bind(u(M_BLOCK))
+            .bind(aggregated)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+            rows.into_iter().map(|(id,)| id).collect::<Vec<_>>()
+        }
+    };
+
+    let prov = contributing(pool).await;
+    assert_eq!(prov, vec![u(M_RANK1)], "latecomer must start excluded");
+
+    // --- ROLE_GRANTED(MEMBER): the existing rank is integrated ---------------
+    let granted = MembershipEvent::RoleGranted(HermesRoleGranted {
+        space_id: u(M_SPACE).as_bytes().to_vec(),
+        member_space_id: u(M_LATE).as_bytes().to_vec(),
+        role: MembershipRole::Member as i32,
+        meta: None,
+    });
+    apply_membership_event(&granted, &storage).await.unwrap();
+
+    let mut prov = contributing(pool).await;
+    prov.sort();
+    assert_eq!(
+        prov,
+        vec![u(M_RANK1), u(M_RANK2)],
+        "becoming a member must integrate the previously-excluded rank"
+    );
+
+    // --- ROLE_REVOKED(MEMBER): the rank drops out again ----------------------
+    let revoked = MembershipEvent::RoleRevoked(HermesRoleRevoked {
+        space_id: u(M_SPACE).as_bytes().to_vec(),
+        member_space_id: u(M_LATE).as_bytes().to_vec(),
+        role: MembershipRole::Member as i32,
+        meta: None,
+    });
+    apply_membership_event(&revoked, &storage).await.unwrap();
+
+    let prov = contributing(pool).await;
+    assert_eq!(
+        prov,
+        vec![u(M_RANK1)],
+        "revoking membership must drop the rank from the aggregate"
+    );
+
+    // --- ROLE_GRANTED(EDITOR): editors are eligible too ----------------------
+    let granted_editor = MembershipEvent::RoleGranted(HermesRoleGranted {
+        space_id: u(M_SPACE).as_bytes().to_vec(),
+        member_space_id: u(M_LATE).as_bytes().to_vec(),
+        role: MembershipRole::Editor as i32,
+        meta: None,
+    });
+    apply_membership_event(&granted_editor, &storage)
+        .await
+        .unwrap();
+
+    let mut prov = contributing(pool).await;
+    prov.sort();
+    assert_eq!(
+        prov,
+        vec![u(M_RANK1), u(M_RANK2)],
+        "an editor's rank must be integrated"
+    );
+
+    // --- SPACE_LEFT: drops both roles and the rank ---------------------------
+    let left = MembershipEvent::SpaceLeft(HermesSpaceLeft {
+        member_id: u(M_LATE).as_bytes().to_vec(),
+        space_id: u(M_SPACE).as_bytes().to_vec(),
+        meta: None,
+    });
+    apply_membership_event(&left, &storage).await.unwrap();
+
+    let prov = contributing(pool).await;
+    assert_eq!(
+        prov,
+        vec![u(M_RANK1)],
+        "leaving the space must drop the rank from the aggregate"
+    );
+    let view_rows: i64 = sqlx::query_scalar(
+        "SELECT (SELECT count(*) FROM ranks.members WHERE member_space_id = $1 AND space_id = $2)
+              + (SELECT count(*) FROM ranks.editors WHERE member_space_id = $1 AND space_id = $2)",
+    )
+    .bind(u(M_LATE))
+    .bind(u(M_SPACE))
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(view_rows, 0, "SPACE_LEFT must clear both view tables");
 }

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -8,9 +8,7 @@
 //! CI `DATABASE_URL` that lacks the `ranks` schema.
 
 use grc_20::model::builder::EditBuilder;
-use hermes_schema::pb::membership::{
-    HermesRoleGranted, HermesRoleRevoked, HermesSpaceLeft, MembershipRole,
-};
+use hermes_schema::pb::membership::{HermesRoleGranted, HermesRoleRevoked, MembershipRole};
 use sdk::core::ids::*;
 use sqlx::Row;
 use uuid::Uuid;
@@ -450,8 +448,7 @@ const M_RANK1: u128 = 0xE2E6_0000_0041;
 const M_RANK2: u128 = 0xE2E6_0000_0042;
 
 /// A rank submitted by a non-member must be integrated when they become a
-/// member (or editor), and dropped again when the role is revoked or they
-/// leave the space.
+/// member (or editor), and dropped again when the role is revoked.
 #[tokio::test]
 async fn membership_events_integrate_and_drop_rankings() {
     let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
@@ -664,19 +661,22 @@ async fn membership_events_integrate_and_drop_rankings() {
         "an editor's rank must be integrated"
     );
 
-    // --- SPACE_LEFT: drops both roles and the rank ---------------------------
-    let left = MembershipEvent::SpaceLeft(HermesSpaceLeft {
-        member_id: u(M_LATE).as_bytes().to_vec(),
+    // --- ROLE_REVOKED(EDITOR): the rank drops out again ----------------------
+    let revoked_editor = MembershipEvent::RoleRevoked(HermesRoleRevoked {
         space_id: u(M_SPACE).as_bytes().to_vec(),
+        member_space_id: u(M_LATE).as_bytes().to_vec(),
+        role: MembershipRole::Editor as i32,
         meta: None,
     });
-    apply_membership_event(&left, &storage).await.unwrap();
+    apply_membership_event(&revoked_editor, &storage)
+        .await
+        .unwrap();
 
     let prov = contributing(pool).await;
     assert_eq!(
         prov,
         vec![u(M_RANK1)],
-        "leaving the space must drop the rank from the aggregate"
+        "revoking the editor role must drop the rank from the aggregate"
     );
     let view_rows: i64 = sqlx::query_scalar(
         "SELECT (SELECT count(*) FROM ranks.members WHERE member_space_id = $1 AND space_id = $2)
@@ -687,5 +687,8 @@ async fn membership_events_integrate_and_drop_rankings() {
     .fetch_one(pool)
     .await
     .unwrap();
-    assert_eq!(view_rows, 0, "SPACE_LEFT must clear both view tables");
+    assert_eq!(
+        view_rows, 0,
+        "both roles revoked — view tables must be empty"
+    );
 }

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -449,9 +449,9 @@ const M_ENTITY_B: u128 = 0xE2E6_0000_0032;
 const M_RANK1: u128 = 0xE2E6_0000_0041;
 const M_RANK2: u128 = 0xE2E6_0000_0042;
 
-/// GEO-688: a rank submitted by a non-member must be integrated when they
-/// become a member (or editor), and dropped again when the role is revoked or
-/// they leave the space.
+/// A rank submitted by a non-member must be integrated when they become a
+/// member (or editor), and dropped again when the role is revoked or they
+/// leave the space.
 #[tokio::test]
 async fn membership_events_integrate_and_drop_rankings() {
     let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {


### PR DESCRIPTION
## Problem

Ranks submitted by someone who isn't a member of the space are excluded from the ranking block's aggregate — and stay excluded even after they become a member. The ranking-indexer only consumes `knowledge.edits`, and membership is read at recompute time from the kg-indexer-maintained `members`/`editors` tables, so a membership change never triggers a recompute. Reacting to membership events while reading those tables directly would also race the kg-indexer's consumer group.

## Changes

- The indexer now also consumes `space.membership` (`ROLE_GRANTED`/`ROLE_REVOKED`, dispatched on the `event-type` header — same logic as the kg-indexer) and maintains its own view of the space registry in `ranks.members`/`ranks.editors`. Eligibility reads this view instead of the public tables, eliminating the cross-indexer race.
- Each membership event updates the view, then recomputes only the blocks in the affected space that hold a submission from that member's personal space. Becoming a member/editor integrates previously-excluded ranks; a revoke drops them.
- Migration `0062` creates the view tables and seeds them from the public `members`/`editors`, so the switch-over is a semantic no-op.
- Membership messages follow the same drop-on-error policy as edits — one bad message never stalls the partition.
- Fixes a latent bug in the cross-edit KG-recovery e2e test: `relations.id` was bound as text instead of uuid, so the test failed against any real database (never caught — the e2e suite is opt-in and CI doesn't run it).

Cross-topic ordering between `knowledge.edits` and `space.membership` is undefined, but converges: whichever event lands last triggers a recompute that reads the consistent local view.

## Notes for deploy

- Aggregates that are *already* stale won't heal on their own — a block recomputes on the next event that touches it. The few affected production blocks need a one-off recompute after deploy.
- `SPACE_LEFT` is emitted by the pipeline but intentionally not handled, for parity with the kg-indexer (which also ignores it). If voluntary leaves should affect membership, both indexers should pick that up together.

## Testing

- Unit tests for the event-type dispatch and event → change mapping.
- e2e (live Postgres): non-member's rank excluded → `ROLE_GRANTED(MEMBER)` integrates it → `ROLE_REVOKED(MEMBER)` drops it → same cycle for the editor role. All 3 e2e tests pass against a fresh DB with all migrations applied.
