### PR TITLE
feat(search): gaia-v2 (testnet) search-admin jobs + migration docs

### DIFF
--- a/search-admin/INDEX_MIGRATIONS.md
+++ b/search-admin/INDEX_MIGRATIONS.md
@@ -53,6 +53,7 @@ This guide walks through migrating from one index version to another using Kuber
 - The job YAML files from the appropriate environment directory:
   - **Production:** `search-indexer-deploy/k8s/production/jobs/`
   - **Staging:** `search-indexer-deploy/k8s/staging/jobs/`
+  - **Testnet (gaia-v2):** `search-indexer-deploy/k8s/v2/jobs/`
 
 ### Step 0: Choose Your Environment
 
@@ -62,6 +63,7 @@ Before running any jobs, decide which environment you're migrating:
 |-------------|-----------|-----------|--------------|
 | Production | `k8s/production/jobs/` | `search` | (none) |
 | Staging | `k8s/staging/jobs/` | `search-staging` | `staging_` |
+| Testnet (gaia-v2) | `k8s/v2/jobs/` | `gaia-v2` | `testnet_` |
 
 ```bash
 # For production
@@ -69,6 +71,9 @@ cd search-indexer-deploy/k8s/production/jobs
 
 # For staging
 cd search-indexer-deploy/k8s/staging/jobs
+
+# For testnet (gaia-v2)
+cd search-indexer-deploy/k8s/v2/jobs
 ```
 
 All commands below assume you've navigated to the appropriate jobs directory.

--- a/search-admin/README.md
+++ b/search-admin/README.md
@@ -156,7 +156,7 @@ kubectl logs -n search -f job/opensearch-delete-index
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `OPENSEARCH_URL` | OpenSearch connection URL | `http://localhost:9200` |
-| `ENVIRONMENT` | Environment name (`staging` or `production`). Staging adds `staging_` prefix to index names. | `production` |
+| `ENVIRONMENT` | Environment name (`staging`, `testnet`, or `production`). `staging`/`testnet` add a `staging_`/`testnet_` prefix to index names; `production` adds none. | `production` |
 | `INDEX_ALIAS` | Base index alias name | `entities` |
 | `RUST_LOG` | Log level (trace, debug, info, warn, error) | `info` |
 

--- a/search-indexer-deploy/README.md
+++ b/search-indexer-deploy/README.md
@@ -123,9 +123,12 @@ search-indexer-deploy/
     |   +-- monitoring.yaml
     |   +-- jobs/               # Production migration jobs (ENVIRONMENT=production)
     +-- staging/
-        +-- namespace.yaml      # namespace: search-staging
+    |   +-- namespace.yaml      # namespace: search-staging
+    |   +-- search-indexer.yaml
+    |   +-- jobs/               # Staging migration jobs (ENVIRONMENT=staging)
+    +-- v2/                     # gaia-v2 / testnet (shared namespace gaia-v2, bootstrapped via deploy-v2)
         +-- search-indexer.yaml
