### PR TITLE
chore: bring-up checklist — arm chain config before merge (substream + hermes start blocks)

### DIFF
--- a/hermes-ipfs-cache/k8s/production/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/production/hermes-ipfs-cache.yaml
@@ -82,8 +82,12 @@ spec:
                 secretKeyRef:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
+            # PLACEHOLDER — set to the new chain's SpaceRegistry deploy block before bring-up.
+            # 0 = stream from genesis (safe: won't miss events, just slower to catch up).
+            # NOTE: a non-numeric value is silently ignored and falls back to the OLD
+            # testnet block, so use 0 — never a REPLACE_WITH string — as the placeholder.
             - name: SUBSTREAMS_START_BLOCK
-              value: "138000"
+              value: "0"
             - name: IPFS_GATEWAY_URL
               valueFrom:
                 secretKeyRef:

--- a/hermes-ipfs-cache/k8s/staging/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/staging/hermes-ipfs-cache.yaml
@@ -84,8 +84,12 @@ spec:
                 secretKeyRef:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
+            # PLACEHOLDER — set to the new chain's SpaceRegistry deploy block before bring-up.
+            # 0 = stream from genesis (safe: won't miss events, just slower to catch up).
+            # NOTE: a non-numeric value is silently ignored and falls back to the OLD
+            # testnet block, so use 0 — never a REPLACE_WITH string — as the placeholder.
             - name: SUBSTREAMS_START_BLOCK
-              value: "138000"
+              value: "0"
             - name: IPFS_GATEWAY_URL
               valueFrom:
                 secretKeyRef:

--- a/hermes-substream/src/lib.rs
+++ b/hermes-substream/src/lib.rs
@@ -13,13 +13,36 @@ pub use helpers::extract_proposal_publish_uris;
 use pb::hermes::*;
 use substreams_ethereum::{block_view::LogView, pb::eth};
 
-// Space Registry proxy contract address (irdc testnet)
+// Space Registry PROXY contract address for the target chain.
+//
+// ⚠️ PLACEHOLDER — set this before bring-up. This value is compiled into the
+// `.spkg` and is NOT runtime-configurable; if it is wrong every service comes
+// up green and streams ZERO events with no error.
+//
+// To arm the substream:
+//   1. Replace the 20 bytes below with the target chain's SpaceRegistry proxy
+//      address (big-endian, one byte per array element).
+//   2. Delete the `compile_error!` line below.
+//   3. Rebuild and commit the regenerated binary:
+//        cd hermes-substream && substreams build
+//        git add hermes-substream/src/lib.rs hermes-substream/hermes-substream-v0.1.0.spkg
+//   4. Ensure proposal-executor's SPACE_REGISTRY_ADDRESS matches this exactly.
+//
+// The guard below makes the build fail until the address is set, so a stale or
+// zero-address `.spkg` can never be shipped by accident.
+compile_error!("SPACE_REGISTRY_ADDRESS is a placeholder — set the target-chain SpaceRegistry proxy address and delete this compile_error! line before building");
 const SPACE_REGISTRY_ADDRESS: [u8; 20] = [
-    0x36, 0x42, 0x31, 0x61, 0x5d, 0xce, 0xa3, 0x3d, 0x13, 0xc8, 0x23, 0xb1, 0x3b, 0x44, 0x9d, 0xd9,
-    0xf5, 0x53, 0x81, 0xe7,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
 ];
 
-// Local Space Registry Proxy
+// --- Previous addresses (kept for format reference) ---
+// irdc testnet Space Registry Proxy:
+// const SPACE_REGISTRY_ADDRESS: [u8; 20] = [
+//     0x36, 0x42, 0x31, 0x61, 0x5d, 0xce, 0xa3, 0x3d, 0x13, 0xc8, 0x23, 0xb1, 0x3b, 0x44, 0x9d, 0xd9,
+//     0xf5, 0x53, 0x81, 0xe7,
+// ];
+// Local Space Registry Proxy:
 // const SPACE_REGISTRY_ADDRESS: [u8; 20] = [
 //     0xe7, 0xf1, 0x72, 0x5e, 0x77, 0x34, 0xce, 0x28, 0x8f, 0x83, 0x67, 0xe1, 0xbb, 0x14, 0x3e, 0x90,
 //     0xbb, 0x3f, 0x05, 0x12,

--- a/hermes/k8s/production/atlas.yaml
+++ b/hermes/k8s/production/atlas.yaml
@@ -60,8 +60,12 @@ spec:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
                   optional: true
+            # PLACEHOLDER — set to the new chain's SpaceRegistry deploy block before bring-up.
+            # 0 = stream from genesis (safe: won't miss events, just slower to catch up).
+            # NOTE: a non-numeric value is silently ignored and falls back to the OLD
+            # testnet block, so use 0 — never a REPLACE_WITH string — as the placeholder.
             - name: SUBSTREAMS_START_BLOCK
-              value: "82655"
+              value: "0"
             - name: ROOT_SPACE_ID
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/production/hermes-pipeline.yaml
+++ b/hermes/k8s/production/hermes-pipeline.yaml
@@ -105,8 +105,12 @@ spec:
                 secretKeyRef:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
