### PR TITLE
fix(proposal-executor): match any AddMember in allowlisted spaces

### DIFF
--- a/proposal-executor/ARCHITECTURE.md
+++ b/proposal-executor/ARCHITECTURE.md
@@ -248,14 +248,23 @@ guard this value, because `docs/protocol/dao-space.md` previously documented the
 SpaceRegistry, so the address is resolved first via `SpaceRegistry.spaceIdToAddress(daoSpaceId)`
 (a zero address ⇒ unregistered space ⇒ `InfraError`).
 
-### Request-to-Join Detection Signature
+### Membership Detection Signature
 
-A membership request, per stage-1 SQL, is a proposal that is **all** of: `Fast` voting mode; a
-single action; that action is `AddMember`; the action targets the proposer itself
-(`proposals.proposed_by = proposal_actions.target_id` — a *self*-request, not an editor adding
-someone); not executed; in an allowlisted space; and with no row in `proposal_votes` (stage-1
-untouched). There is **no creation-time cutoff** — a pre-existing backlog is admitted. When the
-allowlist is empty the query short-circuits to `[]` (kill switch — no DB query issued).
+A membership candidate, per stage-1 SQL, is a proposal that is **all** of: `Fast` voting mode; a
+single action; that action is `AddMember`; not executed; in an allowlisted space; within its
+voting window; and with no row in `proposal_votes` (stage-1 untouched). There is **no creation-time
+cutoff** — a pre-existing backlog is admitted. When the allowlist is empty the query short-circuits
+to `[]` (kill switch — no DB query issued).
+
+The detection does **not** distinguish a self-service request-to-join from an editor-initiated
+`AddMember`: the indexer stores `proposed_by` as the *space*, never the individual proposer, so the
+two are indistinguishable at this layer. The **allowlist is the authorization boundary** — placing
+a space in `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` declares that any member proposed there should be
+auto-admitted. Combined with `fastPathFlatThreshold = 1` (where the proposer's own vote normally
+decides and touches the tally), the bot in practice only ever acts on AddMembers left completely
+unvoted. If self-service-only semantics are ever required, the authoritative on-chain `creator`
+(from `getLatestProposalInformation`) can be compared against the target at stage 2; that constraint
+is intentionally omitted today.
 
 ### Kill Switch & Blast Radius
 

--- a/proposal-executor/ARCHITECTURE.md
+++ b/proposal-executor/ARCHITECTURE.md
@@ -251,10 +251,13 @@ SpaceRegistry, so the address is resolved first via `SpaceRegistry.spaceIdToAddr
 ### Membership Detection Signature
 
 A membership candidate, per stage-1 SQL, is a proposal that is **all** of: `Fast` voting mode; a
-single action; that action is `AddMember`; not executed; in an allowlisted space; within its
-voting window; and with no row in `proposal_votes` (stage-1 untouched). There is **no creation-time
-cutoff** — a pre-existing backlog is admitted. When the allowlist is empty the query short-circuits
-to `[]` (kill switch — no DB query issued).
+single action; that action is `AddMember`; not executed; in an allowlisted space; created in the
+past whose voting period has not yet ended (`created_at <= now <= end_time` + clock-skew buffer);
+and with no row in `proposal_votes` (stage-1 untouched). Note stage-1 only bounds the *close* of the
+window — the authoritative *open* check (`startDate <= now`) is enforced at stage 2 (`isVotingOpen`),
+so a not-yet-open proposal is never voted on. There is **no creation-time cutoff** — a pre-existing
+backlog is admitted. When the allowlist is empty the query short-circuits to `[]` (kill switch — no
+DB query issued).
 
 The detection does **not** distinguish a self-service request-to-join from an editor-initiated
 `AddMember`: the indexer stores `proposed_by` as the *space*, never the individual proposer, so the

--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -27,15 +27,15 @@ export interface Proposal {
 }
 
 /**
- * A request-to-join proposal: a Fast-mode proposal whose single action admits
- * its own proposer (self-service join). Candidate for an auto-accept YES vote.
+ * A membership request: a Fast-mode proposal whose single action is an AddMember
+ * in an allowlisted space. Candidate for an auto-accept YES vote.
  */
 export interface MembershipRequest {
 	/** Proposal UUID (with dashes) */
 	id: string
 	/** DAO space UUID being joined (with dashes); always in the allowlist */
 	spaceId: string
-	/** Member space UUID being added (== proposedBy for a self-service request) */
+	/** Member space UUID being added (with dashes) */
 	requesterId: string
 }
 
@@ -188,11 +188,14 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
  *   60s skew buffer the stage-2 eligibility check applies (isVotingOpen, membership.ts)
  *   is added here so detection never excludes a request that stage 2 would still vote
  *   on — `now` must therefore be the same chain-sourced timestamp stage 2 uses.
- * - Exactly one action, an AddMember targeting the proposer itself
- *   (target_id = proposed_by) — the self-service request-to-join signature, not
- *   an editor-initiated add
+ * - Exactly one action, and it is an AddMember
  * - No indexed votes (NOT EXISTS in proposal_votes) — checks raw indexed votes,
  *   not the async-denormalized yes_count/no_count/abstain_count columns
+ *
+ * NOTE: this does not distinguish a self-service request-to-join from an editor-initiated
+ * AddMember — any untouched, in-window, single-AddMember Fast proposal in an allowlisted
+ * space is auto-accepted. If product requires restricting to self-service requests, we'll
+ * add that constraint.
  *
  * This filters voting_mode = 'Fast' while the executor's query filters 'Slow',
  * so the two paths never return the same proposal.
@@ -210,7 +213,6 @@ WHERE p.space_id = ANY($1)
   AND p.created_at::bigint <= $2::bigint
   AND $2::bigint <= p.end_time + ${CLOCK_SKEW_BUFFER}
   AND a.action_type = 'AddMember'
-  AND a.target_id = p.proposed_by
   AND NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)
   AND (SELECT COUNT(*) FROM proposal_actions a2 WHERE a2.proposal_id = p.id) = 1
 ORDER BY p.created_at::bigint ASC

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -93,9 +93,12 @@ describe("membership detection SQL", () => {
 		expect(membershipSql).toContain("p.voting_mode = 'Fast'")
 	})
 
-	test("requires the action to be a self-service AddMember (target == proposer)", () => {
+	test("requires the action to be an AddMember", () => {
 		expect(membershipSql).toContain("a.action_type = 'AddMember'")
-		expect(membershipSql).toContain("a.target_id = p.proposed_by")
+	})
+
+	test("does not constrain the proposer (self-service and editor-initiated adds both match)", () => {
+		expect(membershipSql).not.toContain("a.target_id = p.proposed_by")
 	})
 
 	test("projects the MembershipRequest row shape {id, spaceId, requesterId}", () => {
@@ -114,11 +117,6 @@ describe("membership detection SQL", () => {
 
 	test("excludes executed proposals", () => {
 		expect(membershipSql).toContain("p.executed_at IS NULL")
-	})
-
-	test("excludes editor-initiated adds by requiring target_id = proposed_by", () => {
-		// An editor-initiated add has proposed_by != target_id, so this predicate filters it out.
-		expect(membershipSql).toContain("a.target_id = p.proposed_by")
 	})
 
 	test("excludes multi-action proposals (exactly one action required)", () => {


### PR DESCRIPTION
Remove the target_id = proposed_by detection filter. proposed_by is always the space (never the individual proposer), so the clause could never match a real membership request and detection always returned zero. The bot now auto-accepts any untouched, in-window, single-AddMember Fast proposal in an allowlisted space; self-service vs editor-initiated adds are not distinguished.