### PR TITLE
feat(membership-acceptor): real-time membership auto-accept service

### DIFF
--- a/.github/workflows/membership-acceptor-check.yml
+++ b/.github/workflows/membership-acceptor-check.yml
@@ -32,7 +32,7 @@ jobs:
           bun-version: 1.3.9
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Check formatting
         run: bun run lint

--- a/.github/workflows/membership-acceptor-check.yml
+++ b/.github/workflows/membership-acceptor-check.yml
@@ -1,0 +1,41 @@
+name: Membership Acceptor Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'membership-acceptor/**'
+      - '.github/workflows/membership-acceptor-check.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./membership-acceptor
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check formatting
+        run: bun run lint
+
+      - name: Type check
+        run: bun run typecheck

--- a/.github/workflows/membership-acceptor-deploy.yml
+++ b/.github/workflows/membership-acceptor-deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy Membership Acceptor (Production)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'membership-acceptor/**'
+      - '.github/workflows/membership-acceptor-deploy.yml'
+
+concurrency:
+  group: membership-acceptor-production
+  cancel-in-progress: true
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+  IMAGE_NAME: membership-acceptor
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+                       -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+                       -f membership-acceptor/Dockerfile membership-acceptor
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Set up kubectl
+        uses: Azure/setup-kubectl@v5
+
+      - name: Configure kubectl for DigitalOcean
+        run: |
+          doctl kubernetes cluster kubeconfig save ${{ secrets.DIGITALOCEAN_CLUSTER_NAME }}
+
+      - name: Deploy to Kubernetes
+        run: |
+          # Pin the image to this commit's SHA and apply the Deployment + Service.
+          sed -i 's|image: registry.digitalocean.com/geo/membership-acceptor:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' membership-acceptor/deployment/production/deployment.yaml
+          kubectl apply -f membership-acceptor/deployment/production/deployment.yaml
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/membership-acceptor -n knowledge --timeout=120s
+
+      - name: Show deployment status
+        if: always()
+        run: |
+          echo "=== Membership Acceptor Deployment (Production) ==="
+          kubectl get deployment membership-acceptor -n knowledge || echo "Deployment not found"
+          echo ""
+          echo "=== Pods ==="
+          kubectl get pods -n knowledge -l app=membership-acceptor || echo "No pods found"
+          echo ""
+          echo "=== Recent Events ==="
+          kubectl get events -n knowledge --sort-by='.lastTimestamp' | tail -10

--- a/.github/workflows/membership-acceptor-tests.yml
+++ b/.github/workflows/membership-acceptor-tests.yml
@@ -32,7 +32,7 @@ jobs:
           bun-version: 1.3.9
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run tests
         run: bun test

--- a/.github/workflows/membership-acceptor-tests.yml
+++ b/.github/workflows/membership-acceptor-tests.yml
@@ -1,0 +1,38 @@
+name: Membership Acceptor Tests
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'membership-acceptor/**'
+      - '.github/workflows/membership-acceptor-tests.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./membership-acceptor
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun test

--- a/membership-acceptor/.env.example
+++ b/membership-acceptor/.env.example
@@ -9,7 +9,34 @@
 # Generate with: openssl rand -hex 32
 GEO_WEBHOOK_SECRET=
 
+# Signing key for the Safe smart account that owns the acceptor's personal space
+# (0x-prefixed, 64 hex chars). This account must be an EDITOR of every space in
+# MEMBERSHIP_AUTOACCEPT_SPACE_IDS, or its votes revert.
+ACCEPTOR_PRIVATE_KEY=0x...
+
+# The acceptor's personal-space id (bytes16, 0x + 32 hex chars).
+ACCEPTOR_SPACE_ID=0x...
+
+# SpaceRegistry contract address.
+SPACE_REGISTRY_ADDRESS=0xB01683b2f0d38d43fcD4D9aAB980166988924132
+
+# Chain RPC endpoint (may contain an API key).
+RPC_URL=https://...
+
+# Pimlico bundler/paymaster API key (gas sponsorship).
+PIMLICO_API_KEY=pim_...
+
+# Geo GraphQL endpoint — used by policies (e.g. the editor check).
+GRAPHQL_ENDPOINT=https://...
+
+# DAO space IDs (UUIDs, comma-separated) this acceptor auto-accepts.
+# Empty = accept none (effective kill switch).
+MEMBERSHIP_AUTOACCEPT_SPACE_IDS=
+
 # === Optional ===
+
+# Chain ID: 80451 (mainnet, default) or 19411 (testnet)
+# CHAIN_ID=80451
 
 # Port the HTTP server listens on (default: 8080)
 # PORT=8080

--- a/membership-acceptor/.env.example
+++ b/membership-acceptor/.env.example
@@ -29,8 +29,8 @@ PIMLICO_API_KEY=pim_...
 # Geo GraphQL endpoint — used by policies (e.g. the editor check).
 GRAPHQL_ENDPOINT=https://...
 
-# DAO space IDs (UUIDs, comma-separated) this acceptor auto-accepts.
-# Empty = accept none (effective kill switch).
+# DAO space ids this acceptor auto-accepts: comma-separated, as 0x-prefixed
+# bytes16 hex (dashed UUIDs are also accepted). Empty = accept none (kill switch).
 MEMBERSHIP_AUTOACCEPT_SPACE_IDS=
 
 # === Optional ===

--- a/membership-acceptor/.env.example
+++ b/membership-acceptor/.env.example
@@ -1,0 +1,22 @@
+# Membership Acceptor — Environment Variables
+# Copy to .env and fill in values.
+
+# === Required ===
+
+# Shared secret for verifying the X-Geo-Signature HMAC on incoming webhooks.
+# MUST equal the `secret` column of this service's row in the notification
+# service's `app_webhooks` table, or every delivery fails verification.
+# Generate with: openssl rand -hex 32
+GEO_WEBHOOK_SECRET=
+
+# === Optional ===
+
+# Port the HTTP server listens on (default: 8080)
+# PORT=8080
+
+# Sentry error reporting DSN (telemetry is console-only when unset)
+# SENTRY_DSN=https://...@sentry.io/...
+# SENTRY_ENVIRONMENT=production
+# SENTRY_RELEASE=
+# SENTRY_TRACES_SAMPLE_RATE=1.0
+# SENTRY_DEBUG=false

--- a/membership-acceptor/.gitignore
+++ b/membership-acceptor/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+*.log

--- a/membership-acceptor/.gitignore
+++ b/membership-acceptor/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .env
+.env.*
+!.env.example
 *.log

--- a/membership-acceptor/.npmrc
+++ b/membership-acceptor/.npmrc
@@ -1,0 +1,2 @@
+# Fallback for users who accidentally run `npm install` instead of `bun install`
+min-release-age=14d

--- a/membership-acceptor/Dockerfile
+++ b/membership-acceptor/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.9 AS builder
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+COPY . .
+
+FROM oven/bun:1.3.9
+ENV NODE_ENV=production
+RUN groupadd --system --gid 1001 geo && useradd --system --uid 1001 --gid geo geo
+WORKDIR /app
+COPY --from=builder --chown=geo:geo /app/package.json /app/bun.lock* ./
+RUN bun install --frozen-lockfile --production
+COPY --from=builder --chown=geo:geo /app/src ./src
+USER geo
+EXPOSE 8080
+CMD ["bun", "run", "src/index.ts"]

--- a/membership-acceptor/README.md
+++ b/membership-acceptor/README.md
@@ -18,7 +18,7 @@ It is structured so it can later be extracted into its own repo that space
 admins deploy themselves, each running a sovereign acceptor with its own wallet
 and membership policy (allow-all, allow-verified, reputation, payment, …).
 
-## Status — Milestone 2 (membership-request detection)
+## Status — Milestone 3 (on-chain vote)
 
 The service:
 
@@ -26,20 +26,60 @@ The service:
   header against `GEO_WEBHOOK_SECRET` (rejects unsigned/tampered requests with 401);
 - exposes `GET /health` for k8s probes;
 - **detects membership requests** in the firehose — a `proposal_created` event
-  with `voting_mode == "fast"` and exactly one `add_member` action that still
-  looks open — and **de-duplicates** them by `proposal_id` (the fan-out delivers
-  one copy per editor of the space);
-- logs `membership request detected — would accept` for each unique match.
+  with `voting_mode == "fast"` and exactly one `add_member` action — gates them by
+  the `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` allowlist, and **de-duplicates** by
+  `proposal_id` (the fan-out delivers one copy per editor of the space);
+- runs a **policy** (API-backed rules — see below) before voting;
+- **casts the YES vote** for each unique allowed+accepted request via the acceptor's Safe
+  smart account (`SpaceRegistry.enter(PROPOSAL_VOTED, Yes)`, gas-sponsored by
+  Pimlico). Fast-path threshold = 1, so the YES executes the AddMember in the same
+  transaction — admitting the member.
 
-It does **not** yet cast votes (M3) — a detected request is logged, and every
-authenticated webhook is acknowledged with `200`. Detection is payload-only and
-best-effort (a trigger, not a source of truth); the authoritative open/untouched
-check happens on-chain in M3 before any vote.
+### The "simple" model (no on-chain pre-reads)
+
+The contract is the source of truth, so there is **no** read-before-vote. We mark
+the proposal seen, attempt the vote, and classify the result:
+
+| Outcome | HTTP | Behavior |
+|---|---|---|
+| `voted` | `200` | YES landed; member admitted. |
+| `benign` (on-chain revert: already voted/executed/closed, or not an editor) | `200` | Nothing to retry — ack so the delivery-worker stops. |
+| `infra` (RPC/bundler failure) | `503` | Roll back the dedupe mark and signal a retry. |
+
+This eliminates the check-then-act race a read-before-vote design would have: a
+duplicate that slips past in-memory dedupe (restart, 2nd replica) simply reverts
+on-chain → no double-admit, just a wasted tx. **Keep `replicas: 1`** — dedupe is
+per-process.
+
+> **Prerequisite:** the acceptor's Safe smart account (`ACCEPTOR_PRIVATE_KEY` /
+> `ACCEPTOR_SPACE_ID`) must be an **editor** of every space in
+> `MEMBERSHIP_AUTOACCEPT_SPACE_IDS`, or its votes revert (`benign`, logged loudly).
+
+### Policies (the BYO extension point)
+
+Requests pass through a cheap→expensive funnel:
+
+```
+detect → WHITELIST (config Set, no I/O) → dedupe → POLICY (GraphQL) → vote
+```
+
+A `Policy` is `(request, ctx) => Promise<{accept, reason}>`; `ctx` carries a
+`GraphQLClient` so a space can express rules backed by API data (reputation,
+payment, external auth, …) without touching the webhook/voting plumbing. Compose
+several with `composePolicies(...)` (AND semantics, first denial wins).
+
+The shipped reference policy is **`editorPolicy`**: it confirms the acceptor is an
+editor of the target space via the `editor(spaceId, memberSpaceId)` GraphQL query.
+It **fails open** — an API error/timeout never suppresses a vote; the chain stays
+the final authority (a genuine non-editor just reverts). Configure the endpoint
+with `GRAPHQL_ENDPOINT`. Add your own policies in `src/index.ts`:
+`composePolicies(editorPolicy, myReputationPolicy)`.
 
 > Implementation note: unlike `proposal-executor` (an Effect-TS CronJob), this is
-> a plain `Bun.serve` HTTP server. The request path is straightforward async
-> code; we keep the same Sentry/structured-logging conventions (see
-> `src/telemetry.ts`) so logs read consistently across the two services.
+> a plain `Bun.serve` HTTP server. The on-chain pieces (ABI, `enter()` encoding,
+> Safe smart wallet) are ported from `proposal-executor` because the published
+> `@geoprotocol/geo-sdk` voting helpers are hardcoded to testnet in the current
+> version and cannot drive a mainnet vote.
 
 ## Layout
 
@@ -48,6 +88,11 @@ check happens on-chain in M3 before any vote.
 | `src/index.ts` | Entry point — parse config, start server, graceful shutdown |
 | `src/server.ts` | Routes + request handling (`createApp` returns a testable fetch handler) |
 | `src/detect.ts` | Membership-request detection + `proposal_id` de-duplication |
+| `src/vote.ts` | The acceptor: whitelist + run policy + cast the YES vote, classify the result |
+| `src/policy.ts` | Policy seam + `composePolicies` + the reference `editorPolicy` |
+| `src/graphql.ts` | Minimal GraphQL client used by policies |
+| `src/wallet.ts` | Safe smart-account setup (Pimlico-sponsored) |
+| `src/contracts.ts` | SpaceRegistry ABI, chains, `enter()` encoding, revert classification |
 | `src/signature.ts` | `X-Geo-Signature` HMAC verification |
 | `src/config.ts` | Env parsing + validation (fail-fast) |
 | `src/telemetry.ts` | Sentry init + structured logger + flush |

--- a/membership-acceptor/README.md
+++ b/membership-acceptor/README.md
@@ -1,0 +1,88 @@
+# membership-acceptor
+
+Real-time membership auto-accept for Geo spaces.
+
+This is the event-driven successor to the `proposal-executor` cron's
+membership-accept path. Instead of polling every 5 minutes, it receives
+notification **webhooks** from the Geo notification service and reacts in
+near real time.
+
+```
+on-chain PROPOSAL_CREATED
+  → hermes-pipeline → Kafka space.governance
+  → notification-indexer → delivery-worker → HMAC-signed webhook
+  → membership-acceptor  ← this service
+```
+
+It is structured so it can later be extracted into its own repo that space
+admins deploy themselves, each running a sovereign acceptor with its own wallet
+and membership policy (allow-all, allow-verified, reputation, payment, …).
+
+## Status — Milestone 1 (webhook connectivity)
+
+This milestone proves the pipe end to end. The service:
+
+- exposes `POST /webhooks/geo` and verifies the `X-Geo-Signature` HMAC-SHA256
+  header against `GEO_WEBHOOK_SECRET` (rejects unsigned/tampered requests with 401);
+- exposes `GET /health` for k8s probes;
+- logs a structured summary of every delivery it receives.
+
+It does **not** yet detect membership requests (M2) or cast votes (M3). Every
+authenticated webhook is acknowledged with `200`.
+
+> Implementation note: unlike `proposal-executor` (an Effect-TS CronJob), this is
+> a plain `Bun.serve` HTTP server. The request path is straightforward async
+> code; we keep the same Sentry/structured-logging conventions (see
+> `src/telemetry.ts`) so logs read consistently across the two services.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/index.ts` | Entry point — parse config, start server, graceful shutdown |
+| `src/server.ts` | Routes + request handling (`createApp` returns a testable fetch handler) |
+| `src/signature.ts` | `X-Geo-Signature` HMAC verification |
+| `src/config.ts` | Env parsing + validation (fail-fast) |
+| `src/telemetry.ts` | Sentry init + structured logger + flush |
+| `deployment/production/` | k8s `Deployment` + `Service` + secret template |
+
+## Develop
+
+```bash
+bun install
+bun test          # unit tests
+bun run typecheck # tsc --noEmit
+bun run lint      # biome
+GEO_WEBHOOK_SECRET=dev-secret bun run start   # serves on :8080
+```
+
+Smoke test locally:
+
+```bash
+SECRET=dev-secret
+BODY='{"event_type":"proposal_created","category":"governance"}'
+SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')"
+curl -s -XPOST localhost:8080/webhooks/geo \
+  -H "content-type: application/json" -H "x-geo-signature: $SIG" -d "$BODY"
+# → {"status":"ok"}
+```
+
+## Registering the webhook
+
+The service receives deliveries only after a row is added to the notification
+service's `app_webhooks` table pointing at it, with a `secret` equal to this
+service's `GEO_WEBHOOK_SECRET`. See
+`notification-service/WEBHOOK_INTEGRATION.md`. In-cluster URL:
+
+```
+http://membership-acceptor.<namespace>.svc.cluster.local/webhooks/geo
+```
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GEO_WEBHOOK_SECRET` | yes | — | Shared secret; must equal `app_webhooks.secret` |
+| `PORT` | no | `8080` | HTTP listen port |
+| `SENTRY_DSN` | no | — | Enables Sentry; console-only when unset |
+| `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` / `SENTRY_TRACES_SAMPLE_RATE` / `SENTRY_DEBUG` | no | — | Sentry tuning |

--- a/membership-acceptor/README.md
+++ b/membership-acceptor/README.md
@@ -18,17 +18,23 @@ It is structured so it can later be extracted into its own repo that space
 admins deploy themselves, each running a sovereign acceptor with its own wallet
 and membership policy (allow-all, allow-verified, reputation, payment, …).
 
-## Status — Milestone 1 (webhook connectivity)
+## Status — Milestone 2 (membership-request detection)
 
-This milestone proves the pipe end to end. The service:
+The service:
 
 - exposes `POST /webhooks/geo` and verifies the `X-Geo-Signature` HMAC-SHA256
   header against `GEO_WEBHOOK_SECRET` (rejects unsigned/tampered requests with 401);
 - exposes `GET /health` for k8s probes;
-- logs a structured summary of every delivery it receives.
+- **detects membership requests** in the firehose — a `proposal_created` event
+  with `voting_mode == "fast"` and exactly one `add_member` action that still
+  looks open — and **de-duplicates** them by `proposal_id` (the fan-out delivers
+  one copy per editor of the space);
+- logs `membership request detected — would accept` for each unique match.
 
-It does **not** yet detect membership requests (M2) or cast votes (M3). Every
-authenticated webhook is acknowledged with `200`.
+It does **not** yet cast votes (M3) — a detected request is logged, and every
+authenticated webhook is acknowledged with `200`. Detection is payload-only and
+best-effort (a trigger, not a source of truth); the authoritative open/untouched
+check happens on-chain in M3 before any vote.
 
 > Implementation note: unlike `proposal-executor` (an Effect-TS CronJob), this is
 > a plain `Bun.serve` HTTP server. The request path is straightforward async
@@ -41,6 +47,7 @@ authenticated webhook is acknowledged with `200`.
 |---|---|
 | `src/index.ts` | Entry point — parse config, start server, graceful shutdown |
 | `src/server.ts` | Routes + request handling (`createApp` returns a testable fetch handler) |
+| `src/detect.ts` | Membership-request detection + `proposal_id` de-duplication |
 | `src/signature.ts` | `X-Geo-Signature` HMAC verification |
 | `src/config.ts` | Env parsing + validation (fail-fast) |
 | `src/telemetry.ts` | Sentry init + structured logger + flush |

--- a/membership-acceptor/biome.json
+++ b/membership-acceptor/biome.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"suspicious": {
+				"noArrayIndexKey": "off",
+				"noExplicitAny": "warn"
+			},
+			"complexity": {
+				"noStaticOnlyClass": "off",
+				"noBannedTypes": "off",
+				"noForEach": "off",
+				"useLiteralKeys": "off"
+			},
+			"style": {
+				"useTemplate": "off"
+			}
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"formatWithErrors": false,
+		"indentStyle": "tab",
+		"indentWidth": 4,
+		"lineWidth": 120
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"quoteProperties": "asNeeded",
+			"semicolons": "asNeeded",
+			"bracketSpacing": false,
+			"trailingCommas": "all"
+		}
+	},
+	"files": {
+		"includes": ["./**/*"]
+	}
+}

