### PR TITLE
fix(ranking-indexer): make membership recompute idempotent; stop constraint-violation crash loop

### DIFF
--- a/ranking-indexer/src/error.rs
+++ b/ranking-indexer/src/error.rs
@@ -20,12 +20,31 @@ impl IndexerError {
         Self::Decode(msg.into())
     }
 
-    /// True when retrying the same input can never succeed (malformed
-    /// message). Everything else — database, Kafka — is treated as transient:
-    /// retried, and never skipped past, since the writes are idempotent and
-    /// redelivery converges.
+    /// True when retrying the same input can never succeed, so the message
+    /// must be logged + skipped rather than retried (which would crash-loop
+    /// the partition forever, since the offset is never committed).
+    ///
+    /// Two cases are poison:
+    /// - `Decode` — a malformed message; the bytes will never parse.
+    /// - A database **integrity-constraint violation** (SQLSTATE class `23`:
+    ///   unique, foreign-key, not-null, check). These are deterministic — the
+    ///   same input fails identically on every redelivery, so retrying can
+    ///   never converge. The recompute writes are idempotent (`ON CONFLICT`),
+    ///   so we should not hit these in practice; this is the safety net that
+    ///   stops a future non-idempotent write from stalling the consumer group.
+    ///
+    /// Everything else — transient database errors (connection drops,
+    /// deadlocks, serialization failures), Kafka errors — stays transient:
+    /// retried, never skipped, since redelivery can converge.
     pub fn is_poison(&self) -> bool {
-        matches!(self, Self::Decode(_))
+        match self {
+            Self::Decode(_) => true,
+            Self::Database(e) => e
+                .as_database_error()
+                .and_then(|db| db.code())
+                .is_some_and(|code| code.starts_with("23")),
+            _ => false,
+        }
     }
 }
 

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -496,14 +496,15 @@ impl Storage {
         .execute(&mut *tx)
         .await?;
 
-        // 2. Drop prior projection relations (RANK_POSITION + Aggregated rankings).
-        //    Scoped by (from_entity_id, type_id, space_id) only — NOT by
-        //    from_space_id. Pre-fix projection rows were written with
-        //    from_space_id IS NULL; adding `from_space_id = block_space_id` would
-        //    skip them (NULL never equals anything), leaving their deterministic
-        //    PK ids in place. The ON-CONFLICT-free INSERTs below would then
-        //    collide on those ids → duplicate-key error → aborted tx → crash
-        //    loop. Matching on the space alone lets pre-fix blocks self-heal.
+        // 2. Drop prior projection relations (RANK_POSITION + Aggregated rankings)
+        //    that are no longer part of the recomputed projection. Scoped by
+        //    (from_entity_id, type_id, space_id) only — NOT by from_space_id,
+        //    so pre-fix rows written with from_space_id IS NULL are still
+        //    cleared (NULL never equals block_space_id). The INSERTs below are
+        //    idempotent (ON CONFLICT on the PK), so even a row this DELETE
+        //    misses converges on re-insert instead of raising a duplicate-key
+        //    error — a unique violation here is also reclassified as poison
+        //    (see error.rs), so it can never crash-loop the partition again.
         sqlx::query(
             "DELETE FROM relations WHERE from_entity_id = $1 AND type_id = ANY($2) AND space_id = $3",
         )
@@ -552,7 +553,12 @@ impl Storage {
             sqlx::query(
                 "INSERT INTO relations \
                  (id, entity_id, type_id, from_entity_id, from_space_id, to_entity_id, to_space_id, space_id, position) \
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) \
+                 ON CONFLICT (id) DO UPDATE SET \
+                   entity_id = EXCLUDED.entity_id, \
+                   to_entity_id = EXCLUDED.to_entity_id, \
+                   to_space_id = EXCLUDED.to_space_id, \
+                   position = EXCLUDED.position",
             )
             .bind(r.relation_id)
             .bind(r.reified_entity_id)
@@ -569,7 +575,12 @@ impl Storage {
             // `values.id` is a text column — serialize the UUID at the bind boundary.
             sqlx::query(
                 "INSERT INTO values (id, entity_id, space_id, property_id, integer) \
-                 VALUES ($1, $2, $3, $4, $5)",
+                 VALUES ($1, $2, $3, $4, $5) \
+                 ON CONFLICT (id) DO UPDATE SET \
+                   entity_id = EXCLUDED.entity_id, \
+                   space_id = EXCLUDED.space_id, \
+                   property_id = EXCLUDED.property_id, \
+                   integer = EXCLUDED.integer",
             )
             .bind(r.value_row_id.to_string())
             .bind(r.reified_entity_id)
@@ -583,10 +594,14 @@ impl Storage {
         // 5. Insert Aggregated rankings provenance relations (block -> submission).
         for ranking_id in contributing_rankings {
             let (relation_id, reified) = provenance_ids(block_id, *ranking_id);
+            // Provenance is a deterministic block -> submission mapping; on a
+            // recompute the same ids re-resolve to the same row, so a conflict
+            // just means it's already present.
             sqlx::query(
                 "INSERT INTO relations \
                  (id, entity_id, type_id, from_entity_id, from_space_id, to_entity_id, space_id) \
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7) \
+                 ON CONFLICT (id) DO NOTHING",
             )
             .bind(relation_id)
             .bind(reified)

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -930,3 +930,198 @@ async fn membership_events_integrate_and_drop_rankings() {
         "both roles revoked — view tables must be empty"
     );
 }
+
+/// Regression for the `values_pkey` crash loop (prod incident 2026-06-22): a
+/// recompute `INSERT INTO values` without `ON CONFLICT` collided whenever a
+/// prior projection value row survived step-1's DELETE — e.g. its
+/// `RANK_POSITION` relation was missing, so the DELETE's `entity_id IN
+/// (SELECT … FROM relations …)` subquery never resolved it. The duplicate-key
+/// was misclassified as transient, so the consumer crash-looped forever on the
+/// same offset. The recompute INSERTs are now idempotent; re-running over an
+/// orphaned value row must converge instead of erroring.
+#[tokio::test]
+async fn recompute_is_idempotent_when_a_prior_value_row_is_orphaned() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    // Distinct scenario ids so this can share a DB with the other e2e tests.
+    const SPACE: u128 = 0xE2E5_0000_3001;
+    const MEMBER: u128 = 0xE2E5_0000_3011;
+    const BLK: u128 = 0xE2E5_0000_3021;
+    const ENT_A: u128 = 0xE2E5_0000_3031;
+    const ENT_B: u128 = 0xE2E5_0000_3032;
+    const RNK: u128 = 0xE2E5_0000_3041;
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+    ] {
+        sqlx::query(sql).bind(u(SPACE)).execute(pool).await.unwrap();
+    }
+    for sql in [
+        "DELETE FROM ranks.ranking_items WHERE ranking_id = $1",
+        "DELETE FROM ranks.rankings WHERE id = $1",
+    ] {
+        sqlx::query(sql).bind(u(RNK)).execute(pool).await.unwrap();
+    }
+    for sql in [
+        "DELETE FROM ranks.ranking_scores WHERE block_id = $1",
+        "DELETE FROM ranks.ranking_blocks WHERE id = $1",
+    ] {
+        sqlx::query(sql).bind(u(BLK)).execute(pool).await.unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.members WHERE space_id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed prerequisites + build the projection -------------------------
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e3')")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)")
+        .bind(u(MEMBER))
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    let block_edit = EditBuilder::new(gid(0x3001))
+        .create_relation(|r| {
+            r.id(gid(0x3100))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(BLK))
+                .to(sid(RANKING_BLOCK_TYPE_ID))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x3101))
+                .relation_type(sid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID))
+                .from(gid(BLK))
+                .to(sid(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID))
+        })
+        .create_entity(gid(BLK), |e| {
+            e.text(sid(NAME_PROPERTY_ID), "Top Films", None)
+        })
+        .build();
+    apply_detected_edit(&detect(&block_edit, u(SPACE), 1, 0), u(SPACE), &storage)
+        .await
+        .unwrap();
+
+    let submission = EditBuilder::new(gid(0x3001 ^ 0xED17))
+        .create_relation(|r| {
+            r.id(gid(0x3200))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(RNK))
+                .to(sid(RANK_TYPE_ID))
+        })
+        .create_entity(gid(RNK), |e| {
+            e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+        })
+        .create_relation(|r| {
+            r.id(gid(0x3201))
+                .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                .from(gid(RNK))
+                .to(gid(BLK))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x3202))
+                .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                .from(gid(RNK))
+                .to(gid(ENT_A))
+                .to_space(gid(SPACE))
+                .position("a0")
+        })
+        .create_relation(|r| {
+            r.id(gid(0x3203))
+                .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                .from(gid(RNK))
+                .to(gid(ENT_B))
+                .to_space(gid(SPACE))
+                .position("a1")
+        })
+        .build();
+    let detected_submission = detect(&submission, u(MEMBER), 2, 0);
+    apply_detected_edit(&detected_submission, u(MEMBER), &storage)
+        .await
+        .unwrap();
+
+    let rank_position = u(Uuid::parse_str(RANK_POSITION_RELATION_TYPE_ID)
+        .unwrap()
+        .as_u128());
+    let value_prop = Uuid::parse_str(RANK_POSITION_VALUE_PROPERTY_ID).unwrap();
+
+    // --- recreate the prod failure state: orphan one projection value row ---
+    // Delete a single RANK_POSITION relation but leave its value row behind.
+    // The next recompute's value-DELETE resolves entity_ids through the
+    // relations it lists, so it can no longer see this orphan — exactly the
+    // condition that made the value INSERT collide on `values.id`.
+    let victim: Uuid = sqlx::query_scalar(
+        "SELECT entity_id FROM relations WHERE from_entity_id = $1 AND type_id = $2 LIMIT 1",
+    )
+    .bind(u(BLK))
+    .bind(rank_position)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let val_before: i64 = sqlx::query_scalar("SELECT count(*) FROM values WHERE entity_id = $1")
+        .bind(victim)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        val_before, 1,
+        "precondition: reified entity has its value row"
+    );
+    sqlx::query(
+        "DELETE FROM relations WHERE entity_id = $1 AND type_id = $2 AND from_entity_id = $3",
+    )
+    .bind(victim)
+    .bind(rank_position)
+    .bind(u(BLK))
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // --- recompute must converge, not crash on values_pkey ------------------
+    let result = apply_detected_edit(&detected_submission, u(MEMBER), &storage).await;
+    assert!(
+        result.is_ok(),
+        "recompute must be idempotent when a value row is orphaned, got: {result:?}"
+    );
+
+    // projection restored: A (#1, value 100) and B (#2, value 50).
+    let rows = sqlx::query(
+        "SELECT r.to_entity_id AS entity, v.integer AS value \
+         FROM relations r JOIN values v ON v.entity_id = r.entity_id AND v.property_id = $3 \
+         WHERE r.from_entity_id = $1 AND r.type_id = $2 ORDER BY r.position",
+    )
+    .bind(u(BLK))
+    .bind(rank_position)
+    .bind(value_prop)
+    .fetch_all(pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 2, "projection restored to two ranked entities");
+    let e0: Uuid = rows[0].get("entity");
+    let v0: i64 = rows[0].get("value");
+    assert_eq!(e0, u(ENT_A), "top-ranked entity should be A");
+    assert_eq!(
+        v0, 100,
+        "top entity scaled to 100 after idempotent recompute"
+    );
+    let v1: i64 = rows[1].get("value");
+    assert_eq!(v1, 50, "second entity converges to 50");
+}


