### PR TITLE
fix(api): treat V2 proposals with an unstarted voting window as PROPOSED

### DIFF
--- a/api/src/proposals/__tests__/queries.test.ts
+++ b/api/src/proposals/__tests__/queries.test.ts
@@ -711,6 +711,48 @@ describe("SQL/TypeScript status parity", () => {
 			const result = computeProposalStatus(proposal, now)
 			expect(result.status).toBe("PROPOSED")
 		})
+
+		// V2: voting window not started yet (end_time = 0, before the first vote).
+		// Mirrors the `p.end_time = 0` branch of sqlIsProposed.
+		it("proposal is PROPOSED when the voting window has not started (Fast, no votes)", () => {
+			const proposal = makeProposal({
+				votingMode: "Fast",
+				flatSupportThreshold: 10n,
+				yesCount: 0n,
+				startTime: 0n,
+				endTime: 0n,
+				executeBy: null,
+			})
+			const result = computeProposalStatus(proposal, now)
+			expect(result.status).toBe("PROPOSED")
+		})
+
+		it("proposal is PROPOSED when the voting window has not started (Fast, flat=0)", () => {
+			const proposal = makeProposal({
+				votingMode: "Fast",
+				flatSupportThreshold: 0n,
+				yesCount: 0n,
+				startTime: 0n,
+				endTime: 0n,
+				executeBy: null,
+			})
+			const result = computeProposalStatus(proposal, now)
+			expect(result.status).toBe("PROPOSED")
+		})
+
+		it("proposal is PROPOSED when the voting window has not started (Slow, no votes)", () => {
+			const proposal = makeProposal({
+				votingMode: "Slow",
+				partialPercentageSupportThreshold: 5_000_000n,
+				quorum: 1n,
+				yesCount: 0n,
+				startTime: 0n,
+				endTime: 0n,
+				executeBy: null,
+			})
+			const result = computeProposalStatus(proposal, now)
+			expect(result.status).toBe("PROPOSED")
+		})
 	})
 
 	describe("edge cases", () => {
@@ -724,9 +766,10 @@ describe("SQL/TypeScript status parity", () => {
 			expect(result.status).toBe("EXECUTABLE")
 		})
 
-		it("handles zero flatSupportThreshold with zero yes votes (Fast path IS executable)", () => {
-			// V2 formula: yesCount >= flatSupportThreshold. With flat=0, any vote
-			// count — including zero — passes the threshold check.
+		it("handles zero flatSupportThreshold with zero yes votes while voting is open (PROPOSED)", () => {
+			// V2 contract: yes > effective(flat) with effective(0)=0, so a flat
+			// threshold of 0 still requires at least one yes vote. With 0 yes and
+			// the window open, the proposal is PROPOSED (not executable).
 			const proposal = makeProposal({
 				votingMode: "Fast",
 				threshold: 0n, // mirrors to flatSupportThreshold=0 via the helper
@@ -734,13 +777,12 @@ describe("SQL/TypeScript status parity", () => {
 				endTime: now + 3600n,
 			})
 			const result = computeProposalStatus(proposal, now)
-			expect(result.status).toBe("EXECUTABLE")
+			expect(result.status).toBe("PROPOSED")
 		})
 
-		it("handles zero flatSupportThreshold with zero yes votes after voting ends (EXECUTABLE)", () => {
-			// Even after voting ends, a Fast proposal that meets its (trivial)
-			// threshold is EXECUTABLE — voting end only matters when the
-			// threshold is NOT met.
+		it("handles zero flatSupportThreshold with zero yes votes after voting ends (REJECTED)", () => {
+			// flat=0 still needs a yes vote (yes > 0); with none and voting ended,
+			// the proposal is REJECTED.
 			const proposal = makeProposal({
 				votingMode: "Fast",
 				threshold: 0n,
@@ -748,7 +790,7 @@ describe("SQL/TypeScript status parity", () => {
 				endTime: now - 100n,
 			})
 			const result = computeProposalStatus(proposal, now)
-			expect(result.status).toBe("EXECUTABLE")
+			expect(result.status).toBe("REJECTED")
 		})
 
 		it("handles threshold=1 exactly met", () => {

--- a/api/src/proposals/__tests__/status.test.ts
+++ b/api/src/proposals/__tests__/status.test.ts
@@ -696,6 +696,100 @@ describe("computeProposalStatus - V2 executeBy deadline", () => {
 })
 
 // =============================================================================
+// V2: voting window not started (endTime == 0, before the first vote)
+// =============================================================================
+
+describe("computeProposalStatus - V2 voting window not started", () => {
+	// In V2 the contract leaves start/last/executeBy at zero until the first
+	// vote and `canExecuteProposal` returns false while `lastDate == 0`. A
+	// freshly-created proposal (no votes) must read as PROPOSED, never as
+	// EXECUTABLE (fast) or REJECTED (slow).
+	const now = 1707000000n
+
+	it("fast proposal with no votes is PROPOSED (not EXECUTABLE)", () => {
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			flatSupportThreshold: 10n,
+			yesCount: 0n,
+			startTime: 0n,
+			endTime: 0n,
+			executeBy: null,
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		expect(result.status).toBe("PROPOSED")
+		expect(result.isThresholdReached).toBe(false)
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+
+	it("fast proposal with flatSupportThreshold=0 and no votes is PROPOSED (regression: was EXECUTABLE)", () => {
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			flatSupportThreshold: 0n,
+			yesCount: 0n,
+			startTime: 0n,
+			endTime: 0n,
+			executeBy: null,
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		expect(result.status).toBe("PROPOSED")
+	})
+
+	it("slow proposal with no votes is PROPOSED (regression: was immediately REJECTED)", () => {
+		const proposal = makeProposal({
+			votingMode: "Slow",
+			partialPercentageSupportThreshold: 5_000_000n,
+			quorum: 1n,
+			yesCount: 0n,
+			noCount: 0n,
+			abstainCount: 0n,
+			startTime: 0n,
+			endTime: 0n,
+			executeBy: null,
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		expect(result.status).toBe("PROPOSED")
+		expect(result.isQuorumReached).toBe(false)
+	})
+})
+
+// =============================================================================
+// V2: fast path flat threshold = 0 requires a yes vote (strict `>` on effective)
+// =============================================================================
+
+describe("computeProposalStatus - V2 fast path flat threshold 0", () => {
+	const now = 1707000000n
+	const window = {startTime: now - 3600n, endTime: now + 3600n}
+
+	it("stays PROPOSED with 0 yes votes once the window is open", () => {
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			flatSupportThreshold: 0n,
+			yesCount: 0n,
+			...window,
+		})
+
+		expect(computeProposalStatus(proposal, now).status).toBe("PROPOSED")
+	})
+
+	it("becomes EXECUTABLE on the first yes vote", () => {
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			flatSupportThreshold: 0n,
+			yesCount: 1n,
+			...window,
+		})
+
+		expect(computeProposalStatus(proposal, now).status).toBe("EXECUTABLE")
+	})
+})
+
+// =============================================================================
 // V2: isEarlyExecutable flag is false for all non-slow-early paths
 // =============================================================================
 

--- a/api/src/proposals/queries.ts
+++ b/api/src/proposals/queries.ts
@@ -346,9 +346,10 @@ function sqlIsAccepted() {
 }
 
 /**
- * Proposal is EXECUTABLE iff not executed, deadline not passed, and any
- * path produces an executable outcome:
- *   - Fast: yes_count >= flat_support_threshold
+ * Proposal is EXECUTABLE iff not executed, deadline not passed, the voting
+ * window has started (end_time > 0; mirrors the contract's `lastDate != 0`
+ * guard in `canExecuteProposal`), and any path produces an executable outcome:
+ *   - Fast: yes_count > effective(flat_support_threshold)
  *   - Slow early: voting ongoing AND total_editors > 0 AND universal > 0
  *                 AND yes_count >= ceil(universal * total_editors / RATIO_BASE)
  *   - Slow late:  voting ended AND quorum met
@@ -358,8 +359,9 @@ function sqlIsExecutable(nowSeconds: bigint) {
 	return sql`(
 		p.executed_at IS NULL
 		AND (p.execute_by IS NULL OR ${nowSeconds}::bigint <= p.execute_by)
+		AND p.end_time > 0
 		AND (
-			(p.voting_mode = 'Fast' AND p.yes_count >= p.flat_support_threshold)
+			(p.voting_mode = 'Fast' AND p.yes_count > (CASE WHEN p.flat_support_threshold = 0 THEN 0 ELSE p.flat_support_threshold - 1 END))
 			OR (
 				p.voting_mode = 'Slow'
 				AND ${nowSeconds}::bigint <= p.end_time
@@ -381,23 +383,29 @@ function sqlIsExecutable(nowSeconds: bigint) {
 }
 
 /**
- * Proposal is PROPOSED iff not executed, deadline not passed, voting
- * ongoing, and no executable path is already matched.
+ * Proposal is PROPOSED iff not executed, deadline not passed, and either the
+ * voting window has not started yet (end_time = 0 — open, awaiting the first
+ * vote) or voting is ongoing with no executable path already matched.
  */
 function sqlIsProposed(nowSeconds: bigint) {
 	return sql`(
 		p.executed_at IS NULL
 		AND (p.execute_by IS NULL OR ${nowSeconds}::bigint <= p.execute_by)
-		AND ${nowSeconds}::bigint <= p.end_time
-		AND NOT (
-			(p.voting_mode = 'Fast' AND p.yes_count >= p.flat_support_threshold)
+		AND (
+			p.end_time = 0
 			OR (
-				p.voting_mode = 'Slow'
-				AND ${sqlTotalEditors()} > 0
-				AND p.universal_percentage_support_threshold > 0
-				AND p.yes_count::numeric >= CEIL(
-					(p.universal_percentage_support_threshold::numeric * ${sqlTotalEditors()}::numeric)
-					/ ${RATIO_BASE}::numeric
+				${nowSeconds}::bigint <= p.end_time
+				AND NOT (
+					(p.voting_mode = 'Fast' AND p.yes_count > (CASE WHEN p.flat_support_threshold = 0 THEN 0 ELSE p.flat_support_threshold - 1 END))
+					OR (
+						p.voting_mode = 'Slow'
+						AND ${sqlTotalEditors()} > 0
+						AND p.universal_percentage_support_threshold > 0
+						AND p.yes_count::numeric >= CEIL(
+							(p.universal_percentage_support_threshold::numeric * ${sqlTotalEditors()}::numeric)
+							/ ${RATIO_BASE}::numeric
+						)
+					)
 				)
 			)
 		)
@@ -406,7 +414,9 @@ function sqlIsProposed(nowSeconds: bigint) {
 
 /**
  * Proposal is REJECTED iff not executed and either the executeBy deadline
- * has passed, or voting ended without any executable path matching.
+ * has passed, or the voting window started and ended (end_time > 0 AND now >
+ * end_time) without any executable path matching. A zero window (end_time = 0)
+ * is never rejected — the proposal is still open (see sqlIsProposed).
  */
 function sqlIsRejected(nowSeconds: bigint) {
 	return sql`(
@@ -414,9 +424,10 @@ function sqlIsRejected(nowSeconds: bigint) {
 		AND (
 			(p.execute_by IS NOT NULL AND ${nowSeconds}::bigint > p.execute_by)
 			OR (
-				${nowSeconds}::bigint > p.end_time
+				p.end_time > 0
+				AND ${nowSeconds}::bigint > p.end_time
 				AND NOT (
-					(p.voting_mode = 'Fast' AND p.yes_count >= p.flat_support_threshold)
+					(p.voting_mode = 'Fast' AND p.yes_count > (CASE WHEN p.flat_support_threshold = 0 THEN 0 ELSE p.flat_support_threshold - 1 END))
 					OR (
 						p.voting_mode = 'Slow'
 						AND (p.yes_count + p.no_count + p.abstain_count) >= p.quorum

--- a/api/src/proposals/status.ts
+++ b/api/src/proposals/status.ts
@@ -17,10 +17,16 @@ import {RATIO_BASE} from "./types"
  * Decision order:
  * 1. Already executed → ACCEPTED
  * 2. Past `executeBy` deadline → REJECTED
- * 3. Fast path: `yesCount >= flatSupportThreshold` → EXECUTABLE
- * 4. Slow-path early execution (before voting ends): when
+ * 3. Voting window not started yet (`endTime == 0`) → PROPOSED. In V2 the
+ *    window (`startDate`/`lastDate`/`executeBy`) stays zero until the first
+ *    vote, and the contract's `canExecuteProposal` returns false while
+ *    `lastDate == 0`. So a proposal with no votes yet is open, never
+ *    executable or rejected on the zero window.
+ * 4. Fast path: `yesCount > effective(flatSupportThreshold)` → EXECUTABLE,
+ *    where `effective(x) = x == 0 ? 0 : x - 1` (matches the contract).
+ * 5. Slow-path early execution (before voting ends): when
  *    `yesCount >= ceil(universalPercentageSupportThreshold × totalEditors / RATIO_BASE)`.
- * 5. Slow-path late execution (after voting ends): quorum + the classic
+ * 6. Slow-path late execution (after voting ends): quorum + the classic
  *    `(RATIO_BASE - partial) × yes > partial × no` ratio.
  *
  * Must stay byte-for-byte consistent with the SQL fragments in `queries.ts`
@@ -56,12 +62,24 @@ export function computeProposalStatus(
 		}
 	}
 
+	// Voting window not started yet: the V2 contract leaves start/last/executeBy
+	// at zero until the first vote, and `canExecuteProposal` returns false while
+	// `lastDate == 0`. Treat this as an open proposal — not executable, not ended.
+	if (proposal.endTime === 0n) {
+		return {
+			status: "PROPOSED",
+			isQuorumReached: false,
+			isThresholdReached: false,
+			isEarlyExecutable: false,
+		}
+	}
+
 	const isVotingEnded = nowSeconds > proposal.endTime
 	const totalVotes = proposal.yesCount + proposal.noCount + proposal.abstainCount
 	const isQuorumReached = totalVotes >= proposal.quorum
 
 	if (proposal.votingMode === "Fast") {
-		const isThresholdReached = proposal.yesCount >= proposal.flatSupportThreshold
+		const isThresholdReached = proposal.yesCount > effectiveThreshold(proposal.flatSupportThreshold)
 
 		if (isThresholdReached) {
 			return {
@@ -128,6 +146,12 @@ export function computeProposalStatus(
 // Integer ceiling division for bigint. Assumes `divisor > 0n` and `dividend >= 0n`.
 function ceilDiv(dividend: bigint, divisor: bigint): bigint {
 	return (dividend + divisor - 1n) / divisor
+}
+
+// Mirrors the contract's `_computeEffectiveSupportThreshold`: a threshold of 0
+// stays 0 (so a single yes vote clears it via strict `>`), otherwise `x - 1`.
+function effectiveThreshold(threshold: bigint): bigint {
+	return threshold === 0n ? 0n : threshold - 1n
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes v2 DAO proposal status/timing on the status endpoint. Reported symptoms: a fast-path edit proposal returned `status: EXECUTABLE` / `canExecute: true` with **zero votes**, and a slow-path proposal was **immediately REJECTED** — both with `timing.startTime: 0` / `timing.endTime: 0` (which also drove the UI's negative "time remaining").

Examples:
- Fast (was EXECUTABLE, 0 votes): `/proposals/08e0dc7be9cb4eb1866d063bddf33329/status`
- Slow (was immediately REJECTED): `/proposals/b77ec6914e65480a83d46b9be2862c74/status`

## Root cause

In v2, `DAOSpace` leaves the voting window at zero until the **first vote** — `startDate`/`lastDate`/`executeBy` stay `0`, and `_startProposalVotingWindow` snapshots them (and re-emits `PROPOSAL_SETTINGS_SELECTED`) on the first vote. The contract's own `canExecuteProposal` guards on this: `if (proposal_.parameters.lastDate == 0) return false;`.

The API status logic didn't model that state. With `end_time = 0`:

- `isVotingEnded = now > end_time` → `now > 0` → always `true`.
- **Slow:** voting "ended" instantly, 0 votes < quorum → **REJECTED**.
- **Fast:** the executable check was `yes_count >= flat_support_threshold`, and this space's `flat = 0`, so `0 >= 0` → **EXECUTABLE / canExecute** with no votes.

Two distinct discrepancies with the contract:
1. Missing the `lastDate == 0` (window-not-started) guard.
2. Fast-path used `>=` instead of the contract's effective-threshold `>`: the contract computes `effective(x) = x == 0 ? 0 : x - 1` and executes when `yes > effective`, so `flat = 0` still needs **one** yes vote.

## Changes (API only)

Mirrored the contract in both `computeProposalStatus` (`status.ts`) and the SQL status fragments (`queries.ts`) — they're kept byte-for-byte in parity, validated by `__tests__/queries.test.ts`:

- **Window not started ⇒ PROPOSED:** when `executed_at IS NULL AND end_time == 0`, the proposal is PROPOSED (open, awaiting the first vote), evaluated before any executable/rejected path.
- **Require window started for execution/rejection:** gated the EXECUTABLE paths and the voting-ended REJECTED path on `end_time > 0`, so a zero window can't be treated as "voting ended."
- **Fast-path parity:** `yes > (flat == 0 ? 0 : flat - 1)` instead of `yes >= flat`.

## Tests

- `status.test.ts`: added window-not-started cases (fast/slow, incl. `flat = 0`) → PROPOSED, plus the `flat = 0` boundary (0 yes → PROPOSED while open; 1 yes → EXECUTABLE).
- `queries.test.ts`: added the same scenarios to the parity block and corrected two pre-existing tests that asserted the old `flat = 0 / zero-vote → EXECUTABLE` behavior.
- Full API suite (with test DB) passes; `tsc --noEmit` clean.
