### PR TITLE
feat(ranking-indexer): support datetime ranking-block bounds (GEO-2253)

### DIFF
--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -33,6 +33,8 @@ struct DetectIds {
     filter_property: Uuid,
     start_date_property: Uuid,
     end_date_property: Uuid,
+    start_datetime_property: Uuid,
+    end_datetime_property: Uuid,
     aggregation_restriction_relation: Uuid,
 }
 
@@ -51,6 +53,8 @@ static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
         filter_property: uid(RANK_FILTER_PROPERTY_ID),
         start_date_property: uid(RANK_START_DATE_PROPERTY_ID),
         end_date_property: uid(RANK_END_DATE_PROPERTY_ID),
+        start_datetime_property: uid(RANK_START_DATETIME_PROPERTY_ID),
+        end_datetime_property: uid(RANK_END_DATETIME_PROPERTY_ID),
         aggregation_restriction_relation: uid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID),
     }
 });
@@ -110,6 +114,28 @@ fn parse_date(s: &str) -> Option<DateTime<Utc>> {
             .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
     }
     None
+}
+
+/// Resolve one submission-window bound of a block: the datetime property
+/// (GEO-2253) wins; the legacy date property is the fallback. When a block
+/// authors both, the legacy value is ignored (even if it differs).
+fn window_bound(
+    values: &[PropertyValue],
+    block: Uuid,
+    bound: &'static str,
+    datetime_property: Uuid,
+    date_property: Uuid,
+) -> Option<DateTime<Utc>> {
+    let new = date_value(values, datetime_property);
+    let old = date_value(values, date_property);
+    if new.is_some() && old.is_some() {
+        tracing::debug!(
+            block = %block,
+            bound,
+            "block authors both the datetime and legacy date property; using the datetime one"
+        );
+    }
+    new.or(old)
 }
 
 /// The rank-relevant ops extracted from a single edit.
@@ -212,8 +238,20 @@ pub fn detect(
                         space_id,
                         name: text_value(&entity.values, ids.name_property),
                         filter: text_value(&entity.values, ids.filter_property),
-                        start_date: date_value(&entity.values, ids.start_date_property),
-                        end_date: date_value(&entity.values, ids.end_date_property),
+                        start_date: window_bound(
+                            &entity.values,
+                            entity_id,
+                            "start",
+                            ids.start_datetime_property,
+                            ids.start_date_property,
+                        ),
+                        end_date: window_bound(
+                            &entity.values,
+                            entity_id,
+                            "end",
+                            ids.end_datetime_property,
+                            ids.end_date_property,
+                        ),
                         restriction_id: restriction_of.get(&entity_id).copied(),
                     });
                 }
