### PR TITLE
fix(api): report unstarted voting window as not ended in timing fields

### DIFF
--- a/api/src/proposals/__tests__/queries.test.ts
+++ b/api/src/proposals/__tests__/queries.test.ts
@@ -266,6 +266,27 @@ describe("GET /proposals/space/:spaceId/status", () => {
 			expect(body.proposals[0].executeBy).toBeNull()
 		})
 
+		it("reports voting as not ended when the window has not started (end_time = 0)", async () => {
+			// V2: window is unset until the first vote. It has neither started nor
+			// ended, so isVotingEnded must be false and timeRemaining null (not a
+			// negative value derived from `0 - now`).
+			const row = makeDbProposalRow({
+				voting_mode: "Slow",
+				start_time: "0",
+				end_time: "0",
+				execute_by: null,
+			})
+			db.execute.mockResolvedValueOnce({rows: [row]})
+
+			const res = await app.request("/proposals/space/660e8400-e29b-41d4-a716-446655440000/status")
+
+			const body = await res.json()
+			expect(body.proposals[0].status).toBe("PROPOSED")
+			expect(body.proposals[0].timing.isVotingEnded).toBe(false)
+			expect(body.proposals[0].timing.timeRemaining).toBeNull()
+			expect(body.proposals[0].timing.endTime).toBe(0)
+		})
+
 		it("projects legacy threshold.required from flatSupportThreshold for Fast proposals", async () => {
 			const row = makeDbProposalRow({
 				voting_mode: "Fast",

--- a/api/src/proposals/router.ts
+++ b/api/src/proposals/router.ts
@@ -171,8 +171,11 @@ function computeResponseFields(proposal: ProposalWithVotes | ProposalListItem, n
 
 	const now = Number(nowSeconds)
 	const endTime = Number(proposal.endTime)
-	const isVotingEnded = now > endTime
-	const timeRemaining = isVotingEnded ? null : endTime - now
+	// V2: the voting window is unset (endTime === 0) until the first vote, so it
+	// has neither started nor ended yet. Only report "ended" once it has started.
+	const windowStarted = endTime > 0
+	const isVotingEnded = windowStarted && now > endTime
+	const timeRemaining = windowStarted && !isVotingEnded ? endTime - now : null
 
 	const totalVotes = proposal.yesCount + proposal.noCount + proposal.abstainCount
 	const quorumRequired = Number(proposal.quorum)


### PR DESCRIPTION
## Summary

Follow-up to #794. That PR fixed the `status` field for V2 proposals whose voting window hasn't started, but the response's `timing` fields still used the old `now > endTime` logic, so a `PROPOSED` proposal was reported with `timing.isVotingEnded: true` (and a negative `timeRemaining`).

Example after #794 — status is correct but timing is not:
```json
"status": "PROPOSED",
"timing": { "startTime": 0, "endTime": 0, "timeRemaining": null, "isVotingEnded": true }
```

## Root cause

In V2 the voting window is unset (`endTime = 0`) until the first vote. `computeResponseFields` in `router.ts` computed:

```ts
const isVotingEnded = now > endTime           // 0 → now > 0 → always true
const timeRemaining = isVotingEnded ? null : endTime - now   // else 0 - now → negative
```

Same `endTime = 0` blind spot that #794 fixed for `status`, but in the display fields.

## Change

Gate both fields on the window having started (`endTime > 0`):

```ts
const windowStarted = endTime > 0
const isVotingEnded = windowStarted && now > endTime
const timeRemaining = windowStarted && !isVotingEnded ? endTime - now : null
```

Resulting `timing` behavior:

| State | `isVotingEnded` | `timeRemaining` |
|---|---|---|
| Window not started (`endTime = 0`) | `false` | `null` |
| Started, ongoing | `false` | `endTime - now` |
| Started, ended | `true` | `null` |

## Tests

- `queries.test.ts`: added a regression test asserting `isVotingEnded: false` / `timeRemaining: null` / `endTime: 0` for an unstarted-window (`end_time = 0`) proposal.
- Full API suite passes (105 tests); `tsc --noEmit` clean.