### PR TITLE
fix(ranking-indexer): backfill blocks orphaned by issue #738's recovery race

### DIFF
--- a/ranking-indexer/Cargo.toml
+++ b/ranking-indexer/Cargo.toml
@@ -8,6 +8,10 @@ description = "Aggregates GEO rank submissions into ranking results and projects
 name = "ranking-indexer"
 path = "src/main.rs"
 
+[[bin]]
+name = "backfill_blocks"
+path = "src/bin/backfill_blocks.rs"
+
 [dependencies]
 hermes-schema = { path = "../hermes-schema" }
 hermes-instrumentation = { path = "../hermes-instrumentation" }

--- a/ranking-indexer/src/bin/backfill_blocks.rs
+++ b/ranking-indexer/src/bin/backfill_blocks.rs
@@ -1,0 +1,91 @@
+//! One-off backfill for Ranking Block entities that never made it into
+//! `ranks.ranking_blocks` (issue #738/#739's recovery path only runs when a
+//! rank happens to link to the block after kg-indexer has already indexed its
+//! type/config — anything that never got a second chance is stuck forever).
+//!
+//! Finds every entity typed `Ranking Block` in the public graph that's
+//! missing from `ranks.ranking_blocks`, recovers its config the same way the
+//! live recovery path does, and recomputes its aggregate. Idempotent — safe
+//! to re-run; already-registered blocks are never touched.
+//!
+//! Usage: `DATABASE_URL=... cargo run -p ranking-indexer --bin backfill_blocks`
+//! Add `DRY_RUN=true` to list candidates without writing anything.
+
+use std::env;
+
+use tracing::{error, info, warn};
+
+use ranking_indexer::error::IndexerError;
+use ranking_indexer::recompute::recompute_block;
+use ranking_indexer::storage::Storage;
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let dry_run = env::var("DRY_RUN").is_ok_and(|v| v == "true" || v == "1");
+
+    let storage = Storage::new(&database_url).await?;
+
+    let candidates = storage.find_unregistered_ranking_blocks().await?;
+    info!(
+        count = candidates.len(),
+        dry_run, "found unregistered blocks"
+    );
+    if candidates.is_empty() {
+        return Ok(());
+    }
+
+    if dry_run {
+        for id in &candidates {
+            info!(block_id = %id, "would recover");
+        }
+        return Ok(());
+    }
+
+    let meta = storage.current_chain_meta().await?;
+
+    let mut recovered = 0;
+    let mut still_unregistered = 0;
+    let mut failed = 0;
+
+    for block_id in candidates {
+        // Re-check under get_block_config_from_kg rather than trusting the
+        // earlier scan — the two queries aren't in the same transaction, and
+        // this mirrors exactly what the live recovery path does.
+        match storage.get_block_config_from_kg(block_id).await {
+            Ok(Some(block)) => {
+                if let Err(e) = storage.upsert_ranking_block(&block).await {
+                    error!(block_id = %block_id, error = %e, "failed to upsert recovered block");
+                    failed += 1;
+                    continue;
+                }
+                if let Err(e) = recompute_block(block_id, meta, &storage).await {
+                    error!(block_id = %block_id, error = %e, "recovered block but recompute failed");
+                    failed += 1;
+                    continue;
+                }
+                info!(block_id = %block_id, "recovered + recomputed");
+                recovered += 1;
+            }
+            Ok(None) => {
+                // Typed in `relations` a moment ago, not typed now — a
+                // concurrent edit removed the type between the scan and here.
+                warn!(block_id = %block_id, "no longer typed as Ranking Block — skipping");
+                still_unregistered += 1;
+            }
+            Err(e) => {
+                error!(block_id = %block_id, error = %e, "failed to read block config from kg");
+                failed += 1;
+            }
+        }
+    }
+
+    info!(recovered, still_unregistered, failed, "backfill complete");
+    Ok(())
+}

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -285,6 +285,49 @@ impl Storage {
         }))
     }
 