@@ -444,6 +482,105 @@ mod tests {
         assert_eq!(
             b.restriction_id,
             Some(Uuid::parse_str(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID).unwrap())
+        );
+    }
+
+    /// A `Ranking Block` typed entity whose values are set by `configure`.
+    fn block_edit(
+        configure: impl FnOnce(
+            grc_20::model::builder::EntityBuilder<'static>,
+        ) -> grc_20::model::builder::EntityBuilder<'static>,
+    ) -> grc_20::Edit<'static> {
+        EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(20))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(BLOCK))
+                    .to(sid(RANKING_BLOCK_TYPE_ID))
+            })
+            .create_entity(gid(BLOCK), configure)
+            .build()
+    }
+
+    #[test]
+    fn legacy_date_props_accept_datetime_values() {
+        use chrono::TimeZone;
+        let edit = block_edit(|e| {
+            e.value(
+                sid(RANK_START_DATE_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-01T12:30:00Z".into()),
+            )
+            .value(
+                sid(RANK_END_DATE_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-30T18:00:00+02:00".into()),
+            )
+        });
+
+        let b = &detect(&edit, space_uuid(), 100, 0).blocks[0];
+        assert_eq!(
+            b.start_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 1, 12, 30, 0).unwrap())
+        );
+        // offsets normalize to UTC
+        assert_eq!(
+            b.end_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 30, 16, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn detects_new_datetime_props() {
+        use chrono::TimeZone;
+        let edit = block_edit(|e| {
+            e.value(
+                sid(RANK_START_DATETIME_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-01T12:30:00Z".into()),
+            )
+            .value(
+                sid(RANK_END_DATETIME_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-30T18:00:00Z".into()),
+            )
+        });
+
+        let b = &detect(&edit, space_uuid(), 100, 0).blocks[0];
+        assert_eq!(
+            b.start_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 1, 12, 30, 0).unwrap())
+        );
+        assert_eq!(
+            b.end_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 30, 18, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn new_datetime_props_win_over_legacy_per_bound() {
+        use chrono::TimeZone;
+        // start: both authored, values disagree -> the datetime property wins;
+        // end: only the legacy date -> falls back per-bound.
+        let edit = block_edit(|e| {
+            e.value(
+                sid(RANK_START_DATE_PROPERTY_ID),
+                Grc20Value::Date("2026-06-01".into()),
+            )
+            .value(
+                sid(RANK_START_DATETIME_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-02T09:00:00Z".into()),
+            )
+            .value(
+                sid(RANK_END_DATE_PROPERTY_ID),
+                Grc20Value::Date("2026-06-30".into()),
+            )
+        });
+
+        let b = &detect(&edit, space_uuid(), 100, 0).blocks[0];
+        assert_eq!(
+            b.start_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 2, 9, 0, 0).unwrap())
+        );
+        assert_eq!(
+            b.end_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 30, 0, 0, 0).unwrap())
         );
     }
 

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -18,6 +18,26 @@ use crate::models::{BlockMeta, Ranking, RankingBlock, RankingItem};
 use crate::publish::{provenance_ids, RankPositionRow};
 use crate::scoring::ScoreRow;
 
+/// Resolve one submission-window bound from separately queried legacy/datetime
+/// columns: the datetime property (GEO-2253) wins per-bound; the legacy date
+/// property is the fallback. Mirrors `detect::window_bound`'s precedence so
+/// the live and KG-recovery paths never disagree on a block that authors both.
+fn resolve_window_bound(
+    block: Uuid,
+    bound: &'static str,
+    datetime_value: Option<DateTime<Utc>>,
+    date_value: Option<DateTime<Utc>>,
+) -> Option<DateTime<Utc>> {
+    if datetime_value.is_some() && date_value.is_some() {
+        tracing::debug!(
+            block = %block,
+            bound,
+            "block authors both the datetime and legacy date property; using the datetime one"
+        );
+    }
+    datetime_value.or(date_value)
+}
+
 #[derive(Clone)]
 pub struct Storage {
     pool: PgPool,
@@ -235,32 +255,48 @@ impl Storage {
             return Ok(None);
         };
 
-        // Config properties: Name/Filter as text, Start/End as datetime. One row
-        // is always returned (aggregates over zero matching values yield NULLs).
+        // Config properties: Name/Filter as text, Start/End as datetime (both
+        // the legacy date property and its GEO-2253 datetime successor — see
+        // `resolve_window_bound`). One row is always returned (aggregates over
+        // zero matching values yield NULLs).
         type ConfigRow = (
             Option<String>,
             Option<String>,
             Option<DateTime<Utc>>,
             Option<DateTime<Utc>>,
+            Option<DateTime<Utc>>,
+            Option<DateTime<Utc>>,
         );
         // Scope to the block's home space: the same entity may be perspectived
         // into other spaces with different config, keyed on (id, space_id).
-        let (name, filter, start_date, end_date): ConfigRow = sqlx::query_as(
-            "SELECT \
-               max(text)         FILTER (WHERE property_id = $2) AS name, \
-               max(text)         FILTER (WHERE property_id = $3) AS filter, \
-               max(datetime_utc) FILTER (WHERE property_id = $4) AS start_date, \
-               max(datetime_utc) FILTER (WHERE property_id = $5) AS end_date \
-             FROM values WHERE entity_id = $1 AND space_id = $6",
-        )
-        .bind(block_id)
-        .bind(pid(ids::NAME_PROPERTY_ID))
-        .bind(pid(ids::RANK_FILTER_PROPERTY_ID))
-        .bind(pid(ids::RANK_START_DATE_PROPERTY_ID))
-        .bind(pid(ids::RANK_END_DATE_PROPERTY_ID))
-        .bind(space_id)
-        .fetch_one(&self.pool)
-        .await?;
+        let (name, filter, legacy_start_date, legacy_end_date, start_datetime, end_datetime): ConfigRow =
+            sqlx::query_as(
+                "SELECT \
+                   max(text)         FILTER (WHERE property_id = $2) AS name, \
+                   max(text)         FILTER (WHERE property_id = $3) AS filter, \
+                   max(datetime_utc) FILTER (WHERE property_id = $4) AS start_date, \
+                   max(datetime_utc) FILTER (WHERE property_id = $5) AS end_date, \
+                   max(datetime_utc) FILTER (WHERE property_id = $6) AS start_datetime, \
+                   max(datetime_utc) FILTER (WHERE property_id = $7) AS end_datetime \
+                 FROM values WHERE entity_id = $1 AND space_id = $8",
+            )
+            .bind(block_id)
+            .bind(pid(ids::NAME_PROPERTY_ID))
+            .bind(pid(ids::RANK_FILTER_PROPERTY_ID))
+            .bind(pid(ids::RANK_START_DATE_PROPERTY_ID))
+            .bind(pid(ids::RANK_END_DATE_PROPERTY_ID))
+            .bind(pid(ids::RANK_START_DATETIME_PROPERTY_ID))
+            .bind(pid(ids::RANK_END_DATETIME_PROPERTY_ID))
+            .bind(space_id)
+            .fetch_one(&self.pool)
+            .await?;
+
+        // The datetime property (GEO-2253) wins per-bound; the legacy date
+        // property is the fallback — same precedence as `detect::window_bound`,
+        // so the live and KG-recovery paths never disagree on a block that
+        // authors both.
+        let start_date = resolve_window_bound(block_id, "start", start_datetime, legacy_start_date);
+        let end_date = resolve_window_bound(block_id, "end", end_datetime, legacy_end_date);
 
         // Aggregation restriction is a relation (as detect() collects it),
         // likewise scoped to the block's home space.

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -7,6 +7,7 @@
 //! connection string. Skips (passes) if unset, so it never runs on a generic
 //! CI `DATABASE_URL` that lacks the `ranks` schema.
 
+use chrono::{TimeZone, Utc};
 use grc_20::model::builder::EditBuilder;
 use hermes_schema::pb::membership::{HermesRoleGranted, HermesRoleRevoked, MembershipRole};
 use sdk::core::ids::*;
@@ -461,6 +462,195 @@ async fn cross_edit_block_is_recovered_from_kg_and_scored() {
         "both ranked entities scored once the block is recovered"
     );
 }
+
+/// Regression (GEO-2253): `get_block_config_from_kg` must resolve the same
+/// datetime-over-legacy-date precedence as `detect::window_bound`, or the
+/// live path and the KG-recovery path disagree on an unregistered block's
+/// window. Start authors both properties (datetime should win); end authors
+/// only the legacy property (must still fall back correctly).
+#[tokio::test]
+async fn cross_edit_block_recovers_datetime_bounds_preferring_new_property_over_legacy() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    const SPACE: u128 = 0xE2E5_0000_3001;
+    const MEMBER: u128 = 0xE2E5_0000_3011;
+    const BLOCK: u128 = 0xE2E5_0000_3021;
+    const TYPE_REL: u128 = 0xE2E5_0000_3022;
+    const START_LEGACY_VAL: u128 = 0xE2E5_0000_3023;
+    const START_DATETIME_VAL: u128 = 0xE2E5_0000_3024;
+    const END_LEGACY_VAL: u128 = 0xE2E5_0000_3025;
+    const ENT_A: u128 = 0xE2E5_0000_3031;
+    const RANK: u128 = 0xE2E5_0000_3041;
+
+    let su = |s: &str| Uuid::parse_str(s).unwrap();
+    let legacy_start = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+    let new_start = Utc.with_ymd_and_hms(2026, 2, 2, 9, 30, 0).unwrap();
+    let legacy_end = Utc.with_ymd_and_hms(2026, 3, 3, 0, 0, 0).unwrap();
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+    ] {
+        sqlx::query(sql).bind(u(SPACE)).execute(pool).await.unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.members WHERE space_id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed prerequisites --------------------------------------------------
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e3')")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)")
+        .bind(u(MEMBER))
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // Seed the KG as kg-indexer would: the block's `TYPES -> Ranking Block`
+    // relation, plus start authored on BOTH the legacy and datetime property
+    // (datetime should win), and end authored on only the legacy property
+    // (must fall back). Never registered in `ranks`.
+    sqlx::query(
+        "INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(u(TYPE_REL))
+    .bind(u(TYPE_REL))
+    .bind(su(TYPE_RELATION_TYPE_ID))
+    .bind(u(BLOCK))
+    .bind(su(RANKING_BLOCK_TYPE_ID))
+    .bind(u(SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, datetime_utc) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(START_LEGACY_VAL).to_string())
+    .bind(u(BLOCK))
+    .bind(u(SPACE))
+    .bind(su(RANK_START_DATE_PROPERTY_ID))
+    .bind(legacy_start)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, datetime_utc) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(START_DATETIME_VAL).to_string())
+    .bind(u(BLOCK))
+    .bind(u(SPACE))
+    .bind(su(RANK_START_DATETIME_PROPERTY_ID))
+    .bind(new_start)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, datetime_utc) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(END_LEGACY_VAL).to_string())
+    .bind(u(BLOCK))
+    .bind(u(SPACE))
+    .bind(su(RANK_END_DATE_PROPERTY_ID))
+    .bind(legacy_end)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Precondition: the block is NOT registered in the ranks schema.
+    assert!(
+        storage.get_ranking_block(u(BLOCK)).await.unwrap().is_none(),
+        "precondition: block must be unregistered before the rank arrives"
+    );
+
+    // --- a member submits a rank linked to the (unregistered) block --------
+    let rank_edit = EditBuilder::new(gid(RANK ^ 0xED17))
+        .create_relation(|r| {
+            r.id(gid(0x310))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(sid(RANK_TYPE_ID))
+        })
+        .create_entity(gid(RANK), |e| {
+            e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+        })
+        .create_relation(|r| {
+            r.id(gid(0x311))
+                .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(BLOCK))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x312))
+                .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(ENT_A))
+                .to_space(gid(SPACE))
+                .position("a0")
+        })
+        .build();
+    apply_detected_edit(&detect(&rank_edit, u(MEMBER), 2, 0), u(MEMBER), &storage)
+        .await
+        .unwrap();
+
+    // --- the recovered block prefers the datetime bound over the legacy one,
+    //     and falls back to legacy where the datetime bound is absent --------
+    let (start_date, end_date): (Option<chrono::DateTime<Utc>>, Option<chrono::DateTime<Utc>>) =
+        sqlx::query_as("SELECT start_date, end_date FROM ranks.ranking_blocks WHERE id = $1")
+            .bind(u(BLOCK))
+            .fetch_one(pool)
+            .await
+            .unwrap();
+
+    assert_eq!(
+        start_date,
+        Some(new_start),
+        "start: the datetime property must win over the legacy one authored on the same block"
+    );
+    assert_eq!(
+        end_date,
+        Some(legacy_end),
+        "end: must fall back to the legacy property when no datetime property is authored"
+    );
+}
+
 /// Regression: a projection row written before this PR has `from_space_id IS
 /// NULL` but keeps the deterministic v5 relation id (the PK). The step-2 DELETE
 /// in `replace_rank_position_projection` must clear it on the next recompute;

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -61,6 +61,11 @@ pub const RANKING_BLOCK_TYPE_ID: &str = "150db6de-fe23-44f0-805a-fa57502e2c32";
 pub const RANK_BLOCK_RELATION_TYPE_ID: &str = "09c219c1-03d1-4d2a-a5c7-8edbf2d0182a";
 pub const RANK_START_DATE_PROPERTY_ID: &str = "eed03a04-0acd-4a9e-81e0-8272ed70a817";
 pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011c";
