### PR TITLE
fix(notification-indexer): resolve space name from page entity, not placeholder

### DIFF
--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -1349,8 +1349,14 @@ async fn enrich_payload(
 ) {
     use notification_indexer::models::{NotificationData, NotificationEventType};
 
-    // Space name (common to all event types)
-    event.payload.space_name = storage.lookup_entity_name(space_id, space_id).await;
+    // Space name (common to all event types). Prefer the space's page-entity
+    // display name (e.g. "Wonderland"); fall back to the bare space entity's
+    // name (the auto-generated "Space <uuid>" placeholder) only if there is no
+    // page entity / name.
+    event.payload.space_name = match storage.lookup_space_name(space_id).await {
+        Some(name) => Some(name),
+        None => storage.lookup_entity_name(space_id, space_id).await,
+    };
 
     match &mut event.payload.data {
         NotificationData::Governance(ref mut gov) => {

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -538,6 +538,41 @@ impl Storage {
         .flatten()
     }
 
+    /// Look up a space's display name (e.g. "Wonderland").
+    ///
+    /// The bare `space_id` entity only carries the auto-generated placeholder
+    /// ("Space <uuid>"). The real name lives on the space's *page entity* — the
+    /// entity inside the space with a Types relation to SPACE_TYPE (the same
+    /// "front page entity" pattern as `lookup_entity_space`, and what the API's
+    /// `spaces_page` function resolves). We read that entity's Name value.
+    ///
+    /// Name values are not space-scoped (matching the API's `entities_name`),
+    /// so we match on `entity_id` only. Returns `None` if the space has no page
+    /// entity or it has no name.
+    pub async fn lookup_space_name(&self, space_id: Uuid) -> Option<String> {
+        sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT v.text
+            FROM relations r
+            JOIN "values" v ON v.entity_id = r.from_entity_id
+            WHERE r.space_id = $1
+              AND r.type_id = $2
+              AND r.to_entity_id = $3
+              AND v.property_id = $4
+              AND v.text IS NOT NULL
+            LIMIT 1
+            "#,
+        )
+        .bind(space_id)
+        .bind(ids::types_relation_type())
+        .bind(ids::space_type())
+        .bind(ids::name_property())
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+    }
+
     /// Look up the human-readable name for a proposal from the proposals table.
     pub async fn lookup_proposal_name(&self, proposal_id: Uuid) -> Option<String> {
         sqlx::query_scalar::<_, String>(


### PR DESCRIPTION
## Problem
Notification emails/feed showed the space as **"Space"** (e.g. *"New proposal in Space"*) instead of the real name like **"Wonderland"**.

Root cause: `enrich_payload` resolved the space name with `lookup_entity_name(space_id, space_id)` — the Name value of the entity whose id **is** the space id. That entity only ever holds the auto-generated placeholder `"Space <uuid>"`. (The webhook server then strips the trailing UUID, leaving bare "Space".)

The real display name lives on the space's **page entity** — the entity inside the space with a `Types → SPACE_TYPE` relation (the same "front page entity" pattern as the existing `lookup_entity_space`, and what the API's `spaces_page` SQL function resolves).

## Fix
- Add `Storage::lookup_space_name(space_id)` — joins `relations` (`Types → SPACE_TYPE`, `space_id`) to `values` and returns the page entity's Name. Unscoped on the value's `space_id`, matching the API's `entities_name`.
- `enrich_payload` now prefers `lookup_space_name`, falling back to the old placeholder lookup only when a space has no page entity (behavior unchanged for those).

## Verification
Ran both queries against the **staging KG DB** for space `1638f271-147c-40f1-8c36-e9e0a8856f10`:
- OLD: `Space 1638f271-147c-40f1-8c36-e9e0a8856f10`
- NEW: **`Wonderland`** ✅

`cargo check -p notification-indexer` passes. (No DB-backed test harness exists in this crate, so no integration test added.)