--- a/membership-acceptor/bun.lock
+++ b/membership-acceptor/bun.lock
@@ -1,0 +1,114 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "membership-acceptor",
+      "dependencies": {
+        "@sentry/node": "^10.36.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@types/bun": "latest",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.15.0", "", { "dependencies": { "@types/estree": "^1.0.8", "astring": "^1.9.0", "esquery": "^1.7.0", "meriyah": "^6.1.4", "semifies": "^1.0.0", "source-map": "^0.6.0" }, "bin": { "code-transformer": "cli.js" } }, "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww=="],
+
+    "@apm-js-collab/code-transformer-bundler-plugins": ["@apm-js-collab/code-transformer-bundler-plugins@0.5.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "es-module-lexer": "^2.1.0", "magic-string": "^0.30.21", "module-details-from-path": "^1.0.4" } }, "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ=="],
+
+    "@apm-js-collab/tracing-hooks": ["@apm-js-collab/tracing-hooks@0.10.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "debug": "^4.4.1", "module-details-from-path": "^1.0.4" } }, "sha512-2/Z3NTewJTruUkmsSnBC5bJlLNUd9keuD1OLlTEpim4FyLhm6m2Rnfv+wrFdUvFfhmH8CRdiDZBqBrn+wyaGuA=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@sentry/conventions": ["@sentry/conventions@0.12.0", "", {}, "sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g=="],
+
+    "@sentry/core": ["@sentry/core@10.60.0", "", {}, "sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw=="],
+
+    "@sentry/node": ["@sentry/node@10.60.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@sentry/core": "10.60.0", "@sentry/node-core": "10.60.0", "@sentry/opentelemetry": "10.60.0", "@sentry/server-utils": "10.60.0", "import-in-the-middle": "^3.0.0" } }, "sha512-u//paUrkKaCr0oNn7r7UulGydkYMSkU1wQOIpG/P/jf7psZWnyXhgeszHzUfZXo6pCdxXG9z9viPvzGjqPQN7A=="],
+
+    "@sentry/node-core": ["@sentry/node-core@10.60.0", "", { "dependencies": { "@sentry/conventions": "^0.12.0", "@sentry/core": "10.60.0", "@sentry/opentelemetry": "10.60.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base"] }, "sha512-aXi9ixvP+hgUZPPZCRwMNHgY2I0gkSeoAKAUuysDJhWDmrygwfGdlkbGmmtW6PQjtMYFx69Igt5btvhjEBoJTw=="],
+
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.60.0", "", { "dependencies": { "@sentry/conventions": "^0.12.0", "@sentry/core": "10.60.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0" } }, "sha512-gl+2NVH+9RmTu7pd9kV1tKif+Th+p9tmnXR1l3Sb3Wqo1ir5FaNMKrloWEKMXjnepii9EJUrEHdSC+i8NoexxQ=="],
+
+    "@sentry/server-utils": ["@sentry/server-utils@10.60.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0", "@apm-js-collab/tracing-hooks": "^0.10.0", "@sentry/conventions": "^0.12.0", "@sentry/core": "10.60.0", "magic-string": "~0.30.0" } }, "sha512-SX+MzWM3nz5ttKT48rlfktm0ERyIpDLma+b6pYeWgW2oFHKcpIu0g0qMGJrZs4lKM3MlgV7IqLa4texMqTp9kQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
+    "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "import-in-the-middle": ["import-in-the-middle@3.2.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "meriyah": ["meriyah@6.1.4", "", {}, "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
+
+    "semifies": ["semifies@1.0.0", "", {}, "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/membership-acceptor/bun.lock
+++ b/membership-acceptor/bun.lock
@@ -6,6 +6,8 @@
       "name": "membership-acceptor",
       "dependencies": {
         "@sentry/node": "^10.36.0",
+        "permissionless": "^0.3.2",
+        "viem": "^2.43.5",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
@@ -15,6 +17,8 @@
     },
   },
   "packages": {
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
     "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.15.0", "", { "dependencies": { "@types/estree": "^1.0.8", "astring": "^1.9.0", "esquery": "^1.7.0", "meriyah": "^6.1.4", "semifies": "^1.0.0", "source-map": "^0.6.0" }, "bin": { "code-transformer": "cli.js" } }, "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww=="],
 
     "@apm-js-collab/code-transformer-bundler-plugins": ["@apm-js-collab/code-transformer-bundler-plugins@0.5.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "es-module-lexer": "^2.1.0", "magic-string": "^0.30.21", "module-details-from-path": "^1.0.4" } }, "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ=="],
@@ -41,6 +45,12 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
@@ -54,6 +64,12 @@
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
+
+    "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
     "@sentry/conventions": ["@sentry/conventions@0.12.0", "", {}, "sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g=="],
 
@@ -73,6 +89,8 @@
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
+    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
@@ -91,7 +109,11 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
     "import-in-the-middle": ["import-in-the-middle@3.2.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ=="],
+
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -100,6 +122,10 @@
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "ox": ["ox@0.14.29", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg=="],
+
+    "permissionless": ["permissionless@0.3.6", "", { "peerDependencies": { "ox": "^0.11.3", "viem": "^2.44.4" }, "optionalPeers": ["ox"] }, "sha512-7RstRCNwJc/kO9Q/ZJpgSPclXez8CaGU77PeYNaWpHCU1kRetu+7kqEUFcIFLdz47F7jpOwtsbAU56hn27c4mg=="],
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
@@ -110,5 +136,9 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "viem": ["viem@2.53.1", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.29", "ws": "8.20.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
   }
 }

--- a/membership-acceptor/deployment/production/deployment.yaml
+++ b/membership-acceptor/deployment/production/deployment.yaml
@@ -34,6 +34,35 @@ spec:
                 secretKeyRef:
                   name: membership-acceptor-credentials
                   key: GEO_WEBHOOK_SECRET
+            # Voting identity (sensitive)
+            - name: ACCEPTOR_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: ACCEPTOR_PRIVATE_KEY
+            - name: PIMLICO_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: PIMLICO_API_KEY
+            - name: RPC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: RPC_URL
+            # Non-sensitive config
+            - name: ACCEPTOR_SPACE_ID
+              value: "0x24208422558b4ac801e24a71a889dfad" # acceptor's personal-space id (bytes16)
+            - name: SPACE_REGISTRY_ADDRESS
+              value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
+            - name: CHAIN_ID
+              value: "19411"
+            - name: GRAPHQL_ENDPOINT
+              value: "https://testnet-api.geobrowser.io/graphql" # Geo GraphQL endpoint (policies, e.g. editor check)
+            # DAO spaces this acceptor auto-accepts (comma-separated UUIDs).
+            # Empty = accept none.
+            - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
+              value: "0xc9f267dcb0d270718c2a3c45a64afd32,0x84a679ce188f061ac9a92380bac2bab5,0x0477636ace64280fc43a9f440a502291"
             # Optional: Sentry error reporting
             - name: SENTRY_DSN
               valueFrom:

--- a/membership-acceptor/deployment/production/deployment.yaml
+++ b/membership-acceptor/deployment/production/deployment.yaml
@@ -59,8 +59,8 @@ spec:
               value: "19411"
             - name: GRAPHQL_ENDPOINT
               value: "https://testnet-api.geobrowser.io/graphql" # Geo GraphQL endpoint (policies, e.g. editor check)
-            # DAO spaces this acceptor auto-accepts (comma-separated UUIDs).
-            # Empty = accept none.
+            # DAO spaces this acceptor auto-accepts: comma-separated space ids as
+            # 0x-prefixed bytes16 hex (dashed UUIDs also accepted). Empty = accept none.
             - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
               value: "0xc9f267dcb0d270718c2a3c45a64afd32,0x84a679ce188f061ac9a92380bac2bab5,0x0477636ace64280fc43a9f440a502291"
             # Optional: Sentry error reporting

--- a/membership-acceptor/deployment/production/deployment.yaml
+++ b/membership-acceptor/deployment/production/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: membership-acceptor
+  namespace: knowledge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: membership-acceptor
+  template:
+    metadata:
+      labels:
+        app: membership-acceptor
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+      imagePullSecrets:
+        - name: geo
+      containers:
+        - name: membership-acceptor
+          image: registry.digitalocean.com/geo/membership-acceptor:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            # Shared secret — MUST equal this service's app_webhooks.secret
+            - name: GEO_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: GEO_WEBHOOK_SECRET
+            # Optional: Sentry error reporting
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              value: "production"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: membership-acceptor
+  namespace: knowledge
+spec:
+  selector:
+    app: membership-acceptor
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/membership-acceptor/deployment/production/secrets.yaml.example
+++ b/membership-acceptor/deployment/production/secrets.yaml.example
@@ -1,0 +1,20 @@
+# Template for membership-acceptor production secrets.
+# Real secrets are managed externally — DO NOT commit actual values.
+#
+# The GEO_WEBHOOK_SECRET here MUST match the `secret` of this service's row in
+# the notification service's app_webhooks table (notifications DB).
+#
+# kubectl create secret generic membership-acceptor-credentials \
+#   --namespace=knowledge \
+#   --from-literal=GEO_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: membership-acceptor-credentials
+  namespace: knowledge
+type: Opaque
+stringData:
+  GEO_WEBHOOK_SECRET: "..."
+  # Optional
+  SENTRY_DSN: "https://...@sentry.io/..."

--- a/membership-acceptor/deployment/production/secrets.yaml.example
+++ b/membership-acceptor/deployment/production/secrets.yaml.example
@@ -4,9 +4,15 @@
 # The GEO_WEBHOOK_SECRET here MUST match the `secret` of this service's row in
 # the notification service's app_webhooks table (notifications DB).
 #
+# The ACCEPTOR_PRIVATE_KEY's smart account must be an EDITOR of every space in
+# MEMBERSHIP_AUTOACCEPT_SPACE_IDS, or its votes revert.
+#
 # kubectl create secret generic membership-acceptor-credentials \
 #   --namespace=knowledge \
-#   --from-literal=GEO_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+#   --from-literal=GEO_WEBHOOK_SECRET="$(openssl rand -hex 32)" \
+#   --from-literal=ACCEPTOR_PRIVATE_KEY='0x...' \
+#   --from-literal=PIMLICO_API_KEY='pim_...' \
+#   --from-literal=RPC_URL='https://...'
 
 apiVersion: v1
 kind: Secret
@@ -16,5 +22,8 @@ metadata:
 type: Opaque
 stringData:
   GEO_WEBHOOK_SECRET: "..."
+  ACCEPTOR_PRIVATE_KEY: "0x..."
+  PIMLICO_API_KEY: "pim_..."
+  RPC_URL: "https://..."
   # Optional
   SENTRY_DSN: "https://...@sentry.io/..."

--- a/membership-acceptor/package.json
+++ b/membership-acceptor/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "membership-acceptor",
 	"version": "0.1.0",
-	"description": "Real-time membership auto-accept — receives notification webhooks and (later) votes to admit members",
+	"description": "Real-time membership auto-accept — receives notification webhooks and votes to admit members",
 	"type": "module",
 	"private": true,
 	"scripts": {
@@ -12,7 +12,9 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@sentry/node": "^10.36.0"
+		"@sentry/node": "^10.36.0",
+		"permissionless": "^0.3.2",
+		"viem": "^2.43.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.11",

--- a/membership-acceptor/package.json
+++ b/membership-acceptor/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "membership-acceptor",
+	"version": "0.1.0",
+	"description": "Real-time membership auto-accept — receives notification webhooks and (later) votes to admit members",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"start": "bun run src/index.ts",
+		"test": "bun test",
+		"lint": "biome check",
+		"lint:fix": "biome check --write",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@sentry/node": "^10.36.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.3.11",
+		"@types/bun": "latest",
+		"typescript": "^5.9.3"
+	}
+}

--- a/membership-acceptor/src/config.ts
+++ b/membership-acceptor/src/config.ts
@@ -1,0 +1,47 @@
+/**
+ * Configuration — parsed and validated once at startup.
+ *
+ * Fails fast (throws) on missing/invalid required values so the container
+ * crash-loops loudly rather than silently accepting every (unverifiable) webhook.
+ */
+
+export interface AcceptorConfig {
+	/** Port the HTTP server listens on. */
+	port: number
+	/**
+	 * Shared secret used to verify the `X-Geo-Signature` HMAC on incoming webhooks.
+	 * Must match the `secret` column of this service's `app_webhooks` row.
+	 */
+	webhookSecret: string
+}
+
+export class ConfigError extends Error {
+	override readonly name = "ConfigError"
+}
+
+const DEFAULT_PORT = 8080
+
+/**
+ * Parse config from the given environment (defaults to `process.env`).
+ * Throws {@link ConfigError} with an actionable message on the first problem.
+ */
+export function parseConfig(env: NodeJS.ProcessEnv = process.env): AcceptorConfig {
+	const webhookSecret = env.GEO_WEBHOOK_SECRET?.trim()
+	if (!webhookSecret) {
+		throw new ConfigError(
+			"GEO_WEBHOOK_SECRET is required — it must equal the `secret` of this service's app_webhooks row",
+		)
+	}
+
+	const rawPort = env.PORT?.trim()
+	let port = DEFAULT_PORT
+	if (rawPort) {
+		const parsed = Number(rawPort)
+		if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+			throw new ConfigError(`Invalid PORT: expected an integer in 1..65535, got "${rawPort}"`)
+		}
+		port = parsed
+	}
+
+	return {port, webhookSecret}
+}

--- a/membership-acceptor/src/config.ts
+++ b/membership-acceptor/src/config.ts
@@ -6,7 +6,7 @@
  * webhooks.
  */
 
-import type {SupportedChainId} from "./contracts.js"
+import {type SupportedChainId, toBytes16Hex} from "./contracts.js"
 
 export interface AppConfig {
 	/** Port the HTTP server listens on. */
@@ -34,8 +34,10 @@ export interface AppConfig {
 	graphqlEndpoint: string
 
 	/**
-	 * Spaces this acceptor auto-accepts (DAO space UUIDs, lowercased). A request
-	 * for any other space is ignored. Empty ⇒ accept none (effective kill switch).
+	 * Spaces this acceptor auto-accepts, canonicalized to `0x`-prefixed bytes16 hex
+	 * (see {@link toBytes16Hex}) so they compare equal to a converted webhook
+	 * `space_id`. A request for any other space is ignored. Empty ⇒ accept none
+	 * (effective kill switch).
 	 */
 	autoacceptSpaceIds: ReadonlySet<string>
 }
@@ -104,12 +106,21 @@ export function parseConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
 		throw new ConfigError(`Invalid CHAIN_ID: expected 80451 (mainnet) or 19411 (testnet), got "${rawChainId}"`)
 	}
 
