### PR TITLE
fix(hermes-pipeline): decode v2 ping-encoded DAO edit proposals (EDITS_PUBLISHED)

### DIFF
--- a/hermes-pipeline/src/decode.rs
+++ b/hermes-pipeline/src/decode.rs
@@ -154,6 +154,33 @@ pub fn decode_publish_args(calldata: &[u8]) -> Result<PublishArgs, DecodeError> 
     })
 }
 
+/// Decode the data payload of a `ping(EDITS_PUBLISHED, ...)` action.
+///
+/// `data` is the ping payload `abi.encode(bytes editsContentUri, bytes editsMetadata)`
+/// — not full calldata, so there is no function selector to skip. Returns the
+/// same [`PublishArgs`] shape as [`decode_publish_args`].
+pub fn decode_edits_published_args(data: &[u8]) -> Result<PublishArgs, DecodeError> {
+    if data.is_empty() {
+        return Err(DecodeError::DataTooShort {
+            expected: 64,
+            actual: data.len(),
+        });
+    }
+
+    // Params encoding (two offsets + tails), matching the SDK's
+    // `encodeAbiParameters([{bytes}, {bytes}], ...)`.
+    type EditsArgsType = sol! { (bytes, bytes) };
+    let (content_uri, metadata) =
+        EditsArgsType::abi_decode_params(data).map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+
+    let content_uri_str = decode_utf8_bytes(content_uri.to_vec())?;
+
+    Ok(PublishArgs {
+        content_uri: content_uri_str,
+        metadata: metadata.to_vec(),
+    })
+}
+
 fn decode_utf8_bytes(mut data: Vec<u8>) -> Result<String, DecodeError> {
     for _ in 0..2 {
         if let Some(unwrapped) = unwrap_bytes_once(&data) {
@@ -1182,6 +1209,29 @@ mod tests {
 
         let decoded = decode_publish_args(&calldata).unwrap();
         assert_eq!(decoded.content_uri, String::from_utf8(uri).unwrap());
+    }
+
+    #[test]
+    fn test_decode_edits_published_args() {
+        // Mirrors the v0.20 SDK payload:
+        // encodeAbiParameters([{bytes contentUri}, {bytes metadata}], [toHex(cid), '0x'])
+        let uri = "ipfs://QmEditProposalCidValue";
+        let metadata = b"some-metadata".to_vec();
+
+        type EditsArgsType = sol! { (bytes, bytes) };
+        let data = EditsArgsType::abi_encode_params(&(
+            PrimBytes::from(uri.as_bytes().to_vec()),
+            PrimBytes::from(metadata.clone()),
+        ));
+
+        let decoded = decode_edits_published_args(&data).unwrap();
+        assert_eq!(decoded.content_uri, uri);
+        assert_eq!(decoded.metadata, metadata);
+    }
+
+    #[test]
+    fn test_decode_edits_published_args_empty_is_err() {
+        assert!(decode_edits_published_args(&[]).is_err());
     }
 
     #[test]

--- a/hermes-pipeline/src/pipelines/governance.rs
+++ b/hermes-pipeline/src/pipelines/governance.rs
@@ -16,8 +16,8 @@ use hermes_instrumentation::{debug, debug_span, info, warn};
 
 use crate::cache::CachedEdit;
 use crate::decode::{
-    self, ProposalActionType, decode_flag_args, decode_ping_args, decode_publish_args,
-    decode_space_id_arg, decode_voting_settings_args,
+    self, ProposalActionType, decode_edits_published_args, decode_flag_args, decode_ping_args,
+    decode_publish_args, decode_space_id_arg, decode_voting_settings_args,
 };
 
 use hermes_relay::{Action, actions};
@@ -440,6 +440,16 @@ fn decode_ping_governance_action(calldata: &[u8]) -> Option<proposal_action::Act
                     },
                 ))
             }
