### PR TITLE
fix(telemetry): honor SENTRY_TRACES_SAMPLE_RATE via SentrySampler

### DIFF
--- a/api/k8s/production/api-sentry.yaml
+++ b/api/k8s/production/api-sentry.yaml
@@ -7,7 +7,7 @@
 #   kubectl create secret generic api-sentry \
 #     --namespace=api \
 #     --from-literal=SENTRY_DSN='<dsn>' \
-#     --from-literal=SENTRY_TRACES_SAMPLE_RATE=1.0 \
+#     --from-literal=SENTRY_TRACES_SAMPLE_RATE=0.3 \
 #     --from-literal=SENTRY_ENVIRONMENT=production \
 #     --from-literal=SENTRY_RELEASE=api@<version> \
 #     --from-literal=SENTRY_DEBUG=false
@@ -23,7 +23,12 @@ metadata:
 type: Opaque
 stringData:
   SENTRY_DSN: "<dsn>"
-  SENTRY_TRACES_SAMPLE_RATE: "1.0"
+  # Honored by SentrySampler in api/src/services/telemetry.ts. gaia-api drives
+  # ~80% of the org's Sentry spans (~27M/mo unsampled vs the 5M quota), so watch
+  # the Spans usage chart at this rate and lower it if we approach the quota.
+  # Error Issues are captured independently of trace sampling, so a dropped
+  # trace never drops its error. Tunable without a redeploy (kubectl edit secret).
+  SENTRY_TRACES_SAMPLE_RATE: "0.3"
   SENTRY_ENVIRONMENT: "production"
   SENTRY_RELEASE: "api@<version>"
   SENTRY_DEBUG: "false"

--- a/api/k8s/staging/api-sentry.yaml
+++ b/api/k8s/staging/api-sentry.yaml
@@ -7,7 +7,7 @@
 #   kubectl create secret generic api-sentry \
 #     --namespace=api-staging \
 #     --from-literal=SENTRY_DSN='<dsn>' \
-#     --from-literal=SENTRY_TRACES_SAMPLE_RATE=1.0 \
+#     --from-literal=SENTRY_TRACES_SAMPLE_RATE=0.1 \
 #     --from-literal=SENTRY_ENVIRONMENT=staging \
 #     --from-literal=SENTRY_RELEASE=api@<version> \
 #     --from-literal=SENTRY_DEBUG=false
@@ -23,7 +23,10 @@ metadata:
 type: Opaque
 stringData:
   SENTRY_DSN: "<dsn>"
-  SENTRY_TRACES_SAMPLE_RATE: "1.0"
+  # Honored by SentrySampler in api/src/services/telemetry.ts. Staging volume is
+  # low, so the rate mainly trades trace fidelity vs noise while debugging.
+  # Tunable without a redeploy (kubectl edit secret).
+  SENTRY_TRACES_SAMPLE_RATE: "0.1"
   SENTRY_ENVIRONMENT: "staging"
   SENTRY_RELEASE: "api@<version>"
   SENTRY_DEBUG: "false"