+// Datetime successors to the start/end date properties (GEO-2253). Minted
+// on-chain 2026-07-09; not yet in geo-sdk. When a block authors both, the
+// datetime property wins per-bound and the legacy date one is ignored.
+pub const RANK_START_DATETIME_PROPERTY_ID: &str = "2d696bf0-510f-403e-985b-8cd1e73feb9b";
+pub const RANK_END_DATETIME_PROPERTY_ID: &str = "c3445f6b-e2c0-4f25-b73a-5eb876c4f50c";
 pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
 pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
 pub const RANK_FILTER_PROPERTY_ID: &str = "14a46854-bfd1-4b18-8215-2785c2dab9f3";


### PR DESCRIPTION
## Summary
- Add `RANK_START_DATETIME_PROPERTY_ID` / `RANK_END_DATETIME_PROPERTY_ID` constants for the new on-chain ranking-block property IDs.
- `ranking-indexer` prefers the datetime property over the legacy date property per-bound, falling back to the legacy value when only it is present; a debug log fires when a block authors both and they disagree.
- Old-props+date and old-props+datetime continue to work unchanged (existing midnight-UTC quirk on bare dates is preserved, per agreed contract).

## Test plan
- [x] `cargo test -p ranking-indexer --lib` — 32/32 pass, including 4 new tests covering: legacy props accepting a `Datetime` value, new props alone, and mixed start/end where the datetime bound wins per-bound over a disagreeing legacy value while the other bound falls back to legacy.
- [x] `cargo clippy -p ranking-indexer -p sdk --lib --tests -- -D warnings` clean.
- [x] `cargo fmt` — no changes needed.