+        }
+        x if x == actions::EDITS_PUBLISHED => {
+            // Edit proposals map to a Publish action.
+            // Note: name is populated later by enrich_publish_action_names.
+            let edits = decode_edits_published_args(&args.data).ok()?;
+            Some(proposal_action::Action::Publish(PublishAction {
+                content_uri: edits.content_uri,
+                metadata: edits.metadata,
+                name: String::new(),
+            }))
         }
         _ => {
             warn!(action_hash = %hex::encode(args.action), "Unrecognized ping action hash, storing as Unknown");
@@ -1769,6 +1779,39 @@ mod tests {
             result.is_none(),
             "Unrecognized ping action should return None"
         );
+    }
+
+    #[test]
+    fn test_decode_ping_edits_published_maps_to_publish() {
+        use alloy::primitives::Bytes as PrimBytes;
+        use alloy::sol_types::SolType;
+
+        // v2: ping(EDITS_PUBLISHED, EMPTY_TOPIC, abi.encode(contentUri, metadata))
+        let content_uri = "ipfs://QmEditProposalCid";
+        let metadata = b"edit-metadata".to_vec();
+
+        type EditsArgsType = alloy::sol! { (bytes, bytes) };
+        let ping_data = EditsArgsType::abi_encode_params(&(
+            PrimBytes::from(content_uri.as_bytes().to_vec()),
+            PrimBytes::from(metadata.clone()),
+        ));
+
+        let calldata = encode_ping_calldata(&actions::EDITS_PUBLISHED, &[0u8; 32], &ping_data);
+
+        // The ping selector should classify as a Ping action type.
+        assert!(matches!(
+            ProposalActionType::from_calldata(&calldata),
+            ProposalActionType::Ping
+        ));
+
+        match decode_ping_governance_action(&calldata) {
+            Some(proposal_action::Action::Publish(action)) => {
+                assert_eq!(action.content_uri, content_uri);
+                assert_eq!(action.metadata, metadata);
+                assert_eq!(action.name, "");
+            }
+            other => panic!("Expected Publish from EDITS_PUBLISHED ping, got {other:?}"),
+        }
     }
 
     #[test]

--- a/hermes-pipeline/src/pipelines/prefetch.rs
+++ b/hermes-pipeline/src/pipelines/prefetch.rs
@@ -21,7 +21,10 @@ use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use hermes_relay::{Action, actions, extract_ipfs_uri};
 
 use crate::cache::{CacheError, CachedEdit, IpfsCache};
-use crate::decode::{ProposalActionType, decode_proposal_created, decode_publish_args};
+use crate::decode::{
+    ProposalActionType, decode_edits_published_args, decode_ping_args, decode_proposal_created,
+    decode_publish_args,
+};
 
 /// Configuration for cache retry behavior.
 #[derive(Debug, Clone)]
