### PR TITLE
feat(v2-manifests): retarget to new testnet cluster (namespace gaia, Gateway API)

### DIFF
--- a/api/k8s/v2/api.yaml
+++ b/api/k8s/v2/api.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: api
 spec:
@@ -24,12 +24,6 @@ spec:
       volumes:
         - name: ssl-certs
           emptyDir: {}
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       initContainers:
         - name: setup-certs
           image: registry.digitalocean.com/geo/api:latest
@@ -195,7 +189,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: api
 spec:
@@ -208,43 +202,30 @@ spec:
   selector:
     app: api
 ---
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+# HTTP routing via the shared Cilium Gateway (`geo-chat-api` in the geo-chat
+# namespace — one LB / IP for the whole cluster, per-service HTTPRoutes).
+# Companion Gateway-side change (geo-chat repo): listeners for
+# testnet-api-v2.geobrowser.io (HTTP + HTTPS with a cert-manager cert) and
+# allowedRoutes opened to the gaia namespace; DNS for the host points at the
+# shared Gateway LB.
+# Note: the old nginx server-snippet gzip and proxy-body-size tuning have no
+# HTTPRoute equivalent — response compression falls to the api process.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: api
-  namespace: gaia-v2
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      gzip on;
-      gzip_comp_level 5;
-      gzip_min_length 512;
-      gzip_proxied any;
-      gzip_vary on;
-      gzip_types
-        application/json
-        application/graphql-response+json
-        application/javascript
-        application/xml
-        text/plain
-        text/css
-        text/javascript
-        text/xml;
+  namespace: gaia
 spec:
-  ingressClassName: nginx
-  tls:
-    - hosts:
-        - testnet-api-v2.geobrowser.io
-      secretName: testnet-api-v2-tls
+  parentRefs:
+    - name: geo-chat-api
+      namespace: geo-chat
+  hostnames:
+    - testnet-api-v2.geobrowser.io
   rules:
-    - host: testnet-api-v2.geobrowser.io
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: api
-                port:
-                  number: 3000
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: api
+          port: 3000

--- a/api/k8s/v2/hpa.yaml
+++ b/api/k8s/v2/hpa.yaml
@@ -2,7 +2,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: api
-  namespace: gaia-v2
+  namespace: gaia
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -34,7 +34,7 @@ spec:
   metrics:
     # v2 scales on resource metrics only — the prod External/Pods metrics
     # (prometheus-adapter + recording rules) are scoped to the prod host and
-    # namespace and don't exist for gaia-v2 until monitoring is wired (Step 15).
+    # namespace and don't exist for gaia until monitoring is wired (Step 15).
     - type: Resource
       resource:
         name: cpu

--- a/api/k8s/v2/valkey.yaml
+++ b/api/k8s/v2/valkey.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api-cache
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: api-cache
 spec:
@@ -19,12 +19,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 999
         fsGroup: 999
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       containers:
         - name: valkey
           image: valkey/valkey:8.1-alpine
@@ -87,7 +81,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api-cache
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: api-cache
 spec:
@@ -105,7 +99,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: api-cache-ingress
-  namespace: gaia-v2
+  namespace: gaia
 spec:
   podSelector:
     matchLabels:

--- a/hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hermes-ipfs-cache
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: hermes-ipfs-cache
 spec:
@@ -24,12 +24,6 @@ spec:
       volumes:
         - name: ssl-certs
           emptyDir: {}
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       initContainers:
         - name: setup-certs
           image: registry.digitalocean.com/geo/hermes-ipfs-cache:latest
@@ -161,7 +155,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hermes-ipfs-cache
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: hermes-ipfs-cache
 spec:

--- a/hermes/k8s/v2/atlas.yaml
+++ b/hermes/k8s/v2/atlas.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: atlas
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: atlas
 spec:
@@ -18,12 +18,6 @@ spec:
       restartPolicy: Always
       imagePullSecrets:
         - name: regcred
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       containers:
         - name: atlas
           image: registry.digitalocean.com/geo/atlas:latest

--- a/hermes/k8s/v2/hermes-pipeline.yaml
+++ b/hermes/k8s/v2/hermes-pipeline.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hermes-pipeline
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: hermes-pipeline
 spec:
@@ -25,12 +25,6 @@ spec:
       volumes:
         - name: ssl-certs
           emptyDir: {}
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       initContainers:
         - name: setup-certs
           image: registry.digitalocean.com/geo/hermes-pipeline:latest
@@ -176,7 +170,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hermes-pipeline
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: hermes-pipeline
 spec:

--- a/kg-indexer/k8s/v2/kg-indexer.yaml
+++ b/kg-indexer/k8s/v2/kg-indexer.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kg-indexer
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: kg-indexer
 spec:
