### PR TITLE
feat(hermes): decode v2 governance Action struct (toAddress + toSpaceId)

### DIFF
--- a/hermes-pipeline/src/decode.rs
+++ b/hermes-pipeline/src/decode.rs
@@ -361,7 +361,8 @@ sol! {
     /// Action to be executed when a proposal passes.
     #[derive(Debug)]
     struct Action {
-        address to;
+        address toAddress;
+        bytes16 toSpaceId;
         uint256 value;
         bytes data;
     }
@@ -467,10 +468,17 @@ pub struct ProposalCreatedData {
 }
 
 /// A single action in a proposal.
+///
+/// `to_address` + `to_space_id` mirror the onchain `Action` call target: when
+/// `to_address` is non-zero it is the explicit target; when it is `address(0)`
+/// the target is resolved onchain from `to_space_id` via
+/// `SpaceRegistry.spaceIdToAddress` at execution time.
 #[derive(Debug, Clone)]
 pub struct ProposalAction {
-    /// Target contract address (20 bytes).
-    pub to: Vec<u8>,
+    /// Explicit call target (20 bytes); `address(0)` ⇒ resolve via `to_space_id`.
+    pub to_address: Vec<u8>,
+    /// GEO space UUID (16 bytes) used to resolve the target when `to_address` is zero.
+    pub to_space_id: Vec<u8>,
     /// ETH value to send (32 bytes, big-endian).
     pub value: Vec<u8>,
     /// Calldata (function selector + encoded args).
@@ -575,7 +583,8 @@ fn decode_proposal_created_inner(data: &[u8]) -> Result<ProposalCreatedData, Dec
         ParamType::FixedBytes(16),
         ParamType::Uint(8),
         ParamType::Array(Box::new(ParamType::Tuple(vec![
-            ParamType::Address,
+            ParamType::Address,         // toAddress (decoded-and-discarded)
+            ParamType::FixedBytes(16),  // toSpaceId (decoded-and-discarded)
             ParamType::Uint(256),
             ParamType::Bytes,
         ]))),
@@ -604,12 +613,25 @@ fn decode_proposal_created_inner(data: &[u8]) -> Result<ProposalCreatedData, Dec
         Token::Array(items) => items
             .iter()
             .map(|item| match item {
-                Token::Tuple(fields) if fields.len() == 3 => {
-                    let to = match &fields[0] {
+                // fields: (toAddress, toSpaceId, value, data) — see `Action` above.
+                Token::Tuple(fields) if fields.len() == 4 => {
+                    let to_address = match &fields[0] {
                         Token::Address(addr) => addr.as_bytes().to_vec(),
-                        _ => return Err(DecodeError::AbiDecode("Invalid action.to".to_string())),
+                        _ => {
+                            return Err(DecodeError::AbiDecode(
+                                "Invalid action.toAddress".to_string(),
+                            ));
+                        }
                     };
-                    let value = match &fields[1] {
+                    let to_space_id = match &fields[1] {
+                        Token::FixedBytes(bytes) => bytes.clone(),
+                        _ => {
+                            return Err(DecodeError::AbiDecode(
+                                "Invalid action.toSpaceId".to_string(),
+                            ));
+                        }
+                    };
+                    let value = match &fields[2] {
                         Token::Uint(v) => {
                             let mut buf = [0u8; 32];
                             v.to_big_endian(&mut buf);
@@ -619,11 +641,16 @@ fn decode_proposal_created_inner(data: &[u8]) -> Result<ProposalCreatedData, Dec
                             return Err(DecodeError::AbiDecode("Invalid action.value".to_string()));
                         }
                     };
-                    let data = match &fields[2] {
+                    let data = match &fields[3] {
                         Token::Bytes(bytes) => bytes.clone(),
                         _ => return Err(DecodeError::AbiDecode("Invalid action.data".to_string())),
                     };
-                    Ok(ProposalAction { to, value, data })
+                    Ok(ProposalAction {
+                        to_address,
+                        to_space_id,
+                        value,
+                        data,
+                    })
                 }
                 _ => Err(DecodeError::AbiDecode("Invalid action tuple".to_string())),
             })
@@ -891,7 +918,8 @@ mod tests {
         let proposal_id = vec![0xAB_u8; 16];
         let voting_mode = EthU256::from(1u8);
         let action_tuple = Token::Tuple(vec![
-            Token::Address(ethabi::Address::zero()),
+            Token::Address(ethabi::Address::zero()), // toAddress
+            Token::FixedBytes(vec![0u8; 16]),        // toSpaceId
             Token::Uint(EthU256::from(1000u64)),
             Token::Bytes(vec![1, 2, 3]),
         ]);
@@ -906,7 +934,14 @@ mod tests {
         assert_eq!(unwrap_level, 0);
         assert_eq!(result.proposal_id, proposal_id);
         assert_eq!(result.actions.len(), 1);
-        assert_eq!(result.actions[0].to, vec![0u8; 20]);
+        assert_eq!(result.actions[0].to_address, vec![0u8; 20]);
+        assert_eq!(result.actions[0].to_space_id, vec![0u8; 16]);
+        assert_eq!(result.actions[0].value, {
+            let mut buf = [0u8; 32];
+            EthU256::from(1000u64).to_big_endian(&mut buf);
+            buf.to_vec()
+        });
+        assert_eq!(result.actions[0].data, vec![1, 2, 3]);
         assert_eq!(result.voting_mode, 1);
     }
 

--- a/hermes-pipeline/src/pipelines/governance.rs
+++ b/hermes-pipeline/src/pipelines/governance.rs
@@ -591,13 +591,15 @@ fn parse_proposal_created(action: &Action, sequence: u32) -> Option<ProposalCrea
             info!(
                 action_type = ?action_type,
                 selector = %selector,
-                target = %hex::encode(&a.to),
+                to_address = %hex::encode(&a.to_address),
+                to_space_id = %hex::encode(&a.to_space_id),
                 data_len = a.data.len(),
                 "Decoded proposal action"
             );
 
             ProposalAction {
-                to: a.to,
+                to_address: a.to_address,
+                to_space_id: a.to_space_id,
                 value: a.value,
                 data: a.data,
                 action: decoded_action,
@@ -815,7 +817,8 @@ mod tests {
         use ethabi::{Token, ethereum_types::U256 as EthU256};
 
         let action_tuple = Token::Tuple(vec![
-            Token::Address(ethabi::Address::zero()),
+            Token::Address(ethabi::Address::zero()), // toAddress
+            Token::FixedBytes(vec![0u8; 16]),        // toSpaceId
             Token::Uint(EthU256::zero()),
             Token::Bytes(vec![]),
         ]);
@@ -991,7 +994,8 @@ mod tests {
             .into_iter()
             .map(|(to, data)| {
                 Token::Tuple(vec![
-                    Token::Address(to),
+                    Token::Address(to),               // toAddress
+                    Token::FixedBytes(vec![0u8; 16]), // toSpaceId
                     Token::Uint(EthU256::zero()),
                     Token::Bytes(data),
                 ])
@@ -1504,7 +1508,8 @@ mod tests {
             proposal_id: vec![3u8; 16],
             voting_mode: 0,
             actions: vec![ProposalAction {
-                to: vec![],
+                to_address: vec![],
+                to_space_id: vec![],
                 value: vec![],
                 data: vec![],
                 action: Some(proposal_action::Action::Publish(PublishAction {
@@ -1781,7 +1786,8 @@ mod tests {
             proposal_id: vec![3u8; 16],
             voting_mode: VotingMode::Fast as i32,
             actions: vec![ProposalAction {
-                to: vec![],
+                to_address: vec![],
+                to_space_id: vec![],
                 value: vec![],
                 data: vec![],
                 action: Some(proposal_action::Action::Publish(PublishAction {

--- a/hermes-relay/src/source/mock_events.rs
+++ b/hermes-relay/src/source/mock_events.rs
@@ -519,6 +519,7 @@ fn encode_proposal_data(
         .map(|a| {
             Token::Tuple(vec![
                 Token::Address(ethabi::Address::from_slice(&a.to)),
+                Token::FixedBytes(vec![0u8; 16]), // toSpaceId: mock targets by address, so zero
                 Token::Uint(EthU256::from_big_endian(&a.value)),
                 Token::Bytes(a.data.clone()),
             ])

--- a/hermes-schema/proto/governance.proto
+++ b/hermes-schema/proto/governance.proto
@@ -120,9 +120,10 @@ message UnsetTopicAction {
 
 // Action to be executed when proposal passes
 message ProposalAction {
-  bytes to = 1;        // 20 bytes - target contract address
-  bytes value = 2;     // 32 bytes - uint256 ETH value to send
-  bytes data = 3;      // calldata (function selector + encoded args)
+  bytes to_address = 1;   // 20 bytes - explicit call target; address(0) => resolve via to_space_id at execution
+  bytes value = 2;        // 32 bytes - uint256 ETH value to send
+  bytes data = 3;         // calldata (function selector + encoded args)
+  bytes to_space_id = 4;  // 16 bytes - GEO space UUID; resolved via SpaceRegistry.spaceIdToAddress when to_address is address(0)
 
   // Decoded action (based on function selector in calldata)
   oneof action {

--- a/hermes-schema/src/pb/governance.rs
+++ b/hermes-schema/src/pb/governance.rs
@@ -119,15 +119,18 @@ pub struct UnsetTopicAction {
 /// Action to be executed when proposal passes
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProposalAction {
-    /// 20 bytes - target contract address
+    /// 20 bytes - explicit call target; address(0) => resolve via to_space_id at execution
     #[prost(bytes = "vec", tag = "1")]
-    pub to: ::prost::alloc::vec::Vec<u8>,
+    pub to_address: ::prost::alloc::vec::Vec<u8>,
     /// 32 bytes - uint256 ETH value to send
     #[prost(bytes = "vec", tag = "2")]
     pub value: ::prost::alloc::vec::Vec<u8>,
     /// calldata (function selector + encoded args)
     #[prost(bytes = "vec", tag = "3")]
     pub data: ::prost::alloc::vec::Vec<u8>,
+    /// 16 bytes - GEO space UUID; resolved via SpaceRegistry.spaceIdToAddress when to_address is address(0)
+    #[prost(bytes = "vec", tag = "4")]
+    pub to_space_id: ::prost::alloc::vec::Vec<u8>,
     /// Decoded action (based on function selector in calldata)
     #[prost(
         oneof = "proposal_action::Action",

--- a/hermes-substream/src/helpers.rs
+++ b/hermes-substream/src/helpers.rs
@@ -78,7 +78,7 @@ fn is_base32_lower(s: &str) -> bool {
 /// Extract IPFS URIs from PROPOSAL_CREATED action data.
 ///
 /// The data is ABI-encoded as: `(bytes16 proposalId, uint8 votingMode, Action[])`
-/// where each Action is `(address to, uint256 value, bytes data)`.
+/// where each Action is `(address toAddress, bytes16 toSpaceId, uint256 value, bytes data)`.
 ///
 /// For Publish actions (selector 0x6b47f61a), the data contains:
 /// `publish(bytes32 topic, bytes contentUri, bytes metadata)`
@@ -141,12 +141,13 @@ fn decode_proposal_actions(data: &[u8]) -> Option<Vec<Vec<u8>>> {
 /// Inner decode function for proposal actions.
 fn decode_proposal_actions_inner(data: &[u8]) -> Option<Vec<Vec<u8>>> {
     // ABI schema: (bytes16 proposalId, uint8 votingMode, Action[])
-    // where Action is (address to, uint256 value, bytes data)
+    // where Action is (address toAddress, bytes16 toSpaceId, uint256 value, bytes data)
     let params = [
         ParamType::FixedBytes(16),
         ParamType::Uint(8),
         ParamType::Array(Box::new(ParamType::Tuple(vec![
-            ParamType::Address,
+            ParamType::Address,        // toAddress (call target; resolved onchain)
+            ParamType::FixedBytes(16), // toSpaceId (call target; resolved onchain)
             ParamType::Uint(256),
             ParamType::Bytes,
         ]))),
@@ -154,12 +155,12 @@ fn decode_proposal_actions_inner(data: &[u8]) -> Option<Vec<Vec<u8>>> {
 
     let tokens = ethabi::decode(&params, data).ok()?;
 
-    // Extract action calldata from the actions array
+    // Extract action calldata (fields[3]) from the actions array
     let actions = match &tokens.get(2)? {
         Token::Array(items) => items
             .iter()
             .filter_map(|item| match item {
-                Token::Tuple(fields) if fields.len() == 3 => match &fields[2] {
+                Token::Tuple(fields) if fields.len() == 4 => match &fields[3] {
                     Token::Bytes(bytes) => Some(bytes.clone()),
                     _ => None,
                 },

--- a/kg-indexer/src/handlers/governance.rs
+++ b/kg-indexer/src/handlers/governance.rs
@@ -528,7 +528,8 @@ mod tests {
 
     fn make_publish_action(name: &str) -> ProposalAction {
         ProposalAction {
-            to: vec![],
+            to_address: vec![],
+            to_space_id: vec![],
             value: vec![],
             data: vec![],
             action: Some(Action::Publish(PublishAction {
@@ -541,7 +542,8 @@ mod tests {
 
     fn make_add_member_action() -> ProposalAction {
         ProposalAction {
-            to: vec![],
+            to_address: vec![],
+            to_space_id: vec![],
             value: vec![],
             data: vec![],
             action: Some(Action::AddMember(AddMemberAction {
@@ -778,7 +780,8 @@ mod tests {
         let proposal_id = Uuid::new_v4();
 
         let action = ProposalAction {
-            to: vec![],
+            to_address: vec![],
+            to_space_id: vec![],
             value: vec![],
             data: vec![],
             action: Some(Action::UpdateVotingSettings(UpdateVotingSettingsAction {


### PR DESCRIPTION
## Summary

Updates the v2 governance `Action` decoding to match the new onchain struct shape. The onchain `Action` gained an explicit space-id target, so its ABI tuple went from the legacy 3 fields to 4:

- **Before:** `(address to, uint256 value, bytes data)`
- **After:** `(address toAddress, bytes16 toSpaceId, uint256 value, bytes data)`

`to_address` is the explicit call target; when it is `address(0)` the target is resolved onchain from `to_space_id` via `SpaceRegistry.spaceIdToAddress` at execution time.

Every place that decodes or constructs this tuple is updated to the 4-field shape, and `calldata` is now read from `fields[3]` instead of `fields[2]`.

## Changes

- **`hermes-schema/proto/governance.proto`** — `ProposalAction`: rename `to` → `to_address`, add `to_space_id = 4`.
- **`hermes-schema/src/pb/governance.rs`** — regenerated prost bindings to match the proto.
- **`hermes-pipeline/src/decode.rs`** — update the `sol!` `Action` struct (`to` → `toAddress` + `bytes16 toSpaceId`), the `ProposalAction` Rust struct, and the ABI decoder to expect a 4-field tuple (value/data read from shifted indices).
- **`hermes-pipeline/src/pipelines/governance.rs`** — propagate `to_address`/`to_space_id` through `parse_proposal_created` and log both.
- **`hermes-substream/src/helpers.rs`** — fix `decode_proposal_actions_inner`, which still assumed the 3-field tuple and pulled calldata from `fields[2]`. With the v2 struct the tuple no longer matched, so `extract_proposal_publish_uris` returned nothing and `map_ipfs_uris` emitted no proposal Publish URIs. Now matches the 4-field tuple and reads calldata from `fields[3]`, mirroring the pipeline decoder.
- **`hermes-relay/src/source/mock_events.rs`** — mock encoder emits the new `toSpaceId` field (zero; mock targets by address).
- **`kg-indexer/src/handlers/governance.rs`** — test helpers updated for the new struct fields.

Clean v2 cutover (fresh deployment), so no legacy 3-field fallback is retained.

## Testing

Existing decode/governance unit tests updated to the 4-field tuple and assertions extended to cover `to_address` / `to_space_id`.