### PR TITLE
feat(ranking-indexer): schedule backfill_blocks as an hourly CronJob

### DIFF
--- a/ranking-indexer/Dockerfile
+++ b/ranking-indexer/Dockerfile
@@ -37,5 +37,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/ranking-indexer/target/release/ranking-indexer /usr/local/bin/ranking-indexer
+COPY --from=builder /app/ranking-indexer/target/release/backfill_blocks /usr/local/bin/backfill_blocks
 
 CMD ["ranking-indexer"]

--- a/ranking-indexer/k8s/production/backfill-cronjob.yaml
+++ b/ranking-indexer/k8s/production/backfill-cronjob.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ranking-indexer-backfill
+  namespace: knowledge
+  labels:
+    app: ranking-indexer-backfill
+spec:
+  # Self-heals blocks the live recovery path (issue #738/#739) missed because
+  # kg-indexer hadn't yet indexed the block's type/config at the moment a rank
+  # linked to it — that recovery only ever gets one shot. Hourly is plenty;
+  # this is a safety net, not a latency-sensitive path.
+  schedule: "0 * * * *"
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: geo
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+          containers:
+            - name: ranking-indexer-backfill
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command: ["backfill_blocks"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              env:
+                - name: PGSSLROOTCERT
+                  value: /ssl/ca.crt
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_URL
+                - name: RUST_LOG
+                  value: "backfill_blocks=info,ranking_indexer=info"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "250m"

--- a/ranking-indexer/k8s/staging/backfill-cronjob.yaml
+++ b/ranking-indexer/k8s/staging/backfill-cronjob.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ranking-indexer-backfill
+  namespace: knowledge-staging
+  labels:
+    app: ranking-indexer-backfill
+    environment: staging
+spec:
+  # Self-heals blocks the live recovery path (issue #738/#739) missed because
+  # kg-indexer hadn't yet indexed the block's type/config at the moment a rank
+  # linked to it — that recovery only ever gets one shot. Hourly is plenty;
+  # this is a safety net, not a latency-sensitive path.
+  schedule: "0 * * * *"
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            environment: staging
+        spec:
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: geo
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+          containers:
+            - name: ranking-indexer-backfill
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command: ["backfill_blocks"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              env:
+                - name: PGSSLROOTCERT
+                  value: /ssl/ca.crt
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_URL
+                - name: RUST_LOG
+                  value: "backfill_blocks=info,ranking_indexer=info"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "250m"

--- a/ranking-indexer/src/bin/backfill_blocks.rs
+++ b/ranking-indexer/src/bin/backfill_blocks.rs
@@ -8,6 +8,10 @@
 //! live recovery path does, and recomputes its aggregate. Idempotent — safe
 //! to re-run; already-registered blocks are never touched.
 //!
+//! Exits non-zero if any block failed to recover, so a scheduled run (see
+//! `k8s/*/backfill-cronjob.yaml`) surfaces failures as a failed Job instead
+//! of a silently-green one.
+//!
 //! Usage: `DATABASE_URL=... cargo run -p ranking-indexer --bin backfill_blocks`
 //! Add `DRY_RUN=true` to list candidates without writing anything.
 
@@ -87,5 +91,8 @@ async fn main() -> Result<(), IndexerError> {
     }
 
     info!(recovered, still_unregistered, failed, "backfill complete");
+    if failed > 0 {
+        std::process::exit(1);
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Adds `ranking-indexer/k8s/{staging,production}/backfill-cronjob.yaml`, running `backfill_blocks` (from #809) hourly instead of by hand — mirrors the `scoring-service` Deployment+CronJob split, so the sweep stays decoupled from the live consumer's own health (the failure mode it heals from shows up worst exactly when the live Deployment is busiest, e.g. during a replay).
- `backfill_blocks` now exits non-zero if any block fails to recover, so a bad run surfaces as a failed Job rather than a silently-green one.
- `Dockerfile` now copies `backfill_blocks` into the final image alongside the main `ranking-indexer` binary — it was being built but not copied, so the CronJob would have failed with "binary not found" without this.

## Scope notes
- Blocks only, matching what already exists (`get_block_config_from_kg`, issue #738/#739). Ranks have the *same* split-edit classification gap with **no** recovery mechanism at all (no `get_rank_config_from_kg` equivalent) — deliberately out of scope here; needs its own design since orphaned rank items/block-links currently fail silently (no FK, plain `UPDATE` with no insert fallback) rather than erroring.
- Only covers the old cluster's `knowledge`/`knowledge-staging` namespaces (this branch is off `main`, which doesn't have the new cluster's `v2`/`gaia` namespace manifests — those live on `staging`, added by #804/#805). A v2 CronJob would need a PR against `staging` instead.
- Schedule is hourly (`0 * * * *`) as a starting point — this is a safety net, not latency-sensitive, so happy to adjust.

## Test plan
- [x] `cargo test -p ranking-indexer --lib` — 29/29 pass
- [x] `cargo clippy -p ranking-indexer --bins --lib --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] YAML-validated both new manifests
- [x] Built the Docker image locally and confirmed both `ranking-indexer` and `backfill_blocks` are present in `/usr/local/bin`