### PR TITLE
feat(notification-service): testnet (v2) deploy support for indexer + delivery-worker

### DIFF
--- a/.github/workflows/build-v2-images.yml
+++ b/.github/workflows/build-v2-images.yml
@@ -54,6 +54,12 @@ jobs:
           - image: scoring-service
             dockerfile: scoring-service/cronjob/Dockerfile
             context: scoring-service/cronjob
+          - image: notification-indexer
+            dockerfile: notification-service/notification-indexer/Dockerfile
+            context: .
+          - image: delivery-worker
+            dockerfile: notification-service/delivery-worker/Dockerfile
+            context: .
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -27,6 +27,8 @@ on:
           - topology-indexer
           - scoring-service
           - proposal-executor
+          - notification-indexer
+          - delivery-worker
       tag:
         description: "Image tag to deploy (from the build workflow, e.g. short SHA). Ignored for valkey (pinned public image)."
         required: true
@@ -73,6 +75,8 @@ jobs:
             topology-indexer)  manifests="scoring-service/deployment/v2/topology-indexer.yaml"; rollout="deployment/topology-indexer" ;;
             scoring-service)   manifests="scoring-service/deployment/v2/cronjob.yaml";      rollout="" ;;
             proposal-executor) manifests="proposal-executor/deployment/v2/cronjob.yaml";    rollout="" ;;
+            notification-indexer) manifests="notification-service/deployment/v2/notification-indexer.yaml"; rollout="deployment/notification-indexer" ;;
+            delivery-worker)   manifests="notification-service/deployment/v2/delivery-worker.yaml"; rollout="deployment/delivery-worker" ;;
             *) echo "unknown service"; exit 1 ;;
           esac
           echo "manifests=$manifests" >> "$GITHUB_OUTPUT"

--- a/notification-service/deployment/v2/delivery-worker.yaml
+++ b/notification-service/deployment/v2/delivery-worker.yaml
@@ -4,7 +4,7 @@
 # to registered webhooks with HMAC-SHA256 signatures.
 #
 # The worker is environment-scoped purely by the DATABASE_URL it points at
-# (the testnet `notification-service-credentials` secret) — it doesn't consume
+# (the v2 KG DB, from the shared `api-secrets` secret) — it doesn't consume
 # Kafka, so it needs no ENVIRONMENT/topic-prefix.
 apiVersion: apps/v1
 kind: Deployment

--- a/notification-service/deployment/v2/delivery-worker.yaml
+++ b/notification-service/deployment/v2/delivery-worker.yaml
@@ -1,0 +1,91 @@
+# Delivery Worker Deployment (v2 / testnet)
+#
+# Polls the notification outbox for pending deliveries and POSTs
+# to registered webhooks with HMAC-SHA256 signatures.
+#
+# The worker is environment-scoped purely by the DATABASE_URL it points at
+# (the testnet `notification-service-credentials` secret) — it doesn't consume
+# Kafka, so it needs no ENVIRONMENT/topic-prefix.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: delivery-worker
+  namespace: gaia-v2
+  labels:
+    app: delivery-worker
+    environment: testnet
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: delivery-worker
+  template:
+    metadata:
+      labels:
+        app: delivery-worker
+        environment: testnet
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: geo
+      containers:
+        - name: delivery-worker
+          image: registry.digitalocean.com/geo/delivery-worker:latest
+          imagePullPolicy: Always
+          env:
+            # Database configuration
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-credentials
+                  key: DATABASE_URL
+            # Worker configuration
+            - name: POLL_INTERVAL_MS
+              value: "5000"
+            - name: MAX_RETRIES
+              value: "100"
+            - name: BATCH_SIZE
+              value: "50"
+            # Logging
+            - name: RUST_LOG
+              value: "info,delivery_worker=debug"
+          ports:
+            - containerPort: 8080
+              name: health
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"

--- a/notification-service/deployment/v2/delivery-worker.yaml
+++ b/notification-service/deployment/v2/delivery-worker.yaml
@@ -41,7 +41,7 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: notification-service-credentials
+                  name: api-secrets
                   key: DATABASE_URL
             # Worker configuration
             - name: POLL_INTERVAL_MS