-	const autoacceptSpaceIds = new Set(
-		(env.MEMBERSHIP_AUTOACCEPT_SPACE_IDS ?? "")
-			.split(",")
-			.map((s) => s.trim().toLowerCase())
-			.filter((s) => s.length > 0),
-	)
+	// Canonicalize every allowlist entry to 0x bytes16 and validate it, so a
+	// typo'd id fails fast at startup instead of silently never matching. Incoming
+	// webhook space_ids are converted the same way before lookup (see allowsSpace).
+	const autoacceptSpaceIds = new Set<string>()
+	for (const raw of (env.MEMBERSHIP_AUTOACCEPT_SPACE_IDS ?? "").split(",")) {
+		const trimmed = raw.trim()
+		if (!trimmed) continue
+		const key = toBytes16Hex(trimmed)
+		if (!BYTES16_RE.test(key)) {
+			throw new ConfigError(
+				`Invalid MEMBERSHIP_AUTOACCEPT_SPACE_IDS entry "${trimmed}": expected a space id (bytes16 hex or UUID)`,
+			)
+		}
+		autoacceptSpaceIds.add(key)
+	}
 
 	return {
 		port,

--- a/membership-acceptor/src/config.ts
+++ b/membership-acceptor/src/config.ts
@@ -2,10 +2,13 @@
  * Configuration — parsed and validated once at startup.
  *
  * Fails fast (throws) on missing/invalid required values so the container
- * crash-loops loudly rather than silently accepting every (unverifiable) webhook.
+ * crash-loops loudly rather than silently mis-voting or accepting unverifiable
+ * webhooks.
  */
 
-export interface AcceptorConfig {
+import type {SupportedChainId} from "./contracts.js"
+
+export interface AppConfig {
 	/** Port the HTTP server listens on. */
 	port: number
 	/**
@@ -13,6 +16,28 @@ export interface AcceptorConfig {
 	 * Must match the `secret` column of this service's `app_webhooks` row.
 	 */
 	webhookSecret: string
+
+	// --- Voting identity / chain ---
+	/** Signing key for the Safe smart account that owns the acceptor's personal space. */
+	acceptorPrivateKey: `0x${string}`
+	/** The acceptor's personal-space id (bytes16 hex) — the enter() `_fromSpaceId`. */
+	acceptorSpaceId: `0x${string}`
+	/** SpaceRegistry contract address. */
+	spaceRegistryAddress: `0x${string}`
+	/** Chain RPC endpoint (may contain an API key). */
+	rpcUrl: string
+	/** Pimlico bundler/paymaster API key (gas sponsorship). */
+	pimlicoApiKey: string
+	/** 80451 (mainnet) or 19411 (testnet). */
+	chainId: SupportedChainId
+	/** Geo GraphQL endpoint — used by policies (e.g. the editor check). */
+	graphqlEndpoint: string
+
+	/**
+	 * Spaces this acceptor auto-accepts (DAO space UUIDs, lowercased). A request
+	 * for any other space is ignored. Empty ⇒ accept none (effective kill switch).
+	 */
+	autoacceptSpaceIds: ReadonlySet<string>
 }
 
 export class ConfigError extends Error {
@@ -20,12 +45,21 @@ export class ConfigError extends Error {
 }
 
 const DEFAULT_PORT = 8080
+const PRIVATE_KEY_RE = /^0x[0-9a-fA-F]{64}$/
+const BYTES16_RE = /^0x[0-9a-fA-F]{32}$/
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+
+function required(env: NodeJS.ProcessEnv, key: string): string {
+	const value = env[key]?.trim()
+	if (!value) throw new ConfigError(`${key} is required`)
+	return value
+}
 
 /**
  * Parse config from the given environment (defaults to `process.env`).
  * Throws {@link ConfigError} with an actionable message on the first problem.
  */
-export function parseConfig(env: NodeJS.ProcessEnv = process.env): AcceptorConfig {
+export function parseConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
 	const webhookSecret = env.GEO_WEBHOOK_SECRET?.trim()
 	if (!webhookSecret) {
 		throw new ConfigError(
@@ -43,5 +77,50 @@ export function parseConfig(env: NodeJS.ProcessEnv = process.env): AcceptorConfi
 		port = parsed
 	}
 
-	return {port, webhookSecret}
+	// Accept the private key with or without the 0x prefix.
+	let acceptorPrivateKey = required(env, "ACCEPTOR_PRIVATE_KEY")
+	if (!acceptorPrivateKey.startsWith("0x")) acceptorPrivateKey = `0x${acceptorPrivateKey}`
+	if (!PRIVATE_KEY_RE.test(acceptorPrivateKey)) {
+		throw new ConfigError("Invalid ACCEPTOR_PRIVATE_KEY: expected a 32-byte hex key (0x + 64 hex chars)")
+	}
+
+	const acceptorSpaceId = required(env, "ACCEPTOR_SPACE_ID")
+	if (!BYTES16_RE.test(acceptorSpaceId)) {
+		throw new ConfigError("Invalid ACCEPTOR_SPACE_ID: expected bytes16 hex (0x + 32 hex chars)")
+	}
+
+	const spaceRegistryAddress = required(env, "SPACE_REGISTRY_ADDRESS")
+	if (!ADDRESS_RE.test(spaceRegistryAddress)) {
+		throw new ConfigError("Invalid SPACE_REGISTRY_ADDRESS: expected an address (0x + 40 hex chars)")
+	}
+
+	const rpcUrl = required(env, "RPC_URL")
+	const pimlicoApiKey = required(env, "PIMLICO_API_KEY")
+	const graphqlEndpoint = required(env, "GRAPHQL_ENDPOINT")
+
+	const rawChainId = env.CHAIN_ID?.trim() || "80451"
+	const chainId = Number(rawChainId)
+	if (chainId !== 80451 && chainId !== 19411) {
+		throw new ConfigError(`Invalid CHAIN_ID: expected 80451 (mainnet) or 19411 (testnet), got "${rawChainId}"`)
+	}
+
+	const autoacceptSpaceIds = new Set(
+		(env.MEMBERSHIP_AUTOACCEPT_SPACE_IDS ?? "")
+			.split(",")
+			.map((s) => s.trim().toLowerCase())
+			.filter((s) => s.length > 0),
+	)
+
+	return {
+		port,
+		webhookSecret,
+		acceptorPrivateKey: acceptorPrivateKey as `0x${string}`,
+		acceptorSpaceId: acceptorSpaceId as `0x${string}`,
+		spaceRegistryAddress: spaceRegistryAddress as `0x${string}`,
+		rpcUrl,
+		pimlicoApiKey,
+		chainId: chainId as SupportedChainId,
+		graphqlEndpoint,
+		autoacceptSpaceIds,
+	}
 }

--- a/membership-acceptor/src/contracts.ts
+++ b/membership-acceptor/src/contracts.ts
@@ -100,6 +100,17 @@ export function uuidToBytes16(uuid: string): Hex {
 	return `0x${stripped}` as Hex
 }
 
+/**
+ * Canonicalize any Geo space id to `0x`-prefixed, dashless, lowercase bytes16 hex.
+ * Accepts a dashed UUID (as delivered in webhook `space_id`) or an already-`0x`
+ * bytes16 value, so the two representations compare equal. Pure formatting — does
+ * not validate length (callers that need that check the result against a regex).
+ * @example toBytes16Hex("c9f267dc-b0d2-7071-8c2a-3c45a64afd32") → "0xc9f267dcb0d270718c2a3c45a64afd32"
+ */
+export function toBytes16Hex(id: string): `0x${string}` {
+	return `0x${id.replace(/^0x/i, "").replace(/-/g, "").toLowerCase()}`
+}
+
 /** Pad a bytes16 hex (32 hex chars) to bytes32 (64 hex chars) with trailing zeros. */
 export function padBytes16ToBytes32(bytes16Hex: Hex): Hex {
 	const withoutPrefix = bytes16Hex.startsWith("0x") ? bytes16Hex.slice(2) : bytes16Hex
@@ -127,25 +138,38 @@ export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
 // ---------------------------------------------------------------------------
 
 /**
- * viem/permissionless error names that indicate an on-chain revert. The chain
- * rejecting a vote (already voted / executed / window closed / not an editor) is
- * a *benign* outcome for us — there is nothing to retry — so we must distinguish
- * it from an infrastructure error (RPC/bundler hiccup) which SHOULD be retried.
+ * Classifying a failure as a *revert* makes it benign (no retry); classifying it
+ * as infra makes it retry. So we only treat a failure as a revert on a STRONG,
+ * unambiguous signal, and let everything else fall through to infra (retryable).
+ *
+ * `ContractFunctionRevertedError` is viem's definite "the contract reverted"
+ * error. We intentionally do NOT key off the broader `ContractFunctionExecutionError`
+ * / `CallExecutionError` wrappers — those also wrap RPC/estimation failures, and
+ * misreading one of those as benign would silently drop a real admission attempt.
  */
-const REVERT_ERROR_NAMES = new Set([
-	"ContractFunctionRevertedError",
-	"ContractFunctionExecutionError",
-	"CallExecutionError",
-])
+const REVERT_ERROR_NAME = "ContractFunctionRevertedError"
 
-const REVERT_MESSAGE_PATTERNS = ["revert", "execution reverted", "CALL_EXCEPTION", "UserOperation reverted"]
+/**
+ * Definite on-chain revert signals: the EVM revert prefix and the governance
+ * custom errors this vote can legitimately hit (already voted/executed/closed, or
+ * not an editor). Anything else is treated as infra and retried.
+ */
+const REVERT_MESSAGE_PATTERNS = [
+	"execution reverted",
+	"CanNotVote",
+	"CanNotExecute",
+	"ProposalAlreadyExecuted",
+	"AlreadyVoted",
+	"InvalidAction",
+	"already executed",
+]
 
-/** True if `error` looks like an on-chain revert (vs. an infrastructure failure). */
+/** True if `error` is unambiguously an on-chain revert (vs. an infrastructure failure). */
 export function isRevert(error: unknown): boolean {
 	const name = error instanceof Error ? error.name : typeof error
-	if (REVERT_ERROR_NAMES.has(name)) return true
+	if (name === REVERT_ERROR_NAME) return true
 
-	if (error instanceof Error && error.cause instanceof Error && REVERT_ERROR_NAMES.has(error.cause.name)) {
+	if (error instanceof Error && error.cause instanceof Error && error.cause.name === REVERT_ERROR_NAME) {
 		return true
 	}
 

--- a/membership-acceptor/src/contracts.ts
+++ b/membership-acceptor/src/contracts.ts
@@ -1,0 +1,161 @@
+/**
+ * Contract ABI, chain definitions, governance constants, encoding helpers, and
+ * revert classification for casting the membership YES vote.
+ *
+ * Ported from proposal-executor/src/{contracts,execute}.ts (which forked geo-cli),
+ * trimmed to what the acceptor needs and de-Effect-ified (plain functions).
+ *
+ * Why not @geoprotocol/geo-sdk: its `daoSpace.voteProposal` hardcodes the TESTNET
+ * registry address and `getSmartAccountWalletClient` hardcodes chain 19411 + a
+ * testnet bundler, so it cannot drive a mainnet vote in the published version.
+ * We reuse the proven viem path instead.
+ */
+
+import {type Address, type Chain, encodeAbiParameters, type Hex} from "viem"
+
+// ---------------------------------------------------------------------------
+// SpaceRegistry ABI — only enter() is needed (we cast votes, never read).
+// ---------------------------------------------------------------------------
+
+export const SpaceRegistryAbi = [
+	{
+		inputs: [
+			{internalType: "bytes16", name: "_fromSpaceId", type: "bytes16"},
+			{internalType: "bytes16", name: "_toSpaceId", type: "bytes16"},
+			{internalType: "bytes32", name: "_action", type: "bytes32"},
+			{internalType: "bytes32", name: "_topic", type: "bytes32"},
+			{internalType: "bytes", name: "_data", type: "bytes"},
+			{internalType: "bytes", name: "_signature", type: "bytes"},
+		],
+		name: "enter",
+		outputs: [],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+] as const
+
+// ---------------------------------------------------------------------------
+// Chain definitions
+// ---------------------------------------------------------------------------
+
+export const mainnetChain: Chain = {
+	id: 80451,
+	name: "Geo Genesis",
+	nativeCurrency: {name: "Ethereum", symbol: "ETH", decimals: 18},
+	rpcUrls: {default: {http: ["https://rpc-geo-genesis-h0q2s21xx8.t.conduit.xyz"]}},
+}
+
+export const testnetChain: Chain = {
+	id: 19411,
+	name: "Geo Genesis Testnet",
+	nativeCurrency: {name: "Ethereum", symbol: "ETH", decimals: 18},
+	rpcUrls: {default: {http: ["https://rpc-geo-test-zc16z3tcvf.t.conduit.xyz"]}},
+}
+
+export type SupportedChainId = 80451 | 19411
+
+export function getChain(chainId: SupportedChainId): Chain {
+	if (chainId === 80451) return mainnetChain
+	if (chainId === 19411) return testnetChain
+	const _exhaustive: never = chainId
+	throw new Error(`Unsupported chain ID: ${_exhaustive}`)
+}
+
+/** Safe deployment addresses for Geo Testnet (canonical addresses differ there). */
+export const TESTNET_SAFE_ADDRESSES = {
+	safeModuleSetupAddress: "0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47" as const,
+	safe4337ModuleAddress: "0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226" as const,
+	safeProxyFactoryAddress: "0xd9d2Ba03a7754250FDD71333F444636471CACBC4" as const,
+	safeSingletonAddress: "0x639245e8476E03e789a244f279b5843b9633b2E7" as const,
+	multiSendAddress: "0x7B21BBDBdE8D01Df591fdc2dc0bE9956Dde1e16C" as const,
+	multiSendCallOnlyAddress: "0x32228dDEA8b9A2bd7f2d71A958fF241D79ca5eEC" as const,
+}
+
+// ---------------------------------------------------------------------------
+// Governance constants
+// ---------------------------------------------------------------------------
+
+/** keccak256('GOVERNANCE.PROPOSAL_VOTED') — action hash for casting a vote via enter() */
+export const PROPOSAL_VOTED_ACTION = "0x4ebf5f29676cedf7e2e4d346a8433289278f95a9fda73691dc1ce24574d5819e" as Hex
+
+/** IDAOSpace.VoteOption.Yes (enum: None=0, Yes=1, No=2, Abstain=3). */
+export const VOTE_YES = 1
+
+/** Empty signature — ignored when msg.sender == _fromSpace. */
+export const EMPTY_SIGNATURE = "0x" as Hex
+
+// ---------------------------------------------------------------------------
+// Encoding helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a UUID string to a bytes16 hex value (strip dashes, prefix 0x).
+ * @example uuidToBytes16("550e8400-e29b-41d4-a716-446655440000") → "0x550e8400e29b41d4a716446655440000"
+ */
+export function uuidToBytes16(uuid: string): Hex {
+	const stripped = uuid.replace(/-/g, "")
+	if (stripped.length !== 32 || !/^[0-9a-fA-F]+$/.test(stripped)) {
+		throw new Error(`Invalid UUID for bytes16 conversion: ${uuid}`)
+	}
+	return `0x${stripped}` as Hex
+}
+
+/** Pad a bytes16 hex (32 hex chars) to bytes32 (64 hex chars) with trailing zeros. */
+export function padBytes16ToBytes32(bytes16Hex: Hex): Hex {
+	const withoutPrefix = bytes16Hex.startsWith("0x") ? bytes16Hex.slice(2) : bytes16Hex
+	if (withoutPrefix.length !== 32) {
+		throw new Error(`Invalid bytes16: expected 32 hex chars, got ${withoutPrefix.length}`)
+	}
+	return `0x${withoutPrefix}${"0".repeat(32)}` as Hex
+}
+
+/**
+ * ABI-encode the PROPOSAL_VOTED data payload: abi.encode(bytes16 proposalId, uint8 voteOption).
+ */
+export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
+	return encodeAbiParameters(
+		[
+			{name: "proposalId", type: "bytes16"},
+			{name: "voteOption", type: "uint8"},
+		],
+		[proposalIdHex, voteOption],
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Revert classification
+// ---------------------------------------------------------------------------
+
+/**
+ * viem/permissionless error names that indicate an on-chain revert. The chain
+ * rejecting a vote (already voted / executed / window closed / not an editor) is
+ * a *benign* outcome for us — there is nothing to retry — so we must distinguish
+ * it from an infrastructure error (RPC/bundler hiccup) which SHOULD be retried.
+ */
+const REVERT_ERROR_NAMES = new Set([
+	"ContractFunctionRevertedError",
+	"ContractFunctionExecutionError",
+	"CallExecutionError",
+])
+
+const REVERT_MESSAGE_PATTERNS = ["revert", "execution reverted", "CALL_EXCEPTION", "UserOperation reverted"]
+
+/** True if `error` looks like an on-chain revert (vs. an infrastructure failure). */
+export function isRevert(error: unknown): boolean {
+	const name = error instanceof Error ? error.name : typeof error
+	if (REVERT_ERROR_NAMES.has(name)) return true
+
+	if (error instanceof Error && error.cause instanceof Error && REVERT_ERROR_NAMES.has(error.cause.name)) {
+		return true
+	}
+
+	const message = String(error)
+	return REVERT_MESSAGE_PATTERNS.some((p) => message.includes(p))
+}
+
+/** Never leak a bundler URL's API key into a log/error message. */
+export function sanitizeError(error: unknown): string {
+	return String(error).replace(/apikey=[^\s&"]+/gi, "apikey=<redacted>")
+}
+
+export type {Address}

--- a/membership-acceptor/src/detect.ts
+++ b/membership-acceptor/src/detect.ts
@@ -105,4 +105,19 @@ export class SeenProposals {
 		}
 		return false
 	}
+
+	/**
+	 * Forget `proposalId` so it can be processed again.
+	 *
+	 * Used to roll back an optimistic `seen()` after an infrastructure failure:
+	 * we mark before voting (so the concurrent fan-out copies dedupe), but if the
+	 * vote fails for a retryable reason we must un-mark, or the delivery-worker's
+	 * retry would be silently deduped and the vote never lands. (We leave the id
+	 * recorded for benign reverts and successes — those should not retry.)
+	 */
+	unmark(proposalId: string): void {
+		if (!this.seenIds.delete(proposalId)) return
+		const idx = this.insertionOrder.indexOf(proposalId)
+		if (idx !== -1) this.insertionOrder.splice(idx, 1)
+	}
 }

--- a/membership-acceptor/src/detect.ts
+++ b/membership-acceptor/src/detect.ts
@@ -1,0 +1,108 @@
+/**
+ * Membership-request detection.
+ *
+ * The acceptor receives the full notification firehose. This module decides
+ * which deliveries are *membership requests* worth acting on, and de-duplicates
+ * the copies the notification fan-out produces.
+ *
+ * Detection is intentionally a cheap, payload-only check — it is a trigger, not
+ * a source of truth. The authoritative "is this still open / untouched" check
+ * happens on-chain in M3 before any vote is cast, because webhook payloads can
+ * be stale or racy.
+ */
+
+/** A delivery that matches the membership-request signature. */
+export interface MembershipRequest {
+	/** Proposal UUID (the dedupe key). */
+	proposalId: string
+	/** DAO space UUID the request is to join. */
+	spaceId: string
+	/**
+	 * Personal-space id of the user requesting membership — i.e. the space being
+	 * added to `spaceId`. Taken from the single `add_member` action's
+	 * `target_address`, which (despite the name) carries the requester's space id
+	 * as a hex-encoded bytes16. Passed through verbatim; M3
+	 * normalizes it as needed for the on-chain check.
+	 */
+	requesterSpaceId: string
+}
+
+// Membership-request signature (see WEBHOOK_INTEGRATION.md / notification-indexer models).
+const MEMBERSHIP_EVENT_TYPE = "proposal_created"
+const FAST_VOTING_MODE = "fast"
+const ADD_MEMBER_ACTION = "add_member"
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+/**
+ * Return a {@link MembershipRequest} if `payload` is a fast-mode, single
+ * `add_member` `proposal_created` event that still looks open, else `null`.
+ *
+ * The "still open" check is best-effort from `settings.end_date`; the real
+ * voting-window / untouched check is on-chain in M3.
+ */
+export function detectMembershipRequest(
+	payload: unknown,
+	nowSeconds: number = Math.floor(Date.now() / 1000),
+): MembershipRequest | null {
+	const p = asRecord(payload)
+	if (!p) return null
+
+	if (p.event_type !== MEMBERSHIP_EVENT_TYPE) return null
+	if (p.voting_mode !== FAST_VOTING_MODE) return null
+
+	// Exactly one action, and it must be add_member.
+	if (!Array.isArray(p.actions) || p.actions.length !== 1) return null
+	const action = asRecord(p.actions[0])
+	if (!action || action.type !== ADD_MEMBER_ACTION) return null
+
+	const proposalId = typeof p.proposal_id === "string" ? p.proposal_id : null
+	const spaceId = typeof p.space_id === "string" ? p.space_id : null
+	if (!proposalId || !spaceId) return null
+
+	// Best-effort still-open check: if the payload advertises an end_date already
+	// in the past, the voting window is closed — skip. Authoritative check is M3.
+	const settings = asRecord(p.settings)
+	const endDate = settings?.end_date
+	if (typeof endDate === "number" && endDate <= nowSeconds) return null
+
+	const requesterSpaceId = typeof action.target_address === "string" ? action.target_address : ""
+	return {proposalId, spaceId, requesterSpaceId}
+}
+
+/**
+ * Bounded de-duplication set keyed by proposal id.
+ *
+ * The notification fan-out delivers one copy of `proposal_created` per editor of
+ * the space (distinct `idempotency_key`s, differing `user_space_id`), so the same
+ * proposal arrives N times. We must dedupe on `proposal_id`, NOT `idempotency_key`.
+ *
+ * This is in-memory and best-effort: it is reset on restart, which only means a
+ * proposal could be re-detected (and, in M3, re-checked on-chain — where the
+ * untouched/idempotency guard makes a redundant vote a no-op). It is not a
+ * durability mechanism.
+ */
+export class SeenProposals {
+	private readonly seenIds = new Set<string>()
+	private readonly insertionOrder: string[] = []
+
+	constructor(private readonly capacity = 10_000) {}
+
+	/**
+	 * Record `proposalId` and report whether it had already been seen.
+	 * Returns `true` if this is a duplicate, `false` if it is the first sighting.
+	 */
+	seen(proposalId: string): boolean {
+		if (this.seenIds.has(proposalId)) return true
+
+		this.seenIds.add(proposalId)
+		this.insertionOrder.push(proposalId)
+		if (this.insertionOrder.length > this.capacity) {
+			const evicted = this.insertionOrder.shift()
+			if (evicted !== undefined) this.seenIds.delete(evicted)
+		}
+		return false
+	}
+}

--- a/membership-acceptor/src/graphql.ts
+++ b/membership-acceptor/src/graphql.ts
@@ -1,0 +1,74 @@
+/**
+ * Minimal GraphQL client for the Geo API.
+ *
+ * This is the shared primitive for BYO policies: a policy receives a
+ * {@link GraphQLClient} and uses it to fetch whatever data its decision needs
+ * (editor status, reputation, payment, …). Kept deliberately thin — POST a
+ * query, surface HTTP and GraphQL-level errors, bound it with a timeout.
+ */
+
+export class GraphQLError extends Error {
+	override readonly name = "GraphQLError"
+}
+
+export interface GraphQLClient {
+	/**
+	 * Execute `query` and return its `data`, typed as `T`. Throws {@link GraphQLError}
+	 * on a network/HTTP failure, a timeout, or a non-empty GraphQL `errors` array.
+	 */
+	query<T>(query: string, variables?: Record<string, unknown>): Promise<T>
+}
+
+export interface GraphQLClientOptions {
+	endpoint: string
+	/** Abort the request after this many ms (default 10s). */
+	timeoutMs?: number
+	/** Extra headers (e.g. auth) merged onto the request. */
+	headers?: Record<string, string>
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000
+
+export function createGraphQLClient(opts: GraphQLClientOptions): GraphQLClient {
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+	return {
+		async query<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+			const controller = new AbortController()
+			const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+			let response: Response
+			try {
+				response = await fetch(opts.endpoint, {
+					method: "POST",
+					headers: {"content-type": "application/json", ...opts.headers},
+					body: JSON.stringify({query, variables}),
+					signal: controller.signal,
+				})
+			} catch (err) {
+				throw new GraphQLError(`request failed: ${err instanceof Error ? err.message : String(err)}`)
+			} finally {
+				clearTimeout(timer)
+			}
+
+			if (!response.ok) {
+				throw new GraphQLError(`HTTP ${response.status} ${response.statusText}`)
+			}
+
+			let body: {data?: T; errors?: Array<{message: string}>}
+			try {
+				body = (await response.json()) as typeof body
+			} catch (err) {
+				throw new GraphQLError(`invalid JSON response: ${err instanceof Error ? err.message : String(err)}`)
+			}
+
+			if (body.errors && body.errors.length > 0) {
+				throw new GraphQLError(body.errors.map((e) => e.message).join("; "))
+			}
+			if (body.data === undefined || body.data === null) {
+				throw new GraphQLError("response had no data")
+			}
+			return body.data
+		},
+	}
+}

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -5,13 +5,17 @@
  * notification service. This is the real-time successor to the proposal-executor
  * cron's membership-accept path.
  *
- * Milestone 1 (this file): stand up the server, verify webhook signatures, and
- * log deliveries. Detection (M2) and on-chain voting (M3) build on top.
+ * Verifies webhook signatures, detects membership requests, and casts the YES
+ * vote on-chain via the acceptor's smart wallet.
  */
 
 import {parseConfig} from "./config.js"
+import {createGraphQLClient} from "./graphql.js"
+import {composePolicies, editorPolicy} from "./policy.js"
 import {createApp} from "./server.js"
 import {flush, log} from "./telemetry.js"
+import {createAcceptor} from "./vote.js"
+import {createSmartWallet} from "./wallet.js"
 
 async function main() {
 	let config: ReturnType<typeof parseConfig>
@@ -26,7 +30,38 @@ async function main() {
 		process.exit(1)
 	}
 
-	const app = createApp(config)
+	if (config.autoacceptSpaceIds.size === 0) {
+		// Not fatal, but the acceptor will ignore every request — make it obvious.
+		log.warn("MEMBERSHIP_AUTOACCEPT_SPACE_IDS is empty — no requests will be accepted")
+	}
+
+	let acceptor: ReturnType<typeof createAcceptor>
+	try {
+		const wallet = await createSmartWallet({
+			privateKey: config.acceptorPrivateKey,
+			pimlicoApiKey: config.pimlicoApiKey,
+			rpcUrl: config.rpcUrl,
+			chainId: config.chainId,
+		})
+		log.info("acceptor wallet ready", {safe_address: wallet.safeAddress, chain_id: config.chainId})
+		const graphql = createGraphQLClient({endpoint: config.graphqlEndpoint})
+		// The editor check is the reference policy; space-defined policies compose here.
+		const policy = composePolicies(editorPolicy)
+		acceptor = createAcceptor({
+			wallet,
+			acceptorSpaceId: config.acceptorSpaceId,
+			spaceRegistryAddress: config.spaceRegistryAddress,
+			allowlist: config.autoacceptSpaceIds,
+			policy,
+			graphql,
+		})
+	} catch (err) {
+		log.error("failed to initialize acceptor wallet — refusing to start", {error: err})
+		await flush()
+		process.exit(1)
+	}
+
+	const app = createApp(config, acceptor)
 
 	const server = Bun.serve({
 		port: config.port,

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -13,13 +13,16 @@ import {parseConfig} from "./config.js"
 import {createApp} from "./server.js"
 import {flush, log} from "./telemetry.js"
 
-function main() {
+async function main() {
 	let config: ReturnType<typeof parseConfig>
 	try {
 		config = parseConfig()
 	} catch (err) {
 		// Misconfiguration — crash loudly so the deployment is visibly broken.
 		log.error("configuration error — refusing to start", {error: err})
+		// Flush buffered telemetry before exiting, or the startup-failure event is
+		// lost (same reason the graceful-shutdown path flushes before exit).
+		await flush()
 		process.exit(1)
 	}
 

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Membership Acceptor — entry point.
+ *
+ * A long-running HTTP server that receives notification webhooks from the Geo
+ * notification service. This is the real-time successor to the proposal-executor
+ * cron's membership-accept path.
+ *
+ * Milestone 1 (this file): stand up the server, verify webhook signatures, and
+ * log deliveries. Detection (M2) and on-chain voting (M3) build on top.
+ */
+
+import {parseConfig} from "./config.js"
+import {createApp} from "./server.js"
+import {flush, log} from "./telemetry.js"
+
+function main() {
+	let config: ReturnType<typeof parseConfig>
+	try {
+		config = parseConfig()
+	} catch (err) {
+		// Misconfiguration — crash loudly so the deployment is visibly broken.
+		log.error("configuration error — refusing to start", {error: err})
+		process.exit(1)
+	}
+
+	const app = createApp(config)
+
+	const server = Bun.serve({
+		port: config.port,
+		fetch: app,
+	})
+
+	log.info("membership-acceptor listening", {
+		port: server.port,
+		webhook_path: "/webhooks/geo",
+		health_path: "/health",
+	})
+
+	// Graceful shutdown: stop accepting connections, flush telemetry, then exit.
+	let shuttingDown = false
+	const shutdown = async (signal: string) => {
+		if (shuttingDown) return
+		shuttingDown = true
+		log.info("shutting down", {signal})
+		await server.stop()
+		await flush()
+		process.exit(0)
+	}
+
+	process.on("SIGTERM", () => void shutdown("SIGTERM"))
+	process.on("SIGINT", () => void shutdown("SIGINT"))
+}
+
+main()

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -10,6 +10,7 @@
  */
 
 import {parseConfig} from "./config.js"
+import {sanitizeError} from "./contracts.js"
 import {createGraphQLClient} from "./graphql.js"
 import {composePolicies, editorPolicy} from "./policy.js"
 import {createApp} from "./server.js"
@@ -23,7 +24,7 @@ async function main() {
 		config = parseConfig()
 	} catch (err) {
 		// Misconfiguration — crash loudly so the deployment is visibly broken.
-		log.error("configuration error — refusing to start", {error: err})
+		log.error("configuration error — refusing to start", {error: sanitizeError(err)})
 		// Flush buffered telemetry before exiting, or the startup-failure event is
 		// lost (same reason the graceful-shutdown path flushes before exit).
 		await flush()
@@ -56,7 +57,9 @@ async function main() {
 			graphql,
 		})
 	} catch (err) {
-		log.error("failed to initialize acceptor wallet — refusing to start", {error: err})
+		// Sanitize: wallet/bundler init errors can embed the Pimlico API key (it's
+		// in the bundler URL), and this goes to logs/Sentry.
+		log.error("failed to initialize acceptor wallet — refusing to start", {error: sanitizeError(err)})
 		await flush()
 		process.exit(1)
 	}

--- a/membership-acceptor/src/policy.ts
+++ b/membership-acceptor/src/policy.ts
@@ -1,0 +1,80 @@
+/**
+ * Policy seam — the extension point for membership acceptors.
+ *
+ * A {@link Policy} decides whether a detected, allowlisted membership request
+ * should be accepted (voted YES). Policies receive a {@link PolicyContext} with a
+ * GraphQL client, so a space owner can express arbitrary rules backed by API data
+ * (editor status, reputation, payment, external auth, …) without touching the
+ * webhook/voting plumbing.
+ *
+ * The reference policy shipped here is {@link editorPolicy}: it confirms the
+ * acceptor is actually an editor of the target space (otherwise the vote would
+ * just revert on-chain). It fails OPEN — an API error never suppresses a vote;
+ * the chain remains the final authority.
+ */
+
+import {sanitizeError} from "./contracts.js"
+import type {MembershipRequest} from "./detect.js"
+import type {GraphQLClient} from "./graphql.js"
+
+export interface PolicyContext {
+	graphql: GraphQLClient
+	/** The acceptor's personal-space id (bytes16 hex, 0x-prefixed). */
+	acceptorSpaceId: string
+}
+
+export interface PolicyDecision {
+	accept: boolean
+	/** Human-readable explanation, logged on both accept and deny. */
+	reason: string
+}
+
+export type Policy = (request: MembershipRequest, ctx: PolicyContext) => Promise<PolicyDecision>
+
+/**
+ * Compose policies with AND semantics: every policy must accept. The first denial
+ * short-circuits and is returned (later policies are not run).
+ */
+export function composePolicies(...policies: Policy[]): Policy {
+	return async (request, ctx) => {
+		for (const policy of policies) {
+			const decision = await policy(request, ctx)
+			if (!decision.accept) return decision
+		}
+		return {accept: true, reason: "all policies passed"}
+	}
+}
+
+interface EditorQueryResult {
+	editor: {memberSpaceId: string} | null
+}
+
+/**
+ * Accept iff the acceptor's space is an editor of the request's DAO space.
+ *
+ * Queries `editor(spaceId, memberSpaceId)` — a non-null result means the acceptor
+ * can vote. The API accepts ids dashed or dashless, so `request.spaceId` is passed
+ * as-is (and it is already an allowlisted, operator-controlled value by this point,
+ * so it is safe to inline); only the `0x` prefix is stripped off the acceptor's
+ * bytes16 space id, which the query does not expect.
+ *
+ * Fails OPEN: if the query errors, we accept and let the on-chain vote be the
+ * authority (a genuine non-editor simply reverts).
+ */
+export const editorPolicy: Policy = async (request, ctx) => {
+	const spaceId = request.spaceId
+	const memberSpaceId = ctx.acceptorSpaceId.replace(/^0x/i, "")
+
+	const query = `query IsEditor { editor(spaceId: "${spaceId}", memberSpaceId: "${memberSpaceId}") { memberSpaceId } }`
+
+	try {
+		const data = await ctx.graphql.query<EditorQueryResult>(query)
+		if (data.editor) {
+			return {accept: true, reason: "acceptor is an editor of the space"}
+		}
+		return {accept: false, reason: `acceptor space ${memberSpaceId} is not an editor of ${spaceId}`}
+	} catch (err) {
+		// Fail open — never let API trouble block a legitimate vote.
+		return {accept: true, reason: `editor check skipped (api error): ${sanitizeError(err)}`}
+	}
+}

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -1,0 +1,96 @@
+/**
+ * HTTP app — routes and request handling.
+ *
+ * `createApp` returns a `fetch`-style handler `(Request) => Promise<Response>` so
+ * it can be driven directly in unit tests (no bound port) and handed to
+ * `Bun.serve` in production.
+ *
+ * Milestone 1 scope: prove connectivity. We verify the HMAC signature and log a
+ * structured summary of every delivery. Detection (M2) and voting (M3) are not
+ * here yet — every authenticated webhook is acknowledged with 200.
+ */
+
+import type {AcceptorConfig} from "./config.js"
+import {verifySignature} from "./signature.js"
+import {log} from "./telemetry.js"
+
+const SIGNATURE_HEADER = "x-geo-signature"
+
+/** Best-effort summary of a notification payload, for logging only. */
+function summarize(payload: unknown): Record<string, unknown> {
+	if (!payload || typeof payload !== "object") {
+		return {payload_type: typeof payload}
+	}
+	const p = payload as Record<string, unknown>
+	return {
+		event_type: p.event_type,
+		category: p.category,
+		space_id: p.space_id,
+		proposal_id: p.proposal_id,
+		idempotency_key: p.idempotency_key,
+	}
+}
+
+function json(body: unknown, status: number): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {"content-type": "application/json"},
+	})
+}
+
+async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Response> {
+	const signature = req.headers.get(SIGNATURE_HEADER)
+	// Read the raw bytes — the HMAC is over exactly what was sent, so we must not
+	// round-trip through JSON before verifying.
+	const body = new Uint8Array(await req.arrayBuffer())
+
+	if (!verifySignature(body, config.webhookSecret, signature)) {
+		log.warn("webhook signature verification failed", {
+			has_signature: signature !== null,
+			body_bytes: body.length,
+		})
+		return json({error: "invalid signature"}, 401)
+	}
+
+	let payload: unknown
+	try {
+		payload = JSON.parse(Buffer.from(body).toString("utf8"))
+	} catch {
+		log.warn("webhook body is not valid JSON", {body_bytes: body.length})
+		return json({error: "invalid JSON body"}, 400)
+	}
+
+	// M1: just observe. M2 will filter to membership requests; M3 will vote.
+	log.info("webhook received", summarize(payload))
+	return json({status: "ok"}, 200)
+}
+
+/**
+ * Build the request handler for the given config.
+ *
+ * Routes:
+ *  - `GET /health`        — liveness/readiness probe
+ *  - `POST /webhooks/geo` — notification webhook sink (HMAC-verified)
+ */
+export function createApp(config: AcceptorConfig): (req: Request) => Promise<Response> {
+	return async (req: Request): Promise<Response> => {
+		const {pathname} = new URL(req.url)
+
+		if (req.method === "GET" && pathname === "/health") {
+			return json({status: "ok"}, 200)
+		}
+
+		if (req.method === "POST" && pathname === "/webhooks/geo") {
+			try {
+				return await handleWebhook(req, config)
+			} catch (err) {
+				// Unexpected failure — 500 makes the delivery-worker retry rather than
+				// silently dropping the event.
+				log.error("unhandled error processing webhook", {error: err})
+				return json({error: "internal error"}, 500)
+			}
+		}
+
+		return json({error: "not found"}, 404)
+	}
+}

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -15,6 +15,12 @@ import {verifySignature} from "./signature.js"
 import {log} from "./telemetry.js"
 
 const SIGNATURE_HEADER = "x-geo-signature"
+const SIGNATURE_PREFIX = "sha256="
+
+// Cap how much we're willing to buffer per webhook. Notification payloads are a
+// few KB at most, so 1 MiB is generous while still preventing an unauthenticated
+// (or malicious) client from forcing large in-memory allocations.
+const MAX_BODY_BYTES = 1_048_576
 
 /** Best-effort summary of a notification payload, for logging only. */
 function summarize(payload: unknown): Record<string, unknown> {
@@ -40,9 +46,36 @@ function json(body: unknown, status: number): Response {
 
 async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Response> {
 	const signature = req.headers.get(SIGNATURE_HEADER)
+
+	// Cheap reject BEFORE buffering the body: a missing or malformed signature
+	// header can never pass the HMAC check, so don't let unauthenticated clients
+	// force us to allocate/CPU on `arrayBuffer()`. The full HMAC verification still
+	// runs below (defense in depth).
+	if (signature === null || !signature.startsWith(SIGNATURE_PREFIX)) {
+		log.warn("webhook signature verification failed", {
+			has_signature: signature !== null,
+		})
+		return json({error: "invalid signature"}, 401)
+	}
+
+	// Reject oversized requests before buffering, when the client advertises a
+	// Content-Length we can trust to be too large.
+	const contentLength = Number(req.headers.get("content-length"))
+	if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+		log.warn("webhook body exceeds size limit", {content_length: contentLength})
+		return json({error: "payload too large"}, 413)
+	}
+
 	// Read the raw bytes — the HMAC is over exactly what was sent, so we must not
 	// round-trip through JSON before verifying.
 	const body = new Uint8Array(await req.arrayBuffer())
+
+	// Guard again post-read: Content-Length may have been absent or understated
+	// (e.g. chunked transfer). Reject before any HMAC/JSON work.
+	if (body.length > MAX_BODY_BYTES) {
+		log.warn("webhook body exceeds size limit", {body_bytes: body.length})
+		return json({error: "payload too large"}, 413)
+	}
 
 	if (!verifySignature(body, config.webhookSecret, signature)) {
 		log.warn("webhook signature verification failed", {

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -5,16 +5,13 @@
  * it can be driven directly in unit tests (no bound port) and handed to
  * `Bun.serve` in production.
  *
- * Milestone 2 scope: verify the HMAC signature, then detect which deliveries are
- * membership requests and de-duplicate them. Voting (M3) is not here yet — a
- * detected request is logged as "would accept" and every authenticated webhook
- * is acknowledged with 200.
  */
 
-import type {AcceptorConfig} from "./config.js"
+import type {AppConfig} from "./config.js"
 import {detectMembershipRequest, SeenProposals} from "./detect.js"
 import {verifySignature} from "./signature.js"
 import {log} from "./telemetry.js"
+import type {Acceptor} from "./vote.js"
 
 const SIGNATURE_HEADER = "x-geo-signature"
 const SIGNATURE_PREFIX = "sha256="
@@ -41,7 +38,12 @@ function json(body: unknown, status: number): Response {
 	})
 }
 
-async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenProposals): Promise<Response> {
+async function handleWebhook(
+	req: Request,
+	config: AppConfig,
+	acceptor: Acceptor,
+	seen: SeenProposals,
+): Promise<Response> {
 	const signature = req.headers.get(SIGNATURE_HEADER)
 
 	// A missing or malformed signature header can never pass the HMAC check, so
@@ -82,7 +84,18 @@ async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenPro
 		return json({status: "ok"}, 200)
 	}
 
-	// Dedupe on proposal_id: the fan-out delivers one copy per editor.
+	// Policy gate: only act on spaces this acceptor serves.
+	if (!acceptor.allowsSpace(request.spaceId)) {
+		log.debug("membership request for an unserved space — ignored", {
+			proposal_id: request.proposalId,
+			space_id: request.spaceId,
+		})
+		return json({status: "ok"}, 200)
+	}
+
+	// Dedupe on proposal_id, marking BEFORE we evaluate/vote so the concurrent
+	// fan-out copies (one per editor) collapse to a single attempt — and so we
+	// only hit the policy's API once per proposal.
 	if (seen.seen(request.proposalId)) {
 		log.debug("membership request already seen — deduped", {
 			proposal_id: request.proposalId,
@@ -91,13 +104,49 @@ async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenPro
 		return json({status: "ok"}, 200)
 	}
 
-	// M2 ends here: detected, not yet voted. M3 verifies on-chain and casts YES.
-	log.info("membership request detected — would accept", {
-		proposal_id: request.proposalId,
-		space_id: request.spaceId,
-		requester_space_id: request.requesterSpaceId,
-	})
-	return json({status: "ok"}, 200)
+	// Policy seam: API-backed rules (editor check, and any space-defined policies).
+	const decision = await acceptor.evaluate(request)
+	if (!decision.accept) {
+		log.info("membership request denied by policy", {
+			proposal_id: request.proposalId,
+			space_id: request.spaceId,
+			reason: decision.reason,
+		})
+		return json({status: "ok"}, 200)
+	}
+
+	const result = await acceptor.vote(request)
+	switch (result.kind) {
+		case "voted":
+			log.info("membership request accepted — vote cast", {
+				proposal_id: request.proposalId,
+				space_id: request.spaceId,
+				requester_space_id: request.requesterSpaceId,
+				tx_hash: result.txHash,
+			})
+			return json({status: "ok"}, 200)
+
+		case "benign":
+			// The chain rejected the vote. Nothing to retry — ack so delivery stops.
+			log.warn("membership vote rejected on-chain — not retrying", {
+				proposal_id: request.proposalId,
+				space_id: request.spaceId,
+				reason: result.message,
+			})
+			return json({status: "ok"}, 200)
+
+		default: {
+			// Infrastructure failure — roll back the dedupe mark so the
+			// delivery-worker's retry isn't silently swallowed, and 5xx to retry.
+			seen.unmark(request.proposalId)
+			log.error("membership vote failed (infrastructure) — will retry", {
+				proposal_id: request.proposalId,
+				space_id: request.spaceId,
+				error: result.message,
+			})
+			return json({error: "vote failed"}, 503)
+		}
+	}
 }
 
 /**
@@ -107,7 +156,7 @@ async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenPro
  *  - `GET /health`        — liveness/readiness probe
  *  - `POST /webhooks/geo` — notification webhook sink (HMAC-verified)
  */
-export function createApp(config: AcceptorConfig): (req: Request) => Promise<Response> {
+export function createApp(config: AppConfig, acceptor: Acceptor): (req: Request) => Promise<Response> {
 	// Dedupe state lives for the lifetime of the process (see SeenProposals).
 	const seen = new SeenProposals()
 
@@ -120,7 +169,7 @@ export function createApp(config: AcceptorConfig): (req: Request) => Promise<Res
 
 		if (req.method === "POST" && pathname === "/webhooks/geo") {
 			try {
-				return await handleWebhook(req, config, seen)
+				return await handleWebhook(req, config, acceptor, seen)
 			} catch (err) {
 				// Unexpected failure — 500 makes the delivery-worker retry rather than
 				// silently dropping the event.

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -17,11 +17,6 @@ import {log} from "./telemetry.js"
 const SIGNATURE_HEADER = "x-geo-signature"
 const SIGNATURE_PREFIX = "sha256="
 
-// Cap how much we're willing to buffer per webhook. Notification payloads are a
-// few KB at most, so 1 MiB is generous while still preventing an unauthenticated
-// (or malicious) client from forcing large in-memory allocations.
-const MAX_BODY_BYTES = 1_048_576
-
 /** Best-effort summary of a notification payload, for logging only. */
 function summarize(payload: unknown): Record<string, unknown> {
 	if (!payload || typeof payload !== "object") {
@@ -47,10 +42,8 @@ function json(body: unknown, status: number): Response {
 async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Response> {
 	const signature = req.headers.get(SIGNATURE_HEADER)
 
-	// Cheap reject BEFORE buffering the body: a missing or malformed signature
-	// header can never pass the HMAC check, so don't let unauthenticated clients
-	// force us to allocate/CPU on `arrayBuffer()`. The full HMAC verification still
-	// runs below (defense in depth).
+	// A missing or malformed signature header can never pass the HMAC check, so
+	// reject it up front. The full HMAC verification still runs below.
 	if (signature === null || !signature.startsWith(SIGNATURE_PREFIX)) {
 		log.warn("webhook signature verification failed", {
 			has_signature: signature !== null,
@@ -58,24 +51,9 @@ async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Resp
 		return json({error: "invalid signature"}, 401)
 	}
 
-	// Reject oversized requests before buffering, when the client advertises a
-	// Content-Length we can trust to be too large.
-	const contentLength = Number(req.headers.get("content-length"))
-	if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
-		log.warn("webhook body exceeds size limit", {content_length: contentLength})
-		return json({error: "payload too large"}, 413)
-	}
-
 	// Read the raw bytes — the HMAC is over exactly what was sent, so we must not
 	// round-trip through JSON before verifying.
 	const body = new Uint8Array(await req.arrayBuffer())
-
-	// Guard again post-read: Content-Length may have been absent or understated
-	// (e.g. chunked transfer). Reject before any HMAC/JSON work.
-	if (body.length > MAX_BODY_BYTES) {
-		log.warn("webhook body exceeds size limit", {body_bytes: body.length})
-		return json({error: "payload too large"}, 413)
-	}
 
 	if (!verifySignature(body, config.webhookSecret, signature)) {
 		log.warn("webhook signature verification failed", {

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -8,6 +8,7 @@
  */
 
 import type {AppConfig} from "./config.js"
+import {sanitizeError} from "./contracts.js"
 import {detectMembershipRequest, SeenProposals} from "./detect.js"
 import {verifySignature} from "./signature.js"
 import {log} from "./telemetry.js"
@@ -104,48 +105,63 @@ async function handleWebhook(
 		return json({status: "ok"}, 200)
 	}
 
-	// Policy seam: API-backed rules (editor check, and any space-defined policies).
-	const decision = await acceptor.evaluate(request)
-	if (!decision.accept) {
-		log.info("membership request denied by policy", {
+	// Once marked seen, any non-terminal failure below must roll the mark back, or
+	// the delivery-worker's retry would be silently deduped and the vote never lands.
+	// A thrown error (e.g. an unexpected policy failure) is exactly such a case.
+	try {
+		// Policy seam: API-backed rules (editor check, and any space-defined policies).
+		const decision = await acceptor.evaluate(request)
+		if (!decision.accept) {
+			log.info("membership request denied by policy", {
+				proposal_id: request.proposalId,
+				space_id: request.spaceId,
+				reason: decision.reason,
+			})
+			return json({status: "ok"}, 200)
+		}
+
+		const result = await acceptor.vote(request)
+		switch (result.kind) {
+			case "voted":
+				log.info("membership request accepted — vote cast", {
+					proposal_id: request.proposalId,
+					space_id: request.spaceId,
+					requester_space_id: request.requesterSpaceId,
+					tx_hash: result.txHash,
+				})
+				return json({status: "ok"}, 200)
+
+			case "benign":
+				// The chain rejected the vote. Nothing to retry — ack so delivery stops.
+				log.warn("membership vote rejected on-chain — not retrying", {
+					proposal_id: request.proposalId,
+					space_id: request.spaceId,
+					reason: result.message,
+				})
+				return json({status: "ok"}, 200)
+
+			default: {
+				// Infrastructure failure — roll back the dedupe mark so the
+				// delivery-worker's retry isn't silently swallowed, and 5xx to retry.
+				seen.unmark(request.proposalId)
+				log.error("membership vote failed (infrastructure) — will retry", {
+					proposal_id: request.proposalId,
+					space_id: request.spaceId,
+					error: result.message,
+				})
+				return json({error: "vote failed"}, 503)
+			}
+		}
+	} catch (err) {
+		// Unexpected throw during evaluate/vote — roll back the dedupe mark and ask
+		// for a retry, instead of letting the outer catch 500 with the mark stuck.
+		seen.unmark(request.proposalId)
+		log.error("membership processing failed — will retry", {
 			proposal_id: request.proposalId,
 			space_id: request.spaceId,
-			reason: decision.reason,
+			error: sanitizeError(err),
 		})
-		return json({status: "ok"}, 200)
-	}
-
-	const result = await acceptor.vote(request)
-	switch (result.kind) {
-		case "voted":
-			log.info("membership request accepted — vote cast", {
-				proposal_id: request.proposalId,
-				space_id: request.spaceId,
-				requester_space_id: request.requesterSpaceId,
-				tx_hash: result.txHash,
-			})
-			return json({status: "ok"}, 200)
-
-		case "benign":
-			// The chain rejected the vote. Nothing to retry — ack so delivery stops.
-			log.warn("membership vote rejected on-chain — not retrying", {
-				proposal_id: request.proposalId,
-				space_id: request.spaceId,
-				reason: result.message,
-			})
-			return json({status: "ok"}, 200)
-
-		default: {
-			// Infrastructure failure — roll back the dedupe mark so the
-			// delivery-worker's retry isn't silently swallowed, and 5xx to retry.
-			seen.unmark(request.proposalId)
-			log.error("membership vote failed (infrastructure) — will retry", {
-				proposal_id: request.proposalId,
-				space_id: request.spaceId,
-				error: result.message,
-			})
-			return json({error: "vote failed"}, 503)
-		}
+		return json({error: "processing failed"}, 503)
 	}
 }
 
@@ -172,8 +188,9 @@ export function createApp(config: AppConfig, acceptor: Acceptor): (req: Request)
 				return await handleWebhook(req, config, acceptor, seen)
 			} catch (err) {
 				// Unexpected failure — 500 makes the delivery-worker retry rather than
-				// silently dropping the event.
-				log.error("unhandled error processing webhook", {error: err})
+				// silently dropping the event. Sanitize: the error may carry a bundler
+				// URL with an API key.
+				log.error("unhandled error processing webhook", {error: sanitizeError(err)})
 				return json({error: "internal error"}, 500)
 			}
 		}

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -5,12 +5,14 @@
  * it can be driven directly in unit tests (no bound port) and handed to
  * `Bun.serve` in production.
  *
- * Milestone 1 scope: prove connectivity. We verify the HMAC signature and log a
- * structured summary of every delivery. Detection (M2) and voting (M3) are not
- * here yet — every authenticated webhook is acknowledged with 200.
+ * Milestone 2 scope: verify the HMAC signature, then detect which deliveries are
+ * membership requests and de-duplicate them. Voting (M3) is not here yet — a
+ * detected request is logged as "would accept" and every authenticated webhook
+ * is acknowledged with 200.
  */
 
 import type {AcceptorConfig} from "./config.js"
+import {detectMembershipRequest, SeenProposals} from "./detect.js"
 import {verifySignature} from "./signature.js"
 import {log} from "./telemetry.js"
 
@@ -39,7 +41,7 @@ function json(body: unknown, status: number): Response {
 	})
 }
 
-async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Response> {
+async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenProposals): Promise<Response> {
 	const signature = req.headers.get(SIGNATURE_HEADER)
 
 	// A missing or malformed signature header can never pass the HMAC check, so
@@ -71,8 +73,30 @@ async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Resp
 		return json({error: "invalid JSON body"}, 400)
 	}
 
-	// M1: just observe. M2 will filter to membership requests; M3 will vote.
-	log.info("webhook received", summarize(payload))
+	// Every authenticated delivery is logged at debug (the firehose is large);
+	// membership requests are surfaced at info below.
+	log.debug("webhook received", summarize(payload))
+
+	const request = detectMembershipRequest(payload)
+	if (!request) {
+		return json({status: "ok"}, 200)
+	}
+
+	// Dedupe on proposal_id: the fan-out delivers one copy per editor.
+	if (seen.seen(request.proposalId)) {
+		log.debug("membership request already seen — deduped", {
+			proposal_id: request.proposalId,
+			space_id: request.spaceId,
+		})
+		return json({status: "ok"}, 200)
+	}
+
+	// M2 ends here: detected, not yet voted. M3 verifies on-chain and casts YES.
+	log.info("membership request detected — would accept", {
+		proposal_id: request.proposalId,
+		space_id: request.spaceId,
+		requester_space_id: request.requesterSpaceId,
+	})
 	return json({status: "ok"}, 200)
 }
 
@@ -84,6 +108,9 @@ async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Resp
  *  - `POST /webhooks/geo` — notification webhook sink (HMAC-verified)
  */
 export function createApp(config: AcceptorConfig): (req: Request) => Promise<Response> {
+	// Dedupe state lives for the lifetime of the process (see SeenProposals).
+	const seen = new SeenProposals()
+
 	return async (req: Request): Promise<Response> => {
 		const {pathname} = new URL(req.url)
 
@@ -93,7 +120,7 @@ export function createApp(config: AcceptorConfig): (req: Request) => Promise<Res
 
 		if (req.method === "POST" && pathname === "/webhooks/geo") {
 			try {
-				return await handleWebhook(req, config)
+				return await handleWebhook(req, config, seen)
 			} catch (err) {
 				// Unexpected failure — 500 makes the delivery-worker retry rather than
 				// silently dropping the event.

--- a/membership-acceptor/src/signature.ts
+++ b/membership-acceptor/src/signature.ts
@@ -1,0 +1,35 @@
+/**
+ * Webhook signature verification.
+ *
+ * The notification delivery-worker signs every request with
+ * `X-Geo-Signature: sha256=<hex>`, where `<hex>` is the HMAC-SHA256 of the raw
+ * request body keyed by the shared secret. See notification-service/WEBHOOK_INTEGRATION.md.
+ */
+
+import {createHmac, timingSafeEqual} from "node:crypto"
+
+const PREFIX = "sha256="
+
+/**
+ * Verify the `X-Geo-Signature` header against the raw request body.
+ *
+ * @param body - the raw request body bytes (NOT re-serialized JSON — the HMAC is
+ *   computed over the exact bytes the worker sent)
+ * @param secret - the shared secret for this webhook
+ * @param signatureHeader - the value of the `X-Geo-Signature` header (may be null)
+ * @returns true iff the header is present, well-formed, and matches
+ */
+export function verifySignature(body: Uint8Array, secret: string, signatureHeader: string | null): boolean {
+	if (!signatureHeader?.startsWith(PREFIX)) {
+		return false
+	}
+
+	const received = signatureHeader.slice(PREFIX.length)
+	const expected = createHmac("sha256", secret).update(body).digest("hex")
+
+	// Length check first: timingSafeEqual throws if the buffers differ in length.
+	if (received.length !== expected.length) {
+		return false
+	}
+	return timingSafeEqual(Buffer.from(received), Buffer.from(expected))
+}

--- a/membership-acceptor/src/signature.ts
+++ b/membership-acceptor/src/signature.ts
@@ -27,9 +27,14 @@ export function verifySignature(body: Uint8Array, secret: string, signatureHeade
 	const received = signatureHeader.slice(PREFIX.length)
 	const expected = createHmac("sha256", secret).update(body).digest("hex")
 
-	// Length check first: timingSafeEqual throws if the buffers differ in length.
-	if (received.length !== expected.length) {
+	// Compare BYTE lengths, not char lengths: timingSafeEqual throws on unequal
+	// buffer lengths, and malformed non-ASCII input can encode to a different byte
+	// length than its char length suggests. Build the buffers first, then bail out
+	// early if their byte lengths differ so we never hand mismatched buffers in.
+	const receivedBuf = Buffer.from(received)
+	const expectedBuf = Buffer.from(expected)
+	if (receivedBuf.length !== expectedBuf.length) {
 		return false
 	}
-	return timingSafeEqual(Buffer.from(received), Buffer.from(expected))
+	return timingSafeEqual(receivedBuf, expectedBuf)
 }

--- a/membership-acceptor/src/telemetry.ts
+++ b/membership-acceptor/src/telemetry.ts
@@ -1,0 +1,116 @@
+/**
+ * Telemetry — Sentry error tracking + structured console logging.
+ *
+ * Adapted from proposal-executor/src/telemetry.ts, but without the Effect-TS
+ * runtime: membership-acceptor is a long-running HTTP server, so the request
+ * path is plain async code rather than Effect fibers. We keep the same
+ * observability conventions (console JSON as the primary channel, Sentry as a
+ * supplementary one) so logs read the same across the two services.
+ *
+ * - console is the primary channel (kubectl logs / log aggregators).
+ * - Sentry is supplementary: error/fatal create issues, lower levels become breadcrumbs.
+ * - Falls back to console-only when SENTRY_DSN is not set.
+ */
+
+import * as Sentry from "@sentry/node"
+
+const SERVICE_NAME = "membership-acceptor"
+
+let sentryInitialized = false
+
+// ---------------------------------------------------------------------------
+// Sentry initialization (eager, at module load)
+// ---------------------------------------------------------------------------
+
+function initSentry() {
+	const dsn = process.env.SENTRY_DSN
+
+	if (!dsn) {
+		console.log(JSON.stringify({level: "info", message: "[TELEMETRY] Sentry disabled (SENTRY_DSN not set)"}))
+		return
+	}
+
+	try {
+		const environment = process.env.SENTRY_ENVIRONMENT || "production"
+		const release = process.env.SENTRY_RELEASE
+		const rawRate = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || "1.0")
+		const tracesSampleRate = Number.isNaN(rawRate) || rawRate < 0 || rawRate > 1 ? 1.0 : rawRate
+		const debug = process.env.SENTRY_DEBUG === "true"
+
+		Sentry.init({dsn, environment, release, tracesSampleRate, debug})
+
+		sentryInitialized = true
+		console.log(JSON.stringify({level: "info", message: `[TELEMETRY] Sentry enabled (env: ${environment})`}))
+	} catch (err) {
+		console.error(`[TELEMETRY] Sentry init failed, continuing without Sentry: ${err}`)
+	}
+}
+
+initSentry()
+
+// ---------------------------------------------------------------------------
+// Structured logger — dual-writes console (primary) + Sentry (supplementary)
+// ---------------------------------------------------------------------------
+
+type LogData = Record<string, unknown>
+
+type Level = "debug" | "info" | "warn" | "error"
+
+const SENTRY_LEVEL: Record<Level, Sentry.SeverityLevel> = {
+	debug: "debug",
+	info: "info",
+	warn: "warning",
+	error: "error",
+}
+
+/** Serialize a value for logging — special-cases Error instances. */
+function serializeValue(value: unknown): unknown {
+	if (value instanceof Error) {
+		return {name: value.name, message: value.message, stack: value.stack}
+	}
+	return value
+}
+
+function serializeData(data?: LogData): LogData | undefined {
+	if (!data) return undefined
+	const out: LogData = {}
+	for (const key of Object.keys(data)) {
+		out[key] = serializeValue(data[key])
+	}
+	return out
+}
+
+function emit(level: Level, message: string, data?: LogData): void {
+	const serialized = serializeData(data)
+
+	if (sentryInitialized) {
+		if (level === "error") {
+			Sentry.captureMessage(message, {level: SENTRY_LEVEL[level], extra: serialized})
+		} else {
+			Sentry.addBreadcrumb({message, data: serialized, level: SENTRY_LEVEL[level], category: SERVICE_NAME})
+		}
+	}
+
+	const consoleMethod = level === "warn" ? "warn" : level === "error" ? "error" : "log"
+	console[consoleMethod](JSON.stringify({level, message, ...serialized}))
+}
+
+export const log = {
+	debug: (message: string, data?: LogData) => emit("debug", message, data),
+	info: (message: string, data?: LogData) => emit("info", message, data),
+	warn: (message: string, data?: LogData) => emit("warn", message, data),
+	error: (message: string, data?: LogData) => emit("error", message, data),
+}
+
+// ---------------------------------------------------------------------------
+// Flush — call before process exit so buffered Sentry events are not lost
+// ---------------------------------------------------------------------------
+
+export async function flush(timeoutMs = 5000): Promise<void> {
+	if (!sentryInitialized) return
+	try {
+		await Sentry.flush(timeoutMs)
+	} catch {
+		// best-effort — never block shutdown on telemetry
+	}
+}

--- a/membership-acceptor/src/vote.ts
+++ b/membership-acceptor/src/vote.ts
@@ -1,0 +1,119 @@
+/**
+ * Casting the membership YES vote.
+ *
+ * Build the enter(PROPOSAL_VOTED, Yes) calldata and send it.
+ * The contract is the authority — a duplicate / closed /
+ * already-executed / unauthorized vote simply reverts, which we classify as a
+ * *benign* outcome (nothing to retry). Only genuine infrastructure failures are
+ * retryable.
+ *
+ * Because fast-path spaces run with flatThreshold = 1, the single YES executes the
+ * AddMember in the same transaction — admitting the member.
+ */
+
+import {type Address, encodeFunctionData} from "viem"
+
+import {
+	EMPTY_SIGNATURE,
+	encodeVoteData,
+	isRevert,
+	PROPOSAL_VOTED_ACTION,
+	padBytes16ToBytes32,
+	SpaceRegistryAbi,
+	sanitizeError,
+	uuidToBytes16,
+	VOTE_YES,
+} from "./contracts.js"
+import type {MembershipRequest} from "./detect.js"
+import type {GraphQLClient} from "./graphql.js"
+import type {Policy, PolicyDecision} from "./policy.js"
+import type {SmartWallet} from "./wallet.js"
+
+/**
+ * Outcome of attempting a vote.
+ * - `voted`  — the YES vote landed (member admitted). txHash for tracing.
+ * - `benign` — the chain rejected it (already voted / executed / closed / not an
+ *              editor). Nothing to retry; ack the webhook so it stops retrying.
+ * - `infra`  — an infrastructure failure (RPC/bundler). The webhook should retry.
+ */
+export type VoteResult =
+	| {kind: "voted"; txHash: string}
+	| {kind: "benign"; message: string}
+	| {kind: "infra"; message: string}
+
+/**
+ * The acceptor's view used by the HTTP layer: which spaces it serves, and how to
+ * vote. Injected into `createApp` so tests can stub it without a real wallet.
+ */
+export interface Acceptor {
+	/** Cheap config gate: true if this acceptor serves `spaceId` (the whitelist). */
+	allowsSpace(spaceId: string): boolean
+	/** Run the policy seam (API-backed rules, e.g. the editor check) for a request. */
+	evaluate(request: MembershipRequest): Promise<PolicyDecision>
+	/** Cast the YES vote for a detected, allowed, accepted, not-yet-seen request. */
+	vote(request: MembershipRequest): Promise<VoteResult>
+}
+
+export interface AcceptorConfig {
+	wallet: SmartWallet
+	/** The acceptor's personal-space id (bytes16 hex) — the enter() `_fromSpaceId`. */
+	acceptorSpaceId: `0x${string}`
+	spaceRegistryAddress: Address
+	/** Spaces (UUIDs, lowercased) this acceptor auto-accepts. Empty ⇒ accept none. */
+	allowlist: ReadonlySet<string>
+	/** The (possibly composed) policy run before voting. */
+	policy: Policy
+	/** GraphQL client passed to policies for API-backed decisions. */
+	graphql: GraphQLClient
+}
+
+/** Build the real, wallet-backed acceptor. */
+export function createAcceptor(config: AcceptorConfig): Acceptor {
+	return {
+		allowsSpace(spaceId: string): boolean {
+			return config.allowlist.has(spaceId.toLowerCase())
+		},
+
+		evaluate(request: MembershipRequest): Promise<PolicyDecision> {
+			return config.policy(request, {graphql: config.graphql, acceptorSpaceId: config.acceptorSpaceId})
+		},
+
+		async vote(request: MembershipRequest): Promise<VoteResult> {
+			try {
+				const daoSpaceId = uuidToBytes16(request.spaceId)
+				const proposalIdHex = uuidToBytes16(request.proposalId)
+
+				const calldata = encodeFunctionData({
+					abi: SpaceRegistryAbi,
+					functionName: "enter",
+					args: [
+						config.acceptorSpaceId, // _fromSpaceId: acceptor's personal space
+						daoSpaceId, // _toSpaceId: DAO space being joined
+						PROPOSAL_VOTED_ACTION, // _action
+						padBytes16ToBytes32(proposalIdHex), // _topic: bytes32(proposalId)
+						encodeVoteData(proposalIdHex, VOTE_YES), // _data: abi.encode(proposalId, Yes)
+						EMPTY_SIGNATURE, // _signature: unused when msg.sender == _fromSpace
+					],
+				})
+
+				const account = config.wallet.smartAccountClient.account
+				if (!account) {
+					// Misconfigured wallet — retrying won't help, but it's not a chain
+					// revert either; surface as infra so it's loud and retried.
+					return {kind: "infra", message: "smart account client has no account"}
+				}
+
+				const txHash = await config.wallet.smartAccountClient.sendTransaction({
+					account,
+					chain: config.wallet.chain,
+					to: config.spaceRegistryAddress,
+					data: calldata,
+				})
+				return {kind: "voted", txHash}
+			} catch (error) {
+				const message = sanitizeError(error)
+				return isRevert(error) ? {kind: "benign", message} : {kind: "infra", message}
+			}
+		},
+	}
+}

--- a/membership-acceptor/src/vote.ts
+++ b/membership-acceptor/src/vote.ts
@@ -21,6 +21,7 @@ import {
 	padBytes16ToBytes32,
 	SpaceRegistryAbi,
 	sanitizeError,
+	toBytes16Hex,
 	uuidToBytes16,
 	VOTE_YES,
 } from "./contracts.js"
@@ -71,7 +72,9 @@ export interface AcceptorConfig {
 export function createAcceptor(config: AcceptorConfig): Acceptor {
 	return {
 		allowsSpace(spaceId: string): boolean {
-			return config.allowlist.has(spaceId.toLowerCase())
+			// Webhook space_id arrives as a dashed UUID; the allowlist is 0x bytes16.
+			// Canonicalize both to the same form before comparing.
+			return config.allowlist.has(toBytes16Hex(spaceId))
 		},
 
 		evaluate(request: MembershipRequest): Promise<PolicyDecision> {

--- a/membership-acceptor/src/wallet.ts
+++ b/membership-acceptor/src/wallet.ts
@@ -1,0 +1,66 @@
+/**
+ * Smart-wallet setup — a gas-sponsored Safe smart account (Pimlico paymaster).
+ *
+ * The acceptor votes via SpaceRegistry.enter() with `_fromSpaceId` = its own
+ * personal space; the protocol requires msg.sender to be that space's account, so
+ * the signer must be the Safe smart account that owns the acceptor's personal
+ * space. Ported from proposal-executor/src/execute.ts (de-Effect-ified).
+ */
+
+import {createSmartAccountClient, type SmartAccountClient} from "permissionless"
+import {toSafeSmartAccount} from "permissionless/accounts"
+import {createPimlicoClient} from "permissionless/clients/pimlico"
+import {type Address, type Chain, createPublicClient, http} from "viem"
+import {entryPoint07Address} from "viem/account-abstraction"
+import {privateKeyToAccount} from "viem/accounts"
+
+import {getChain, type SupportedChainId, TESTNET_SAFE_ADDRESSES} from "./contracts.js"
+
+export interface SmartWallet {
+	readonly smartAccountClient: SmartAccountClient
+	readonly chain: Chain
+	readonly safeAddress: Address
+}
+
+export interface WalletConfig {
+	privateKey: `0x${string}`
+	pimlicoApiKey: string
+	rpcUrl: string
+	chainId: SupportedChainId
+}
+
+/** Create a gas-sponsored Safe smart account. Called once at startup. */
+export async function createSmartWallet(config: WalletConfig): Promise<SmartWallet> {
+	const chain = getChain(config.chainId)
+	const bundlerUrl = `https://api.pimlico.io/v2/${config.chainId}/rpc?apikey=${config.pimlicoApiKey}`
+
+	const publicClient = createPublicClient({chain, transport: http(config.rpcUrl)})
+	const owner = privateKeyToAccount(config.privateKey)
+
+	const safeAccount = await toSafeSmartAccount({
+		client: publicClient,
+		owners: [owner],
+		entryPoint: {address: entryPoint07Address, version: "0.7" as const},
+		version: "1.4.1" as const,
+		...(config.chainId === 19411 ? TESTNET_SAFE_ADDRESSES : {}),
+	})
+
+	const bundlerTransport = http(bundlerUrl)
+	const paymasterClient = createPimlicoClient({
+		transport: bundlerTransport,
+		chain,
+		entryPoint: {address: entryPoint07Address, version: "0.7"},
+	})
+
+	const smartAccountClient = createSmartAccountClient({
+		chain,
+		account: safeAccount,
+		paymaster: paymasterClient,
+		bundlerTransport,
+		userOperation: {
+			estimateFeesPerGas: async () => (await paymasterClient.getUserOperationGasPrice()).fast,
+		},
+	})
+
+	return {smartAccountClient, chain, safeAddress: safeAccount.address}
+}

--- a/membership-acceptor/tests/config.test.ts
+++ b/membership-acceptor/tests/config.test.ts
@@ -2,35 +2,80 @@ import {describe, expect, test} from "bun:test"
 
 import {ConfigError, parseConfig} from "../src/config.js"
 
+/** A complete, valid environment. Individual tests clone and mutate it. */
+function validEnv(): NodeJS.ProcessEnv {
+	return {
+		GEO_WEBHOOK_SECRET: "s3cr3t",
+		ACCEPTOR_PRIVATE_KEY: `0x${"1".repeat(64)}`,
+		ACCEPTOR_SPACE_ID: `0x${"a".repeat(32)}`,
+		SPACE_REGISTRY_ADDRESS: `0x${"b".repeat(40)}`,
+		RPC_URL: "https://rpc.example",
+		PIMLICO_API_KEY: "pim_test",
+		GRAPHQL_ENDPOINT: "https://api.example/graphql",
+		MEMBERSHIP_AUTOACCEPT_SPACE_IDS: "d4f5a6b7-0000-0000-0000-000000000000",
+	}
+}
+
 describe("parseConfig", () => {
-	test("parses a valid environment with default port", () => {
-		const config = parseConfig({GEO_WEBHOOK_SECRET: "s3cr3t"})
-		expect(config).toEqual({port: 8080, webhookSecret: "s3cr3t"})
+	test("parses a full valid environment", () => {
+		const c = parseConfig(validEnv())
+		expect(c.port).toBe(8080)
+		expect(c.webhookSecret).toBe("s3cr3t")
+		expect(c.chainId).toBe(80451) // mainnet default
+		expect(c.spaceRegistryAddress).toBe(`0x${"b".repeat(40)}`)
+		expect([...c.autoacceptSpaceIds]).toEqual(["d4f5a6b7-0000-0000-0000-000000000000"])
 	})
 
-	test("honors a valid PORT", () => {
-		const config = parseConfig({GEO_WEBHOOK_SECRET: "s3cr3t", PORT: "3000"})
-		expect(config.port).toBe(3000)
+	test("adds the 0x prefix to a bare private key", () => {
+		const c = parseConfig({...validEnv(), ACCEPTOR_PRIVATE_KEY: "1".repeat(64)})
+		expect(c.acceptorPrivateKey).toBe(`0x${"1".repeat(64)}`)
 	})
 
-	test("trims the secret", () => {
-		const config = parseConfig({GEO_WEBHOOK_SECRET: "  s3cr3t  "})
-		expect(config.webhookSecret).toBe("s3cr3t")
+	test("lowercases and de-duplicates the allowlist, dropping blanks", () => {
+		const c = parseConfig({...validEnv(), MEMBERSHIP_AUTOACCEPT_SPACE_IDS: " AAA , aaa ,, BBB "})
+		expect([...c.autoacceptSpaceIds].sort()).toEqual(["aaa", "bbb"])
 	})
 
-	test("throws when GEO_WEBHOOK_SECRET is missing", () => {
-		expect(() => parseConfig({})).toThrow(ConfigError)
+	test("an empty allowlist is allowed (kill switch)", () => {
+		const c = parseConfig({...validEnv(), MEMBERSHIP_AUTOACCEPT_SPACE_IDS: ""})
+		expect(c.autoacceptSpaceIds.size).toBe(0)
 	})
 
-	test("throws when GEO_WEBHOOK_SECRET is blank", () => {
-		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "   "})).toThrow(ConfigError)
+	test("honors a valid PORT and CHAIN_ID", () => {
+		const c = parseConfig({...validEnv(), PORT: "3000", CHAIN_ID: "19411"})
+		expect(c.port).toBe(3000)
+		expect(c.chainId).toBe(19411)
 	})
 
-	test("throws on a non-numeric PORT", () => {
-		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "s", PORT: "abc"})).toThrow(ConfigError)
+	test.each([
+		["GEO_WEBHOOK_SECRET", {GEO_WEBHOOK_SECRET: ""}],
+		["ACCEPTOR_PRIVATE_KEY", {ACCEPTOR_PRIVATE_KEY: undefined}],
+		["ACCEPTOR_SPACE_ID", {ACCEPTOR_SPACE_ID: undefined}],
+		["SPACE_REGISTRY_ADDRESS", {SPACE_REGISTRY_ADDRESS: undefined}],
+		["RPC_URL", {RPC_URL: undefined}],
+		["PIMLICO_API_KEY", {PIMLICO_API_KEY: undefined}],
+		["GRAPHQL_ENDPOINT", {GRAPHQL_ENDPOINT: undefined}],
+	])("throws when %s is missing", (_label, override) => {
+		expect(() => parseConfig({...validEnv(), ...override})).toThrow(ConfigError)
+	})
+
+	test("throws on a malformed private key", () => {
+		expect(() => parseConfig({...validEnv(), ACCEPTOR_PRIVATE_KEY: "0xnothex"})).toThrow(ConfigError)
+	})
+
+	test("throws on a malformed ACCEPTOR_SPACE_ID (not bytes16)", () => {
+		expect(() => parseConfig({...validEnv(), ACCEPTOR_SPACE_ID: `0x${"a".repeat(40)}`})).toThrow(ConfigError)
+	})
+
+	test("throws on a malformed SPACE_REGISTRY_ADDRESS", () => {
+		expect(() => parseConfig({...validEnv(), SPACE_REGISTRY_ADDRESS: "0x1234"})).toThrow(ConfigError)
+	})
+
+	test("throws on an unsupported CHAIN_ID", () => {
+		expect(() => parseConfig({...validEnv(), CHAIN_ID: "1"})).toThrow(ConfigError)
 	})
 
 	test("throws on an out-of-range PORT", () => {
-		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "s", PORT: "70000"})).toThrow(ConfigError)
+		expect(() => parseConfig({...validEnv(), PORT: "70000"})).toThrow(ConfigError)
 	})
 })

--- a/membership-acceptor/tests/config.test.ts
+++ b/membership-acceptor/tests/config.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from "bun:test"
+
+import {ConfigError, parseConfig} from "../src/config.js"
+
+describe("parseConfig", () => {
+	test("parses a valid environment with default port", () => {
+		const config = parseConfig({GEO_WEBHOOK_SECRET: "s3cr3t"})
+		expect(config).toEqual({port: 8080, webhookSecret: "s3cr3t"})
+	})
+
+	test("honors a valid PORT", () => {
+		const config = parseConfig({GEO_WEBHOOK_SECRET: "s3cr3t", PORT: "3000"})
+		expect(config.port).toBe(3000)
+	})
+
+	test("trims the secret", () => {
+		const config = parseConfig({GEO_WEBHOOK_SECRET: "  s3cr3t  "})
+		expect(config.webhookSecret).toBe("s3cr3t")
+	})
+
+	test("throws when GEO_WEBHOOK_SECRET is missing", () => {
+		expect(() => parseConfig({})).toThrow(ConfigError)
+	})
+
+	test("throws when GEO_WEBHOOK_SECRET is blank", () => {
+		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "   "})).toThrow(ConfigError)
+	})
+
+	test("throws on a non-numeric PORT", () => {
+		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "s", PORT: "abc"})).toThrow(ConfigError)
+	})
+
+	test("throws on an out-of-range PORT", () => {
+		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "s", PORT: "70000"})).toThrow(ConfigError)
+	})
+})

--- a/membership-acceptor/tests/config.test.ts
+++ b/membership-acceptor/tests/config.test.ts
@@ -23,7 +23,8 @@ describe("parseConfig", () => {
 		expect(c.webhookSecret).toBe("s3cr3t")
 		expect(c.chainId).toBe(80451) // mainnet default
 		expect(c.spaceRegistryAddress).toBe(`0x${"b".repeat(40)}`)
-		expect([...c.autoacceptSpaceIds]).toEqual(["d4f5a6b7-0000-0000-0000-000000000000"])
+		// Allowlist is canonicalized to 0x bytes16 (the dashed UUID's dashless form).
+		expect([...c.autoacceptSpaceIds]).toEqual(["0xd4f5a6b7000000000000000000000000"])
 	})
 
 	test("adds the 0x prefix to a bare private key", () => {
@@ -31,9 +32,23 @@ describe("parseConfig", () => {
 		expect(c.acceptorPrivateKey).toBe(`0x${"1".repeat(64)}`)
 	})
 
-	test("lowercases and de-duplicates the allowlist, dropping blanks", () => {
-		const c = parseConfig({...validEnv(), MEMBERSHIP_AUTOACCEPT_SPACE_IDS: " AAA , aaa ,, BBB "})
-		expect([...c.autoacceptSpaceIds].sort()).toEqual(["aaa", "bbb"])
+	test("canonicalizes, de-duplicates, and drops blanks in the allowlist", () => {
+		// Same space in 0x-upper, dashless-lower, and dashed-UUID forms → one entry;
+		// plus a distinct space. All canonicalize to 0x bytes16.
+		const dupA0x = `0x${"A".repeat(32)}`
+		const dupADashless = "a".repeat(32)
+		const distinctUuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+		const c = parseConfig({
+			...validEnv(),
+			MEMBERSHIP_AUTOACCEPT_SPACE_IDS: ` ${dupA0x} , ${dupADashless} ,, ${distinctUuid} `,
+		})
+		expect([...c.autoacceptSpaceIds].sort()).toEqual([`0x${"a".repeat(32)}`, `0x${"b".repeat(32)}`])
+	})
+
+	test("throws on an allowlist entry that isn't a valid space id", () => {
+		expect(() => parseConfig({...validEnv(), MEMBERSHIP_AUTOACCEPT_SPACE_IDS: "not-a-real-id"})).toThrow(
+			ConfigError,
+		)
 	})
 
 	test("an empty allowlist is allowed (kill switch)", () => {

--- a/membership-acceptor/tests/contracts.test.ts
+++ b/membership-acceptor/tests/contracts.test.ts
@@ -6,6 +6,7 @@ import {
 	isRevert,
 	padBytes16ToBytes32,
 	sanitizeError,
+	toBytes16Hex,
 	uuidToBytes16,
 	VOTE_YES,
 } from "../src/contracts.js"
@@ -17,6 +18,22 @@ describe("uuidToBytes16", () => {
 
 	test("throws on a non-UUID", () => {
 		expect(() => uuidToBytes16("not-a-uuid")).toThrow()
+	})
+})
+
+describe("toBytes16Hex", () => {
+	test("converts a dashed UUID to 0x bytes16", () => {
+		expect(toBytes16Hex("c9f267dc-b0d2-7071-8c2a-3c45a64afd32")).toBe("0xc9f267dcb0d270718c2a3c45a64afd32")
+	})
+
+	test("is idempotent on an already-0x bytes16 (lowercased)", () => {
+		expect(toBytes16Hex("0xC9F267DCB0D270718C2A3C45A64AFD32")).toBe("0xc9f267dcb0d270718c2a3c45a64afd32")
+	})
+
+	test("a dashed UUID and its 0x form canonicalize equal", () => {
+		expect(toBytes16Hex("c9f267dc-b0d2-7071-8c2a-3c45a64afd32")).toBe(
+			toBytes16Hex("0xc9f267dcb0d270718c2a3c45a64afd32"),
+		)
 	})
 })
 
@@ -65,14 +82,29 @@ describe("isRevert", () => {
 		expect(isRevert(new Error("wrap", {cause}))).toBe(true)
 	})
 
-	test("true on message patterns", () => {
+	test("true on definite revert message patterns", () => {
 		expect(isRevert(new Error("execution reverted: CanNotVote"))).toBe(true)
-		expect(isRevert("UserOperation reverted")).toBe(true)
+		expect(isRevert(new Error("ProposalAlreadyExecuted()"))).toBe(true)
+		expect(isRevert(new Error("reverted with AlreadyVoted"))).toBe(true)
 	})
 
 	test("false for plain infrastructure errors", () => {
 		expect(isRevert(new Error("ECONNREFUSED"))).toBe(false)
 		expect(isRevert(new Error("fetch failed"))).toBe(false)
+	})
+
+	test("false for the broad execution/call wrappers (not necessarily reverts)", () => {
+		// These wrap RPC/estimation failures too, so they must NOT be auto-benign.
+		const exec = new Error("call failed")
+		exec.name = "ContractFunctionExecutionError"
+		expect(isRevert(exec)).toBe(false)
+
+		const call = new Error("call failed")
+		call.name = "CallExecutionError"
+		expect(isRevert(call)).toBe(false)
+
+		// A bare "UserOperation reverted" with no revert reason is ambiguous → infra.
+		expect(isRevert(new Error("UserOperation reverted"))).toBe(false)
 	})
 })
 

--- a/membership-acceptor/tests/contracts.test.ts
+++ b/membership-acceptor/tests/contracts.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, test} from "bun:test"
+
+import {
+	encodeVoteData,
+	getChain,
+	isRevert,
+	padBytes16ToBytes32,
+	sanitizeError,
+	uuidToBytes16,
+	VOTE_YES,
+} from "../src/contracts.js"
+
+describe("uuidToBytes16", () => {
+	test("strips dashes and 0x-prefixes", () => {
+		expect(uuidToBytes16("550e8400-e29b-41d4-a716-446655440000")).toBe("0x550e8400e29b41d4a716446655440000")
+	})
+
+	test("throws on a non-UUID", () => {
+		expect(() => uuidToBytes16("not-a-uuid")).toThrow()
+	})
+})
+
+describe("padBytes16ToBytes32", () => {
+	test("right-pads a bytes16 to bytes32 with zeros", () => {
+		expect(padBytes16ToBytes32("0x550e8400e29b41d4a716446655440000")).toBe(
+			`0x550e8400e29b41d4a716446655440000${"0".repeat(32)}`,
+		)
+	})
+
+	test("throws when not 32 hex chars", () => {
+		expect(() => padBytes16ToBytes32("0x1234")).toThrow()
+	})
+})
+
+describe("encodeVoteData", () => {
+	test("encodes (bytes16 proposalId, uint8 YES) as two abi words", () => {
+		const encoded = encodeVoteData("0x550e8400e29b41d4a716446655440000", VOTE_YES)
+		// 2 × 32-byte words = 128 hex chars after 0x.
+		expect(encoded).toHaveLength(2 + 128)
+		// Word 1: bytes16 left-aligned (value then 16 zero bytes).
+		expect(encoded.startsWith("0x550e8400e29b41d4a716446655440000")).toBe(true)
+		// Word 2: uint8 right-aligned → all zeros except the final byte = 0x01 (YES).
+		const voteWord = encoded.slice(2 + 64)
+		expect(voteWord).toBe(`${"0".repeat(63)}1`)
+	})
+})
+
+describe("getChain", () => {
+	test("maps the supported chain ids", () => {
+		expect(getChain(80451).id).toBe(80451)
+		expect(getChain(19411).id).toBe(19411)
+	})
+})
+
+describe("isRevert", () => {
+	test("true for known revert error names", () => {
+		const e = new Error("boom")
+		e.name = "ContractFunctionRevertedError"
+		expect(isRevert(e)).toBe(true)
+	})
+
+	test("true when the cause is a revert", () => {
+		const cause = new Error("reverted")
+		cause.name = "ContractFunctionRevertedError"
+		expect(isRevert(new Error("wrap", {cause}))).toBe(true)
+	})
+
+	test("true on message patterns", () => {
+		expect(isRevert(new Error("execution reverted: CanNotVote"))).toBe(true)
+		expect(isRevert("UserOperation reverted")).toBe(true)
+	})
+
+	test("false for plain infrastructure errors", () => {
+		expect(isRevert(new Error("ECONNREFUSED"))).toBe(false)
+		expect(isRevert(new Error("fetch failed"))).toBe(false)
+	})
+})
+
+describe("sanitizeError", () => {
+	test("redacts a bundler apikey", () => {
+		const msg = sanitizeError(new Error("https://api.pimlico.io/v2/80451/rpc?apikey=pim_secret failed"))
+		expect(msg).toContain("apikey=<redacted>")
+		expect(msg).not.toContain("pim_secret")
+	})
+})

--- a/membership-acceptor/tests/detect.test.ts
+++ b/membership-acceptor/tests/detect.test.ts
@@ -110,6 +110,31 @@ describe("SeenProposals", () => {
 		expect(seen.seen("p2")).toBe(true)
 	})
 
+	test("unmark lets an id be processed again", () => {
+		const seen = new SeenProposals()
+		expect(seen.seen("p1")).toBe(false)
+		expect(seen.seen("p1")).toBe(true)
+		seen.unmark("p1")
+		expect(seen.seen("p1")).toBe(false) // forgotten → first sighting again
+		expect(seen.seen("p1")).toBe(true)
+	})
+
+	test("unmark of an unknown id is a no-op", () => {
+		const seen = new SeenProposals()
+		seen.unmark("never-seen")
+		expect(seen.seen("never-seen")).toBe(false)
+	})
+
+	test("unmark frees the capacity slot (no phantom eviction)", () => {
+		const seen = new SeenProposals(2)
+		expect(seen.seen("a")).toBe(false)
+		expect(seen.seen("b")).toBe(false)
+		seen.unmark("a") // {b}
+		expect(seen.seen("c")).toBe(false) // {b,c} — within capacity, nothing evicted
+		expect(seen.seen("b")).toBe(true)
+		expect(seen.seen("c")).toBe(true)
+	})
+
 	test("evicts oldest ids beyond capacity (FIFO)", () => {
 		const seen = new SeenProposals(2)
 		expect(seen.seen("a")).toBe(false) // {a}

--- a/membership-acceptor/tests/detect.test.ts
+++ b/membership-acceptor/tests/detect.test.ts
@@ -1,0 +1,122 @@
+import {describe, expect, test} from "bun:test"
+
+import {detectMembershipRequest, type MembershipRequest, SeenProposals} from "../src/detect.js"
+
+const NOW = 1_700_000_000
+
+/** A canonical fast-mode, single add_member proposal_created payload. */
+function membershipPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		version: 1,
+		event_type: "proposal_created",
+		category: "governance",
+		space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+		proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
+		voting_mode: "fast",
+		// target_address carries the requester's personal-space id (not an EOA address).
+		actions: [{type: "add_member", target_address: "a1b2c3d4-0000-0000-0000-000000000000"}],
+		settings: {start_date: NOW - 10, end_date: NOW + 86_400, voting_mode: "fast"},
+		...overrides,
+	}
+}
+
+describe("detectMembershipRequest", () => {
+	test("detects a fast single-add_member proposal_created", () => {
+		const req = detectMembershipRequest(membershipPayload(), NOW)
+		expect(req).toEqual({
+			proposalId: "c3e4f5a6-0000-0000-0000-000000000000",
+			spaceId: "d4f5a6b7-0000-0000-0000-000000000000",
+			requesterSpaceId: "a1b2c3d4-0000-0000-0000-000000000000",
+		} satisfies MembershipRequest)
+	})
+
+	test("ignores non proposal_created events", () => {
+		expect(detectMembershipRequest(membershipPayload({event_type: "proposal_voted"}), NOW)).toBeNull()
+	})
+
+	test("ignores slow voting mode", () => {
+		expect(detectMembershipRequest(membershipPayload({voting_mode: "slow"}), NOW)).toBeNull()
+	})
+
+	test("ignores proposals with more than one action", () => {
+		const actions = [
+			{type: "add_member", target_address: "0xaaaa"},
+			{type: "add_editor", target_address: "0xbbbb"},
+		]
+		expect(detectMembershipRequest(membershipPayload({actions}), NOW)).toBeNull()
+	})
+
+	test("ignores a single non-add_member action", () => {
+		const actions = [{type: "add_editor", target_address: "0xbbbb"}]
+		expect(detectMembershipRequest(membershipPayload({actions}), NOW)).toBeNull()
+	})
+
+	test("ignores an empty actions array", () => {
+		expect(detectMembershipRequest(membershipPayload({actions: []}), NOW)).toBeNull()
+	})
+
+	test("ignores a payload missing proposal_id", () => {
+		const p = membershipPayload()
+		delete p.proposal_id
+		expect(detectMembershipRequest(p, NOW)).toBeNull()
+	})
+
+	test("ignores a payload missing space_id", () => {
+		const p = membershipPayload()
+		delete p.space_id
+		expect(detectMembershipRequest(p, NOW)).toBeNull()
+	})
+
+	test("best-effort: ignores a proposal whose end_date is already in the past", () => {
+		expect(detectMembershipRequest(membershipPayload({settings: {end_date: NOW - 1}}), NOW)).toBeNull()
+	})
+
+	test("detects when end_date is in the future", () => {
+		expect(detectMembershipRequest(membershipPayload({settings: {end_date: NOW + 1}}), NOW)).not.toBeNull()
+	})
+
+	test("detects when settings/end_date is absent (no window info to act on)", () => {
+		const p = membershipPayload()
+		delete p.settings
+		expect(detectMembershipRequest(p, NOW)).not.toBeNull()
+	})
+
+	test("requesterSpaceId is empty when target_address is missing", () => {
+		const actions = [{type: "add_member"}]
+		expect(detectMembershipRequest(membershipPayload({actions}), NOW)?.requesterSpaceId).toBe("")
+	})
+
+	test("returns null for non-object payloads", () => {
+		expect(detectMembershipRequest(null, NOW)).toBeNull()
+		expect(detectMembershipRequest("string", NOW)).toBeNull()
+		expect(detectMembershipRequest(42, NOW)).toBeNull()
+		expect(detectMembershipRequest([], NOW)).toBeNull()
+	})
+})
+
+describe("SeenProposals", () => {
+	test("first sighting is not a duplicate; second is", () => {
+		const seen = new SeenProposals()
+		expect(seen.seen("p1")).toBe(false)
+		expect(seen.seen("p1")).toBe(true)
+		expect(seen.seen("p1")).toBe(true)
+	})
+
+	test("tracks distinct ids independently", () => {
+		const seen = new SeenProposals()
+		expect(seen.seen("p1")).toBe(false)
+		expect(seen.seen("p2")).toBe(false)
+		expect(seen.seen("p1")).toBe(true)
+		expect(seen.seen("p2")).toBe(true)
+	})
+
+	test("evicts oldest ids beyond capacity (FIFO)", () => {
+		const seen = new SeenProposals(2)
+		expect(seen.seen("a")).toBe(false) // {a}
+		expect(seen.seen("b")).toBe(false) // {a,b}
+		expect(seen.seen("c")).toBe(false) // len>2 → evict "a" → {b,c}
+		expect(seen.seen("a")).toBe(false) // "a" was evicted → new again; evict "b" → {c,a}
+		expect(seen.seen("c")).toBe(true) // "c" still tracked
+		expect(seen.seen("b")).toBe(false) // "b" was evicted → new again
+	})
+})

--- a/membership-acceptor/tests/graphql.test.ts
+++ b/membership-acceptor/tests/graphql.test.ts
@@ -1,0 +1,62 @@
+import {afterEach, describe, expect, test} from "bun:test"
+
+import {createGraphQLClient, GraphQLError} from "../src/graphql.js"
+
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+	globalThis.fetch = realFetch
+})
+
+function mockFetch(impl: (url: string, init: RequestInit) => Promise<Response> | Response) {
+	// biome-ignore lint/suspicious/noExplicitAny: test seam for the global fetch
+	globalThis.fetch = ((url: any, init: any) => Promise.resolve(impl(String(url), init))) as typeof fetch
+}
+
+const client = createGraphQLClient({endpoint: "https://api.example/graphql"})
+
+describe("createGraphQLClient", () => {
+	test("posts the query and returns data", async () => {
+		let capturedUrl = ""
+		mockFetch((url) => {
+			capturedUrl = url
+			return new Response(JSON.stringify({data: {editor: {memberSpaceId: "abc"}}}), {status: 200})
+		})
+
+		const data = await client.query<{editor: {memberSpaceId: string} | null}>("query { editor { memberSpaceId } }")
+		expect(data.editor?.memberSpaceId).toBe("abc")
+		expect(capturedUrl).toBe("https://api.example/graphql")
+	})
+
+	test("passes variables through", async () => {
+		let sentVars: unknown
+		mockFetch((_url, init) => {
+			sentVars = (JSON.parse(String(init.body)) as {variables: unknown}).variables
+			return new Response(JSON.stringify({data: {ok: true}}), {status: 200})
+		})
+		await client.query("query($x: String!){ ok }", {x: "y"})
+		expect(sentVars).toEqual({x: "y"})
+	})
+
+	test("throws GraphQLError on a non-empty errors array", async () => {
+		mockFetch(() => new Response(JSON.stringify({errors: [{message: "boom"}]}), {status: 200}))
+		await expect(client.query("query { x }")).rejects.toThrow(GraphQLError)
+	})
+
+	test("throws GraphQLError on an HTTP error", async () => {
+		mockFetch(() => new Response("nope", {status: 500, statusText: "Server Error"}))
+		await expect(client.query("query { x }")).rejects.toThrow(GraphQLError)
+	})
+
+	test("throws GraphQLError when data is absent", async () => {
+		mockFetch(() => new Response(JSON.stringify({}), {status: 200}))
+		await expect(client.query("query { x }")).rejects.toThrow(GraphQLError)
+	})
+
+	test("throws GraphQLError on a network failure", async () => {
+		mockFetch(() => {
+			throw new Error("ECONNREFUSED")
+		})
+		await expect(client.query("query { x }")).rejects.toThrow(GraphQLError)
+	})
+})

--- a/membership-acceptor/tests/policy.test.ts
+++ b/membership-acceptor/tests/policy.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, test} from "bun:test"
+
+import type {MembershipRequest} from "../src/detect.js"
+import type {GraphQLClient} from "../src/graphql.js"
+import {composePolicies, editorPolicy, type Policy, type PolicyContext} from "../src/policy.js"
+
+const REQUEST: MembershipRequest = {
+	proposalId: "c3e4f5a6-0000-0000-0000-000000000000",
+	spaceId: "a19c345a-b986-6679-b001-d7d2138d88a1",
+	requesterSpaceId: "1310f810-454c-d482-e35c-e81cb86ca383",
+}
+const ACCEPTOR_SPACE_ID = `0x${"a".repeat(32)}`
+
+/** A GraphQL client whose `query` is stubbed. */
+function graphqlReturning(impl: (query: string) => unknown): GraphQLClient {
+	return {query: async (query: string) => impl(query) as never}
+}
+
+function ctxWith(graphql: GraphQLClient): PolicyContext {
+	return {graphql, acceptorSpaceId: ACCEPTOR_SPACE_ID}
+}
+
+describe("editorPolicy", () => {
+	test("accepts when the editor query returns a record", async () => {
+		const graphql = graphqlReturning(() => ({editor: {memberSpaceId: "a".repeat(32)}}))
+		const decision = await editorPolicy(REQUEST, ctxWith(graphql))
+		expect(decision.accept).toBe(true)
+	})
+
+	test("denies when the editor query returns null", async () => {
+		const graphql = graphqlReturning(() => ({editor: null}))
+		const decision = await editorPolicy(REQUEST, ctxWith(graphql))
+		expect(decision.accept).toBe(false)
+	})
+
+	test("inlines spaceId as-is and the acceptor id with 0x stripped", async () => {
+		let sentQuery = ""
+		const graphql = graphqlReturning((q) => {
+			sentQuery = q
+			return {editor: {memberSpaceId: "x"}}
+		})
+		await editorPolicy(REQUEST, ctxWith(graphql))
+		expect(sentQuery).toContain('spaceId: "a19c345a-b986-6679-b001-d7d2138d88a1"') // dashed, as-is
+		expect(sentQuery).toContain(`memberSpaceId: "${"a".repeat(32)}"`) // 0x stripped
+	})
+
+	test("fails OPEN when the query throws (API error)", async () => {
+		const graphql = graphqlReturning(() => {
+			throw new Error("api down")
+		})
+		const decision = await editorPolicy(REQUEST, ctxWith(graphql))
+		expect(decision.accept).toBe(true)
+		expect(decision.reason).toContain("editor check skipped")
+	})
+})
+
+describe("composePolicies", () => {
+	const accept: Policy = async () => ({accept: true, reason: "yes"})
+
+	test("accepts only when every policy accepts", async () => {
+		const decision = await composePolicies(accept, accept)(REQUEST, ctxWith(graphqlReturning(() => ({}))))
+		expect(decision.accept).toBe(true)
+	})
+
+	test("short-circuits on the first denial", async () => {
+		let secondRan = false
+		const trackingDeny: Policy = async () => {
+			return {accept: false, reason: "first"}
+		}
+		const tracking: Policy = async () => {
+			secondRan = true
+			return {accept: true, reason: "second"}
+		}
+		const decision = await composePolicies(trackingDeny, tracking)(REQUEST, ctxWith(graphqlReturning(() => ({}))))
+		expect(decision).toEqual({accept: false, reason: "first"})
+		expect(secondRan).toBe(false)
+	})
+})

--- a/membership-acceptor/tests/server.test.ts
+++ b/membership-acceptor/tests/server.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, test} from "bun:test"
+import {createHmac} from "node:crypto"
+
+import type {AcceptorConfig} from "../src/config.js"
+import {createApp} from "../src/server.js"
+
+const config: AcceptorConfig = {port: 8080, webhookSecret: "test-secret-0123456789abcdef"}
+const app = createApp(config)
+
+function sign(body: string, secret = config.webhookSecret): string {
+	return "sha256=" + createHmac("sha256", secret).update(Buffer.from(body)).digest("hex")
+}
+
+function webhookRequest(body: string, signature: string | null): Request {
+	const headers: Record<string, string> = {"content-type": "application/json"}
+	if (signature !== null) headers["x-geo-signature"] = signature
+	return new Request("http://localhost:8080/webhooks/geo", {method: "POST", headers, body})
+}
+
+const SAMPLE = JSON.stringify({
+	version: 1,
+	event_type: "proposal_created",
+	category: "governance",
+	space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+	proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
+	idempotency_key: "12345:0:proposal_created:b2c3d4e5",
+})
+
+describe("GET /health", () => {
+	test("returns 200 ok", async () => {
+		const res = await app(new Request("http://localhost:8080/health"))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({status: "ok"})
+	})
+})
+
+describe("POST /webhooks/geo", () => {
+	test("accepts a correctly signed payload", async () => {
+		const res = await app(webhookRequest(SAMPLE, sign(SAMPLE)))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({status: "ok"})
+	})
+
+	test("rejects an invalid signature with 401", async () => {
+		const res = await app(webhookRequest(SAMPLE, sign(SAMPLE, "wrong-secret")))
+		expect(res.status).toBe(401)
+	})
+
+	test("rejects a missing signature with 401", async () => {
+		const res = await app(webhookRequest(SAMPLE, null))
+		expect(res.status).toBe(401)
+	})
+
+	test("rejects a signed-but-non-JSON body with 400", async () => {
+		const body = "not json"
+		const res = await app(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(400)
+	})
+
+	test("rejects a tampered body with 401 (signature no longer matches)", async () => {
+		const signature = sign(SAMPLE)
+		const tampered = SAMPLE.replace("proposal_created", "proposal_executed")
+		const res = await app(webhookRequest(tampered, signature))
+		expect(res.status).toBe(401)
+	})
+})
+
+describe("unknown routes", () => {
+	test("GET / returns 404", async () => {
+		const res = await app(new Request("http://localhost:8080/"))
+		expect(res.status).toBe(404)
+	})
+
+	test("wrong method on /webhooks/geo returns 404", async () => {
+		const res = await app(new Request("http://localhost:8080/webhooks/geo", {method: "GET"}))
+		expect(res.status).toBe(404)
+	})
+})

--- a/membership-acceptor/tests/server.test.ts
+++ b/membership-acceptor/tests/server.test.ts
@@ -63,6 +63,36 @@ describe("POST /webhooks/geo", () => {
 		const res = await app(webhookRequest(tampered, signature))
 		expect(res.status).toBe(401)
 	})
+
+	test("accepts and acks a membership-request payload (M2 detection path)", async () => {
+		const membership = JSON.stringify({
+			version: 1,
+			event_type: "proposal_created",
+			category: "governance",
+			space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+			proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
+			voting_mode: "fast",
+			actions: [{type: "add_member", target_address: "0x1234"}],
+		})
+		const res = await app(webhookRequest(membership, sign(membership)))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({status: "ok"})
+	})
+
+	test("acks a duplicate membership delivery with 200 (deduped, no error)", async () => {
+		const membership = JSON.stringify({
+			event_type: "proposal_created",
+			space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+			proposal_id: "dupe-proposal-id",
+			voting_mode: "fast",
+			actions: [{type: "add_member", target_address: "0x1234"}],
+		})
+		const sig = sign(membership)
+		const first = await app(webhookRequest(membership, sig))
+		const second = await app(webhookRequest(membership, sig))
+		expect(first.status).toBe(200)
+		expect(second.status).toBe(200)
+	})
 })
 
 describe("unknown routes", () => {

--- a/membership-acceptor/tests/server.test.ts
+++ b/membership-acceptor/tests/server.test.ts
@@ -1,13 +1,47 @@
 import {describe, expect, test} from "bun:test"
 import {createHmac} from "node:crypto"
 
-import type {AcceptorConfig} from "../src/config.js"
+import type {AppConfig} from "../src/config.js"
 import {createApp} from "../src/server.js"
+import type {Acceptor, VoteResult} from "../src/vote.js"
 
-const config: AcceptorConfig = {port: 8080, webhookSecret: "test-secret-0123456789abcdef"}
-const app = createApp(config)
+const SECRET = "test-secret-0123456789abcdef"
+const ALLOWED_SPACE = "d4f5a6b7-0000-0000-0000-000000000000"
 
-function sign(body: string, secret = config.webhookSecret): string {
+const baseConfig: AppConfig = {
+	port: 8080,
+	webhookSecret: SECRET,
+	acceptorPrivateKey: `0x${"1".repeat(64)}`,
+	acceptorSpaceId: `0x${"a".repeat(32)}`,
+	spaceRegistryAddress: `0x${"b".repeat(40)}`,
+	rpcUrl: "http://rpc.test",
+	pimlicoApiKey: "pim_test",
+	chainId: 80451,
+	graphqlEndpoint: "https://api.test/graphql",
+	autoacceptSpaceIds: new Set([ALLOWED_SPACE]),
+}
+
+/** A stub acceptor that records vote calls and returns configurable decisions/results. */
+function stubAcceptor(opts: {allows?: (s: string) => boolean; accept?: boolean; result?: VoteResult} = {}) {
+	const calls: string[] = []
+	const evaluated: string[] = []
+	const acceptor: Acceptor = {
+		allowsSpace: opts.allows ?? ((s) => baseConfig.autoacceptSpaceIds.has(s.toLowerCase())),
+		evaluate: async (req) => {
+			evaluated.push(req.proposalId)
+			return opts.accept === false
+				? {accept: false, reason: "denied by test policy"}
+				: {accept: true, reason: "ok"}
+		},
+		vote: async (req) => {
+			calls.push(req.proposalId)
+			return opts.result ?? {kind: "voted", txHash: "0xabc"}
+		},
+	}
+	return {acceptor, calls, evaluated}
+}
+
+function sign(body: string, secret = SECRET): string {
 	return "sha256=" + createHmac("sha256", secret).update(Buffer.from(body)).digest("hex")
 }
 
@@ -17,92 +51,133 @@ function webhookRequest(body: string, signature: string | null): Request {
 	return new Request("http://localhost:8080/webhooks/geo", {method: "POST", headers, body})
 }
 
-const SAMPLE = JSON.stringify({
+const NON_MEMBERSHIP = JSON.stringify({
 	version: 1,
 	event_type: "proposal_created",
 	category: "governance",
-	space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+	space_id: ALLOWED_SPACE,
 	proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
 	idempotency_key: "12345:0:proposal_created:b2c3d4e5",
 })
 
+function membershipBody(proposalId = "c3e4f5a6-0000-0000-0000-000000000000", spaceId = ALLOWED_SPACE): string {
+	return JSON.stringify({
+		event_type: "proposal_created",
+		category: "governance",
+		space_id: spaceId,
+		proposal_id: proposalId,
+		voting_mode: "fast",
+		actions: [{type: "add_member", target_address: "a1b2c3d4-0000-0000-0000-000000000000"}],
+	})
+}
+
 describe("GET /health", () => {
 	test("returns 200 ok", async () => {
-		const res = await app(new Request("http://localhost:8080/health"))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(new Request("http://localhost:8080/health"))
 		expect(res.status).toBe(200)
 		expect(await res.json()).toEqual({status: "ok"})
 	})
 })
 
-describe("POST /webhooks/geo", () => {
-	test("accepts a correctly signed payload", async () => {
-		const res = await app(webhookRequest(SAMPLE, sign(SAMPLE)))
-		expect(res.status).toBe(200)
-		expect(await res.json()).toEqual({status: "ok"})
-	})
-
+describe("POST /webhooks/geo — signature & parsing", () => {
 	test("rejects an invalid signature with 401", async () => {
-		const res = await app(webhookRequest(SAMPLE, sign(SAMPLE, "wrong-secret")))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(NON_MEMBERSHIP, sign(NON_MEMBERSHIP, "wrong")))
 		expect(res.status).toBe(401)
 	})
 
 	test("rejects a missing signature with 401", async () => {
-		const res = await app(webhookRequest(SAMPLE, null))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(NON_MEMBERSHIP, null))
 		expect(res.status).toBe(401)
 	})
 
 	test("rejects a signed-but-non-JSON body with 400", async () => {
-		const body = "not json"
-		const res = await app(webhookRequest(body, sign(body)))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest("not json", sign("not json")))
 		expect(res.status).toBe(400)
 	})
 
-	test("rejects a tampered body with 401 (signature no longer matches)", async () => {
-		const signature = sign(SAMPLE)
-		const tampered = SAMPLE.replace("proposal_created", "proposal_executed")
-		const res = await app(webhookRequest(tampered, signature))
-		expect(res.status).toBe(401)
-	})
-
-	test("accepts and acks a membership-request payload (M2 detection path)", async () => {
-		const membership = JSON.stringify({
-			version: 1,
-			event_type: "proposal_created",
-			category: "governance",
-			space_id: "d4f5a6b7-0000-0000-0000-000000000000",
-			proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
-			voting_mode: "fast",
-			actions: [{type: "add_member", target_address: "0x1234"}],
-		})
-		const res = await app(webhookRequest(membership, sign(membership)))
+	test("acks a non-membership event with 200 and does not vote", async () => {
+		const {acceptor, calls} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(NON_MEMBERSHIP, sign(NON_MEMBERSHIP)))
 		expect(res.status).toBe(200)
-		expect(await res.json()).toEqual({status: "ok"})
+		expect(calls).toHaveLength(0)
+	})
+})
+
+describe("POST /webhooks/geo — membership voting", () => {
+	test("votes once on a valid membership request and acks 200", async () => {
+		const {acceptor, calls} = stubAcceptor()
+		const body = membershipBody()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(200)
+		expect(calls).toEqual(["c3e4f5a6-0000-0000-0000-000000000000"])
 	})
 
-	test("acks a duplicate membership delivery with 200 (deduped, no error)", async () => {
-		const membership = JSON.stringify({
-			event_type: "proposal_created",
-			space_id: "d4f5a6b7-0000-0000-0000-000000000000",
-			proposal_id: "dupe-proposal-id",
-			voting_mode: "fast",
-			actions: [{type: "add_member", target_address: "0x1234"}],
-		})
-		const sig = sign(membership)
-		const first = await app(webhookRequest(membership, sig))
-		const second = await app(webhookRequest(membership, sig))
-		expect(first.status).toBe(200)
-		expect(second.status).toBe(200)
+	test("ignores a request for a space not in the allowlist (no vote)", async () => {
+		const {acceptor, calls} = stubAcceptor()
+		const body = membershipBody("c3e4f5a6-0000-0000-0000-000000000000", "ffffffff-0000-0000-0000-000000000000")
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(200)
+		expect(calls).toHaveLength(0)
+	})
+
+	test("dedupes duplicate deliveries — votes once across N copies", async () => {
+		const {acceptor, calls} = stubAcceptor()
+		const app = createApp(baseConfig, acceptor)
+		const body = membershipBody()
+		const sig = sign(body)
+		await app(webhookRequest(body, sig))
+		await app(webhookRequest(body, sig))
+		await app(webhookRequest(body, sig))
+		expect(calls).toHaveLength(1)
+	})
+
+	test("policy denial acks 200 and does not vote", async () => {
+		const {acceptor, calls, evaluated} = stubAcceptor({accept: false})
+		const body = membershipBody()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(200)
+		expect(evaluated).toHaveLength(1) // policy was consulted
+		expect(calls).toHaveLength(0) // but no vote
+	})
+
+	test("benign on-chain rejection acks 200 (no retry)", async () => {
+		const {acceptor} = stubAcceptor({result: {kind: "benign", message: "already voted"}})
+		const body = membershipBody()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(200)
+	})
+
+	test("infra failure returns 5xx and a retry re-votes (dedupe rolled back)", async () => {
+		const {acceptor, calls} = stubAcceptor({result: {kind: "infra", message: "rpc down"}})
+		const app = createApp(baseConfig, acceptor)
+		const body = membershipBody()
+		const sig = sign(body)
+		const first = await app(webhookRequest(body, sig))
+		const second = await app(webhookRequest(body, sig))
+		expect(first.status).toBe(503)
+		expect(second.status).toBe(503)
+		// Both attempts actually reached the vote (the failed mark was rolled back).
+		expect(calls).toHaveLength(2)
 	})
 })
 
 describe("unknown routes", () => {
 	test("GET / returns 404", async () => {
-		const res = await app(new Request("http://localhost:8080/"))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(new Request("http://localhost:8080/"))
 		expect(res.status).toBe(404)
 	})
 
 	test("wrong method on /webhooks/geo returns 404", async () => {
-		const res = await app(new Request("http://localhost:8080/webhooks/geo", {method: "GET"}))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(
+			baseConfig,
+			acceptor,
+		)(new Request("http://localhost:8080/webhooks/geo", {method: "GET"}))
 		expect(res.status).toBe(404)
 	})
 })

--- a/membership-acceptor/tests/signature.test.ts
+++ b/membership-acceptor/tests/signature.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, test} from "bun:test"
+import {createHmac} from "node:crypto"
+
+import {verifySignature} from "../src/signature.js"
+
+const SECRET = "test-secret-0123456789abcdef"
+
+function sign(body: string, secret = SECRET): string {
+	return "sha256=" + createHmac("sha256", secret).update(Buffer.from(body)).digest("hex")
+}
+
+describe("verifySignature", () => {
+	test("accepts a correctly signed body", () => {
+		const body = JSON.stringify({event_type: "proposal_created"})
+		expect(verifySignature(Buffer.from(body), SECRET, sign(body))).toBe(true)
+	})
+
+	test("rejects a tampered body", () => {
+		const body = JSON.stringify({event_type: "proposal_created"})
+		const signature = sign(body)
+		const tampered = JSON.stringify({event_type: "proposal_executed"})
+		expect(verifySignature(Buffer.from(tampered), SECRET, signature)).toBe(false)
+	})
+
+	test("rejects a signature made with the wrong secret", () => {
+		const body = "payload"
+		expect(verifySignature(Buffer.from(body), SECRET, sign(body, "wrong-secret"))).toBe(false)
+	})
+
+	test("rejects a missing signature header", () => {
+		expect(verifySignature(Buffer.from("payload"), SECRET, null)).toBe(false)
+	})
+
+	test("rejects a header without the sha256= prefix", () => {
+		const raw = createHmac("sha256", SECRET).update(Buffer.from("payload")).digest("hex")
+		expect(verifySignature(Buffer.from("payload"), SECRET, raw)).toBe(false)
+	})
+
+	test("rejects a malformed/short signature without throwing", () => {
+		expect(verifySignature(Buffer.from("payload"), SECRET, "sha256=deadbeef")).toBe(false)
+	})
+
+	test("verifies over raw bytes, not re-serialized JSON (key order preserved)", () => {
+		// Two JSON encodings of the same object with different key order produce
+		// different signatures — the worker signs exact bytes.
+		const sent = '{"b":2,"a":1}'
+		const signature = sign(sent)
+		expect(verifySignature(Buffer.from(sent), SECRET, signature)).toBe(true)
+		expect(verifySignature(Buffer.from('{"a":1,"b":2}'), SECRET, signature)).toBe(false)
+	})
+})

--- a/membership-acceptor/tests/vote.test.ts
+++ b/membership-acceptor/tests/vote.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from "bun:test"
 
+import {toBytes16Hex} from "../src/contracts.js"
 import type {MembershipRequest} from "../src/detect.js"
 import type {GraphQLClient} from "../src/graphql.js"
 import type {Policy} from "../src/policy.js"
@@ -31,7 +32,7 @@ function acceptorWith(send: () => Promise<string>, allowlist = [REQUEST.spaceId]
 		wallet: fakeWallet(send),
 		acceptorSpaceId: `0x${"a".repeat(32)}`,
 		spaceRegistryAddress: `0x${"b".repeat(40)}`,
-		allowlist: new Set(allowlist.map((s) => s.toLowerCase())),
+		allowlist: new Set(allowlist.map(toBytes16Hex)),
 		policy,
 		graphql: noopGraphql,
 	})

--- a/membership-acceptor/tests/vote.test.ts
+++ b/membership-acceptor/tests/vote.test.ts
@@ -1,0 +1,103 @@
+import {describe, expect, test} from "bun:test"
+
+import type {MembershipRequest} from "../src/detect.js"
+import type {GraphQLClient} from "../src/graphql.js"
+import type {Policy} from "../src/policy.js"
+import {createAcceptor} from "../src/vote.js"
+import type {SmartWallet} from "../src/wallet.js"
+
+const noopGraphql: GraphQLClient = {query: async () => ({}) as never}
+const acceptAll: Policy = async () => ({accept: true, reason: "ok"})
+
+const REQUEST: MembershipRequest = {
+	proposalId: "c3e4f5a6-0000-0000-0000-000000000000",
+	spaceId: "d4f5a6b7-0000-0000-0000-000000000000",
+	requesterSpaceId: "a1b2c3d4-0000-0000-0000-000000000000",
+}
+
+/** Build a SmartWallet whose sendTransaction is stubbed by `send`. */
+function fakeWallet(send: () => Promise<string>): SmartWallet {
+	return {
+		// biome-ignore lint/suspicious/noExplicitAny: minimal stub of the smart account client
+		smartAccountClient: {account: {address: "0xacct"}, sendTransaction: send} as any,
+		// biome-ignore lint/suspicious/noExplicitAny: chain shape is irrelevant to the test
+		chain: {id: 80451} as any,
+		safeAddress: "0xsafe",
+	}
+}
+
+function acceptorWith(send: () => Promise<string>, allowlist = [REQUEST.spaceId], policy: Policy = acceptAll) {
+	return createAcceptor({
+		wallet: fakeWallet(send),
+		acceptorSpaceId: `0x${"a".repeat(32)}`,
+		spaceRegistryAddress: `0x${"b".repeat(40)}`,
+		allowlist: new Set(allowlist.map((s) => s.toLowerCase())),
+		policy,
+		graphql: noopGraphql,
+	})
+}
+
+describe("allowsSpace", () => {
+	test("matches allowlisted spaces case-insensitively", () => {
+		const a = acceptorWith(async () => "0x", [REQUEST.spaceId.toUpperCase()])
+		expect(a.allowsSpace(REQUEST.spaceId)).toBe(true)
+		expect(a.allowsSpace("ffffffff-0000-0000-0000-000000000000")).toBe(false)
+	})
+
+	test("empty allowlist allows nothing", () => {
+		const a = acceptorWith(async () => "0x", [])
+		expect(a.allowsSpace(REQUEST.spaceId)).toBe(false)
+	})
+})
+
+describe("evaluate", () => {
+	test("delegates to the configured policy with the acceptor's space id", async () => {
+		let seenMember = ""
+		const policy: Policy = async (_req, ctx) => {
+			seenMember = ctx.acceptorSpaceId
+			return {accept: false, reason: "nope"}
+		}
+		const a = acceptorWith(async () => "0x", [REQUEST.spaceId], policy)
+		const decision = await a.evaluate(REQUEST)
+		expect(decision).toEqual({accept: false, reason: "nope"})
+		expect(seenMember).toBe(`0x${"a".repeat(32)}`)
+	})
+})
+
+describe("vote", () => {
+	test("returns voted with the tx hash on success", async () => {
+		const a = acceptorWith(async () => "0xdeadbeef")
+		const result = await a.vote(REQUEST)
+		expect(result).toEqual({kind: "voted", txHash: "0xdeadbeef"})
+	})
+
+	test("classifies an on-chain revert as benign", async () => {
+		const a = acceptorWith(async () => {
+			const e = new Error("execution reverted: CanNotVote")
+			e.name = "ContractFunctionRevertedError"
+			throw e
+		})
+		const result = await a.vote(REQUEST)
+		expect(result.kind).toBe("benign")
+	})
+
+	test("classifies an RPC/bundler failure as infra", async () => {
+		const a = acceptorWith(async () => {
+			throw new Error("fetch failed: ECONNREFUSED")
+		})
+		const result = await a.vote(REQUEST)
+		expect(result.kind).toBe("infra")
+	})
+
+	test("redacts an apikey leaked in an error message", async () => {
+		const a = acceptorWith(async () => {
+			throw new Error("https://api.pimlico.io/v2/80451/rpc?apikey=pim_secret down")
+		})
+		const result = await a.vote(REQUEST)
+		expect(result.kind).toBe("infra")
+		if (result.kind === "infra") {
+			expect(result.message).toContain("apikey=<redacted>")
+			expect(result.message).not.toContain("pim_secret")
+		}
+	})
+})

--- a/membership-acceptor/tsconfig.json
+++ b/membership-acceptor/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"target": "ES2022",
+		"verbatimModuleSyntax": true,
+		"resolveJsonModule": true,
+		"moduleDetection": "force",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"moduleResolution": "Bundler",
+		"module": "ESNext",
+		"noEmit": true,
+		"lib": ["ES2024"],
+		"types": ["bun"]
+	},
+	"include": ["./**/*"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What

Adds **`membership-acceptor`**, a small long-running service that accepts space membership requests in **real time**. It replaces the ~5-minute `proposal-executor` cron polling for the membership-accept path: instead of polling, it reacts to notification webhooks and casts the approving vote within seconds of a request being created.

```
on-chain PROPOSAL_CREATED
  → hermes-pipeline → Kafka space.governance
  → notification-indexer → delivery-worker → HMAC-signed webhook
  → membership-acceptor  ← this service
      detect → whitelist → dedupe → policy → vote
```

It's structured so it can later be extracted and self-hosted by individual spaces, each running its own acceptor with its own wallet and membership policy.

## How it works

A webhook delivery flows through a cheap → expensive funnel; each gate filters before the next does any work:

1. **Verify** the `X-Geo-Signature` HMAC-SHA256 over the raw body (rejects unsigned/tampered requests with 401).
2. **Detect** a membership request from the payload: `proposal_created`, `voting_mode == "fast"`, exactly one `add_member` action.
3. **Whitelist** — only act on spaces listed in `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` (space ids accepted as `0x` bytes16 or dashed UUID; canonicalized internally). Empty ⇒ accept none (kill switch).
4. **De-duplicate** by `proposal_id` — the notification fan-out delivers one copy per editor of the space, so the same proposal arrives N times. Marking happens before the policy/vote so the copies collapse to a single attempt (and a single policy API call).
5. **Policy** — run an extensible, API-backed policy (see below).
6. **Vote** — cast `SpaceRegistry.enter(PROPOSAL_VOTED, Yes)` from a Pimlico-sponsored Safe smart account. Because fast-path spaces run with a flat threshold of 1, that single YES executes the `AddMember` in the same transaction, admitting the member.

### No on-chain pre-reads (the contract is the authority)

The vote path does **not** read proposal state before voting. A duplicate / closed / already-executed / unauthorized vote simply **reverts** on-chain, which is classified as *benign* (acknowledge, don't retry). Only genuine infrastructure failures are retried. This avoids a check-then-act race: a duplicate that slips past the in-memory dedupe (e.g. a restart) just reverts — no double-admit, only a wasted transaction. The result maps to HTTP so the delivery-worker's retry behaves correctly:

| Outcome | HTTP | Meaning |
|---|---|---|
| voted | 200 | YES landed; member admitted |
| policy denied | 200 | terminal for this proposal; stop delivery |
| benign revert | 200 | nothing to retry |
| infra failure | 503 | roll back the dedupe mark and retry |

> Dedupe is in-memory and per-process, so the deployment runs a single replica; the chain remains the correctness backstop.

### Policy layer

Acceptance rules are pluggable. A `Policy` is `(request, ctx) => { accept, reason }`, where `ctx` provides a GraphQL client so a rule can be backed by API data (reputation, payment, external auth, …). `composePolicies(...)` runs several with AND semantics. The shipped reference policy, **`editorPolicy`**, confirms the acceptor is an editor of the target space (otherwise the vote would revert); it **fails open** so an API hiccup never suppresses a legitimate vote — the chain stays the authority.

## Configuration

Fail-fast validation at startup (`GEO_WEBHOOK_SECRET`, `ACCEPTOR_PRIVATE_KEY`, `ACCEPTOR_SPACE_ID`, `SPACE_REGISTRY_ADDRESS`, `RPC_URL`, `PIMLICO_API_KEY`, `CHAIN_ID`, `GRAPHQL_ENDPOINT`, `MEMBERSHIP_AUTOACCEPT_SPACE_IDS`). Error logs are run through a sanitizer that redacts the bundler API key embedded in the Pimlico URL.

**Operational prerequisite:** the acceptor's smart account (`ACCEPTOR_PRIVATE_KEY` / `ACCEPTOR_SPACE_ID`) must be an **editor** of every allowlisted space, or its votes revert.

## Layout

- `src/server.ts` — HTTP routes + the request pipeline (`createApp` returns a testable fetch handler)
- `src/signature.ts` — `X-Geo-Signature` HMAC verification
- `src/detect.ts` — membership-request detection + `proposal_id` de-duplication
- `src/policy.ts` / `src/graphql.ts` — the policy seam + reference `editorPolicy` + GraphQL client
- `src/vote.ts` / `src/wallet.ts` / `src/contracts.ts` — vote casting, Safe smart-account setup, ABI/encoding/revert classification
- `src/config.ts` — env parsing + validation
- `src/telemetry.ts` — Sentry + structured logging
- `deployment/production/` — k8s Deployment + Service + secret template

## Notes

- It's a plain `Bun.serve` HTTP server (not Effect-TS like `proposal-executor`) — the request path is straightforward async; it keeps the same Sentry/structured-logging conventions.
- The on-chain pieces are reused from `proposal-executor`'s viem implementation rather than the published SDK, whose voting helpers are currently testnet-only.

## Testing

`bun run typecheck`, `bun run lint` (biome), and `bun test` (91 unit tests) all pass — covering signature verification, detection + dedupe/unmark, the GraphQL client error paths, the editor policy (incl. fail-open) and composition, vote classification (incl. API-key redaction), config validation, and the full server pipeline.
