### PR TITLE
chore(rust): fix RUSTSEC advisories (8→1) + add cargo-deny CI

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,49 @@
+name: Cargo Deny (supply-chain)
+
+# Scans the workspace lockfile for known-vulnerable / yanked crates (RUSTSEC),
+# duplicate/incompatible version pairings, and disallowed sources. Runs on
+# dependency changes AND on a daily schedule, so a newly-published advisory on
+# an unchanged dependency is caught even without a commit.
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/cargo-deny.yml'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/cargo-deny.yml'
+  schedule:
+    # 09:00 UTC daily — catch new RUSTSEC advisories on unchanged deps.
+    - cron: '0 9 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Least privilege: this is a read-only check; it never writes to the repo.
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      # Third-party actions pinned to immutable commit SHAs (Dependabot's
+      # github-actions ecosystem keeps the pins + version comments fresh).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
+        with:
+          tool: cargo-deny
+
+      - name: Check advisories, bans, sources
+        run: cargo deny check advisories bans sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,9 +1373,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -5100,9 +5100,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -5733,9 +5733,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7053,9 +7053,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -7074,9 +7074,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,45 @@
+# cargo-deny configuration — supply-chain advisories/bans/sources for the Rust workspace.
+# Run locally and in CI: `cargo deny check advisories bans sources`
+# (.github/workflows/cargo-deny.yml)
+
+[graph]
+# Check the default feature set / host target — i.e. what actually ships. Deps
+# behind disabled features (e.g. rsa, quinn-proto) therefore aren't flagged.
+all-features = false
+
+[advisories]
+version = 2
+# Baseline of advisories accepted as of this PR. Crucially, NO RUSTSEC
+# *vulnerability* is ignored here — only pre-existing unmaintained/unsound
+# advisories on transitive deps — so a newly-introduced vulnerable crate still
+# fails CI. Revisit as the parents upgrade.
+#
+# RUSTSEC-2023-0071 (rsa — Marvin timing side-channel) is deliberately NOT
+# ignored: it has no upstream fix, but `rsa` is feature-gated out of the default
+# build graph, so cargo-deny doesn't flag it today. Leaving it un-ignored means
+# that if `rsa` ever enters the shipped graph, CI fails and forces a fresh
+# decision — rather than a global ignore silently masking a no-fix vulnerability.
+ignore = [
+    # Unmaintained (transitive, no action available without upstreams moving):
+    "RUSTSEC-2021-0141", # dotenv unmaintained (use dotenvy — follow-up)
+    "RUSTSEC-2024-0384", # instant unmaintained
+    "RUSTSEC-2024-0388", # derivative unmaintained
+    "RUSTSEC-2024-0436", # paste unmaintained
+    "RUSTSEC-2025-0012", # backoff unmaintained
+    "RUSTSEC-2025-0134", # rustls-pemfile unmaintained
+    "RUSTSEC-2026-0173", # rustls-pemfile unmaintained
+    # Unsound (transitive, low-severity):
+    "RUSTSEC-2026-0002", # lru — IterMut Stacked-Borrows unsoundness
+    "RUSTSEC-2026-0012", # keccak unsound
+    "RUSTSEC-2026-0097", # rand unsound (custom-logger edge case)
+]
+
+[bans]
+# Duplicate/incompatible version pairings (the class behind the time/sentry-types
+# E0119) — surfaced as warnings to start; tighten to "deny" once cleaned up.
+multiple-versions = "warn"
+wildcards = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## What

Upstream counterpart of defi-wonderland/gaia#237 — clears the current RUSTSEC advisories in the workspace lockfile and adds a `cargo-deny` CI gate. `cargo audit` goes from **8 vulnerabilities → 1**.

## Lockfile bumps (Cargo.lock only — all transitive, no `Cargo.toml` edits)

| Crate | Bump | Advisory — impact |
|---|---|---|
| **rustls-webpki** | 0.103.9 → 0.103.13 | RUSTSEC-2026-0104/-0098/-0099/-0049 — reachable panic in CRL parsing (DoS) + name-constraint/revocation bypass. `rustls` is compiled into atlas, chain-tip-exporter, hermes-ipfs-cache, hermes-pipeline, and the k8s client across the indexers. |
| **bytes** | 1.11.0 → 1.11.1 | RUSTSEC-2026-0007 — integer overflow in `BytesMut::reserve`. |
| **time** | 0.3.46 → 0.3.47 | RUSTSEC-2026-0009 — DoS via stack exhaustion. 0.3.47 stays **below** the 0.3.48 that caused the `sentry-types` E0119 build break (#744). |
| **quinn-proto** | 0.11.13 → 0.11.14 | RUSTSEC-2026-0037 — QUIC DoS; feature-gated / not in the default build graph. |

`cargo check` on the direct consumers builds clean — these are semver-patch bumps.

**Remaining (1):** RUSTSEC-2023-0071 (`rsa`, Marvin timing side-channel) has **no upstream fix** and isn't in the default build graph. It's deliberately **not** ignored, so cargo-deny will flag it if `rsa` ever becomes reachable.

## `deny.toml` + CI

- **`deny.toml`** — `advisories` (vulnerabilities fail; pre-existing transitive *unmaintained*/*unsound* advisories baselined so **new** vulns still fail), `bans` (duplicate/incompatible versions — the E0119 class — as warnings), `sources` (deny unknown registries/git).
- **`.github/workflows/cargo-deny.yml`** — runs `cargo deny check advisories bans sources` on dependency changes **and daily at 09:00 UTC** (catches new advisories on unchanged deps without a commit). Actions SHA-pinned; least-privilege `contents: read` token.

No source/behavior changes — lockfile + config + workflow only.
