### PR TITLE
fix(ranking-indexer): populate from_space_id and register projected entities

### DIFF
--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use grc_20::{Id as Grc20Id, Op as Grc20Op, PropertyValue, Value as Grc20Value};
 use uuid::Uuid;
 
-use crate::models::{Ranking, RankingBlock, RankingItem};
+use crate::models::{BlockMeta, Ranking, RankingBlock, RankingItem};
 
 /// System IDs we match against, parsed once from their string constants.
 struct DetectIds {
@@ -120,6 +120,8 @@ pub struct DetectedEdit {
     pub items: Vec<RankingItem>,
     /// `(ranking_id, block_id)` links from `RANK_BLOCK` relations.
     pub block_links: Vec<(Uuid, Uuid)>,
+    /// Block provenance of the edit, recorded on entities the recompute mints.
+    pub meta: BlockMeta,
 }
 
 impl DetectedEdit {
@@ -146,7 +148,13 @@ pub fn detect(
 ) -> DetectedEdit {
     let ids = &*IDS;
     let submitted_at = DateTime::<Utc>::from_timestamp(block_timestamp, 0);
-    let mut out = DetectedEdit::default();
+    let mut out = DetectedEdit {
+        meta: BlockMeta {
+            number: block_number,
+            timestamp: block_timestamp,
+        },
+        ..DetectedEdit::default()
+    };
 
     // Pass 1: index entity property-values and resolve TYPES membership, and
     // collect the rank relations (votes + block links).

--- a/ranking-indexer/src/membership.rs
+++ b/ranking-indexer/src/membership.rs
@@ -10,6 +10,7 @@ use hermes_schema::pb::membership::{HermesRoleGranted, HermesRoleRevoked, Member
 use uuid::Uuid;
 
 use crate::error::IndexerError;
+use crate::models::BlockMeta;
 use crate::recompute::recompute_block;
 use crate::storage::Storage;
 
@@ -35,6 +36,20 @@ pub struct MembershipChange {
     pub space_id: Uuid,
     pub member_space_id: Uuid,
     pub kind: ChangeKind,
+}
+
+/// Block provenance of the event, recorded on entities a triggered recompute
+/// mints. Defaults to zero when meta is absent, matching the edit path.
+fn block_meta(event: &MembershipEvent) -> BlockMeta {
+    let meta = match event {
+        MembershipEvent::RoleGranted(e) => e.meta.as_ref(),
+        MembershipEvent::RoleRevoked(e) => e.meta.as_ref(),
+    };
+    meta.map(|m| BlockMeta {
+        number: m.block_number as i64,
+        timestamp: m.created_at as i64,
+    })
+    .unwrap_or_default()
 }
 
 fn ids(space_id: &[u8], member_space_id: &[u8]) -> Result<(Uuid, Uuid), IndexerError> {
@@ -86,6 +101,7 @@ pub async fn apply_membership_event(
     storage: &Storage,
 ) -> Result<(), IndexerError> {
     let change = change_for(event)?;
+    let meta = block_meta(event);
 
     match change.kind {
         ChangeKind::AddMember => {
@@ -114,7 +130,7 @@ pub async fn apply_membership_event(
         .blocks_with_rankings_from(change.space_id, change.member_space_id)
         .await?;
     for block_id in &blocks {
-        recompute_block(*block_id, storage).await?;
+        recompute_block(*block_id, meta, storage).await?;
     }
 
     tracing::debug!(

--- a/ranking-indexer/src/models.rs
+++ b/ranking-indexer/src/models.rs
@@ -3,6 +3,16 @@
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
+/// Block provenance for entities the projection mints, carried from the
+/// triggering edit or membership event down to the public-graph write. The
+/// `entities` table requires `created_at`/`*_block` (Unix seconds + block
+/// number as text), matching what the kg-indexer records.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BlockMeta {
+    pub number: i64,
+    pub timestamp: i64,
+}
+
 /// A `ranks.ranking_blocks` row — one per Ranking Block entity.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RankingBlock {

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -14,7 +14,7 @@ use crate::dedup::dedup_latest;
 use crate::detect::DetectedEdit;
 use crate::eligibility::{filter_eligible, SpaceKind};
 use crate::error::IndexerError;
-use crate::models::{Ranking, RankingItem};
+use crate::models::{BlockMeta, Ranking, RankingItem};
 use crate::storage::Storage;
 use crate::{publish, scoring};
 
@@ -53,7 +53,11 @@ pub async fn affected_blocks(
 }
 
 /// Recompute a single block's aggregate end to end.
-pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), IndexerError> {
+pub async fn recompute_block(
+    block_id: Uuid,
+    meta: BlockMeta,
+    storage: &Storage,
+) -> Result<(), IndexerError> {
     let block = match storage.get_ranking_block(block_id).await? {
         Some(block) => block,
         None => {
@@ -111,7 +115,13 @@ pub async fn recompute_block(block_id: Uuid, storage: &Storage) -> Result<(), In
     let projection = publish::build_projection(block_id, &scores);
     let contributing: Vec<Uuid> = ballots.iter().map(|(r, _)| r.id).collect();
     storage
-        .replace_rank_position_projection(block_id, block.space_id, &projection, &contributing)
+        .replace_rank_position_projection(
+            block_id,
+            block.space_id,
+            meta,
+            &projection,
+            &contributing,
+        )
         .await?;
 
     tracing::debug!(
@@ -164,7 +174,7 @@ pub async fn apply_detected_edit(
     }
 
     for block_id in affected_blocks(detected, storage).await? {
-        recompute_block(block_id, storage).await?;
+        recompute_block(block_id, detected.meta, storage).await?;
     }
 
     Ok(())

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -497,12 +497,18 @@ impl Storage {
         .await?;
 
         // 2. Drop prior projection relations (RANK_POSITION + Aggregated rankings).
+        //    Scoped by (from_entity_id, type_id, space_id) only — NOT by
+        //    from_space_id. Pre-fix projection rows were written with
+        //    from_space_id IS NULL; adding `from_space_id = block_space_id` would
+        //    skip them (NULL never equals anything), leaving their deterministic
+        //    PK ids in place. The ON-CONFLICT-free INSERTs below would then
+        //    collide on those ids → duplicate-key error → aborted tx → crash
+        //    loop. Matching on the space alone lets pre-fix blocks self-heal.
         sqlx::query(
-            "DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2) AND space_id = $3 AND from_space_id = $4",
+            "DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2) AND space_id = $3",
         )
         .bind(block_id)
         .bind(&[rank_position, aggregated][..])
-        .bind(block_space_id)
         .bind(block_space_id)
         .execute(&mut *tx)
         .await?;

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -497,10 +497,11 @@ impl Storage {
 
         // 2. Drop prior projection relations (RANK_POSITION + Aggregated rankings).
         sqlx::query(
-            "DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2) AND space_id = $3",
+            "DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2) AND space_id = $3 AND from_space_id = $4",
         )
         .bind(block_id)
         .bind(&[rank_position, aggregated][..])
+        .bind(block_space_id)
         .bind(block_space_id)
         .execute(&mut *tx)
         .await?;
@@ -509,13 +510,14 @@ impl Storage {
         for r in rows {
             sqlx::query(
                 "INSERT INTO relations \
-                 (id, entity_id, type_id, from_entity_id, to_entity_id, to_space_id, space_id, position) \
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                 (id, entity_id, type_id, from_entity_id, from_space_id, to_entity_id, to_space_id, space_id, position) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
             )
             .bind(r.relation_id)
             .bind(r.reified_entity_id)
             .bind(rank_position)
             .bind(block_id)
+            .bind(block_space_id)
             .bind(r.entity_id)
             .bind(r.space_id)
             .bind(block_space_id)
@@ -542,13 +544,14 @@ impl Storage {
             let (relation_id, reified) = provenance_ids(block_id, *ranking_id);
             sqlx::query(
                 "INSERT INTO relations \
-                 (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
-                 VALUES ($1, $2, $3, $4, $5, $6)",
+                 (id, entity_id, type_id, from_entity_id, from_space_id, to_entity_id, space_id) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
             )
             .bind(relation_id)
             .bind(reified)
             .bind(aggregated)
             .bind(block_id)
+            .bind(block_space_id)
             .bind(ranking_id)
             .bind(block_space_id)
             .execute(&mut *tx)

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::eligibility::SpaceKind;
 use crate::error::IndexerError;
-use crate::models::{Ranking, RankingBlock, RankingItem};
+use crate::models::{BlockMeta, Ranking, RankingBlock, RankingItem};
 use crate::publish::{provenance_ids, RankPositionRow};
 use crate::scoring::ScoreRow;
 
@@ -465,6 +465,7 @@ impl Storage {
         &self,
         block_id: Uuid,
         block_space_id: Uuid,
+        meta: BlockMeta,
         rows: &[RankPositionRow],
         contributing_rankings: &[Uuid],
     ) -> Result<(), IndexerError> {
@@ -506,7 +507,40 @@ impl Storage {
         .execute(&mut *tx)
         .await?;
 
-        // 3. Insert the ordered RANK_POSITION relations + their value rows.
+        // 3. Register every entity this projection mints in `entities` (the
+        //    source of truth for entity existence the API resolves against).
+        let mut entity_ids: Vec<Uuid> = Vec::with_capacity(rows.len() * 2 + contributing_rankings.len() * 2);
+        for r in rows {
+            entity_ids.push(r.relation_id);
+            entity_ids.push(r.reified_entity_id);
+        }
+        for ranking_id in contributing_rankings {
+            let (relation_id, reified) = provenance_ids(block_id, *ranking_id);
+            entity_ids.push(relation_id);
+            entity_ids.push(reified);
+        }
+        if !entity_ids.is_empty() {
+            // `entities` columns are text: Unix seconds + block number, as the
+            // kg-indexer records. `created_at` only sticks on first insert;
+            // re-aggregation just bumps `updated_at`.
+            let created_at = meta.timestamp.to_string();
+            let created_at_block = meta.number.to_string();
+            let stamps = vec![created_at; entity_ids.len()];
+            let blocks = vec![created_at_block; entity_ids.len()];
+            sqlx::query(
+                "INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block) \
+                 SELECT * FROM UNNEST($1::uuid[], $2::text[], $3::text[], $2::text[], $3::text[]) \
+                 ON CONFLICT (id) DO UPDATE SET \
+                   updated_at = EXCLUDED.updated_at, updated_at_block = EXCLUDED.updated_at_block",
+            )
+            .bind(&entity_ids)
+            .bind(&stamps)
+            .bind(&blocks)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        // 4. Insert the ordered RANK_POSITION relations + their value rows.
         for r in rows {
             sqlx::query(
                 "INSERT INTO relations \
@@ -539,7 +573,7 @@ impl Storage {
             .await?;
         }
 
-        // 4. Insert Aggregated rankings provenance relations (block -> submission).
+        // 5. Insert Aggregated rankings provenance relations (block -> submission).
         for ranking_id in contributing_rankings {
             let (relation_id, reified) = provenance_ids(block_id, *ranking_id);
             sqlx::query(

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -509,7 +509,8 @@ impl Storage {
 
         // 3. Register every entity this projection mints in `entities` (the
         //    source of truth for entity existence the API resolves against).
-        let mut entity_ids: Vec<Uuid> = Vec::with_capacity(rows.len() * 2 + contributing_rankings.len() * 2);
+        let mut entity_ids: Vec<Uuid> =
+            Vec::with_capacity(rows.len() * 2 + contributing_rankings.len() * 2);
         for r in rows {
             entity_ids.push(r.relation_id);
             entity_ids.push(r.reified_entity_id);

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -259,6 +259,25 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
         prov, 2,
         "non-member submission must be excluded from provenance"
     );
+
+    // entities: every reified entity the projection mints must be registered in
+    // `entities` (the API's source of truth for entity existence). Otherwise
+    // the reified entity carrying the rank value has no row and `entity(id)`
+    // returns null, hiding the value from the graph.
+    let orphans: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM relations r \
+         LEFT JOIN entities e ON e.id = r.entity_id \
+         WHERE r.from_entity_id = $1 AND r.type_id = ANY($2) AND e.id IS NULL",
+    )
+    .bind(u(BLOCK))
+    .bind(&[rank_position, aggregated][..])
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        orphans, 0,
+        "projected reified entities must be registered in the entities table"
+    );
 }
 
 /// Regression for #738: a block whose `TYPES -> Ranking Block` relation and its

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -207,7 +207,7 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
     let value_prop = Uuid::parse_str(RANK_POSITION_VALUE_PROPERTY_ID).unwrap();
 
     let rows = sqlx::query(
-        "SELECT r.to_entity_id AS entity, r.to_space_id AS space, v.integer AS value, r.position AS position \
+        "SELECT r.to_entity_id AS entity, r.to_space_id AS space, r.from_space_id AS from_space, v.integer AS value, r.position AS position \
          FROM relations r \
          JOIN values v ON v.entity_id = r.entity_id AND v.property_id = $3 \
          WHERE r.from_entity_id = $1 AND r.type_id = $2 \
@@ -226,12 +226,18 @@ async fn end_to_end_dao_block_filters_nonmembers_and_publishes() {
     let e0: Uuid = rows[0].get("entity");
     let v0: i64 = rows[0].get("value");
     let s0: Uuid = rows[0].get("space");
+    let fs0: Uuid = rows[0].get("from_space");
     assert_eq!(e0, u(ENTITY_A), "top-ranked entity should be A");
     assert_eq!(v0, 100, "top entity scaled to 100");
     assert_eq!(
         s0,
         u(BLOCK_SPACE),
         "ranked perspective carried on to_space_id"
+    );
+    assert_eq!(
+        fs0,
+        u(BLOCK_SPACE),
+        "block's home space carried on from_space_id"
     );
 
     let e1: Uuid = rows[1].get("entity");

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -461,6 +461,219 @@ async fn cross_edit_block_is_recovered_from_kg_and_scored() {
         "both ranked entities scored once the block is recovered"
     );
 }
+/// Regression: a projection row written before this PR has `from_space_id IS
+/// NULL` but keeps the deterministic v5 relation id (the PK). The step-2 DELETE
+/// in `replace_rank_position_projection` must clear it on the next recompute;
+/// if it were scoped by `from_space_id = block_space_id`, the NULL row would
+/// survive and the ON-CONFLICT-free re-INSERT would collide on the PK →
+/// duplicate-key error → aborted tx → post-#745 crash loop. This guards that a
+/// pre-fix block self-heals (re-acquires `from_space_id = block_space`) on
+/// recompute instead of crash-looping.
+#[tokio::test]
+async fn prefix_null_from_space_projection_self_heals_on_recompute() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    // Distinct scenario ids so this can share a DB with the other e2e tests.
+    const SPACE: u128 = 0xE2E7_0000_0001;
+    const MEMBER: u128 = 0xE2E7_0000_0011;
+    const BLOCK: u128 = 0xE2E7_0000_0021;
+    const ENT_A: u128 = 0xE2E7_0000_0031;
+    const ENT_B: u128 = 0xE2E7_0000_0032;
+    const RANK: u128 = 0xE2E7_0000_0041;
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+        "DELETE FROM ranks.members WHERE space_id = $1",
+        "DELETE FROM spaces WHERE id = $1",
+    ] {
+        sqlx::query(sql).bind(u(SPACE)).execute(pool).await.unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed: DAO space with one member ------------------------------------
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e7')")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)")
+        .bind(u(MEMBER))
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- create the block ---------------------------------------------------
+    let block_edit = EditBuilder::new(gid(0xE2E7_0001))
+        .create_relation(|r| {
+            r.id(gid(0xE2E7_0100))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(BLOCK))
+                .to(sid(RANKING_BLOCK_TYPE_ID))
+        })
+        .create_relation(|r| {
+            r.id(gid(0xE2E7_0101))
+                .relation_type(sid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+                .from(gid(BLOCK))
+                .to(sid(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID))
+        })
+        .create_entity(gid(BLOCK), |e| {
+            e.text(sid(NAME_PROPERTY_ID), "Top Songs", None)
+        })
+        .build();
+    apply_detected_edit(&detect(&block_edit, u(SPACE), 1, 0), u(SPACE), &storage)
+        .await
+        .unwrap();
+
+    // --- a member submits a rank → a normal projection is written -----------
+    let submit = |rank: u128, rel_base: u128, first: u128, second: u128| {
+        EditBuilder::new(gid(rank ^ 0xED17))
+            .create_relation(|r| {
+                r.id(gid(rel_base))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(sid(RANK_TYPE_ID))
+            })
+            .create_entity(gid(rank), |e| {
+                e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 1))
+                    .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(BLOCK))
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 2))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(first))
+                    .to_space(gid(SPACE))
+                    .position("a0")
+            })
+            .create_relation(|r| {
+                r.id(gid(rel_base + 3))
+                    .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                    .from(gid(rank))
+                    .to(gid(second))
+                    .to_space(gid(SPACE))
+                    .position("a1")
+            })
+            .build()
+    };
+
+    apply_detected_edit(
+        &detect(&submit(RANK, 0xE2E7_0200, ENT_A, ENT_B), u(MEMBER), 2, 0),
+        u(MEMBER),
+        &storage,
+    )
+    .await
+    .unwrap();
+
+    let rank_position = Uuid::parse_str(RANK_POSITION_RELATION_TYPE_ID).unwrap();
+    let aggregated = Uuid::parse_str(AGGREGATED_RANKINGS_RELATION_TYPE_ID).unwrap();
+
+    // The first recompute produced deterministic-id projection relations.
+    let projected: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2)",
+    )
+    .bind(u(BLOCK))
+    .bind(&[rank_position, aggregated][..])
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert!(projected > 0, "first recompute must write a projection");
+
+    // --- SIMULATE a pre-fix row: blank out from_space_id ---------------------
+    // Rows written before this PR carried the deterministic PK id but NULL
+    // from_space_id. Replicate exactly that state.
+    sqlx::query(
+        "UPDATE relations SET from_space_id = NULL \
+         WHERE from_entity_id = $1 AND type_id = ANY($2)",
+    )
+    .bind(u(BLOCK))
+    .bind(&[rank_position, aggregated][..])
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let null_rows: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM relations \
+         WHERE from_entity_id = $1 AND type_id = ANY($2) AND from_space_id IS NULL",
+    )
+    .bind(u(BLOCK))
+    .bind(&[rank_position, aggregated][..])
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(null_rows, projected, "pre-fix state: all rows now NULL");
+
+    // --- recompute the same block: must NOT crash with a duplicate-key error -
+    // Re-applying the rank forces another `replace_rank_position_projection`.
+    // The step-2 DELETE must clear the NULL-from_space rows (matching on space
+    // alone) so the re-INSERT of the same deterministic ids succeeds.
+    apply_detected_edit(
+        &detect(&submit(RANK, 0xE2E7_0200, ENT_A, ENT_B), u(MEMBER), 3, 0),
+        u(MEMBER),
+        &storage,
+    )
+    .await
+    .expect("recompute over a pre-fix (NULL from_space_id) projection must not collide");
+
+    // --- the block self-healed: every projection row now carries from_space --
+    let remaining_null: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM relations \
+         WHERE from_entity_id = $1 AND type_id = ANY($2) AND from_space_id IS NULL",
+    )
+    .bind(u(BLOCK))
+    .bind(&[rank_position, aggregated][..])
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(remaining_null, 0, "recompute must clear pre-fix NULL rows");
+
+    let healed: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM relations \
+         WHERE from_entity_id = $1 AND type_id = ANY($2) AND from_space_id = $3",
+    )
+    .bind(u(BLOCK))
+    .bind(&[rank_position, aggregated][..])
+    .bind(u(SPACE))
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        healed, projected,
+        "every projection row must now carry from_space_id = block space"
+    );
+}
+
 // Membership-lifecycle scenario UUIDs (distinct namespace so both e2e tests
 // can run against the same database, even concurrently).
 const M_SPACE: u128 = 0xE2E6_0000_0001;


### PR DESCRIPTION
## Summary

Two correctness fixes to the public-graph projection the ranking-indexer writes (RANK_POSITION + Aggregated rankings relations), both in `replace_rank_position_projection`.

### 1. Populate `from_space_id` on projected relations
The projected relations left `from_space_id` NULL, unlike every other relation in `public.relations` (the kg-indexer always sets it). The `from` entity is the block, which lives in the block's home space, so `from_space_id` is set to `block_space_id` — the same value already bound to `space_id`. The projection-replacement DELETE mirrors the new column.

### 2. Register projected entities so the API resolves them
The projection wrote `relations` and rank-position `values` rows keyed on **reified entity ids**, but never inserted those ids into the `entities` table. `entities` is the source of truth the API's `entity(id)` resolves against, so the reified entity carrying the rank value had no row — `entity(id)` returned `null` and the value (e.g. the `100` for the top-ranked entity) never surfaced in the graph or the geobrowser.

Mirroring the kg-indexer, we now register both the relation id and its reified entity id (for RANK_POSITION rows and provenance relations), upserting them into `entities` within the projection transaction (`ON CONFLICT` bumps `updated_at` on re-aggregation). Block provenance (`created_at` / `*_block`) is threaded from the triggering edit or membership event via a new `BlockMeta` carried on `DetectedEdit` and into `recompute_block`.

## Testing
- `cargo test -p ranking-indexer`, `cargo clippy --all-targets` pass.
- New e2e assertions: `from_space_id` carries the block's home space, and no projected reified entity is left orphaned in `entities`. (e2e tests require `RANKING_INDEXER_E2E_DATABASE_URL`.)

## Notes
- Fixes **new** projections. Reified entities written before this change get their `entities` row on the next recompute of their block (resubmission, membership change, or a backfill).
- The stricter `from_space_id` predicate on the replacement DELETE won't match pre-fix rows whose `from_space_id` is NULL; deterministic relation ids mean re-aggregation upserts cleanly via the PK rather than duplicating.