### PR TITLE
chore(api): bump gaia-v2 api HPA to min 4 / max 8 (match prod floor)

### DIFF
--- a/api/k8s/v2/hpa.yaml
+++ b/api/k8s/v2/hpa.yaml
@@ -8,8 +8,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: api
-  minReplicas: 1
-  maxReplicas: 2
+  minReplicas: 4
+  maxReplicas: 8
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0


### PR DESCRIPTION
## What
Raise the **gaia-v2** `api` HorizontalPodAutoscaler from `minReplicas: 1 / maxReplicas: 2` to `minReplicas: 4 / maxReplicas: 8`, matching the prod (`api` namespace) HPA floor/ceiling.

```diff
-  minReplicas: 1
-  maxReplicas: 2
+  minReplicas: 4
+  maxReplicas: 8
```

## Why
gaia-v2 was pinned at 2 API replicas (~100 connections of pool capacity), so under load it saturated its per-pod pg pool and shed `503 SERVICE_UNAVAILABLE` ("database pressure") with no room to scale out. Prod runs 4–8. This brings gaia-v2 in line.

## Notes
- Metrics intentionally stay **resource-only** (CPU 70% / mem 80%) as today; porting prod's External/Pods pool-saturation metrics is a separate change once gaia-v2 monitoring is wired (Step 15). With resource-only metrics it will effectively sit at the new floor of **4** (CPU/mem stay low during pool-pressure shedding) rather than auto-climbing to 8.
- Deployed via the manual `deploy-v2.yml` workflow (`api/k8s/v2/hpa.yaml`), not Argo. The live HPA is already patched to 4/8; this makes it durable so the next `deploy-v2 api` run doesn't revert it.
- Node capacity: `gaia-v2-pool` autoscale was raised to 4–6 × s-4vcpu-8gb, which has room for up to 8 API pods alongside the indexers.