### PR DESCRIPTION
## Incident
`KafkaConsumerGroupEmpty` on `ranking-indexer-v1` (prod, ~2026-06-22 20:26 UTC). Consumer group drained to **zero members** — not scaled to 0, but **CrashLoopBackOff**.

## Root cause
A `space.membership` event at **offset 72615** triggered a block re-aggregation. The recompute does DELETE-then-INSERT into `relations`/`values` **without `ON CONFLICT`**. Step-1's value DELETE resolves `entity_id`s through the block's `RANK_POSITION` relations; when a prior value row's relation was missing, the DELETE skipped it and the value INSERT collided on **`values_pkey`**.

The duplicate-key surfaced as `IndexerError::Database`, which `error.rs` classified as **transient** ("writes are idempotent, redelivery converges" — untrue here). It retried 4×, then `std::process::exit(1)` to force redelivery. The offset was never committed, so Kafka redelivered the **same** message → infinite crash loop.

(The `storage.rs` comment already documented this exact failure mode from a prior incident; the earlier fix narrowed the DELETE scope but left the INSERTs non-idempotent.)

## Fix — two layers
1. **Idempotent recompute writes.** `ON CONFLICT (id) DO UPDATE` on the `RANK_POSITION` relations + value rows (the recomputed content wins); `DO NOTHING` on the stable block→submission provenance relations. Re-running converges instead of colliding.
2. **Constraint violations are poison, not transient.** SQLSTATE class `23` (unique / FK / not-null / check) is deterministic and can never converge by retrying — now logged + skipped instead of crash-looping. Genuinely transient DB errors (connection, deadlock `40001`, etc.) still retry as before. This is the safety net so no future non-idempotent write can drain the consumer group again.

## Test
Opt-in e2e regression (`recompute_is_idempotent_when_a_prior_value_row_is_orphaned`) that reproduces the orphaned-value-row state and asserts the recompute returns `Ok` with the projection intact. `cargo build`, `cargo test`, `cargo fmt --check`, `cargo clippy --tests` all clean.

## Deploy note
⚠️ The crashing prod image `1f60e60e` is **not on `main`** — an unmerged/feature build reached production. After merge, redeploy ranking-indexer **from `main`**. If prod is still crash-looping at review time, a stopgap is to roll back to the last-good image `1ce31f55` (06-18) to restore the consumer group while this lands.