### PR TITLE
ci(gaia-v2): target cluster as dispatch input; add notification pair + ranking-indexer

### DIFF
--- a/.github/workflows/build-v2-images.yml
+++ b/.github/workflows/build-v2-images.yml
@@ -1,6 +1,9 @@
 name: Build gaia-v2 images (manual)
 
-# Builds and pushes all images needed for the gaia-v2 (chain-migration) stack.
+# Builds and pushes images needed for the gaia-v2 (chain-migration) stack.
+# By default builds ALL images; use the `service` input to build a single one
+# when you only have service-scoped changes.
+#
 # Build-and-push only — deploys stay manual per the GEO-664 runbook (Step 12:
 # sed the image tag into the k8s/v2 manifests and kubectl apply).
 #
@@ -9,60 +12,73 @@ name: Build gaia-v2 images (manual)
 
 on:
   workflow_dispatch:
+    inputs:
+      service:
+        description: Which service to build and push
+        type: choice
+        default: all
+        options:
+          - all
+          - hermes-pipeline
+          - hermes-ipfs-cache
+          - kg-indexer
+          - api
+          - proposal-executor
+          - atlas
+          - search-indexer
+          - vote-indexer
+          - topology-indexer
+          - scoring-service
+          - notification-indexer
+          - delivery-worker
+          - ranking-indexer
 
 concurrency:
-  group: build-v2-images
+  group: build-v2-images-${{ inputs.service }}
   cancel-in-progress: false
 
 env:
   REGISTRY: registry.digitalocean.com/geo
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Compute build matrix
+        id: set-matrix
+        env:
+          SERVICE: ${{ inputs.service }}
+        run: |
+          ALL='[
+            {"image":"hermes-pipeline","dockerfile":"hermes-pipeline/Dockerfile","context":"."},
+            {"image":"hermes-ipfs-cache","dockerfile":"hermes-ipfs-cache/Dockerfile","context":"."},
+            {"image":"kg-indexer","dockerfile":"kg-indexer/Dockerfile","context":"."},
+            {"image":"api","dockerfile":"api/Dockerfile","context":"./api"},
+            {"image":"proposal-executor","dockerfile":"proposal-executor/Dockerfile","context":"proposal-executor"},
+            {"image":"atlas","dockerfile":"atlas/Dockerfile","context":"."},
+            {"image":"search-indexer","dockerfile":"search-indexer/Dockerfile","context":"."},
+            {"image":"vote-indexer","dockerfile":"scoring-service/vote-indexer/Dockerfile","context":"."},
+            {"image":"topology-indexer","dockerfile":"scoring-service/topology-indexer/Dockerfile","context":"."},
+            {"image":"scoring-service","dockerfile":"scoring-service/cronjob/Dockerfile","context":"scoring-service/cronjob"},
+            {"image":"notification-indexer","dockerfile":"notification-service/notification-indexer/Dockerfile","context":"."},
+            {"image":"delivery-worker","dockerfile":"notification-service/delivery-worker/Dockerfile","context":"."},
+            {"image":"ranking-indexer","dockerfile":"ranking-indexer/Dockerfile","context":"."}
+          ]'
+          if [ "$SERVICE" = "all" ]; then
+            MATRIX="$(echo "$ALL" | jq -c '{include: .}')"
+          else
+            MATRIX="$(echo "$ALL" | jq -c --arg svc "$SERVICE" '{include: [.[] | select(.image == $svc)]}')"
+          fi
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - image: hermes-pipeline
-            dockerfile: hermes-pipeline/Dockerfile
-            context: .
-          - image: hermes-ipfs-cache
-            dockerfile: hermes-ipfs-cache/Dockerfile
-            context: .
-          - image: kg-indexer
-            dockerfile: kg-indexer/Dockerfile
-            context: .
-          - image: api
-            dockerfile: api/Dockerfile
-            context: ./api
-          - image: proposal-executor
-            dockerfile: proposal-executor/Dockerfile
-            context: proposal-executor
-          - image: atlas
-            dockerfile: atlas/Dockerfile
-            context: .
-          - image: search-indexer
-            dockerfile: search-indexer/Dockerfile
-            context: .
-          - image: vote-indexer
-            dockerfile: scoring-service/vote-indexer/Dockerfile
-            context: .
-          - image: topology-indexer
-            dockerfile: scoring-service/topology-indexer/Dockerfile
-            context: .
-          - image: scoring-service
-            dockerfile: scoring-service/cronjob/Dockerfile
-            context: scoring-service/cronjob
-          - image: notification-indexer
-            dockerfile: notification-service/notification-indexer/Dockerfile
-            context: .
-          - image: delivery-worker
-            dockerfile: notification-service/delivery-worker/Dockerfile
-            context: .
-          - image: ranking-indexer
-            dockerfile: ranking-indexer/Dockerfile
-            context: .
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -92,5 +108,6 @@ jobs:
       - name: Print image tags
         run: |
           echo "## gaia-v2 images" >> "$GITHUB_STEP_SUMMARY"