--- a/api/src/services/__tests__/telemetry.test.ts
+++ b/api/src/services/__tests__/telemetry.test.ts
@@ -1,0 +1,108 @@
+import {ROOT_CONTEXT, TraceFlags, trace} from "@opentelemetry/api"
+import {resourceFromAttributes} from "@opentelemetry/resources"
+import {BasicTracerProvider, type Sampler} from "@opentelemetry/sdk-trace-base"
+import {ATTR_SERVICE_NAME} from "@opentelemetry/semantic-conventions"
+import * as Sentry from "@sentry/node"
+import {SentrySampler, SentrySpanProcessor} from "@sentry/opentelemetry"
+import {afterEach, describe, expect, it} from "vitest"
+
+/**
+ * These tests pin the fix: `SENTRY_TRACES_SAMPLE_RATE` only takes effect
+ * because telemetry.ts installs `SentrySampler` on its hand-built
+ * `BasicTracerProvider`. With `skipOpenTelemetrySetup: true`, Sentry does NOT
+ * install its sampler for us, and `SentrySpanProcessor` exports every span it
+ * receives — so without an explicit sampler the OTEL default (AlwaysOnSampler)
+ * records everything and the rate is silently ignored. We assert at the OTEL
+ * sampling-decision boundary: a sampled span is recording (TraceFlags.SAMPLED),
+ * a dropped one is not. That decision is what gates the SentrySpanProcessor.
+ */
+
+// A no-op transport so init never touches the network.
+function noopTransport() {
+	return {
+		send: () => Promise.resolve({}),
+		flush: () => Promise.resolve(true),
+	}
+}
+
+function initSentryWithRate(tracesSampleRate: number) {
+	Sentry.init({
+		dsn: "https://abc123@o1.ingest.sentry.io/1",
+		tracesSampleRate,
+		skipOpenTelemetrySetup: true,
+		transport: noopTransport,
+	})
+	const client = Sentry.getClient()
+	if (!client) throw new Error("Sentry client not initialized")
+	return client
+}
+
+// Mirror the production wiring from telemetry.ts: SentrySampler + SentrySpanProcessor
+// on a BasicTracerProvider. Optionally omit the sampler to reproduce the original bug.
+function makeTracer(sampler: Sampler | undefined) {
+	const provider = new BasicTracerProvider({
+		resource: resourceFromAttributes({[ATTR_SERVICE_NAME]: "gaia-api-test"}),
+		...(sampler ? {sampler} : {}),
+		spanProcessors: [new SentrySpanProcessor()],
+	})
+	return provider.getTracer("test")
+}
+
+afterEach(async () => {
+	await Sentry.flush(0)
+	await Sentry.close(0)
+})
+
+describe("telemetry trace sampling", () => {
+	it("drops root spans when SENTRY_TRACES_SAMPLE_RATE is 0", () => {
+		const client = initSentryWithRate(0)
+		const tracer = makeTracer(new SentrySampler(client))
+
+		const span = tracer.startSpan("GET /graphql")
+		expect(span.isRecording()).toBe(false)
+		expect(span.spanContext().traceFlags).toBe(TraceFlags.NONE)
+		span.end()
+	})
+
+	it("keeps root spans when SENTRY_TRACES_SAMPLE_RATE is 1.0", () => {
+		const client = initSentryWithRate(1.0)
+		const tracer = makeTracer(new SentrySampler(client))
+
+		const span = tracer.startSpan("GET /graphql")
+		expect(span.isRecording()).toBe(true)
+		expect(span.spanContext().traceFlags).toBe(TraceFlags.SAMPLED)
+		span.end()
+	})
+
+	it("child spans inherit the parent's sampling decision (rate 1.0 parent → kept child)", () => {
+		const client = initSentryWithRate(1.0)
+		const tracer = makeTracer(new SentrySampler(client))
+
+		// Mirror instrumentationPlugin.ts: the GraphQL op span is parented to the
+		// HTTP root span via a manually-rebuilt context (OTEL async context does
+		// not propagate through graphql-yoga). The child must inherit the root's
+		// decision so all spans of a request are kept or dropped together.
+		const parent = tracer.startSpan("GET /graphql")
+		const parentContext = trace.setSpanContext(ROOT_CONTEXT, {
+			...parent.spanContext(),
+			isRemote: false,
+		})
+		const child = tracer.startSpan("graphql query spaces", {}, parentContext)
+
+		expect(parent.isRecording()).toBe(true)
+		expect(child.isRecording()).toBe(true)
+		child.end()
+		parent.end()
+	})
+
+	it("REGRESSION GUARD: without SentrySampler the rate is ignored (records at rate 0)", () => {
+		initSentryWithRate(0)
+		// No sampler → OTEL default AlwaysOnSampler → every span recorded regardless
+		// of tracesSampleRate. This is the bug the SentrySampler change fixes.
+		const tracer = makeTracer(undefined)
+
+		const span = tracer.startSpan("GET /graphql")
+		expect(span.isRecording()).toBe(true)
+		span.end()
+	})
+})

--- a/api/src/services/telemetry.ts
+++ b/api/src/services/telemetry.ts
@@ -1,10 +1,10 @@
 import {NodeSdk} from "@effect/opentelemetry"
 import {trace} from "@opentelemetry/api"
 import {resourceFromAttributes} from "@opentelemetry/resources"
-import {BasicTracerProvider} from "@opentelemetry/sdk-trace-base"
+import {BasicTracerProvider, type Sampler} from "@opentelemetry/sdk-trace-base"
 import {ATTR_SERVICE_NAME} from "@opentelemetry/semantic-conventions"
 import * as Sentry from "@sentry/node"
-import {SentrySpanProcessor} from "@sentry/opentelemetry"
+import {SentrySampler, SentrySpanProcessor} from "@sentry/opentelemetry"
 import {Effect, HashMap, Layer, Logger, LogLevel} from "effect"
 
 const SERVICE_NAME = "gaia-api"
@@ -12,6 +12,7 @@ const SERVICE_NAME = "gaia-api"
 // Track whether Sentry is initialized
 let sentryInitialized = false
 let spanProcessor: SentrySpanProcessor | undefined
+let sampler: Sampler | undefined
 
 // Initialize Sentry and OTEL eagerly at module load time
 // This ensures tracing is ready before any requests arrive
