### PR TITLE
fix(notification-indexer): adapt to governance-v2 proto (un-buildable since #759)

### DIFF
--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -589,8 +589,9 @@ fn make_settings() -> hermes_schema::pb::governance::ProposalSettings {
         last_date: 1700086400,
         voting_mode: 0,
         quorum: 1,
-        flat_threshold: 1,
-        percentage_threshold: 0,
+        flat_support_threshold: 1,
+        partial_percentage_support_threshold: 0,
+        ..Default::default()
     }
 }
 
@@ -665,6 +666,7 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         proposal_id: PROP_3E_VOTED_BYTES.to_vec(),
         vote: hermes_schema::pb::governance::ProposalVoteOption::VoteOptionYes as i32,
         meta: Some(make_meta(12348, 1700003000)),
+        ..Default::default()
     };
     send_event(
         &producer,
@@ -695,8 +697,9 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
             last_date: 1700172800,
             voting_mode: 1,
             quorum: 5,
-            flat_threshold: 0,
-            percentage_threshold: 5000000,
+            flat_support_threshold: 0,
+            partial_percentage_support_threshold: 5000000,
+            ..Default::default()
         }),
         meta: Some(make_meta(12349, 1700004000)),
     };

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -519,13 +519,21 @@ fn voting_mode_to_string(mode: i32) -> Result<String, HandlerError> {
 fn settings_to_payload(
     settings: &hermes_schema::pb::governance::ProposalSettings,
 ) -> Result<ProposalSettingsPayload, HandlerError> {
+    // Governance v2 (#759) split the v1 thresholds. Payload field names are the
+    // stable webhook contract; the v1-equivalent sources are (per the documented
+    // semantics in api/src/proposals/types.ts):
+    //   flat_threshold       <- flat_support_threshold (fast path, absolute YES count)
+    //   percentage_threshold <- partial_percentage_support_threshold (slow path,
+    //                           late-execution bar — the "did it pass" threshold)
+    // universal_percentage_support_threshold (early execution) is a new v2 concept
+    // with no v1 counterpart and is intentionally not mapped here.
     Ok(ProposalSettingsPayload {
         start_date: settings.start_date,
         end_date: settings.last_date,
         voting_mode: voting_mode_to_string(settings.voting_mode)?,
         quorum: settings.quorum,
-        flat_threshold: settings.flat_threshold,
-        percentage_threshold: settings.percentage_threshold,
+        flat_threshold: settings.flat_support_threshold,
+        percentage_threshold: settings.partial_percentage_support_threshold,
     })
 }
 
@@ -585,8 +593,11 @@ fn action_to_summary(action: &hermes_schema::pb::governance::ProposalAction) -> 
             action_type: "update_voting_settings".to_string(),
             voting_settings: Some(VotingSettingsUpdate {
                 quorum: s.quorum,
-                fast_threshold: s.fast_threshold,
-                slow_threshold: s.slow_threshold,
+                // Same gov-v2 mapping as settings_to_payload: fast path is the
+                // flat YES-count threshold, slow path is the late-execution
+                // (partial) percentage threshold.
+                fast_threshold: s.flat_support_threshold,
+                slow_threshold: s.partial_percentage_support_threshold,
                 duration: s.duration,
             }),
             ..ActionSummary::default()
@@ -1611,6 +1622,7 @@ mod tests {
             proposal_id: make_test_uuid(0x03),
             vote: ProposalVoteOption::VoteOptionYes as i32,
             meta: Some(make_metadata(888, 1700003000)),
+            ..Default::default()
         };
 
         let event = handle_proposal_voted(&msg).expect("should parse");
@@ -1634,6 +1646,7 @@ mod tests {
             proposal_id: make_test_uuid(0x03),
             vote: ProposalVoteOption::VoteOptionNo as i32,
             meta: Some(make_metadata(889, 1700003001)),
+            ..Default::default()
         };
 
         let event = handle_proposal_voted(&msg).expect("should parse");
@@ -1649,6 +1662,7 @@ mod tests {
             proposal_id: make_test_uuid(0x03),
             vote: ProposalVoteOption::VoteOptionAbstain as i32,
             meta: Some(make_metadata(890, 1700003002)),
+            ..Default::default()
         };
 
         let event = handle_proposal_voted(&msg).expect("should parse");
@@ -1664,6 +1678,7 @@ mod tests {
             proposal_id: make_test_uuid(0x03),
             vote: ProposalVoteOption::VoteOptionYes as i32,
             meta: Some(make_metadata(42, 100)),
+            ..Default::default()
         };
 
         let event = handle_proposal_voted(&msg).expect("should parse");
@@ -1678,6 +1693,7 @@ mod tests {
             proposal_id: make_test_uuid(0x03),
             vote: ProposalVoteOption::VoteOptionYes as i32,
             meta: Some(make_metadata(100, 999)),
+            ..Default::default()
         };
 
         let event = handle_proposal_voted(&msg).expect("should parse");
@@ -1739,8 +1755,9 @@ mod tests {
                 last_date: 1700086400,
                 voting_mode: 1,
                 quorum: 5,
-                flat_threshold: 0,
-                percentage_threshold: 5000000,
+                flat_support_threshold: 0,
+                partial_percentage_support_threshold: 5000000,
+                ..Default::default()
             }),
             meta: Some(make_metadata(777, 1700004000)),
         };
@@ -1817,6 +1834,7 @@ mod tests {
             proposal_id: make_test_uuid(0x03),
             vote: 1,
             meta: None,
+            ..Default::default()
         };
         assert!(matches!(
             handle_proposal_voted(&msg).unwrap_err(),


### PR DESCRIPTION
Unblocks the last service of the gaia pre-prod migration (notification-indexer + delivery-worker; the rest of the stack is live on `geo-testnet-k8s`).

## Context

#759 (gov-v2) reshaped the hermes protos on this branch, and notification-indexer was never adapted — it has been un-buildable on staging since June 18. Nobody noticed because its build-workflow entry (#770) landed where `workflow_dispatch` can't see it; yesterday's first-ever CI build of this image surfaced it.

## The mapping decision (please sanity-check this, it's the whole PR)

The webhook payload keeps its existing field names (`flat_threshold`, `percentage_threshold`) — no consumer contract change. Values now source from gov-v2 fields per the documented semantics in `api/src/proposals/types.ts`:

| payload field (unchanged) | gov-v2 source | why |
|---|---|---|
| `flat_threshold` | `flat_support_threshold` | direct rename — fast path, absolute YES count |
| `percentage_threshold` | `partial_percentage_support_threshold` | slow-path **late-execution** bar = the v1 "did it pass at window end" threshold |
| *(not mapped)* | `universal_percentage_support_threshold` | early-execution is a new v2 concept with no v1 counterpart |

Same mapping in the `UpdateVotingSettings` action summary. Test/e2e proto constructors get `..Default::default()` for the new `proposal_version` / `execute_by` fields (proto3 zero = unset, per #759's own convention).

@0xJagger — you own the gov-v2 semantics; if the partial-vs-universal call is wrong, say the word and it's a two-line change. Merging on lazy consensus since this blocks the migration and the mapping follows the documented definitions.

## Verification

- `cargo check -p notification-indexer` clean; **84/84 unit tests pass**; `notification-e2e-tests` compiles.
- Follow-up after merge: build + deploy the pair to `geo-testnet-k8s` (workflow entries already exist from #804).