### PR TITLE
fix(proposal-executor): fill v2 config; add required membership-bot env

### DIFF
--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -61,18 +61,25 @@ spec:
                     secretKeyRef:
                       name: proposal-executor-credentials
                       key: PIMLICO_API_KEY
+                - name: MEMBERSHIP_BOT_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: MEMBERSHIP_BOT_PRIVATE_KEY
                 # Config (non-sensitive — plain values)
                 - name: EXECUTOR_SPACE_ID
-                  value: "REPLACE_WITH_NEW_EXECUTOR_SPACE_ID"
+                  value: "0xc669ec5cfd998cb14ca129a0f9838f78"
+                - name: MEMBERSHIP_BOT_SPACE_ID
+                  value: "0x4612d0863fe0b321052cb8d404a7afac"
                 - name: SPACE_REGISTRY_ADDRESS
-                  value: "REPLACE_WITH_NEW_SPACE_REGISTRY_ADDRESS"
+                  value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
                 - name: RPC_URL
                   valueFrom:
                     secretKeyRef:
                       name: proposal-executor-credentials
                       key: RPC_URL
                 - name: CHAIN_ID
-                  value: "REPLACE_WITH_NEW_CHAIN_ID"
+                  value: "19411"
                 # Optional: Sentry error reporting
                 - name: SENTRY_DSN
                   valueFrom:


### PR DESCRIPTION
Last service of the gaia pre-prod migration. Everything here was provisioned today and is verifiable on-chain / in-cluster:

| Placeholder | Value | Provenance |
|---|---|---|
| `EXECUTOR_SPACE_ID` | `0xc669ec5cfd998cb14ca129a0f9838f78` | fresh key, Safe `0x5980…aB0`, registered via `geo space create --smart-account` (block 158993) |
| `MEMBERSHIP_BOT_SPACE_ID` | `0x4612d0863fe0b321052cb8d404a7afac` | fresh key, distinct identity per RUNBOOK (block 158994) |
| `SPACE_REGISTRY_ADDRESS` | `0xB01683b2f0d38d43fcD4D9aAB980166988924132` | gov-v2 registry — **verified via `eth_getCode`: code on 19411, no code on 80451** |
| `CHAIN_ID` | `19411` | gov-v2 = new contracts on the same testnet chain, not a new chain |

Also **adds two missing env entries** (`MEMBERSHIP_BOT_PRIVATE_KEY`, `MEMBERSHIP_BOT_SPACE_ID`): `parseConfig` requires both with no defaults, so the manifest as written would have failed at startup even with the placeholders filled.

Notes:
- Fresh keys (not production's) — the old executor runs on the same chain, and sharing a Safe identity between two cron executors is a nonce race.
- `proposal-executor-credentials` is already provisioned in the `gaia` namespace on `geo-testnet-k8s`.
- Side-finding from the chain verification, flagged separately to Yaniv: geo-chat's `ETHEREUM_RPC_URL` on the new cluster points at chain 80451, where the registry it's configured with has no code.
- Deploy after merge: `deploy-v2` with tag `400235b4` (image already built; executor code unchanged since).