+            # PLACEHOLDER — set to the new chain's SpaceRegistry deploy block before bring-up.
+            # 0 = stream from genesis (safe: won't miss events, just slower to catch up).
+            # NOTE: a non-numeric value is silently ignored and falls back to the OLD
+            # testnet block, so use 0 — never a REPLACE_WITH string — as the placeholder.
             - name: SUBSTREAMS_START_BLOCK
-              value: "138000"
+              value: "0"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/staging/atlas.yaml
+++ b/hermes/k8s/staging/atlas.yaml
@@ -62,8 +62,12 @@ spec:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
                   optional: true
+            # PLACEHOLDER — set to the new chain's SpaceRegistry deploy block before bring-up.
+            # 0 = stream from genesis (safe: won't miss events, just slower to catch up).
+            # NOTE: a non-numeric value is silently ignored and falls back to the OLD
+            # testnet block, so use 0 — never a REPLACE_WITH string — as the placeholder.
             - name: SUBSTREAMS_START_BLOCK
-              value: "82655"
+              value: "0"
             - name: ROOT_SPACE_ID
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/staging/hermes-pipeline.yaml
+++ b/hermes/k8s/staging/hermes-pipeline.yaml
@@ -107,8 +107,12 @@ spec:
                 secretKeyRef:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
+            # PLACEHOLDER — set to the new chain's SpaceRegistry deploy block before bring-up.
+            # 0 = stream from genesis (safe: won't miss events, just slower to catch up).
+            # NOTE: a non-numeric value is silently ignored and falls back to the OLD
+            # testnet block, so use 0 — never a REPLACE_WITH string — as the placeholder.
             - name: SUBSTREAMS_START_BLOCK
-              value: "138000"
+              value: "0"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## ⚠️ Do not merge as-is — this is a bring-up checklist

This branch blanks all chain-specific config to safe placeholders. **The bring-up operator arms it by pushing a commit to this same branch** filling in the real target-chain values, then merges (`staging` → `main` → prod). CI stays red (`compile_error!` guard) until it's armed, so it can't be merged blank by accident.

## Operator checklist — commit these to this branch before merging

- [ ] **1. Substream registry address** — in `hermes-substream/src/lib.rs`, set the 20-byte `SPACE_REGISTRY_ADDRESS` to the target chain's SpaceRegistry **proxy** address (big-endian, one byte per array element) and **delete the `compile_error!` line**.
- [ ] **2. Rebuild + commit the binary** — `cd hermes-substream && substreams build`, then commit `lib.rs` + `hermes-substream-v0.1.0.spkg`. (The address is baked into the `.spkg` and is not runtime-configurable; a wrong value = every service comes up green and streams **zero events with no error**.)
- [ ] **3. Start blocks** — set `SUBSTREAMS_START_BLOCK` in the six manifests below to the new chain's SpaceRegistry deploy block. Leave `0` (genesis) only if you accept a slow catch-up. **Never** a `REPLACE_WITH` string — a non-numeric value is silently ignored and falls back to the old testnet block.
- [ ] **4. Cluster secrets (not in repo)** — `SUBSTREAMS_ENDPOINT`, `SUBSTREAMS_API_TOKEN` (`hermes-ipfs-cache-secrets`), `RPC_URL`.

| Manifest | Placeholder → set to |
|---|---|
| `hermes/k8s/production/atlas.yaml` | `0` → deploy block |
| `hermes/k8s/production/hermes-pipeline.yaml` | `0` → deploy block |
| `hermes-ipfs-cache/k8s/production/hermes-ipfs-cache.yaml` | `0` → deploy block |
| `hermes/k8s/staging/atlas.yaml` | `0` → deploy block |
| `hermes/k8s/staging/hermes-pipeline.yaml` | `0` → deploy block |
| `hermes-ipfs-cache/k8s/staging/hermes-ipfs-cache.yaml` | `0` → deploy block |

> ⚠️ **Timing:** once merged to `staging`, the staging hermes stack restarts from genesis on whatever chain its secrets point at. Arm with the real deploy block (or merge right at bring-up) — don't leave it armed on `staging` pre-cutover.

## Explicitly NOT in this PR

- **`proposal-executor` / `membership-acceptor` chain config** (`SPACE_REGISTRY_ADDRESS`, `CHAIN_ID`, `EXECUTOR_SPACE_ID`, space IDs, `GRAPHQL_ENDPOINT`) — coupled to pending **wallet-management** changes, landing separately. Their `CHAIN_ID` is an exhaustive `80451 | 19411` match and Safe addresses are gated on `chainId === 19411`, so a genuinely new chain ID there needs *code* changes, not just env. **When arming, make proposal-executor's `SPACE_REGISTRY_ADDRESS` match `lib.rs` exactly.**

## Verification (of the placeholder state)

- ✅ `cargo check` fails with the intended `compile_error!` guard message (stays red until armed).
- ✅ All six manifests parse as valid YAML.
- ⚠️ `.spkg` deliberately **not** rebuilt here (still the old binary) — regenerated during arming, step 2.
