### PR TITLE
feat(api): support returning entities without a value in entities_ordered_by_property

### DIFF
--- a/api/drizzle/0067_support_entities_without_value.sql
+++ b/api/drizzle/0067_support_entities_without_value.sql
@@ -45,6 +45,7 @@ CREATE OR REPLACE FUNCTION public.entities_ordered_by_property(
 )
 RETURNS SETOF entities AS $fn$
 DECLARE
+  types_rel_id  constant uuid := '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1';  -- TYPES relation: links an entity to its type entity
   resolved_type   text;
   sort_expr       text;
   null_pred       text;
@@ -109,7 +110,7 @@ BEGIN
   IF type_ids IS NOT NULL AND cardinality(type_ids) > 0 THEN
     type_pred := format(
       ' AND EXISTS (SELECT 1 FROM relations r WHERE r.from_entity_id = v.entity_id AND r.type_id = %L AND r.to_entity_id = ANY(%L::uuid[]) AND r.space_id = v.space_id)',
-      '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1', type_ids);
+      types_rel_id, type_ids);
   END IF;
 
   -- Value-less entities can only be bounded by the TYPES relation; without type_ids there is
@@ -138,11 +139,9 @@ BEGIN
     END IF;
 
     -- Candidate set for value-less entities: entities of type_ids (within space_ids).
-    -- '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1' is TYPES_RELATION_ID, the system "Types" relation
-    -- that links an entity (from_entity_id) to its type entity (to_entity_id).
     candidate_pred := format(
       'r.type_id = %L AND r.to_entity_id = ANY(%L::uuid[])',
-      '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1', type_ids) || rel_space_pred;
+      types_rel_id, type_ids) || rel_space_pred;
 
     sql :=
          'WITH scored AS ('

--- a/api/drizzle/0067_support_entities_without_value.sql
+++ b/api/drizzle/0067_support_entities_without_value.sql
@@ -59,6 +59,16 @@ DECLARE
   with_unscored   boolean;
   sql             text;
 BEGIN
+  -- include_without_value requires space_ids. The value-less branch enumerates the full
+  -- type population and the whole set is ordered/materialized before PostGraphile applies
+  -- LIMIT/OFFSET (pagination happens outside this function, see 0060), so an unbounded
+  -- (all-spaces) candidate scan could be very large. Requiring space_ids bounds the scan to
+  -- the requested spaces. COALESCE so an explicit NULL flag behaves like false (no guard).
+  IF COALESCE(include_without_value, false) AND (space_ids IS NULL OR cardinality(space_ids) = 0) THEN
+    RAISE EXCEPTION 'space_ids is required when include_without_value is true'
+      USING ERRCODE = '22023';
+  END IF;
+
   IF data_type IS NOT NULL THEN
     resolved_type := lower(data_type);
   ELSE
@@ -128,6 +138,8 @@ BEGIN
     END IF;
 
     -- Candidate set for value-less entities: entities of type_ids (within space_ids).
+    -- '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1' is TYPES_RELATION_ID, the system "Types" relation
+    -- that links an entity (from_entity_id) to its type entity (to_entity_id).
     candidate_pred := format(
       'r.type_id = %L AND r.to_entity_id = ANY(%L::uuid[])',
       '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1', type_ids) || rel_space_pred;

--- a/api/drizzle/0067_support_entities_without_value.sql
+++ b/api/drizzle/0067_support_entities_without_value.sql
@@ -103,8 +103,11 @@ BEGIN
   END IF;
 
   -- Value-less entities can only be bounded by the TYPES relation; without type_ids there is
-  -- no cheap, well-defined candidate set, so fall back to scored-only behavior.
-  with_unscored := include_without_value AND type_ids IS NOT NULL AND cardinality(type_ids) > 0;
+  -- no cheap, well-defined candidate set, so fall back to scored-only behavior. COALESCE guards
+  -- the nullable flag: PostGraphile exposes includeWithoutValue as a nullable Boolean, and a
+  -- NULL must behave like false (NULL AND ... yields NULL, which would otherwise fall through
+  -- the IF NOT below into the unscored branch).
+  with_unscored := COALESCE(include_without_value, false) AND type_ids IS NOT NULL AND cardinality(type_ids) > 0;
 
   IF NOT with_unscored THEN
     -- Backward-compatible path (identical to 0060): only entities WITH a usable value.