@@ -102,6 +105,19 @@ fn collect_uris(actions: &[Action]) -> Vec<FetchRequest> {
                 let action_type = ProposalActionType::from_calldata(&proposal_action.data);
                 if matches!(action_type, ProposalActionType::Publish)
                     && let Ok(args) = decode_publish_args(&proposal_action.data)
+                {
+                    requests.push(FetchRequest {
+                        uri: args.content_uri,
+                        space_id: action.to_id.clone(), // space owning the proposal
+                    });
+                }
+
+                // Edit proposals arrive as ping(EDITS_PUBLISHED, ...); extract
+                // the content URI so name enrichment has cached edit data.
+                if matches!(action_type, ProposalActionType::Ping)
+                    && let Ok(ping) = decode_ping_args(&proposal_action.data)
+                    && ping.action == actions::EDITS_PUBLISHED
+                    && let Ok(args) = decode_edits_published_args(&ping.data)
                 {
                     requests.push(FetchRequest {
                         uri: args.content_uri,


### PR DESCRIPTION
## Summary

DAO edit proposals created with the v0.20 SDK (`daoSpaces.proposeEdit`) index as `actionType: "UNKNOWN"` / `name: "Unknown Action"` with an empty diff on gaia-v2. Add/remove member proposals are unaffected. This is an indexer bug — the SDK usage is correct.

**Example (staging):** `GET /proposals/8c0c32ce22d24a6fac114e472fa92372/status` → `actionType: UNKNOWN`, `name: "Unknown Action"`, diff `entities: []`.

## How the SDK encodes an edit

In the v2 contracts, `DAOSpace` no longer has a dedicated `publish(bytes32,bytes,bytes)` function. The v0.20 SDK routes an edit through the generic `ping(bytes32 action, bytes32 subject, bytes data)` function instead (`geo-sdk/src/client/dao-spaces.ts` → `encodePublishEditProposalAction`):

```ts
// one entry in the proposal's Action[]
{
  to: daoSpaceAddress,
  value: 0n,
  data: encodeFunctionData({
    abi: DaoSpaceAbi,
    functionName: 'ping',
    args: [
      EDITS_PUBLISHED_ACTION,   // keccak256(toHex('GOVERNANCE.EDITS_PUBLISHED'))
      EMPTY_TOPIC,              // bytes32(0)
      encodeAbiParameters(
        [
          { type: 'bytes', name: 'editsContentUri' },
          { type: 'bytes', name: 'editsMetadata' },
        ],
        [toHex(cid), '0x'],     // contentUri = "ipfs://…", metadata empty
      ),
    ],
  }),
}
```

So the on-chain calldata for an edit action is:

- selector: `ping` (`0xc70d8282`)
- `action`: `keccak256('GOVERNANCE.EDITS_PUBLISHED')`
- `subject`: `bytes32(0)`
- `data`: `abi.encode(bytes editsContentUri, bytes editsMetadata)` (params encoding — two offsets + tails)

Legacy (v1) edits used the dedicated `publish(...)` selector (`0x6b47f61a`), which the indexer decodes directly into a `Publish` action.

## Root cause

When decoding a proposal's inner actions (`hermes-pipeline/src/pipelines/governance.rs`):

1. `ProposalActionType::from_calldata` reads the `ping` selector → `ProposalActionType::Ping`.
2. `decode_ping_governance_action` matches the ping `action` hash against a fixed set (`TOPIC_SET`, `TOPIC_UNSET`, `SUBSPACE_*`).
3. There was **no arm for `EDITS_PUBLISHED`**, so it hit the fallback → `"Unrecognized ping action hash, storing as Unknown"` → the action was stored as `Unknown`.

Everything the UI saw cascades from that miss: `actionType: UNKNOWN`; `name: "Unknown Action"` (the name is normally set by `enrich_publish_action_names` from the edit's IPFS content, which only runs for `Publish` actions); empty diff (no `content_uri` was ever captured).

Member proposals work because `addMember`/`removeMember` keep their own dedicated selectors and are decoded directly — only the edit path moved under `ping`.

## Changes

- **`decode.rs`** — add `decode_edits_published_args`, which decodes the ping `data` payload `abi.encode(bytes contentUri, bytes metadata)` into the same `PublishArgs` shape as `decode_publish_args` (via `abi_decode_params` on `(bytes, bytes)`, reusing `decode_utf8_bytes` so the content URI string is identical to the legacy path).
- **`governance.rs`** — add an `EDITS_PUBLISHED` arm to `decode_ping_governance_action` that routes the decoded payload through the existing `PublishAction`. Downstream name enrichment and diff resolution then behave identically to v1 edit proposals — no downstream/proto changes needed.
- **`prefetch.rs`** — `collect_uris` now also extracts the IPFS content URI from ping-encoded `EDITS_PUBLISHED` inner actions (previously only `Publish` inner actions were prefetched), so name enrichment has cached edit data.

## Notes

- The legacy `publish(...)` selector, `ProposalActionType::Publish`, and `decode_publish_args` are intentionally **kept** — they still decode historical v1 edit proposals.
- The reported example also shows `status: REJECTED` with zero timing; that's tracked separately in GEO-723 as it may be either a downstream effect or a genuine expiry.

## Testing

- `decode::tests::test_decode_edits_published_args` (+ empty-input error case)
- `pipelines::governance::tests::test_decode_ping_edits_published_maps_to_publish` — full ping→Publish path
- `cargo test -p hermes-pipeline` — all pass.