+    /// Entities typed `Ranking Block` in the indexed public graph that never
+    /// made it into `ranks.ranking_blocks`.
+    ///
+    /// `get_block_config_from_kg` (issue #738/#739) only ever runs when a rank
+    /// happens to link to the block *after* the block's own typing/config is
+    /// indexed; if no rank has linked to it since, or the link raced ahead of
+    /// kg-indexer committing the type relation, the block is stuck here
+    /// forever with nothing to retry it. Used by the one-off backfill binary
+    /// (`bin/backfill_blocks.rs`) and can also back a periodic reconciliation
+    /// sweep.
+    pub async fn find_unregistered_ranking_blocks(&self) -> Result<Vec<Uuid>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT DISTINCT r.from_entity_id FROM relations r \
+             WHERE r.type_id = $1 AND r.to_entity_id = $2 \
+               AND r.from_entity_id NOT IN (SELECT id FROM ranks.ranking_blocks)",
+        )
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANKING_BLOCK_TYPE_ID))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// The chain height/timestamp hermes has indexed up to, for stamping
+    /// entities the backfill binary mints (it runs off-band, with no edit of
+    /// its own to take `BlockMeta` from). Falls back to `(0, 0)` if the cursor
+    /// row is absent (e.g. a fresh/local database) — the projection is stamped
+    /// but otherwise unaffected, since dedup/ordering key off `rankings`'
+    /// own `updated_at_block`, not this value.
+    pub async fn current_chain_meta(&self) -> Result<BlockMeta, IndexerError> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT block_number FROM meta WHERE id = 'hermes_pipeline'")
+                .fetch_optional(&self.pool)
+                .await?;
+        let number = row.and_then(|(s,)| s.parse::<i64>().ok()).unwrap_or(0);
+        Ok(BlockMeta {
+            number,
+            timestamp: Utc::now().timestamp(),
+        })
+    }
+
     /// Load all submissions currently linked to a block (pre-dedup).
     pub async fn get_rankings_for_block(
         &self,


### PR DESCRIPTION
## Summary
- `recompute_block`'s existing recovery path (issue #738/#739, `get_block_config_from_kg`) only fires once, at the moment a rank links to an unregistered block. If kg-indexer hasn't yet committed that block's type/config to `public.relations`/`public.values` at that exact instant — two independent Kafka consumers, no ordering guarantee — the recovery returns `None` and the block is stuck forever with no retry.
- Adds `Storage::find_unregistered_ranking_blocks()` (typed as Ranking Block in the public graph, missing from `ranks.ranking_blocks`) and `Storage::current_chain_meta()` (for stamping entities the backfill mints off-band).
- Adds `bin/backfill_blocks.rs`: finds candidates, re-verifies each via the existing `get_block_config_from_kg`, and re-runs `upsert_ranking_block` + `recompute_block` — no new recovery logic, just re-triggering the existing correct path. Idempotent, safe to re-run. `DRY_RUN=true` lists candidates without writing.

## Context
Found while investigating a report that rankings weren't aggregating on the new testnet cluster (chain 55516). Root-caused to this race rather than a detect.rs classification bug — confirmed by replicating `get_block_config_from_kg`'s query directly against the affected blocks and finding it already returns correct data.

Already run against the new testnet cluster (`gaia` namespace, `do-nyc2-geo-testnet-k8s`): recovered all 4 orphaned blocks, `ranks.ranking_scores` went from 0 to 17 rows. Not yet run against the old cluster's production `knowledge` namespace (1/17 blocks there hit the same race) — holding off until explicitly asked.

A structural fix (periodic reconciliation sweep, so this self-heals without a manual re-run) is a separate follow-up, not included here.

## Test plan
- [x] `cargo test -p ranking-indexer --lib` — 29/29 pass
- [x] `cargo clippy -p ranking-indexer --bins --lib --tests -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Ran `DRY_RUN=true` then live against the new testnet cluster; verified via direct DB query that `ranking_blocks`/`ranking_scores` populated correctly and the specific reported block ("Best Neighborhood") now has real scored entities