+          echo "Service(s) built: \`${{ inputs.service }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "Tag for manifests: \`${GITHUB_SHA:0:8}\` (or full \`${GITHUB_SHA}\`)" >> "$GITHUB_STEP_SUMMARY"
           echo "Build result: ${{ needs.build.result }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-v2-images.yml
+++ b/.github/workflows/build-v2-images.yml
@@ -54,6 +54,15 @@ jobs:
           - image: scoring-service
             dockerfile: scoring-service/cronjob/Dockerfile
             context: scoring-service/cronjob
+          - image: notification-indexer
+            dockerfile: notification-service/notification-indexer/Dockerfile
+            context: .
+          - image: delivery-worker
+            dockerfile: notification-service/delivery-worker/Dockerfile
+            context: .
+          - image: ranking-indexer
+            dockerfile: ranking-indexer/Dockerfile
+            context: .
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -1,7 +1,11 @@
 name: Deploy gaia-v2 service (manual)
 
-# Deploys one gaia-v2 service: seds the image tag into its k8s/v2 manifest(s)
-# and applies them to the gaia-v2 namespace, then gates on rollout status.
+# Deploys one gaia v2-stack service: seds the image tag into its k8s/v2
+# manifest(s) and applies them, then gates on rollout status.
+#
+# Target cluster is a dispatch input. Default is geo-testnet-k8s (the new
+# testnet cluster, namespace `gaia`); k8s-geo-testnet (namespace `gaia-v2`)
+# remains selectable while the legacy cluster is being retired.
 #
 # Companion to "Build gaia-v2 images (manual)" — build first, then deploy with
 # the tag the build run printed. Bring-up order and per-service health gates
@@ -27,18 +31,29 @@ on:
           - topology-indexer
           - scoring-service
           - proposal-executor
+          - notification-indexer
+          - delivery-worker
+          - ranking-indexer
       tag:
         description: "Image tag to deploy (from the build workflow, e.g. short SHA). Ignored for valkey (pinned public image)."
         required: true
         type: string
+      cluster:
+        description: "Target cluster. geo-testnet-k8s = new testnet cluster (namespace gaia); k8s-geo-testnet = legacy cluster (namespace gaia-v2, being retired)."
+        required: true
+        type: choice
+        default: geo-testnet-k8s
+        options:
+          - geo-testnet-k8s
+          - k8s-geo-testnet
 
 concurrency:
-  group: deploy-v2-${{ inputs.service }}
+  group: deploy-v2-${{ inputs.cluster }}-${{ inputs.service }}
   cancel-in-progress: false
 
 env:
   REGISTRY: registry.digitalocean.com/geo
-  NAMESPACE: gaia-v2
+  NAMESPACE: ${{ inputs.cluster == 'k8s-geo-testnet' && 'gaia-v2' || 'gaia' }}
 
 jobs:
   deploy:
@@ -56,7 +71,7 @@ jobs:
         uses: azure/setup-kubectl@v5
 
       - name: Configure kubectl for DigitalOcean
-        run: doctl kubernetes cluster kubeconfig save ${{ secrets.DIGITALOCEAN_CLUSTER_NAME }}
+        run: doctl kubernetes cluster kubeconfig save ${{ inputs.cluster }}
 
       - name: Resolve service mapping
         id: map
@@ -73,6 +88,9 @@ jobs:
             topology-indexer)  manifests="scoring-service/deployment/v2/topology-indexer.yaml"; rollout="deployment/topology-indexer" ;;
             scoring-service)   manifests="scoring-service/deployment/v2/cronjob.yaml";      rollout="" ;;
             proposal-executor) manifests="proposal-executor/deployment/v2/cronjob.yaml";    rollout="" ;;
+            notification-indexer) manifests="notification-service/deployment/v2/notification-indexer.yaml"; rollout="deployment/notification-indexer" ;;
+            delivery-worker)   manifests="notification-service/deployment/v2/delivery-worker.yaml"; rollout="deployment/delivery-worker" ;;
+            ranking-indexer)   manifests="ranking-indexer/k8s/v2/ranking-indexer.yaml";     rollout="deployment/ranking-indexer" ;;
             *) echo "unknown service"; exit 1 ;;
           esac
           echo "manifests=$manifests" >> "$GITHUB_OUTPUT"
@@ -88,7 +106,7 @@ jobs:
             }
 
       - name: Ensure namespace exists
-        run: kubectl apply -f kg-indexer/k8s/v2/namespace.yaml
+        run: kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Guard against unfilled placeholders
         run: |

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -98,12 +98,24 @@ jobs:
 
       - name: Verify image tag exists in registry
         if: inputs.service != 'valkey'
+        env:
+          TAG: ${{ inputs.tag }}
+          SERVICE: ${{ inputs.service }}
         run: |
-          doctl registry repository list-tags ${{ inputs.service }} --format Tag --no-header | \
-            grep -qx "${{ inputs.tag }}" || {
-              echo "::error::Tag ${{ inputs.tag }} not found in $REGISTRY/${{ inputs.service }} — run the build workflow first."
-              exit 1
-            }
+          # Capture doctl output separately so a doctl failure is distinguishable
+          # from "tag not found". Match the tag against the FIRST column only:
+          # the runner's doctl ignores --format/--no-header and prints the full
+          # table, and a substring grep could false-positive on the hex digest
+          # column. First-field exact match works with either output format.
+          if ! tags=$(doctl registry repository list-tags "$SERVICE"); then
+            echo "::error::doctl failed listing tags for $REGISTRY/$SERVICE — registry/auth problem, not a missing tag."
+            exit 1
+          fi
+          if ! echo "$tags" | awk -v t="$TAG" '$1==t{found=1} END{exit !found}'; then
+            echo "::error::Tag $TAG not found in $REGISTRY/$SERVICE — run the build workflow first. Tags present:"
+            echo "$tags"
+            exit 1
+          fi
 
       - name: Ensure namespace exists
         run: kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
Part of the gaia pre-prod migration to the new `geo-testnet-k8s` cluster (context in the reputation/infra threads; cluster-side provisioning — namespace `gaia`, DB, secrets — is already done and verified).

## deploy-v2.yml

- **New `cluster` dispatch input** (choice) replacing the `DIGITALOCEAN_CLUSTER_NAME` secret:
  - `geo-testnet-k8s` — new testnet cluster, namespace `gaia` (**default**)
  - `k8s-geo-testnet` — legacy cluster, namespace `gaia-v2` (selectable while it's being retired)
  - `NAMESPACE` derives from the choice; the concurrency group includes the cluster so old/new deploys of the same service don't serialize against each other.
- **Namespace-ensure is now ref-agnostic**: idempotent `kubectl create ns --dry-run=client | apply` instead of applying `kg-indexer/k8s/v2/namespace.yaml`, so the step works for both namespaces regardless of which ref's manifests are checked out.
- **Three new services** in the dropdown + case mapping:
  - `notification-indexer`, `delivery-worker` — ports the workflow half of #770, which landed on the `staging` branch where `workflow_dispatch` can't see it (workflows must exist on the default branch to be dispatchable — same trap #743 documented).
  - `ranking-indexer` — its v2 manifest lands in the companion `staging`-branch PR; dispatching before that merges fails cleanly at the apply step (file not found).

## build-v2-images.yml

- Adds `notification-indexer`, `delivery-worker` (#770 port) and `ranking-indexer` to the build matrix. Dockerfile paths for the notification pair match #770; ranking-indexer matches its production build (`ranking-indexer/Dockerfile`, repo-root context).

## Notes for reviewers

- Deploys are still dispatched with `--ref staging` so the applied manifests come from that branch; this PR only changes where they're applied and what's buildable.
- The `DIGITALOCEAN_CLUSTER_NAME` secret is no longer read by these two workflows (cluster names aren't sensitive); the per-service production/staging deploy workflows still use it and are untouched.