@@ -54,10 +55,26 @@ function initSentry() {
 	// We intentionally skip SentryContextManager to avoid conflicts with Effect's Fiber-based context.
 	// Effect has its own scoped provider; this global provider is only for trace.getTracer() calls.
 	spanProcessor = new SentrySpanProcessor()
+
+	// SentrySampler is what actually honors `tracesSampleRate`. Because we pass
+	// `skipOpenTelemetrySetup: true`, Sentry does NOT install its sampler for us,
+	// and SentrySpanProcessor exports every span it receives unconditionally — so
+	// without an explicit sampler the OTEL default (AlwaysOnSampler) records every
+	// span and `tracesSampleRate` is silently ignored. Installing SentrySampler
+	// moves the head-sampling decision to span-start: root spans are sampled at
+	// `tracesSampleRate`, and child spans (e.g. the GraphQL operation span, which
+	// is parented to the HTTP span via the manually-propagated trace context)
+	// inherit the root's decision, so all spans of a request are kept or dropped
+	// together. Errors are still captured independently (captureException /
+	// captureMessage), so dropping a trace never drops its error Issue.
+	const client = Sentry.getClient()
+	sampler = client ? new SentrySampler(client) : undefined
+
 	const globalProvider = new BasicTracerProvider({
 		resource: resourceFromAttributes({
 			[ATTR_SERVICE_NAME]: SERVICE_NAME,
 		}),
+		...(sampler ? {sampler} : {}),
 		spanProcessors: [spanProcessor],
 	})
 	trace.setGlobalTracerProvider(globalProvider)
@@ -69,10 +86,13 @@ function initSentry() {
 // Initialize immediately when module is loaded
 initSentry()
 
-// Effect layer config - reuses the already-initialized Sentry
+// Effect layer config - reuses the already-initialized Sentry.
+// Pass the same SentrySampler through tracerConfig so Effect-originated root
+// spans honor `tracesSampleRate` too, consistent with the global provider above.
 const makeTelemetryConfig = Effect.sync(() => ({
 	resource: {serviceName: SERVICE_NAME},
 	spanProcessor: spanProcessor,
+	...(sampler ? {tracerConfig: {sampler}} : {}),
 }))
 
 // Effect layer with SentrySpanProcessor


### PR DESCRIPTION
## Problem

gaia-api alone drives ~80% of the org's Sentry spans (~27M/mo unsampled vs the 5M plan quota), rate-limiting the project.

`SENTRY_TRACES_SAMPLE_RATE` was already lowered on the live secrets, but it had **no effect**. Confirmed at the source level in `@sentry/opentelemetry@10.36.0`:

- `tracesSampleRate` is read **only** by `SentrySampler.shouldSample`.
- `Sentry.init` uses `skipOpenTelemetrySetup: true`, and `telemetry.ts` builds its own `BasicTracerProvider` with **no `sampler`** → OTEL defaults to `AlwaysOnSampler`.
- `SentrySpanProcessor.onEnd` exports every span it receives **unconditionally** (sampling in this SDK happens at span *start*).

Net: every span became a Sentry transaction regardless of the configured rate.

## Fix

Install `SentrySampler` on the global `BasicTracerProvider`, and pass it through `tracerConfig.sampler` to the Effect `NodeSdk` provider so Effect-originated root spans are sampled consistently. This moves the head-sampling decision to span start:

- Root spans are sampled at `tracesSampleRate`.
- Child spans (the GraphQL op span, parented to the HTTP span via manual trace-context propagation, `isRemote:false`) **inherit** the root's decision, so a request's spans are kept or dropped together.
- Error Issues are captured independently (`captureException` / `captureMessage`), so a dropped trace never drops its error.

The rate stays tunable via the secret without a redeploy.

## Config

Committed k8s secret defaults:
- production: `0.3`
- staging: `0.1`

> ⚠️ At `0.3`, prod is estimated at ~8M spans/mo — still above the 5M quota. Watch the Sentry Spans usage chart after rollout and lower the rate further if we approach the limit. The lever is tunable in-cluster (`kubectl edit secret`) without a redeploy.

## Tests

`api/src/services/__tests__/telemetry.test.ts` mirrors the production wiring and asserts gating at the OTEL sampling-decision boundary:
- rate `0` → span non-recording (dropped)
- rate `1.0` → span recording (kept)
- child inherits the parent's decision
- **regression guard**: without `SentrySampler`, rate `0` still records (reproduces the original bug)

## Rollout

Staging-first; confirm the Sentry Spans usage chart behaves as expected over 24–48h (optionally `SENTRY_DEBUG=true` briefly → SDK logs `Discarding root span because its trace was not chosen to be sampled`), then production.
