### PR TITLE
fix(api): report unstarted voting window as active in proposal diff

### DIFF
--- a/api/src/versioned/__tests__/integration.test.ts
+++ b/api/src/versioned/__tests__/integration.test.ts
@@ -148,6 +148,7 @@ const uuid = {
 	proposalClosed: normalizeUuid("10000000-0008-4000-8000-000000000002"),
 	proposalExecuted: normalizeUuid("10000000-0008-4000-8000-000000000003"),
 	proposalNoPublish: normalizeUuid("10000000-0008-4000-8000-000000000004"),
+	proposalUnstarted: normalizeUuid("10000000-0008-4000-8000-000000000005"),
 
 	// Value IDs (for value_versions)
 	val: (n: number) => normalizeUuid(`10000000-0009-4000-8000-${n.toString().padStart(12, "0")}`),
@@ -826,6 +827,13 @@ describe.skipIf(SKIP_INTEGRATION)("Versioned Endpoints - Comprehensive Integrati
 	describe("Proposal Diff", () => {
 		it("returns proposal status as active when end_time is in future", async () => {
 			const res = await app.request(`/versioned/proposals/${uuid.proposalActive}/diff?spaceId=${uuid.space1}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			expect(body.proposalStatus).toBe("active")
+		})
+
+		it("returns proposal status as active when the voting window has not started (end_time = 0)", async () => {
+			const res = await app.request(`/versioned/proposals/${uuid.proposalUnstarted}/diff?spaceId=${uuid.space1}`)
 			expect(res.status).toBe(200)
 			const body = await res.json()
 			expect(body.proposalStatus).toBe("active")
@@ -1591,6 +1599,9 @@ async function setupTestData(pool: Pool): Promise<void> {
 
 		// Proposal without publish action
 		await insertProposalV2(uuid.proposalNoPublish, now - 1000, now + 86400, null)
+
+		// V2 proposal whose voting window has not started yet (start/end = 0)
+		await insertProposalV2(uuid.proposalUnstarted, 0, 0, null)
 
 		await client.query("COMMIT")
 	} catch (error) {

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -302,7 +302,9 @@ function getProposalStatus(proposal: ProposalWithAction["proposal"]): ProposalSt
 		return "executed"
 	}
 	const now = BigInt(Math.floor(Date.now() / 1000))
-	if (now < proposal.endTime) {
+	// endTime === 0 means the V2 voting window hasn't started yet (no votes cast).
+	// Such a proposal is still open — treat it as active, not closed.
+	if (proposal.endTime === 0n || now < proposal.endTime) {
 		return "active"
 	}
 	return "closed"


### PR DESCRIPTION
## Summary

The versioned proposal **diff** endpoint reports `proposalStatus: "closed"` for a V2 proposal whose voting window hasn't started yet. Sibling to #794 (status endpoint) and #795 (timing fields) — same `end_time = 0` blind spot, this time in the diff endpoint.

Example (`GET /versioned/proposals/{id}/diff`): a just-created proposal returns
```json
"proposalStatus": "closed"
```
even though it's open (no votes cast yet).

## Root cause

In V2 the voting window is unset (`end_time = 0`) until the first vote. `getProposalStatus` in `proposal-diff.ts` computed:

```ts
if (now < proposal.endTime) return "active"   // now < 0 → false
return "closed"
```

So `end_time = 0` fell through to `"closed"`. Beyond the wrong label, this also changes the diff's base state: `"closed"` diffs against **versioned** state at `end_time`, whereas an open proposal should diff against **live** state (`fetchBaseData` routes `"active"` → `fetchLive()`).

## Change

```ts
// end_time === 0 means the V2 voting window hasn't started yet (no votes cast)
if (proposal.endTime === 0n || now < proposal.endTime) return "active"
return "closed"
```

Unstarted-window proposals are now `"active"` — correct label, and correctly diffed against live state.

## Tests

- `integration.test.ts`: added a `proposalUnstarted` fixture (`end_time = 0`) and an assertion that the diff endpoint returns `proposalStatus: "active"`, alongside the existing active/closed/executed cases.
- `tsc --noEmit` clean.