--- a/api/drizzle/0067_support_entities_without_value.sql
+++ b/api/drizzle/0067_support_entities_without_value.sql
@@ -1,0 +1,153 @@
+-- Support returning entities WITHOUT a value for the ordered property in
+-- entities_ordered_by_property (and its PostGraphile *Connection field).
+--
+-- Background: the function (see 0060) drives entirely from the "values" table and applies
+-- a per-type NOT NULL / non-empty predicate, so only entities that HAVE a usable value for
+-- `property_id` can ever appear. Entities that match the space/type filters but have no
+-- value for the property were never even candidates (this is the reported bug: a scored
+-- "table view" only returned the handful of entities that happened to have a score).
+--
+-- This adds an opt-in `include_without_value` parameter (default false, so existing queries
+-- are byte-for-byte unchanged — same SQL, same plan). When true, entities of `type_ids`
+-- within `space_ids` that have no usable value for the property are unioned in with a NULL
+-- sort value.
+--
+-- Ordering of the value-less entities (per product guidance: "scores can be negative, so
+-- null should be considered the same as zero"):
+--   * numeric data types (integer/float/decimal): the NULL sort value is ordered as 0 via
+--     COALESCE(sort_value, 0). DESC => positives -> zero/null -> negatives; ASC the reverse.
+--     Entities with a literal 0 and value-less entities sort together, which is intended.
+--   * non-numeric types (text/date/time/datetime/boolean/point): "zero" is undefined, so
+--     value-less entities are ordered last (NULLS LAST) in both ASC and DESC.
+--
+-- The value-less candidate set is anchored on the TYPES relation
+-- (8f151ba4-de20-4e3c-9cb4-99ddf96f48f1) because entities carry no space/type column of
+-- their own. `include_without_value` therefore requires `type_ids`; when it is true but no
+-- type_ids are supplied the function falls back to scored-only (backward-compatible) output.
+--
+-- Note: an entity whose only value fails the null/non-empty predicate (e.g. empty text, or
+-- a row with a NULL typed column) is treated as value-less and surfaces via the unscored
+-- branch, which matches the "no usable value" intent.
+
+DROP FUNCTION IF EXISTS public.entities_ordered_by_property(uuid, uuid[], sort_order, text);
+--> statement-breakpoint
+DROP FUNCTION IF EXISTS public.entities_ordered_by_property(uuid, uuid[], sort_order, text, uuid);
+--> statement-breakpoint
+DROP FUNCTION IF EXISTS public.entities_ordered_by_property(uuid, uuid[], sort_order, text, uuid[]);
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION public.entities_ordered_by_property(
+  property_id uuid,
+  space_ids uuid[] DEFAULT NULL,
+  sort_direction sort_order DEFAULT 'ASC',
+  data_type text DEFAULT NULL,
+  type_ids uuid[] DEFAULT NULL,
+  include_without_value boolean DEFAULT false
+)
+RETURNS SETOF entities AS $fn$
+DECLARE
+  resolved_type   text;
+  sort_expr       text;
+  null_pred       text;
+  null_cast       text;
+  is_numeric      boolean := false;
+  dir             text;
+  space_pred      text := '';
+  type_pred       text := '';
+  rel_space_pred  text := '';
+  candidate_pred  text;
+  order_expr      text;
+  with_unscored   boolean;
+  sql             text;
+BEGIN
+  IF data_type IS NOT NULL THEN
+    resolved_type := lower(data_type);
+  ELSE
+    SELECT lower(v."text")
+      INTO resolved_type
+      FROM relations r
+      JOIN "values" v ON v.entity_id = r.to_entity_id
+     WHERE r.from_entity_id = entities_ordered_by_property.property_id
+       AND r.type_id    = '6d29d578-49bb-4959-baf7-2cc696b1671a'
+       AND v.property_id = 'a126ca53-0c8e-48d5-b888-82c734c38935'
+     ORDER BY r.id
+     LIMIT 1;
+  END IF;
+
+  -- null_cast is the SQL type of sort_expr; the value-less branch selects NULL::null_cast so
+  -- the UNION ALL with the scored branch has matching column types.
+  CASE resolved_type
+    WHEN 'text'     THEN sort_expr := 'left(v."text", 1024)'; null_pred := 'v."text" IS NOT NULL AND length(btrim(v."text")) > 0'; null_cast := 'text';
+    WHEN 'integer'  THEN sort_expr := 'v.integer';            null_pred := 'v.integer IS NOT NULL'; is_numeric := true; null_cast := 'bigint';
+    WHEN 'float'    THEN sort_expr := 'v.float';              null_pred := 'v.float IS NOT NULL'; is_numeric := true; null_cast := 'double precision';
+    WHEN 'decimal'  THEN sort_expr := 'v."decimal"';          null_pred := 'v."decimal" IS NOT NULL'; is_numeric := true; null_cast := 'numeric';
+    WHEN 'boolean'  THEN sort_expr := 'v.boolean';            null_pred := 'v.boolean IS NOT NULL'; null_cast := 'boolean';
+    WHEN 'date'     THEN sort_expr := 'v.date';               null_pred := 'v.date IS NOT NULL AND length(btrim(v.date)) > 0'; null_cast := 'text';
+    WHEN 'time'     THEN sort_expr := 'v."time"';             null_pred := 'v."time" IS NOT NULL AND length(btrim(v."time")) > 0'; null_cast := 'text';
+    WHEN 'datetime' THEN sort_expr := 'v.datetime';           null_pred := 'v.datetime IS NOT NULL AND length(btrim(v.datetime)) > 0'; null_cast := 'text';
+    WHEN 'point'    THEN sort_expr := 'v.point';              null_pred := 'v.point IS NOT NULL AND length(btrim(v.point)) > 0'; null_cast := 'text';
+    ELSE
+      RETURN;
+  END CASE;
+
+  dir := CASE WHEN sort_direction::text = 'DESC' THEN 'DESC' ELSE 'ASC' END;
+
+  IF space_ids IS NOT NULL AND cardinality(space_ids) > 0 THEN
+    space_pred     := format(' AND v.space_id = ANY(%L::uuid[])', space_ids);
+    rel_space_pred := format(' AND r.space_id = ANY(%L::uuid[])', space_ids);
+  END IF;
+
+  IF type_ids IS NOT NULL AND cardinality(type_ids) > 0 THEN
+    type_pred := format(
+      ' AND EXISTS (SELECT 1 FROM relations r WHERE r.from_entity_id = v.entity_id AND r.type_id = %L AND r.to_entity_id = ANY(%L::uuid[]) AND r.space_id = v.space_id)',
+      '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1', type_ids);
+  END IF;
+
+  -- Value-less entities can only be bounded by the TYPES relation; without type_ids there is
+  -- no cheap, well-defined candidate set, so fall back to scored-only behavior.
+  with_unscored := include_without_value AND type_ids IS NOT NULL AND cardinality(type_ids) > 0;
+
+  IF NOT with_unscored THEN
+    -- Backward-compatible path (identical to 0060): only entities WITH a usable value.
+    sql :=
+         'SELECT e.* FROM ('
+      || '  SELECT DISTINCT ON (v.entity_id) v.entity_id, ' || sort_expr || ' AS sort_value'
+      || '  FROM "values" v'
+      || '  WHERE v.property_id = ' || quote_nullable(property_id) || ' AND ' || null_pred || space_pred || type_pred
+      || '  ORDER BY v.entity_id, ' || sort_expr || ' ' || dir
+      || ') sub JOIN entities e ON e.id = sub.entity_id'
+      || ' ORDER BY sub.sort_value ' || dir || ', e.id';
+  ELSE
+    -- Null sorts as zero for numeric types; otherwise null sorts last in both directions.
+    IF is_numeric THEN
+      order_expr := 'COALESCE(sub.sort_value, 0) ' || dir;
+    ELSE
+      order_expr := 'sub.sort_value ' || dir || ' NULLS LAST';
+    END IF;
+
+    -- Candidate set for value-less entities: entities of type_ids (within space_ids).
+    candidate_pred := format(
+      'r.type_id = %L AND r.to_entity_id = ANY(%L::uuid[])',
+      '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1', type_ids) || rel_space_pred;
+
+    sql :=
+         'WITH scored AS ('
+      || '  SELECT DISTINCT ON (v.entity_id) v.entity_id, ' || sort_expr || ' AS sort_value'
+      || '  FROM "values" v'
+      || '  WHERE v.property_id = ' || quote_nullable(property_id) || ' AND ' || null_pred || space_pred || type_pred
+      || '  ORDER BY v.entity_id, ' || sort_expr || ' ' || dir
+      || '), candidates AS ('
+      || '  SELECT DISTINCT r.from_entity_id AS entity_id FROM relations r WHERE ' || candidate_pred
+      || '), unscored AS ('
+      || '  SELECT c.entity_id, NULL::' || null_cast || ' AS sort_value FROM candidates c'
+      || '  WHERE NOT EXISTS (SELECT 1 FROM scored s WHERE s.entity_id = c.entity_id)'
+      || ') SELECT e.* FROM ('
+      || '  SELECT entity_id, sort_value FROM scored'
+      || '  UNION ALL'
+      || '  SELECT entity_id, sort_value FROM unscored'
+      || ') sub JOIN entities e ON e.id = sub.entity_id'
+      || ' ORDER BY ' || order_expr || ', e.id';
+  END IF;
+
+  RETURN QUERY EXECUTE sql;
+END;
+$fn$ LANGUAGE plpgsql STABLE;

--- a/api/drizzle/meta/0067_snapshot.json
+++ b/api/drizzle/meta/0067_snapshot.json
@@ -1,0 +1,3916 @@
+{
+  "id": "ccaead3e-802e-4c73-b2d0-fbf98886b4be",
+  "prevId": "e856074b-f116-485a-8e89-6cfe0c5143a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_types": {
+          "name": "notification_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_ids": {
+          "name": "space_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "columns": [
+            "app_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "columns": [
+            "block_number",
+            "sequence"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "columns": [
+            "uri"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "tableTo": "notification_outbox",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "tableTo": "app_webhooks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_poll_cursors": {
+      "name": "notification_poll_cursors",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor_updated_at": {
+          "name": "cursor_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "tableTo": "proposals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_blocks": {
+      "name": "ranking_blocks",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restriction_id": {
+          "name": "restriction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_blocks_id_space_id_pk": {
+          "name": "ranking_blocks_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_items": {
+      "name": "ranking_items",
+      "schema": "ranks",
+      "columns": {
+        "ranking_id": {
+          "name": "ranking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_items_ranking_id_entity_id_space_id_pk": {
+          "name": "ranking_items_ranking_id_entity_id_space_id_pk",
+          "columns": [
+            "ranking_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_scores": {
+      "name": "ranking_scores",
+      "schema": "ranks",
+      "columns": {
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranking_scores_block_position_idx": {
+          "name": "ranking_scores_block_position_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_scores_block_id_entity_id_space_id_pk": {
+          "name": "ranking_scores_block_id_entity_id_space_id_pk",
+          "columns": [
+            "block_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.rankings": {
+      "name": "rankings",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank_type": {
+          "name": "rank_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "update_index": {
+          "name": "update_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rankings_block_id_idx": {
+          "name": "rankings_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rankings_block_space_idx": {
+          "name": "rankings_block_space_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rankings_space_id_idx": {
+          "name": "rankings_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rankings_id_space_id_pk": {
+          "name": "rankings_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.editors": {
+      "name": "editors",
+      "schema": "ranks",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranks_editors_space_id_idx": {
+          "name": "ranks_editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.members": {
+      "name": "members",
+      "schema": "ranks",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranks_members_space_id_idx": {
+          "name": "ranks_members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_last_to_entity_id": {
+          "name": "context_last_to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relation_versions_blocks_to_entity_idx": {
+          "name": "relation_versions_blocks_to_entity_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"relation_versions\".\"type_id\" = 'beaba5cb-a677-41a8-b353-77030613fc70'::uuid",
+          "concurrently": false
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false
+        },
+        "relation_versions_context_root_idx": {
+          "name": "relation_versions_context_root_idx",
+          "columns": [
+            {
+              "expression": "context_root_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"relation_versions\".\"context_root_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "tableTo": "entities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "tableTo": "entities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "tableTo": "spaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_last_to_entity_id": {
+          "name": "context_last_to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false
+        },
+        "value_versions_context_root_idx": {
+          "name": "value_versions_context_root_idx",
+          "columns": [
+            {
+              "expression": "context_root_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"value_versions\".\"context_root_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_count_updated_at": {
+          "name": "idx_votes_count_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "object_type = 0",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {
+    "ranks": "ranks"
+  },
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1782337116842,
       "tag": "0066_tiresome_mister_fear",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1782497674043,
+      "tag": "0067_support_entities_without_value",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/kg/__tests__/entitiesOrderedByPropertyWithoutValue.test.ts
+++ b/api/src/kg/__tests__/entitiesOrderedByPropertyWithoutValue.test.ts
@@ -1,0 +1,228 @@
+import {Pool} from "pg"
+import {afterAll, beforeAll, describe, expect, it} from "vitest"
+import {graphqlServer} from "../postgraphile"
+
+// entities_ordered_by_property must be able to return entities that match the
+// space/type filters but have NO usable value for the ordered property, via the opt-in
+// `includeWithoutValue` flag. Per product guidance, for numeric properties a missing value
+// is treated as zero (DESC: positives -> zero/null -> negatives; ASC the reverse); without
+// the flag the prior behavior (value-less entities excluded) is preserved.
+
+async function executeGraphQL(query: string, variables?: Record<string, unknown>) {
+	const response = await graphqlServer.fetch(
+		new Request("http://localhost/graphql", {
+			method: "POST",
+			headers: {"Content-Type": "application/json"},
+			body: JSON.stringify({query, variables}),
+		}),
+		{},
+	)
+	return response.json()
+}
+
+const undash = (uuid: string) => uuid.replace(/-/g, "")
+
+const TYPES_RELATION_ID = "8f151ba4-de20-4e3c-9cb4-99ddf96f48f1"
+
+// Well-known fixture UUIDs, chosen so they can't collide with real data and so the
+// entity ids sort in a known order (the function tie-breaks ties on e.id ASC).
+const SPACE = "00000000-cccc-4ccc-cccc-000000000001"
+const TYPE_ID = "00000000-cccc-4ccc-cccc-0000000000aa"
+const PROPERTY_ID = "00000000-cccc-4ccc-cccc-0000000000bb"
+
+// integer = 100
+const E_POS = "00000000-dddd-4ddd-dddd-000000000001"
+// integer = 0
+const E_ZERO = "00000000-dddd-4ddd-dddd-000000000002"
+// integer = -50
+const E_NEG = "00000000-dddd-4ddd-dddd-000000000003"
+// no value row for PROPERTY_ID
+const E_NOVAL_1 = "00000000-dddd-4ddd-dddd-000000000004"
+const E_NOVAL_2 = "00000000-dddd-4ddd-dddd-000000000005"
+
+const ALL_ENTITY_IDS = [E_POS, E_ZERO, E_NEG, E_NOVAL_1, E_NOVAL_2]
+
+// Relation rows are themselves entities; give each its own id (= the subject entity id
+// here is fine since we only key cleanup off from_entity_id / entity_id).
+const REL_IDS = [
+	"00000000-eeee-4eee-eeee-000000000001",
+	"00000000-eeee-4eee-eeee-000000000002",
+	"00000000-eeee-4eee-eeee-000000000003",
+	"00000000-eeee-4eee-eeee-000000000004",
+	"00000000-eeee-4eee-eeee-000000000005",
+]
+
+async function cleanupFixtures(pool: Pool) {
+	await pool.query(`DELETE FROM "values" WHERE entity_id = ANY($1::uuid[])`, [ALL_ENTITY_IDS])
+	await pool.query(`DELETE FROM relations WHERE from_entity_id = ANY($1::uuid[]) OR id = ANY($2::uuid[])`, [
+		ALL_ENTITY_IDS,
+		REL_IDS,
+	])
+	await pool.query(`DELETE FROM entities WHERE id = ANY($1::uuid[])`, [ALL_ENTITY_IDS])
+}
+
+async function seedFixtures(pool: Pool) {
+	await pool.query(
+		`INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block)
+		 SELECT unnest($1::uuid[]), '0', '0', '0', '0'`,
+		[ALL_ENTITY_IDS],
+	)
+
+	// All five entities are of TYPE_ID in SPACE via a TYPES relation. This is what makes
+	// the value-less entities discoverable when includeWithoutValue is true.
+	await pool.query(
+		`INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id)
+		 SELECT unnest($1::uuid[]), unnest($2::uuid[]), $3, unnest($2::uuid[]), $4, $5`,
+		[REL_IDS, ALL_ENTITY_IDS, TYPES_RELATION_ID, TYPE_ID, SPACE],
+	)
+
+	// Integer values for three of the five entities: positive, zero, negative.
+	await pool.query(
+		`INSERT INTO "values" (id, property_id, entity_id, space_id, integer) VALUES
+			($1, $4, $5, $6, 100),
+			($2, $4, $7, $6, 0),
+			($3, $4, $8, $6, -50)`,
+		[`geo696-${E_POS}`, `geo696-${E_ZERO}`, `geo696-${E_NEG}`, PROPERTY_ID, E_POS, SPACE, E_ZERO, E_NEG],
+	)
+}
+
+const ORDER_QUERY = `
+	query Q($propertyId: UUID!, $spaceIds: [UUID!], $typeIds: [UUID!], $dir: SortOrder!, $include: Boolean) {
+		entitiesOrderedByProperty(
+			propertyId: $propertyId
+			spaceIds: $spaceIds
+			typeIds: $typeIds
+			dataType: "integer"
+			sortDirection: $dir
+			includeWithoutValue: $include
+			first: 50
+		) {
+			id
+		}
+	}
+`
+
+function idsOf(result: {data?: {entitiesOrderedByProperty?: Array<{id: string}>}}): string[] {
+	return (result.data?.entitiesOrderedByProperty ?? []).map((e) => e.id)
+}
+
+const baseVars = {
+	propertyId: undash(PROPERTY_ID),
+	spaceIds: [undash(SPACE)],
+	typeIds: [undash(TYPE_ID)],
+}
+
+describe("entitiesOrderedByProperty — include entities without a value", () => {
+	let pool: Pool
+
+	beforeAll(async () => {
+		pool = new Pool({connectionString: process.env.DATABASE_URL})
+		// Idempotent cleanup in case a prior run aborted between seed and teardown.
+		await cleanupFixtures(pool)
+		await seedFixtures(pool)
+	})
+
+	afterAll(async () => {
+		if (pool) {
+			await cleanupFixtures(pool)
+			await pool.end()
+		}
+	})
+
+	it("exposes includeWithoutValue as a Boolean argument on both fields", async () => {
+		const result = await executeGraphQL(`
+			{
+				__type(name: "Query") {
+					fields { name args { name type { name kind ofType { name } } } }
+				}
+			}
+		`)
+		expect(result.errors).toBeUndefined()
+
+		for (const fieldName of ["entitiesOrderedByProperty", "entitiesOrderedByPropertyConnection"]) {
+			const field = result.data.__type.fields.find((f: {name: string}) => f.name === fieldName)
+			expect(field, `${fieldName} should exist`).toBeDefined()
+			const arg = field.args.find((a: {name: string}) => a.name === "includeWithoutValue")
+			expect(arg, `${fieldName}.includeWithoutValue should exist`).toBeDefined()
+			const typeName = arg.type.name ?? arg.type.ofType?.name
+			expect(typeName).toBe("Boolean")
+		}
+	})
+
+	it("excludes value-less entities by default (preserves prior behavior)", async () => {
+		const result = await executeGraphQL(ORDER_QUERY, {...baseVars, dir: "DESC", include: false})
+		expect(result.errors).toBeUndefined()
+		const ids = idsOf(result)
+		// Only the three entities that have an integer value, ordered DESC: 100, 0, -50.
+		expect(ids).toEqual([undash(E_POS), undash(E_ZERO), undash(E_NEG)])
+		expect(ids).not.toContain(undash(E_NOVAL_1))
+		expect(ids).not.toContain(undash(E_NOVAL_2))
+	})
+
+	it("omitting includeWithoutValue behaves the same as false", async () => {
+		const result = await executeGraphQL(
+			`
+				query Q($propertyId: UUID!, $spaceIds: [UUID!], $typeIds: [UUID!]) {
+					entitiesOrderedByProperty(
+						propertyId: $propertyId
+						spaceIds: $spaceIds
+						typeIds: $typeIds
+						dataType: "integer"
+						sortDirection: DESC
+						first: 50
+					) { id }
+				}
+			`,
+			baseVars,
+		)
+		expect(result.errors).toBeUndefined()
+		expect(idsOf(result)).toEqual([undash(E_POS), undash(E_ZERO), undash(E_NEG)])
+	})
+
+	it("DESC: includes value-less entities at the zero position (positives -> zero/null -> negatives)", async () => {
+		const result = await executeGraphQL(ORDER_QUERY, {...baseVars, dir: "DESC", include: true})
+		expect(result.errors).toBeUndefined()
+		// 100 first; then the zero group {E_ZERO, E_NOVAL_1, E_NOVAL_2} ordered by id ASC
+		// (null treated as zero); then -50 last.
+		expect(idsOf(result)).toEqual([
+			undash(E_POS),
+			undash(E_ZERO),
+			undash(E_NOVAL_1),
+			undash(E_NOVAL_2),
+			undash(E_NEG),
+		])
+	})
+
+	it("ASC: includes value-less entities at the zero position (negatives -> zero/null -> positives)", async () => {
+		const result = await executeGraphQL(ORDER_QUERY, {...baseVars, dir: "ASC", include: true})
+		expect(result.errors).toBeUndefined()
+		expect(idsOf(result)).toEqual([
+			undash(E_NEG),
+			undash(E_ZERO),
+			undash(E_NOVAL_1),
+			undash(E_NOVAL_2),
+			undash(E_POS),
+		])
+	})
+
+	it("falls back to scored-only when includeWithoutValue is true but no typeIds are given", async () => {
+		const result = await executeGraphQL(
+			`
+				query Q($propertyId: UUID!, $spaceIds: [UUID!]) {
+					entitiesOrderedByProperty(
+						propertyId: $propertyId
+						spaceIds: $spaceIds
+						dataType: "integer"
+						sortDirection: DESC
+						includeWithoutValue: true
+						first: 50
+					) { id }
+				}
+			`,
+			{propertyId: undash(PROPERTY_ID), spaceIds: [undash(SPACE)]},
+		)
+		expect(result.errors).toBeUndefined()
+		const ids = idsOf(result)
+		expect(ids).toEqual([undash(E_POS), undash(E_ZERO), undash(E_NEG)])
+	})
+})

--- a/api/src/kg/__tests__/entitiesOrderedByPropertyWithoutValue.test.ts
+++ b/api/src/kg/__tests__/entitiesOrderedByPropertyWithoutValue.test.ts
@@ -29,6 +29,9 @@ const TYPES_RELATION_ID = "8f151ba4-de20-4e3c-9cb4-99ddf96f48f1"
 const SPACE = "00000000-cccc-4ccc-cccc-000000000001"
 const TYPE_ID = "00000000-cccc-4ccc-cccc-0000000000aa"
 const PROPERTY_ID = "00000000-cccc-4ccc-cccc-0000000000bb"
+// Separate properties to exercise the non-numeric (text) and other-numeric (float) branches.
+const PROPERTY_TEXT = "00000000-cccc-4ccc-cccc-0000000000cc"
+const PROPERTY_FLOAT = "00000000-cccc-4ccc-cccc-0000000000dd"
 
 // integer = 100
 const E_POS = "00000000-dddd-4ddd-dddd-000000000001"
@@ -84,6 +87,42 @@ async function seedFixtures(pool: Pool) {
 			($3, $4, $8, $6, -50)`,
 		[`geo696-${E_POS}`, `geo696-${E_ZERO}`, `geo696-${E_NEG}`, PROPERTY_ID, E_POS, SPACE, E_ZERO, E_NEG],
 	)
+
+	// Text values on a separate property — non-numeric, so value-less entities sort NULLS LAST.
+	await pool.query(
+		`INSERT INTO "values" (id, property_id, entity_id, space_id, text) VALUES
+			($1, $4, $5, $7, 'banana'),
+			($2, $4, $6, $7, 'apple'),
+			($3, $4, $8, $7, 'cherry')`,
+		[
+			`geo696-text-${E_POS}`,
+			`geo696-text-${E_ZERO}`,
+			`geo696-text-${E_NEG}`,
+			PROPERTY_TEXT,
+			E_POS,
+			E_ZERO,
+			SPACE,
+			E_NEG,
+		],
+	)
+
+	// Float values on a separate property — numeric, so a missing value sorts as zero.
+	await pool.query(
+		`INSERT INTO "values" (id, property_id, entity_id, space_id, float) VALUES
+			($1, $4, $5, $7, 2.5),
+			($2, $4, $6, $7, 0),
+			($3, $4, $8, $7, -1.5)`,
+		[
+			`geo696-float-${E_POS}`,
+			`geo696-float-${E_ZERO}`,
+			`geo696-float-${E_NEG}`,
+			PROPERTY_FLOAT,
+			E_POS,
+			E_ZERO,
+			SPACE,
+			E_NEG,
+		],
+	)
 }
 
 const ORDER_QUERY = `
@@ -93,6 +132,23 @@ const ORDER_QUERY = `
 			spaceIds: $spaceIds
 			typeIds: $typeIds
 			dataType: "integer"
+			sortDirection: $dir
+			includeWithoutValue: $include
+			first: 50
+		) {
+			id
+		}
+	}
+`
+
+// Same as ORDER_QUERY but with a parameterized dataType, for the text/float cases.
+const ORDER_QUERY_DT = `
+	query Q($propertyId: UUID!, $spaceIds: [UUID!], $typeIds: [UUID!], $dataType: String!, $dir: SortOrder!, $include: Boolean) {
+		entitiesOrderedByProperty(
+			propertyId: $propertyId
+			spaceIds: $spaceIds
+			typeIds: $typeIds
+			dataType: $dataType
 			sortDirection: $dir
 			includeWithoutValue: $include
 			first: 50
@@ -235,5 +291,158 @@ describe("entitiesOrderedByProperty — include entities without a value", () =>
 		expect(result.errors).toBeUndefined()
 		const ids = idsOf(result)
 		expect(ids).toEqual([undash(E_POS), undash(E_ZERO), undash(E_NEG)])
+	})
+
+	it("text (non-numeric): value-less entities sort to the tail via NULLS LAST, DESC", async () => {
+		const result = await executeGraphQL(ORDER_QUERY_DT, {
+			propertyId: undash(PROPERTY_TEXT),
+			spaceIds: [undash(SPACE)],
+			typeIds: [undash(TYPE_ID)],
+			dataType: "text",
+			dir: "DESC",
+			include: true,
+		})
+		expect(result.errors).toBeUndefined()
+		// DESC: cherry > banana > apple, then value-less entities last (NULLS LAST).
+		expect(idsOf(result)).toEqual([
+			undash(E_NEG),
+			undash(E_POS),
+			undash(E_ZERO),
+			undash(E_NOVAL_1),
+			undash(E_NOVAL_2),
+		])
+	})
+
+	it("text (non-numeric): value-less entities sort to the tail via NULLS LAST, ASC", async () => {
+		const result = await executeGraphQL(ORDER_QUERY_DT, {
+			propertyId: undash(PROPERTY_TEXT),
+			spaceIds: [undash(SPACE)],
+			typeIds: [undash(TYPE_ID)],
+			dataType: "text",
+			dir: "ASC",
+			include: true,
+		})
+		expect(result.errors).toBeUndefined()
+		// ASC: apple < banana < cherry, then value-less last (NULLS LAST in both directions).
+		expect(idsOf(result)).toEqual([
+			undash(E_ZERO),
+			undash(E_POS),
+			undash(E_NEG),
+			undash(E_NOVAL_1),
+			undash(E_NOVAL_2),
+		])
+	})
+
+	it("float (numeric): a missing value sorts as zero, DESC", async () => {
+		const result = await executeGraphQL(ORDER_QUERY_DT, {
+			propertyId: undash(PROPERTY_FLOAT),
+			spaceIds: [undash(SPACE)],
+			typeIds: [undash(TYPE_ID)],
+			dataType: "float",
+			dir: "DESC",
+			include: true,
+		})
+		expect(result.errors).toBeUndefined()
+		// 2.5 first; then the zero group {0, value-less} by id; then -1.5.
+		expect(idsOf(result)).toEqual([
+			undash(E_POS),
+			undash(E_ZERO),
+			undash(E_NOVAL_1),
+			undash(E_NOVAL_2),
+			undash(E_NEG),
+		])
+	})
+
+	it("raises when includeWithoutValue is true but no spaceIds are given", async () => {
+		const result = await executeGraphQL(
+			`
+				query Q($propertyId: UUID!, $typeIds: [UUID!]) {
+					entitiesOrderedByProperty(
+						propertyId: $propertyId
+						typeIds: $typeIds
+						dataType: "integer"
+						sortDirection: DESC
+						includeWithoutValue: true
+						first: 50
+					) { id }
+				}
+			`,
+			{propertyId: undash(PROPERTY_ID), typeIds: [undash(TYPE_ID)]},
+		)
+		// space_ids is mandatory when includeWithoutValue is true (bounds the candidate scan).
+		expect(result.errors).toBeDefined()
+		expect(result.data?.entitiesOrderedByProperty ?? null).toBeFalsy()
+	})
+})
+
+// An entity is "scored" only when its value and its TYPES relation live in the SAME space.
+// An entity valued in one space but typed in another is therefore not scored in any single
+// space and is intentionally treated as value-less (sorts at the zero position). Isolated
+// fixtures (distinct UUIDs) so this multi-space layout can't perturb the single-space suite.
+const MS_SPACE_A = "00000000-c2cc-4ccc-cccc-00000000000a"
+const MS_SPACE_B = "00000000-c2cc-4ccc-cccc-00000000000b"
+const MS_TYPE = "00000000-c2cc-4ccc-cccc-0000000000aa"
+const MS_PROP = "00000000-c2cc-4ccc-cccc-0000000000bb"
+const MS_HI = "00000000-c2dd-4ddd-dddd-000000000001" // integer 50, typed + valued in SPACE_A
+const MS_CROSS = "00000000-c2dd-4ddd-dddd-000000000002" // integer 999 in SPACE_A, typed in SPACE_B
+const MS_LO = "00000000-c2dd-4ddd-dddd-000000000003" // integer -50, typed + valued in SPACE_A
+const MS_ENTITY_IDS = [MS_HI, MS_CROSS, MS_LO]
+
+async function cleanupMs(pool: Pool) {
+	await pool.query(`DELETE FROM "values" WHERE entity_id = ANY($1::uuid[])`, [MS_ENTITY_IDS])
+	await pool.query(`DELETE FROM relations WHERE from_entity_id = ANY($1::uuid[])`, [MS_ENTITY_IDS])
+	await pool.query(`DELETE FROM entities WHERE id = ANY($1::uuid[])`, [MS_ENTITY_IDS])
+}
+
+describe("entitiesOrderedByProperty — multi-space scoping", () => {
+	let pool: Pool
+
+	beforeAll(async () => {
+		pool = new Pool({connectionString: process.env.DATABASE_URL})
+		await cleanupMs(pool)
+		await pool.query(
+			`INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block)
+			 SELECT unnest($1::uuid[]), '0', '0', '0', '0'`,
+			[MS_ENTITY_IDS],
+		)
+		// MS_HI / MS_LO are typed in SPACE_A; MS_CROSS is typed in SPACE_B.
+		await pool.query(
+			`INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) VALUES
+				($1, $1, $4, $1, $5, $6),
+				($2, $2, $4, $2, $5, $7),
+				($3, $3, $4, $3, $5, $6)`,
+			[MS_HI, MS_CROSS, MS_LO, TYPES_RELATION_ID, MS_TYPE, MS_SPACE_A, MS_SPACE_B],
+		)
+		// All three carry their integer value in SPACE_A.
+		await pool.query(
+			`INSERT INTO "values" (id, property_id, entity_id, space_id, integer) VALUES
+				($1, $4, $5, $6, 50),
+				($2, $4, $7, $6, 999),
+				($3, $4, $8, $6, -50)`,
+			["geo696-ms-hi", "geo696-ms-cross", "geo696-ms-lo", MS_PROP, MS_HI, MS_SPACE_A, MS_CROSS, MS_LO],
+		)
+	})
+
+	afterAll(async () => {
+		if (pool) {
+			await cleanupMs(pool)
+			await pool.end()
+		}
+	})
+
+	it("treats an entity valued in one space but typed in another as value-less (sorts at zero)", async () => {
+		const result = await executeGraphQL(ORDER_QUERY_DT, {
+			propertyId: undash(MS_PROP),
+			spaceIds: [undash(MS_SPACE_A), undash(MS_SPACE_B)],
+			typeIds: [undash(MS_TYPE)],
+			dataType: "integer",
+			dir: "DESC",
+			include: true,
+		})
+		expect(result.errors).toBeUndefined()
+		// MS_HI (50) is scored. MS_CROSS holds integer 999 in SPACE_A but its TYPES relation is
+		// in SPACE_B, so it is not scored in any single space and sorts at zero — above MS_LO
+		// (-50) and below MS_HI — despite its value.
+		expect(idsOf(result)).toEqual([undash(MS_HI), undash(MS_CROSS), undash(MS_LO)])
 	})
 })

--- a/api/src/kg/__tests__/entitiesOrderedByPropertyWithoutValue.test.ts
+++ b/api/src/kg/__tests__/entitiesOrderedByPropertyWithoutValue.test.ts
@@ -205,6 +205,17 @@ describe("entitiesOrderedByProperty — include entities without a value", () =>
 		])
 	})
 
+	it("treats an explicit includeWithoutValue: null the same as false (excludes value-less)", async () => {
+		// PostGraphile exposes includeWithoutValue as a nullable Boolean, so a client can pass
+		// null explicitly. With typeIds present, null must NOT opt into the unscored branch.
+		const result = await executeGraphQL(ORDER_QUERY, {...baseVars, dir: "DESC", include: null})
+		expect(result.errors).toBeUndefined()
+		const ids = idsOf(result)
+		expect(ids).toEqual([undash(E_POS), undash(E_ZERO), undash(E_NEG)])
+		expect(ids).not.toContain(undash(E_NOVAL_1))
+		expect(ids).not.toContain(undash(E_NOVAL_2))
+	})
+
 	it("falls back to scored-only when includeWithoutValue is true but no typeIds are given", async () => {
 		const result = await executeGraphQL(
 			`


### PR DESCRIPTION
## Summary

`entitiesOrderedByPropertyConnection` only ever returned entities that **have** a value for the ordered property. The backing function (`entities_ordered_by_property`) drives entirely from the `"values"` table and applies a per-type non-null/non-empty predicate, so entities that match the space/type filters but lack a value for the property were never candidates — e.g. a score-sorted view returned only the handful of entities that happened to have a score.

This adds an opt-in way to include those value-less entities.

## Changes

- **Migration `0067_support_entities_without_value.sql`** — `CREATE OR REPLACE`s the function with a new parameter `include_without_value boolean DEFAULT false`. PostGraphile auto-exposes it as `includeWithoutValue` on both `entitiesOrderedByProperty` and `entitiesOrderedByPropertyConnection`.
- **Integration test** `entitiesOrderedByPropertyWithoutValue.test.ts`.

## Behavior

- **Default `false`** → emits the existing query unchanged (same SQL, same plan). All current callers are byte-for-byte unaffected.
- **`true`** → entities of the given `typeIds` within `spaceIds` that have no usable value are `UNION ALL`'d into the result.
- **A missing value is treated as zero** for numeric types (`integer`/`float`/`decimal`) via `COALESCE(sort_value, 0)`: `DESC` → positives → zero/null → negatives; `ASC` the reverse. Non-numeric types order value-less entities last (`NULLS LAST`).
- The value-less candidate set is anchored on the TYPES relation (entities carry no space/type column), so the flag **requires `typeIds`**; when `true` without `typeIds` it falls back to scored-only output.
- `includeWithoutValue` is nullable at the GraphQL layer; an explicit `null` is coalesced to `false` (does not opt in).

## Testing

- Integration test covers: arg exposure on both fields, default exclusion, ASC/DESC null-as-zero ordering, explicit `null` == `false`, and the no-`typeIds` fallback.
- Verified end-to-end against a fresh `postgres:16` via `scripts/setup-test-db.ts` (all migrations apply clean; tests pass). `tsc` and `biome` clean.