@@ -24,12 +24,6 @@ spec:
       volumes:
         - name: ssl-certs
           emptyDir: {}
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       initContainers:
         - name: setup-certs
           image: registry.digitalocean.com/geo/kg-indexer:latest

--- a/kg-indexer/k8s/v2/namespace.yaml
+++ b/kg-indexer/k8s/v2/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: gaia-v2
+  name: gaia

--- a/notification-service/deployment/v2/delivery-worker.yaml
+++ b/notification-service/deployment/v2/delivery-worker.yaml
@@ -10,7 +10,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: delivery-worker
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: delivery-worker
     environment: testnet

--- a/notification-service/deployment/v2/notification-indexer.yaml
+++ b/notification-service/deployment/v2/notification-indexer.yaml
@@ -10,7 +10,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: notification-indexer
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: notification-indexer
     environment: testnet

--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: proposal-executor
-  namespace: gaia-v2
+  namespace: gaia
 spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
@@ -23,12 +23,6 @@ spec:
           volumes:
             - name: ssl-certs
               emptyDir: {}
-          nodeSelector:
-            doks.digitalocean.com/node-pool: gaia-v2-pool
-          tolerations:
-            - key: dedicated
-              value: gaia-v2
-              effect: NoSchedule
           initContainers:
             - name: setup-certs
               image: registry.digitalocean.com/geo/proposal-executor:latest

--- a/ranking-indexer/k8s/v2/ranking-indexer.yaml
+++ b/ranking-indexer/k8s/v2/ranking-indexer.yaml
@@ -1,0 +1,105 @@
+# Ranking Indexer Deployment
+#
+# Consumes RANK_VOTES ops from the knowledge.edits stream and materializes
+# ranking aggregates into the ranks.* schema. ranks.ranking_scores is the
+# reputation system's v1 Expert-band signal, so this service is part of the
+# rep-critical path (see docs/plans/2026-06-22-feat-reputation-system-plan.md).
+# Modeled on the knowledge-staging deployment; env/resources match it, with
+# the shared kafka-credentials secret standing in for ranking-indexer-secrets.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ranking-indexer
+  namespace: gaia
+  labels:
+    app: ranking-indexer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ranking-indexer
+  template:
+    metadata:
+      labels:
+        app: ranking-indexer
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+      containers:
+        - name: ranking-indexer
+          image: registry.digitalocean.com/geo/ranking-indexer:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: PGSSLROOTCERT
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_USERNAME
+                  optional: true
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_PASSWORD
+                  optional: true
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_SSL_CA_PEM
+                  optional: true
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: KAFKA_GROUP_ID
+              value: "ranking-indexer-testnet-v1"
+            - name: RUST_LOG
+              value: "ranking_indexer=info"
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "500m"

--- a/scoring-service/deployment/v2/cronjob.yaml
+++ b/scoring-service/deployment/v2/cronjob.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: scoring-service
-  namespace: gaia-v2
+  namespace: gaia
 spec:
   schedule: "0 3 * * *"  # Run at 3am every day
   failedJobsHistoryLimit: 3
@@ -13,12 +13,6 @@ spec:
           restartPolicy: OnFailure
           imagePullSecrets:
             - name: regcred
-          nodeSelector:
-            doks.digitalocean.com/node-pool: gaia-v2-pool
-          tolerations:
-            - key: dedicated
-              value: gaia-v2
-              effect: NoSchedule
           containers:
             - name: scoring-service
               image: registry.digitalocean.com/geo/scoring-service:latest

--- a/scoring-service/deployment/v2/topology-indexer.yaml
+++ b/scoring-service/deployment/v2/topology-indexer.yaml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: topology-indexer
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: topology-indexer
 spec:
@@ -26,12 +26,6 @@ spec:
         fsGroup: 1001
       imagePullSecrets:
         - name: regcred
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       containers:
         - name: topology-indexer
           image: registry.digitalocean.com/geo/topology-indexer:latest

--- a/scoring-service/deployment/v2/vote-indexer.yaml
+++ b/scoring-service/deployment/v2/vote-indexer.yaml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vote-indexer
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: vote-indexer
 spec:
@@ -26,12 +26,6 @@ spec:
         fsGroup: 1001
       imagePullSecrets:
         - name: regcred
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       containers:
         - name: vote-indexer
           image: registry.digitalocean.com/geo/vote-indexer:latest

--- a/search-indexer-deploy/k8s/v2/jobs/backfill-name-raw-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/backfill-name-raw-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opensearch-backfill-name-raw
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: opensearch-admin
     task: backfill-name-raw

--- a/search-indexer-deploy/k8s/v2/jobs/create-index-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/create-index-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opensearch-create-index
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: opensearch-admin
     task: create-index

--- a/search-indexer-deploy/k8s/v2/jobs/delete-index-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/delete-index-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opensearch-delete-index
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: opensearch-admin
     task: delete-index