-        +-- jobs/               # Staging migration jobs (ENVIRONMENT=staging)
+        +-- jobs/               # Testnet migration jobs (ENVIRONMENT=testnet)
 ```
 
 ## Index Migrations
@@ -136,6 +139,7 @@ OpenSearch index migrations are managed using the [search-admin](../search-admin
 
 - **Production:** `k8s/production/jobs/` (namespace: `search`, no index prefix)
 - **Staging:** `k8s/staging/jobs/` (namespace: `search-staging`, `staging_` prefix)
+- **Testnet (gaia-v2):** `k8s/v2/jobs/` (namespace: `gaia-v2`, `testnet_` prefix)
 
 **For full migration workflows and step-by-step instructions, see:**
 

--- a/search-indexer-deploy/k8s/jobs/README.md
+++ b/search-indexer-deploy/k8s/jobs/README.md
@@ -19,6 +19,7 @@ k8s/
 **Important**: The `ENVIRONMENT` variable controls the index naming:
 - `ENVIRONMENT=production` → indices use base names (e.g., `entities_v3`)
 - `ENVIRONMENT=staging` → indices get `staging_` prefix (e.g., `staging_entities_v3`)
+- `ENVIRONMENT=testnet` → indices get `testnet_` prefix (e.g., `testnet_entities_v3`)
 
 ## Prerequisites
 
@@ -268,7 +269,7 @@ The jobs support these environment variables:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `OPENSEARCH_URL` | OpenSearch endpoint URL | Read from `opensearch-credentials` secret |
-| `ENVIRONMENT` | Environment name (`staging` or `production`) | Set in job YAML |
+| `ENVIRONMENT` | Environment name (`staging`, `testnet`, or `production`) | Set in job YAML |
 | `INDEX_ALIAS` | Base index alias name | `entities` |
 | `SOURCE_VERSION` | Source index version (full-migration only) | Required (set in job YAML) |
 | `TARGET_VERSION` | Target index version (full-migration only) | Required (set in job YAML) |
@@ -285,6 +286,7 @@ The `ENVIRONMENT` variable controls how indices are named:
 |-------------|------------|-----------------|-------|
 | `production` | `entities` | `entities_v3` | `entities` |
 | `staging` | `entities` | `staging_entities_v3` | `staging_entities` |
+| `testnet` | `entities` | `testnet_entities_v3` | `testnet_entities` |
 
 ### Getting the OpenSearch URL
 

--- a/search-indexer-deploy/k8s/v2/jobs/backfill-name-raw-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/backfill-name-raw-job.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opensearch-backfill-name-raw
+  namespace: gaia-v2
+  labels:
+    app: opensearch-admin
+    task: backfill-name-raw
+    environment: testnet
+spec:
+  ttlSecondsAfterFinished: 86400  # 24 hours
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: opensearch-admin
+        task: backfill-name-raw
+        environment: testnet
+    spec:
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: backfill-name-raw
+        image: registry.digitalocean.com/geo/search-admin:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: opensearch-credentials
+              key: OPENSEARCH_URL
+        - name: ENVIRONMENT
+          value: "testnet"
+        - name: INDEX_ALIAS
+          value: "entities"
+        - name: INDEX_VERSION
+          value: "0"  # CHANGE THIS: Index version to backfill
+        - name: DRY_RUN
+          value: "false"  # Set to "true" to preview without making changes
+        - name: RUST_LOG
+          value: "info"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          if [ "$DRY_RUN" = "true" ]; then
+            search-admin backfill-name-raw --version "$INDEX_VERSION" --dry-run
+          else
+            search-admin backfill-name-raw --version "$INDEX_VERSION"
+          fi
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"

--- a/search-indexer-deploy/k8s/v2/jobs/create-index-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/create-index-job.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opensearch-create-index
+  namespace: gaia-v2
+  labels:
+    app: opensearch-admin
+    task: create-index
+    environment: testnet
+spec:
+  ttlSecondsAfterFinished: 86400  # 24 hours
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: opensearch-admin
+        task: create-index
+        environment: testnet
+    spec:
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: create-index
+        image: registry.digitalocean.com/geo/search-admin:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: opensearch-credentials
+              key: OPENSEARCH_URL
+        - name: ENVIRONMENT
+          value: "testnet"
+        - name: INDEX_ALIAS
+          value: "entities"
+        - name: INDEX_VERSION
+          value: "5"  # CHANGE THIS: Set to the new index version
+        - name: RUST_LOG
+          value: "info"
+        command:
+        - search-admin
+        - create-index
+        - --version
+        - "$(INDEX_VERSION)"
+        - --skip-if-exists
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"

--- a/search-indexer-deploy/k8s/v2/jobs/delete-index-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/delete-index-job.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opensearch-delete-index
+  namespace: gaia-v2
+  labels:
+    app: opensearch-admin
+    task: delete-index
+    environment: testnet
+spec:
+  ttlSecondsAfterFinished: 86400  # 24 hours
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: opensearch-admin
+        task: delete-index
+        environment: testnet
+    spec:
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: delete-index
+        image: registry.digitalocean.com/geo/search-admin:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: opensearch-credentials
+              key: OPENSEARCH_URL
+        - name: ENVIRONMENT
+          value: "testnet"
+        - name: INDEX_ALIAS
+          value: "entities"
+        - name: INDEX_VERSION
+          value: "2"  # CHANGE THIS: Set to the index version to DELETE
+        - name: CONFIRM_DELETE
+          value: "false"  # CHANGE THIS to "true" to actually delete (safety check)
+        - name: RUST_LOG
+          value: "info"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          if [ "$CONFIRM_DELETE" = "true" ]; then
+            search-admin delete-index \
+              --version "$INDEX_VERSION" \
+              --confirm \
+              --yes
+          else
+            echo "SAFETY CHECK FAILED"
+            echo ""
+            echo "This is a destructive operation."
+            echo "Set CONFIRM_DELETE to 'true' to proceed."
+            exit 1
+          fi
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"

--- a/search-indexer-deploy/k8s/v2/jobs/full-migration-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/full-migration-job.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opensearch-full-migration
+  namespace: gaia-v2
+  labels:
+    app: opensearch-admin
+    task: full-migration
+    environment: testnet
+spec:
+  ttlSecondsAfterFinished: 86400  # 24 hours
+  backoffLimit: 1  # Don't retry automatically - migrations are sensitive
+  template:
+    metadata:
+      labels:
+        app: opensearch-admin
+        task: full-migration
+        environment: testnet
+    spec:
+      imagePullSecrets:
+      - name: regcred
+      # Use ServiceAccount with permissions to manage deployments
+      serviceAccountName: search-admin
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: full-migration
+        image: registry.digitalocean.com/geo/search-admin:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: opensearch-credentials
+              key: OPENSEARCH_URL
+        - name: ENVIRONMENT
+          value: "testnet"
+        - name: INDEX_ALIAS
+          value: "entities"
+        - name: SOURCE_VERSION
+          value: "2"  # CHANGE THIS: Current/source index version
+        - name: TARGET_VERSION
+          value: "3"  # CHANGE THIS: New/target index version
+        - name: NAMESPACE
+          value: "gaia-v2"  # Kubernetes namespace for gaia-v2 (testnet)
+        - name: DEPLOYMENT_NAME
+          value: "search-indexer"
+        - name: RUST_LOG
+          value: "info"
+        command:
+        - search-admin
+        - full-migration
+        - --source-version
+        - "$(SOURCE_VERSION)"
+        - --target-version
+        - "$(TARGET_VERSION)"
+        - --namespace
+        - "$(NAMESPACE)"
+        - --deployment-name
+        - "$(DEPLOYMENT_NAME)"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"

--- a/search-indexer-deploy/k8s/v2/jobs/list-indices-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/list-indices-job.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opensearch-list-indices
+  namespace: gaia-v2
+  labels:
+    app: opensearch-admin
+    task: list-indices
+    environment: testnet
+spec:
+  ttlSecondsAfterFinished: 86400  # 24 hours
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: opensearch-admin
+        task: list-indices
+        environment: testnet
+    spec:
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: list-indices
+        image: registry.digitalocean.com/geo/search-admin:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: opensearch-credentials
+              key: OPENSEARCH_URL
+        - name: ENVIRONMENT
+          value: "testnet"
+        - name: INDEX_ALIAS
+          value: "entities"
+        - name: SHOW_DETAILED
+          value: "true"  # Set to "false" for simple list
+        - name: RUST_LOG
+          value: "info"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          if [ "$SHOW_DETAILED" = "true" ]; then
+            search-admin list-indices --detailed
+          else
+            search-admin list-indices
+          fi
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"

--- a/search-indexer-deploy/k8s/v2/jobs/reindex-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/reindex-job.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opensearch-reindex
+  namespace: gaia-v2
+  labels:
+    app: opensearch-admin
+    task: reindex
+    environment: testnet
+spec:
+  ttlSecondsAfterFinished: 86400  # 24 hours
+  backoffLimit: 1  # Don't retry automatically - reindex is expensive
+  template:
+    metadata:
+      labels:
+        app: opensearch-admin
+        task: reindex
+        environment: testnet
+    spec:
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: reindex
+        image: registry.digitalocean.com/geo/search-admin:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: opensearch-credentials
+              key: OPENSEARCH_URL
+        - name: ENVIRONMENT
+          value: "testnet"
+        - name: INDEX_ALIAS
+          value: "entities"
+        - name: SOURCE_VERSION
+          value: "2"  # CHANGE THIS: Source index version to copy from
+        - name: TARGET_VERSION
+          value: "3"  # CHANGE THIS: Target index version to copy to
+        - name: RUST_LOG
+          value: "info"
+        command:
+        - search-admin
+        - reindex
+        - --source-version
+        - "$(SOURCE_VERSION)"
+        - --target-version
+        - "$(TARGET_VERSION)"
+        - --wait-for-completion
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"

--- a/search-indexer-deploy/k8s/v2/jobs/update-alias-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/update-alias-job.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opensearch-update-alias
+  namespace: gaia-v2
+  labels:
+    app: opensearch-admin
+    task: update-alias
+    environment: testnet
+spec:
+  ttlSecondsAfterFinished: 86400  # 24 hours
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: opensearch-admin
+        task: update-alias
+        environment: testnet
+    spec:
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: update-alias
+        image: registry.digitalocean.com/geo/search-admin:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: OPENSEARCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: opensearch-credentials
+              key: OPENSEARCH_URL
+        - name: ENVIRONMENT
+          value: "testnet"
+        - name: INDEX_ALIAS
+          value: "entities"
+        - name: TARGET_VERSION
+          value: "5"  # CHANGE THIS: Index version to point the alias to
+        - name: RUST_LOG
+          value: "info"
+        command:
+        - search-admin
+        - update-alias
+        - --version
+        - "$(TARGET_VERSION)"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"


### PR DESCRIPTION
## Why

The companion to #752, targeted at **`staging`** (where the gaia-v2 manifests live). The `testnet` `ENVIRONMENT` **code** already exists on `staging` (search-admin / search-indexer-shared / api / hermes-kafka) — this PR adds the two things `staging` is still missing for the gaia-v2 search standup: the **search-admin job manifests** and the **migration-runbook doc updates**. No code changes (they'd be redundant on staging).

## What's in this PR

**Deploy — `search-indexer-deploy/k8s/v2/jobs/` (new):** all 7 search-admin job manifests (create-index, update-alias, list-indices, reindex, delete-index, full-migration, backfill-name-raw), `namespace: gaia-v2`, `ENVIRONMENT=testnet`, `imagePullSecrets: regcred`, version `5` (matches the v2 search-indexer `ENTITIES_INDEX_VERSION`).

**Docs:** testnet rows in `search-admin/README.md` + `search-indexer-deploy/k8s/jobs/README.md`; testnet (gaia-v2) jobs directory added to `search-admin/INDEX_MIGRATIONS.md` and `search-indexer-deploy/README.md`.

## Standup usage

`create-index --version 5` → `testnet_entities_v5`, then `update-alias --version 5` → alias `testnet_entities`. Isolated from prod/staging on the shared OpenSearch by the `testnet_` prefix.

## Notes / prereqs

- **full-migration** additionally needs a `search-admin` ServiceAccount + RBAC in `gaia-v2` (not yet present). The other 6 jobs don't.
- Operator prereqs: `opensearch-credentials` secret in `gaia-v2`; `search-admin` image rebuilt from `staging`; testnet Kafka topics produced by the v2 hermes-pipeline.
- `list-indices` uses the default `testnet_entities*` pattern; for a full shared-cluster inventory run with `--pattern '*entities*'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)