--- a/notification-service/deployment/v2/notification-indexer.yaml
+++ b/notification-service/deployment/v2/notification-indexer.yaml
@@ -1,0 +1,117 @@
+# Notification Indexer Deployment (v2 / testnet)
+#
+# Consumes governance events from Kafka and writes to the notification outbox.
+# Also polls for expired proposals to generate rejection notifications.
+#
+# ENVIRONMENT=testnet makes hermes_kafka::get_topic_prefix() return "testnet.",
+# so this indexer consumes the testnet.* Kafka topics; consumer groups are
+# suffixed -testnet-v1 to keep offsets isolated from staging/production.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-indexer
+  namespace: gaia-v2
+  labels:
+    app: notification-indexer
+    environment: testnet
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notification-indexer
+  template:
+    metadata:
+      labels:
+        app: notification-indexer
+        environment: testnet
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: geo
+      containers:
+        - name: notification-indexer
+          image: registry.digitalocean.com/geo/notification-indexer:latest
+          imagePullPolicy: Always
+          env:
+            # Database configuration
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-credentials
+                  key: DATABASE_URL
+            # Kafka configuration
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_USERNAME
+                  optional: true
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_PASSWORD
+                  optional: true
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_SSL_CA_PEM
+                  optional: true
+            # Consumer configuration
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: KAFKA_GROUP_ID_GOVERNANCE
+              value: "notification-indexer-governance-testnet-v1"
+            - name: KAFKA_GROUP_ID_KNOWLEDGE_EDITS
+              value: "notification-indexer-knowledge-edits-testnet-v1"
+            - name: REJECTION_POLL_INTERVAL_SECS
+              value: "60"
+            # Logging
+            - name: RUST_LOG
+              value: "info,notification_indexer=debug"
+          ports:
+            - containerPort: 8080
+              name: health
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/notification-service/deployment/v2/notification-indexer.yaml
+++ b/notification-service/deployment/v2/notification-indexer.yaml
@@ -41,30 +41,30 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: notification-service-credentials
+                  name: api-secrets
                   key: DATABASE_URL
             # Kafka configuration
             - name: KAFKA_BROKER
               valueFrom:
                 secretKeyRef:
-                  name: kafka-credentials
+                  name: kg-indexer-secrets
                   key: KAFKA_BROKER
             - name: KAFKA_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: kafka-credentials
+                  name: kg-indexer-secrets
                   key: KAFKA_USERNAME
                   optional: true
             - name: KAFKA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: kafka-credentials
+                  name: kg-indexer-secrets
                   key: KAFKA_PASSWORD
                   optional: true
             - name: KAFKA_SSL_CA_PEM
               valueFrom:
                 secretKeyRef:
-                  name: kafka-credentials
+                  name: kg-indexer-secrets
                   key: KAFKA_SSL_CA_PEM
                   optional: true
             # Consumer configuration


### PR DESCRIPTION
Adds the notification services to the gaia-v2 (testnet) deploy path.

## Changes
- **`notification-service/deployment/v2/{notification-indexer,delivery-worker}.yaml`** — namespace `gaia-v2`, `ENVIRONMENT="testnet"` (→ `testnet.*` Kafka topic prefix via `hermes_kafka::get_topic_prefix`), consumer groups `…-testnet-v1`. No standalone namespace.yaml — `deploy-v2` ensures `gaia-v2` (same pattern as `scoring-service/deployment/v2/`).
- **`deploy-v2.yml`** — added `notification-indexer` + `delivery-worker` to the service dropdown + case mapping (manifest path + `deployment/<name>` rollout).
- **`build-v2-images.yml`** — added both to the build matrix (`notification-service/<svc>/Dockerfile`, context `.`, matching the staging build).

## No code change
The indexer already supports `ENVIRONMENT=testnet` — `get_topic_prefix()` maps it to the `testnet.` prefix. The delivery-worker is env-scoped purely by its `DATABASE_URL`.

## Provisioning prereq (not in this PR)
The `gaia-v2` namespace needs a `notification-service-credentials` secret pointing at the **testnet notifications DB** (`kafka-credentials` already exists there). The indexer idles until the `testnet.*` topics are produced.

## Deploy
Run *Build gaia-v2 images* (now builds both) → take the printed tag → run *Deploy gaia-v2 service* once per service with that tag.