--- a/search-indexer-deploy/k8s/v2/jobs/full-migration-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/full-migration-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opensearch-full-migration
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: opensearch-admin
     task: full-migration
@@ -59,7 +59,7 @@ spec:
         - name: TARGET_VERSION
           value: "3"  # CHANGE THIS: New/target index version
         - name: NAMESPACE
-          value: "gaia-v2"  # Kubernetes namespace for gaia-v2 (testnet)
+          value: "gaia"  # Kubernetes namespace for gaia (testnet)
         - name: DEPLOYMENT_NAME
           value: "search-indexer"
         - name: RUST_LOG

--- a/search-indexer-deploy/k8s/v2/jobs/list-indices-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/list-indices-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opensearch-list-indices
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: opensearch-admin
     task: list-indices

--- a/search-indexer-deploy/k8s/v2/jobs/reindex-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/reindex-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opensearch-reindex
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: opensearch-admin
     task: reindex

--- a/search-indexer-deploy/k8s/v2/jobs/update-alias-job.yaml
+++ b/search-indexer-deploy/k8s/v2/jobs/update-alias-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opensearch-update-alias
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: opensearch-admin
     task: update-alias

--- a/search-indexer-deploy/k8s/v2/search-indexer.yaml
+++ b/search-indexer-deploy/k8s/v2/search-indexer.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: search-indexer
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: search-indexer
 spec:
@@ -25,7 +25,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: search-indexer
-  namespace: gaia-v2
+  namespace: gaia
   labels:
     app: search-indexer
 spec:
@@ -47,12 +47,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
-      nodeSelector:
-        doks.digitalocean.com/node-pool: gaia-v2-pool
-      tolerations:
-        - key: dedicated
-          value: gaia-v2
-          effect: NoSchedule
       containers:
         - name: search-indexer
           image: registry.digitalocean.com/geo/search-indexer:latest


### PR DESCRIPTION
Companion to #804 (deploy workflows). Together: the v2 stack becomes deployable to the new `geo-testnet-k8s` cluster. Base is `staging` because that's the ref `deploy-v2` applies manifests from.

## Changes

- **`namespace: gaia-v2` → `gaia`** across all 22 v2 manifests. The `gaia` namespace on `geo-testnet-k8s` is already provisioned and verified: secrets (`api-secrets`, `kafka-credentials`, `kg-indexer-secrets`, `hermes-pipeline-secrets`, `opensearch-credentials`, `scoring-service-credentials`, `search-indexer-secrets`), `regcred` pull secret, and DB connectivity (pooled + DDL as `gaia_app`) tested end-to-end from in-cluster.
- **Dropped the `gaia-v2-pool` nodeSelector + `dedicated` toleration blocks** everywhere: the new cluster is single-pool (`geo-testnet-main`, s-4vcpu-8gb ×3, autoscale to 5) with no taints — and a nodeSelector for a pool that doesn't exist would leave every pod Pending.
- **api: nginx `Ingress` → Gateway API `HTTPRoute`**, attached cross-namespace to the shared Cilium Gateway (`geo-chat-api` in `geo-chat` — the cluster convention: one LB/IP, per-service routes; confirmed with Yaniv). Host stays `testnet-api-v2.geobrowser.io`.
- **New: `ranking-indexer/k8s/v2/ranking-indexer.yaml`** — first v2 manifest for ranking-indexer, which is rep-critical (`ranks.ranking_scores` is the reputation Expert band's v1 signal; mid-July rankings push wants it validated here). Modeled on the knowledge-staging deployment: same image/resources, `DATABASE_URL` + CA from `api-secrets` (kg-indexer init-container pattern), Kafka via the shared `kafka-credentials`, `ENVIRONMENT=testnet`, consumer group `ranking-indexer-testnet-v1`.

## Not in this PR (deliberate)

- **Gateway-side companion change** (geo-chat repo / Yaniv): listeners for `testnet-api-v2.geobrowser.io` (HTTP + HTTPS with a cert-manager cert) and `allowedRoutes` opened to the `gaia` namespace — the Gateway's listeners are currently hostname-scoped to chat with `from: Same`. Until that lands, the HTTPRoute simply won't attach (visible in its status conditions); everything else deploys fine.
- DNS for `testnet-api-v2.geobrowser.io` → shared Gateway LB (`45.55.102.237`) at cutover.
- Behavior note: nginx `server-snippet` gzip and `proxy-body-size: 100m` have no HTTPRoute equivalent. Compression falls to the api process; if the 100m upload path matters on this host, it needs an api-side limit check.

## Validation

All 23 manifests pass `kubectl apply --dry-run=client` against `geo-testnet-k8s` (HTTPRoute validates against the live Gateway API CRDs).