### PR TITLE
perf(scoring): optimize space ranking and make topology the source of truth for distance

### DIFF
--- a/scoring-service/cronjob/src/algorithm/models.py
+++ b/scoring-service/cronjob/src/algorithm/models.py
@@ -152,9 +152,9 @@ class Space:
 
     def calculate_space_score(
         self,
-        entities: list[Entity],
-        users: list[User],
         spaces: list["Space"],
+        member_counts: dict[str, int],
+        entity_counts: dict[str, int],
         root_space_id: str = ROOT_SPACE_ID,
     ) -> None:
         """Calculate space score based on distance from root (GEO)."""
@@ -168,12 +168,8 @@ class Space:
         else:
             self.space_score = SPACE_SCORE_DECAY_BASE**DISCONNECTED_SPACE_DEPTH
 
-        self.member_count = sum(
-            1 for user in users if self.id in user.member_spaces or self.id in user.editor_spaces
-        )
-        self.entity_count = len(
-            [e for e in entities if any(p.space_id == self.id for p in e.perspectives)]
-        )
+        self.member_count = member_counts.get(self.id, 0)
+        self.entity_count = entity_counts.get(self.id, 0)
 
     def _calculate_distance_to_root(
         self, spaces: list["Space"], root_space_id: str, max_depth: int = MAX_SPACE_DEPTH

--- a/scoring-service/cronjob/src/algorithm/models.py
+++ b/scoring-service/cronjob/src/algorithm/models.py
@@ -10,7 +10,6 @@ from src.constants import ROOT_SPACE_ID
 
 SPACE_SCORE_DECAY_BASE = 0.8        # Base for space score decay calculation
 DISCONNECTED_SPACE_DEPTH = 11       # Depth used for disconnected spaces (no path to root)
-MAX_SPACE_DEPTH = 10                # Maximum depth for parent traversal
 
 __all__ = [
     "VoteType",
@@ -157,58 +156,21 @@ class Space:
         entity_counts: dict[str, int],
         root_space_id: str = ROOT_SPACE_ID,
     ) -> None:
-        """Calculate space score based on distance from root (GEO)."""
-        # If distance_to_root was pre-set by the topology indexer, skip BFS.
-        if self.distance_to_root is None:
-            self.distance_to_root = self._calculate_distance_to_root(spaces, root_space_id)
+        """Calculate space score based on distance from root (GEO).
 
-        # Calculate space score based on distance to root
-        if self.distance_to_root >= 0:
-            self.space_score = SPACE_SCORE_DECAY_BASE**self.distance_to_root
-        else:
-            self.space_score = SPACE_SCORE_DECAY_BASE**DISCONNECTED_SPACE_DEPTH
+        ``distance_to_root`` is computed upstream by the topology indexer (atlas) and
+        read from the ``scoring_topology_distances`` table. The invariant is: a space
+        with no topology entry is not connected to the root, so it is treated as
+        disconnected. ``distance_to_root`` should already be set by the data provider;
+        ``None`` is handled defensively here as disconnected.
+        """
+        if self.distance_to_root is None:
+            self.distance_to_root = DISCONNECTED_SPACE_DEPTH
+
+        self.space_score = SPACE_SCORE_DECAY_BASE**self.distance_to_root
 
         self.member_count = member_counts.get(self.id, 0)
         self.entity_count = entity_counts.get(self.id, 0)
-
-    def _calculate_distance_to_root(
-        self, spaces: list["Space"], root_space_id: str, max_depth: int = MAX_SPACE_DEPTH
-    ) -> int:
-        """Calculate the number of hops from this space to the root space."""
-        if self.id == root_space_id:
-            return 0
-
-        if not self.parent_space_id:
-            return max_depth + 1
-
-        # Build space lookup for parent traversal
-        space_lookup = {space.id: space for space in spaces}
-
-        # FIXME: we should support multi-parent space-subspace relations
-        # Calculate distance with depth protection
-        distance = 1
-        current_space_id: str | None = self.parent_space_id
-        visited = {self.id}
-
-        while (
-            current_space_id is not None
-            and current_space_id not in visited
-            and distance <= max_depth
-        ):
-            visited.add(current_space_id)
-
-            if current_space_id == root_space_id:
-                return distance
-
-            current_space = space_lookup.get(current_space_id)
-            if not current_space:
-                break
-
-            distance += 1
-            current_space_id = current_space.parent_space_id
-
-        # Return invalid distance if no path found
-        return max_depth + 1
 
 
 @dataclass

--- a/scoring-service/cronjob/src/algorithm/scoring.py
+++ b/scoring-service/cronjob/src/algorithm/scoring.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import time
+from collections import Counter, defaultdict
 from datetime import datetime
 
 import numpy as np
@@ -16,6 +17,34 @@ ACTIVITY_WEIGHT = 0.1           # Activity weight in composite space score (10%)
 from .utils import calculate_space_distances
 
 logger = logging.getLogger(__name__)
+
+
+def compute_space_aggregates(
+    entities: list[Entity], users: list[User]
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Precompute per-space member and entity counts in a single pass.
+
+    Returns:
+        ``(member_counts, entity_counts)`` keyed by space id. ``member_counts`` counts
+        each user once per space they are a member or editor of; ``entity_counts``
+        counts distinct entities that have at least one perspective in the space.
+    """
+    member_counts: Counter[str] = Counter()
+    for user in users:
+        # Union dedups users who are both member and editor of the same space,
+        # matching the previous `member_spaces or editor_spaces` semantics.
+        for space_id in user.member_spaces | user.editor_spaces:
+            member_counts[space_id] += 1
+
+    # Track distinct entity ids per space so an entity with several perspectives in the
+    # same space is counted once (matches the previous list-comprehension semantics).
+    entity_ids_by_space: dict[str, set[str]] = defaultdict(set)
+    for entity in entities:
+        for perspective in entity.perspectives:
+            entity_ids_by_space[perspective.space_id].add(entity.id)
+    entity_counts = {space_id: len(ids) for space_id, ids in entity_ids_by_space.items()}
+
+    return dict(member_counts), entity_counts
 
 
 class EntityScorer:
@@ -281,8 +310,9 @@ class RankingEngine:
 
         # Step 0: Calculate space scores if spaces are provided
         if spaces is not None:
+            member_counts, entity_counts = compute_space_aggregates(entities, users)
             for space in spaces:
-                space.calculate_space_score(entities, users, spaces)
+                space.calculate_space_score(spaces, member_counts, entity_counts)
 
         # Step 1: Apply distance-based weighting to votes if enabled
         processed_votes = votes
@@ -365,9 +395,11 @@ class RankingEngine:
         total = len(spaces)
         log_interval = max(1, total // 4)
 
+        member_counts, entity_counts = compute_space_aggregates(entities, users)
+
         # Calculate scores for all spaces
         for i, space in enumerate(spaces):
-            space.calculate_space_score(entities, users, spaces)
+            space.calculate_space_score(spaces, member_counts, entity_counts)
 
             if self.config.use_activity_metrics:
                 space.activity_score = self.space_scorer.calculate_activity_score(space, entities)

--- a/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
+++ b/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
@@ -223,11 +223,15 @@ class ScoringDataProvider:
         has to derive them — it only consumes pre-computed distances.
         """
         spaces = []
-        non_root_spaces = {str(space_id) for (space_id,) in space_rows if space_id != ROOT_SPACE_ID}
+        # spaces.id comes back from psycopg as a uuid.UUID, while ROOT_SPACE_ID is a
+        # string — compare on the string form so root detection actually works.
+        non_root_spaces = {
+            str(space_id) for (space_id,) in space_rows if str(space_id) != ROOT_SPACE_ID
+        }
 
         for (space_id,) in space_rows:
             space_id_str = str(space_id)
-            is_root = space_id == ROOT_SPACE_ID
+            is_root = space_id_str == ROOT_SPACE_ID
             sub_space_ids = non_root_spaces if is_root else set()
             parent_space_id = None if is_root else ROOT_SPACE_ID
             distance_to_root = 0 if is_root else 1

--- a/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
+++ b/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
@@ -215,14 +215,22 @@ class ScoringDataProvider:
         return spaces
 
     def _build_spaces_flat(self, space_rows: list[tuple]) -> list[Space]:
-        """Build Space objects using flat hierarchy (all children of root)."""
+        """Build Space objects using flat hierarchy (all children of root).
+
+        Fallback used when the topology indexer has not populated
+        scoring_topology_distances yet. Distances are set explicitly here (0 for root,
+        1 for every other space as a direct child of root) so the scoring model never
+        has to derive them — it only consumes pre-computed distances.
+        """
         spaces = []
         non_root_spaces = {str(space_id) for (space_id,) in space_rows if space_id != ROOT_SPACE_ID}
 
         for (space_id,) in space_rows:
             space_id_str = str(space_id)
-            sub_space_ids = non_root_spaces if space_id == ROOT_SPACE_ID else set()
-            parent_space_id = None if space_id == ROOT_SPACE_ID else ROOT_SPACE_ID
+            is_root = space_id == ROOT_SPACE_ID
+            sub_space_ids = non_root_spaces if is_root else set()
+            parent_space_id = None if is_root else ROOT_SPACE_ID
+            distance_to_root = 0 if is_root else 1
             spaces.append(
                 Space(
                     id=space_id_str,
@@ -230,6 +238,7 @@ class ScoringDataProvider:
                     created_at=datetime.now(),
                     parent_space_id=parent_space_id,
                     subspace_ids=sub_space_ids,
+                    distance_to_root=distance_to_root,
                 )
             )
 

--- a/scoring-service/cronjob/tests/test_scoring_data_provider.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_provider.py
@@ -342,7 +342,7 @@ class TestSpaceScoreCalculation:
         spaces = [root, child_1, child_3]
 
         for space in spaces:
-            space.calculate_space_score([], [], spaces)
+            space.calculate_space_score(spaces, {}, {})
 
         assert root.space_score == 1.0
         assert root.space_score > child_1.space_score

--- a/scoring-service/cronjob/tests/test_scoring_data_provider.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_provider.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.algorithm.models import Space, VoteType
+from src.algorithm.models import (
+    DISCONNECTED_SPACE_DEPTH,
+    SPACE_SCORE_DECAY_BASE,
+    Space,
+    VoteType,
+)
 from src.constants import ROOT_SPACE_ID
 from src.scoring_data_provider import ScoringDataProvider, ScoringData
 
@@ -304,9 +309,12 @@ class TestScoringDataProvider:
             root = next(s for s in spaces if s.id == ROOT_SPACE_ID)
             assert root.parent_space_id is None
             assert "space-1" in root.subspace_ids
+            # Flat fallback sets distances explicitly: root=0, every other space=1.
+            assert root.distance_to_root == 0
 
             child = next(s for s in spaces if s.id == "space-1")
             assert child.parent_space_id == ROOT_SPACE_ID
+            assert child.distance_to_root == 1
 
     def test_fetch_scoring_topology_distances(self) -> None:
         """Test that topology distances are fetched correctly."""
@@ -347,3 +355,13 @@ class TestSpaceScoreCalculation:
         assert root.space_score == 1.0
         assert root.space_score > child_1.space_score
         assert child_1.space_score > child_3.space_score
+
+    def test_unset_distance_defaults_to_disconnected(self) -> None:
+        """A space with no distance (no topology entry) is scored as disconnected."""
+        now = datetime.now()
+        space = Space(id="orphan", created_at=now, distance_to_root=None)
+
+        space.calculate_space_score([space], {}, {})
+
+        assert space.distance_to_root == DISCONNECTED_SPACE_DEPTH
+        assert space.space_score == SPACE_SCORE_DECAY_BASE**DISCONNECTED_SPACE_DEPTH

--- a/scoring-service/cronjob/tests/test_scoring_data_provider.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_provider.py
@@ -1,5 +1,6 @@
 """Unit tests for the ScoringDataProvider module."""
 
+import uuid
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -313,6 +314,41 @@ class TestScoringDataProvider:
             assert root.distance_to_root == 0
 
             child = next(s for s in spaces if s.id == "space-1")
+            assert child.parent_space_id == ROOT_SPACE_ID
+            assert child.distance_to_root == 1
+
+    def test_flat_fallback_identifies_root_with_uuid_ids(self) -> None:
+        """Flat fallback must detect the root even when spaces.id rows are uuid.UUID.
+
+        psycopg returns UUID columns as uuid.UUID objects, not strings. Comparing the
+        raw uuid.UUID against the string ROOT_SPACE_ID is always False, which would
+        misclassify the root as a child (distance 1, self-parent). Root detection must
+        use the string form.
+        """
+        with patch("src.scoring_data_provider.scoring_data_provider.psycopg.connect") as mock_connect:
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_connect.return_value.__enter__.return_value = mock_conn
+            mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+            child_id = uuid.uuid4()
+            mock_cursor.fetchall.side_effect = [
+                # spaces query — ids come back as uuid.UUID objects (production behavior)
+                [(uuid.UUID(ROOT_SPACE_ID),), (child_id,)],
+                # topology distances query — empty (indexer hasn't run)
+                [],
+            ]
+
+            provider = ScoringDataProvider("postgresql://test:test@localhost/test")
+            spaces = provider._fetch_spaces(mock_conn)
+
+            root = next(s for s in spaces if s.id == ROOT_SPACE_ID)
+            assert root.parent_space_id is None
+            assert root.distance_to_root == 0
+            assert str(child_id) in root.subspace_ids
+            assert ROOT_SPACE_ID not in root.subspace_ids
+
+            child = next(s for s in spaces if s.id == str(child_id))
             assert child.parent_space_id == ROOT_SPACE_ID
             assert child.distance_to_root == 1
 

--- a/scoring-service/cronjob/tests/test_space_aggregates.py
+++ b/scoring-service/cronjob/tests/test_space_aggregates.py
@@ -1,0 +1,95 @@
+"""Tests for the precomputed per-space tallies used in space scoring.
+
+These cover ``compute_space_aggregates`` and verify that ``Space.calculate_space_score``
+reads ``member_count`` / ``entity_count`` from the required precomputed tallies.
+"""
+
+from datetime import datetime
+
+from src.algorithm.models import Entity, Perspective, Space, User
+from src.algorithm.scoring import compute_space_aggregates
+
+
+def _entity(entity_id: str, space_ids: list[str]) -> Entity:
+    """Build an entity with one perspective per given space id."""
+    now = datetime.now()
+    entity = Entity(id=entity_id, created_at=now)
+    entity.perspectives = [
+        Perspective(
+            id=f"{entity_id}-{i}",
+            space_id=space_id,
+            entity_id=entity_id,
+            created_at=now,
+        )
+        for i, space_id in enumerate(space_ids)
+    ]
+    return entity
+
+
+def test_member_counts_dedup_member_and_editor() -> None:
+    """A user who is both member and editor of a space is counted once."""
+    users = [
+        User(id="u1", member_spaces={"s0", "s1"}, editor_spaces=set()),
+        User(id="u2", member_spaces={"s1"}, editor_spaces={"s2"}),
+        # u3 is BOTH member and editor of s2 -> must count once for s2.
+        User(id="u3", member_spaces={"s0", "s2"}, editor_spaces={"s2"}),
+    ]
+
+    member_counts, _ = compute_space_aggregates([], users)
+
+    assert member_counts == {"s0": 2, "s1": 2, "s2": 2}
+
+
+def test_entity_counts_dedup_multiple_perspectives_same_space() -> None:
+    """An entity with multiple perspectives in one space counts once for that space."""
+    entities = [
+        _entity("e1", ["s1", "s2"]),       # in s1 and s2
+        _entity("e2", ["s1"]),             # in s1
+        _entity("e3", ["s2", "s2", "s2"]),  # 3 perspectives, all in s2 -> count once
+    ]
+
+    _, entity_counts = compute_space_aggregates(entities, [])
+
+    assert entity_counts == {"s1": 2, "s2": 2}
+
+
+def test_empty_inputs_produce_empty_tallies() -> None:
+    member_counts, entity_counts = compute_space_aggregates([], [])
+    assert member_counts == {}
+    assert entity_counts == {}
+
+
+def test_calculate_space_score_reads_counts_from_tallies() -> None:
+    """calculate_space_score populates member/entity counts from the required tallies."""
+    now = datetime.now()
+    spaces = [
+        Space(id="s0", created_at=now, distance_to_root=0),
+        Space(id="s1", created_at=now, distance_to_root=1),
+        Space(id="s2", created_at=now, distance_to_root=2),
+        Space(id="s3", created_at=now, distance_to_root=3),  # absent from both tallies
+    ]
+    users = [
+        User(id="u1", member_spaces={"s0", "s1"}, editor_spaces=set()),
+        User(id="u2", member_spaces={"s1"}, editor_spaces={"s2"}),
+        User(id="u3", member_spaces={"s0", "s2"}, editor_spaces={"s2"}),
+    ]
+    entities = [
+        _entity("e1", ["s1", "s2"]),
+        _entity("e2", ["s1"]),
+        _entity("e3", ["s2", "s2"]),  # dedup within s2
+    ]
+
+    member_counts, entity_counts = compute_space_aggregates(entities, users)
+
+    for space in spaces:
+        space.calculate_space_score(spaces, member_counts, entity_counts)
+
+    by_id = {s.id: s for s in spaces}
+    assert by_id["s0"].member_count == 2
+    assert by_id["s1"].member_count == 2
+    assert by_id["s2"].member_count == 2
+    assert by_id["s1"].entity_count == 2
+    assert by_id["s2"].entity_count == 2
+    # A space absent from the tallies defaults to zero counts.
+    assert by_id["s3"].member_count == 0
+    assert by_id["s3"].entity_count == 0

--- a/scoring-service/deployment/production/cronjob.yaml
+++ b/scoring-service/deployment/production/cronjob.yaml
@@ -87,8 +87,8 @@ spec:
                       optional: true
               resources:
                 requests:
+                  memory: "1280Mi"
+                  cpu: "500m"
+                limits:
                   memory: "2048Mi"
                   cpu: "1000m"
-                limits:
-                  memory: "4096Mi"
-                  cpu: "2000m"

--- a/scoring-service/deployment/staging/cronjob.yaml
+++ b/scoring-service/deployment/staging/cronjob.yaml
@@ -62,8 +62,8 @@ spec:
                   value: "z_score_sigmoid"
               resources:
                 requests:
+                  memory: "1280Mi"
+                  cpu: "500m"
+                limits:
                   memory: "2048Mi"
                   cpu: "1000m"
-                limits:
-                  memory: "4096Mi"
-                  cpu: "2000m"


### PR DESCRIPTION
## What

Optimizes the scoring cronjob's `rank_spaces` step (the pipeline bottleneck — ~8 min for ~280/1126 spaces) and removes the now-dead in-model distance BFS.

### 1. De-quadratic the per-space counts

`Space.calculate_space_score` scanned all users (`O(U)`) and all entities with a nested perspective walk (`O(E×P)`) **for every space**, and ran in two hot loops per pipeline (`rank_spaces` and `rank_entities`). This inverts the loops: a single-pass `compute_space_aggregates()` builds the member/entity tallies once, and each space does an `O(1)` lookup.

- `member_counts`: `Counter` over `member_spaces | editor_spaces` (a user who is both member and editor of a space counts once).
- `entity_counts`: distinct entity ids per space via sets (an entity with multiple perspectives in one space counts once).
- Overall: `O(S × (U + E×P))` → `O(U + E×P + S)`. Plain dicts/sets — algorithmic, no new deps.

### 2. Topology indexer is the single source of truth for distance

`distance_to_root` is computed upstream by the topology indexer and read from `scoring_topology_distances`. The legacy in-model BFS (`_calculate_distance_to_root`) derived connectivity from `parent_space_id` chains — a second source of truth that could diverge and no longer ran in production.

- Removed the BFS and the unused `MAX_SPACE_DEPTH`; `calculate_space_score` now treats `distance_to_root is None` as disconnected.
- **Invariant:** a space with no topology entry is not connected to the root and is scored as disconnected.
- The flat-hierarchy fallback (used when the indexer hasn't run yet) now sets distances explicitly (`0` for root, `1` for others), so the model only ever consumes pre-computed distances.

### 3. Fix root detection in the flat fallback

`spaces.id` comes back from psycopg as a `uuid.UUID`, so comparing it directly against the string root id was always False — the root was misclassified as a child (distance 1, self-parent) whenever the flat fallback ran. Root detection now compares on the string form, with a regression test that mocks ids as `uuid.UUID` objects.

## Notes

- `Space.parent_space_id` and the pairwise space-distance util are left untouched — only used by the distance-weighting path, which is off by default.
- Test suite green (97 tests).
