### PR TITLE
feat(ranking-indexer): recover orphaned Rank submissions in the sweep too

### DIFF
--- a/ranking-indexer/src/bin/backfill_blocks.rs
+++ b/ranking-indexer/src/bin/backfill_blocks.rs
@@ -1,20 +1,30 @@
-//! One-off backfill for Ranking Block entities that never made it into
-//! `ranks.ranking_blocks` (issue #738/#739's recovery path only runs when a
-//! rank happens to link to the block after kg-indexer has already indexed its
-//! type/config — anything that never got a second chance is stuck forever).
+//! One-off/scheduled backfill for Ranking Block and Rank entities that never
+//! made it into the `ranks` schema because their `TYPES` relation arrived in
+//! a different edit than their own creation (`detect()` only classifies an
+//! entity from the current edit's own ops).
 //!
-//! Finds every entity typed `Ranking Block` in the public graph that's
-//! missing from `ranks.ranking_blocks`, recovers its config the same way the
-//! live recovery path does, and recomputes its aggregate. Idempotent — safe
-//! to re-run; already-registered blocks are never touched.
+//! For blocks, the live consumer has a reactive one-shot recovery (issue
+//! #738/#739, `get_block_config_from_kg`) that runs the moment a rank links
+//! to an unregistered block — but it never retries, so anything that raced
+//! ahead of kg-indexer indexing the type, or that nothing has linked to
+//! since, is stuck forever. For ranks, there is no reactive recovery at all;
+//! this binary is the only thing that ever finds them.
 //!
-//! Exits non-zero if any block failed to recover, so a scheduled run (see
+//! Finds every entity typed `Ranking Block`/`Rank` in the public graph
+//! that's missing from `ranks.ranking_blocks`/`ranks.rankings`, recovers its
+//! config from the same source those tables are meant to reflect, and
+//! recomputes the aggregate for every block touched (directly, or via a
+//! recovered rank that links to one). Idempotent — safe to re-run;
+//! already-registered blocks/ranks are never touched.
+//!
+//! Exits non-zero if anything failed to recover, so a scheduled run (see
 //! `k8s/*/backfill-cronjob.yaml`) surfaces failures as a failed Job instead
 //! of a silently-green one.
 //!
 //! Usage: `DATABASE_URL=... cargo run -p ranking-indexer --bin backfill_blocks`
 //! Add `DRY_RUN=true` to list candidates without writing anything.
 
+use std::collections::HashSet;
 use std::env;
 
 use tracing::{error, info, warn};
@@ -36,29 +46,42 @@ async fn main() -> Result<(), IndexerError> {
 
     let storage = Storage::new(&database_url).await?;
 
-    let candidates = storage.find_unregistered_ranking_blocks().await?;
+    let block_candidates = storage.find_unregistered_ranking_blocks().await?;
+    let rank_candidates = storage.find_unregistered_ranks().await?;
     info!(
-        count = candidates.len(),
-        dry_run, "found unregistered blocks"
+        blocks = block_candidates.len(),
+        ranks = rank_candidates.len(),
+        dry_run,
+        "found unregistered blocks/ranks"
     );
-    if candidates.is_empty() {
+
+    if dry_run {
+        for id in &block_candidates {
+            info!(block_id = %id, "would recover block");
+        }
+        for id in &rank_candidates {
+            info!(rank_id = %id, "would recover rank");
+        }
         return Ok(());
     }
 
-    if dry_run {
-        for id in &candidates {
-            info!(block_id = %id, "would recover");
-        }
+    if block_candidates.is_empty() && rank_candidates.is_empty() {
         return Ok(());
     }
 
     let meta = storage.current_chain_meta().await?;
 
-    let mut recovered = 0;
-    let mut still_unregistered = 0;
+    let mut recovered_blocks = 0;
+    let mut still_unregistered_blocks = 0;
+    let mut recovered_ranks = 0;
+    let mut still_unregistered_ranks = 0;
     let mut failed = 0;
 
-    for block_id in candidates {
+    // Blocks first: a recovered rank's block_id is guaranteed to already be
+    // registered by the time we get to it below, since this scan already
+    // covers every currently-unregistered block, not just ones ranks
+    // happen to point at.
+    for block_id in block_candidates {
         // Re-check under get_block_config_from_kg rather than trusting the
         // earlier scan — the two queries aren't in the same transaction, and
         // this mirrors exactly what the live recovery path does.
@@ -74,14 +97,14 @@ async fn main() -> Result<(), IndexerError> {
                     failed += 1;
                     continue;
                 }
-                info!(block_id = %block_id, "recovered + recomputed");
-                recovered += 1;
+                info!(block_id = %block_id, "recovered + recomputed block");
+                recovered_blocks += 1;
             }
             Ok(None) => {
                 // Typed in `relations` a moment ago, not typed now — a
                 // concurrent edit removed the type between the scan and here.
                 warn!(block_id = %block_id, "no longer typed as Ranking Block — skipping");
-                still_unregistered += 1;
+                still_unregistered_blocks += 1;
             }
             Err(e) => {
                 error!(block_id = %block_id, error = %e, "failed to read block config from kg");
@@ -90,7 +113,54 @@ async fn main() -> Result<(), IndexerError> {
         }
     }
 
-    info!(recovered, still_unregistered, failed, "backfill complete");
+    let mut affected_blocks: HashSet<uuid::Uuid> = HashSet::new();
+    for rank_id in rank_candidates {
+        match storage.get_rank_config_from_kg(rank_id).await {
+            Ok(Some(rank)) => {
+                let block_id = rank.block_id;
+                if let Err(e) = storage.upsert_ranking(&rank).await {
+                    error!(rank_id = %rank_id, error = %e, "failed to upsert recovered rank");
+                    failed += 1;
+                    continue;
+                }
+                info!(rank_id = %rank_id, block_id = ?block_id, "recovered rank");
+                recovered_ranks += 1;
+                if let Some(block_id) = block_id {
+                    affected_blocks.insert(block_id);
+                }
+            }
+            Ok(None) => {
+                warn!(rank_id = %rank_id, "no longer typed as Rank — skipping");
+                still_unregistered_ranks += 1;
+            }
+            Err(e) => {
+                error!(rank_id = %rank_id, error = %e, "failed to read rank config from kg");
+                failed += 1;
+            }
+        }
+    }
+
+    // Recompute every block a recovered rank links to — its aggregate needs
+    // to include the rank that just appeared.
+    for block_id in affected_blocks {
+        if let Err(e) = recompute_block(block_id, meta, &storage).await {
+            error!(
+                block_id = %block_id,
+                error = %e,
+                "recompute failed for block affected by a recovered rank"
+            );
+            failed += 1;
+        }
+    }
+
+    info!(
+        recovered_blocks,
+        still_unregistered_blocks,
+        recovered_ranks,
+        still_unregistered_ranks,
+        failed,
+        "backfill complete"
+    );
     if failed > 0 {
         std::process::exit(1);
     }

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -310,6 +310,120 @@ impl Storage {
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
+    /// Entities typed `Rank` in the indexed public graph that never made it
+    /// into `ranks.rankings` — the identical split-edit gap as
+    /// `find_unregistered_ranking_blocks`, but for Rank submissions.
+    ///
+    /// Unlike blocks, nothing in the live consumer ever retries this (no
+    /// `get_block_config_from_kg`-style reactive trigger exists for ranks),
+    /// so recovery here is driven entirely by the periodic sweep — see
+    /// `get_rank_config_from_kg`.
+    pub async fn find_unregistered_ranks(&self) -> Result<Vec<Uuid>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT DISTINCT r.from_entity_id FROM relations r \
+             WHERE r.type_id = $1 AND r.to_entity_id = $2 \
+               AND r.from_entity_id NOT IN (SELECT id FROM ranks.rankings)",
+        )
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANK_TYPE_ID))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Reconstruct a Rank submission's config from the indexed public graph.
+    ///
+    /// Mirrors `get_block_config_from_kg` (issue #738/#739) for the identical
+    /// gap on Rank entities: `detect()` only registers a rank when its
+    /// `TYPES -> Rank` relation and its `rank_type` property arrive in the
+    /// *same* edit. There is deliberately no reactive live-path trigger for
+    /// this (unlike blocks, which recover the moment a rank links to one) —
+    /// recovery is periodic-sweep-only, so this also resolves `block_id`
+    /// directly from the `RANK_BLOCK` relation here rather than depending on
+    /// `set_ranking_block`'s live path, which is a bare `UPDATE` that
+    /// silently touches zero rows against a not-yet-registered rank.
+    ///
+    /// `submitted_at`/`updated_at_block` come from `public.entities`
+    /// (`updated_at`/`updated_at_block`, not `created_at`, so dedup ordering
+    /// reflects the *latest* on-chain change) rather than a live edit's
+    /// metadata, since a recovery run has no current edit to take them from.
+    /// `update_index` has no public-schema equivalent; recovered ranks get
+    /// `0`, which only risks a wrong dedup tie-break against another
+    /// submission landing in the exact same chain block (narrow, accepted).
+    /// `author_address` is `None`, matching what the live path always
+    /// produces today (unimplemented there too — not a recovery gap).
+    /// Returns `None` if the entity is not (yet) typed as a Rank.
+    pub async fn get_rank_config_from_kg(
+        &self,
+        rank_id: Uuid,
+    ) -> Result<Option<Ranking>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+
+        let typed: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT space_id FROM relations \
+             WHERE from_entity_id = $1 AND type_id = $2 AND to_entity_id = $3 \
+             LIMIT 1",
+        )
+        .bind(rank_id)
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANK_TYPE_ID))
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some((space_id,)) = typed else {
+            return Ok(None);
+        };
+
+        let rank_type: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT text FROM values \
+             WHERE entity_id = $1 AND space_id = $2 AND property_id = $3 LIMIT 1",
+        )
+        .bind(rank_id)
+        .bind(space_id)
+        .bind(pid(ids::RANK_TYPE_PROPERTY_ID))
+        .fetch_optional(&self.pool)
+        .await?;
+        let rank_type = rank_type.and_then(|(t,)| t);
+
+        let block_id: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT to_entity_id FROM relations \
+             WHERE from_entity_id = $1 AND type_id = $2 LIMIT 1",
+        )
+        .bind(rank_id)
+        .bind(pid(ids::RANK_BLOCK_RELATION_TYPE_ID))
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let entity: Option<(String, String)> =
+            sqlx::query_as("SELECT updated_at, updated_at_block FROM entities WHERE id = $1")
+                .bind(rank_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        let (submitted_at, updated_at_block) = match entity {
+            Some((updated_at, updated_at_block)) => (
+                updated_at
+                    .parse::<i64>()
+                    .ok()
+                    .and_then(|ts| DateTime::<Utc>::from_timestamp(ts, 0)),
+                updated_at_block.parse::<i64>().unwrap_or(0),
+            ),
+            None => (None, 0),
+        };
+
+        Ok(Some(Ranking {
+            id: rank_id,
+            block_id: block_id.map(|(b,)| b),
+            space_id,
+            author_address: None,
+            rank_type,
+            submitted_at,
+            updated_at_block,
+            update_index: 0,
+        }))
+    }
+
     /// The chain height/timestamp hermes has indexed up to, for stamping
     /// entities the backfill binary mints (it runs off-band, with no edit of
     /// its own to take `BlockMeta` from). Falls back to `(0, 0)` if the cursor

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -15,7 +15,8 @@ use uuid::Uuid;
 
 use ranking_indexer::detect::detect;
 use ranking_indexer::membership::{apply_membership_event, MembershipEvent};
-use ranking_indexer::recompute::apply_detected_edit;
+use ranking_indexer::models::BlockMeta;
+use ranking_indexer::recompute::{apply_detected_edit, recompute_block};
 use ranking_indexer::storage::Storage;
 
 fn gid(n: u128) -> [u8; 16] {
@@ -949,12 +950,12 @@ async fn recompute_is_idempotent_when_a_prior_value_row_is_orphaned() {
     let pool = storage.pool();
 
     // Distinct scenario ids so this can share a DB with the other e2e tests.
-    const SPACE: u128 = 0xE2E5_0000_3001;
-    const MEMBER: u128 = 0xE2E5_0000_3011;
-    const BLK: u128 = 0xE2E5_0000_3021;
+    const SPACE: u128 = 0xE2E5_0000_4001;
+    const MEMBER: u128 = 0xE2E5_0000_4011;
+    const BLK: u128 = 0xE2E5_0000_4021;
     const ENT_A: u128 = 0xE2E5_0000_3031;
     const ENT_B: u128 = 0xE2E5_0000_3032;
-    const RNK: u128 = 0xE2E5_0000_3041;
+    const RNK: u128 = 0xE2E5_0000_4041;
 
     // --- clean prior runs (idempotent) -------------------------------------
     for sql in [
@@ -1124,4 +1125,203 @@ async fn recompute_is_idempotent_when_a_prior_value_row_is_orphaned() {
     );
     let v1: i64 = rows[1].get("value");
     assert_eq!(v1, 50, "second entity converges to 50");
+}
+
+/// Companion to `cross_edit_block_is_recovered_from_kg_and_scored`, for the
+/// identical split-edit gap on Rank entities — except there's no reactive
+/// live-path trigger for ranks (unlike blocks), so recovery is
+/// periodic-sweep-only: `find_unregistered_ranks` + `get_rank_config_from_kg`
+/// + a manual `upsert_ranking` + `recompute_block`, exactly what
+/// `bin/backfill_blocks.rs` runs on a schedule.
+#[tokio::test]
+async fn cross_edit_rank_is_recovered_from_kg_and_scored() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    const BLOCK_SPACE: u128 = 0xE2E5_0000_4001;
+    const MEMBER_SPACE: u128 = 0xE2E5_0000_4011; // the rank's own (personal) space
+    const BLOCK: u128 = 0xE2E5_0000_4021;
+    const RANK: u128 = 0xE2E5_0000_4041;
+    const TYPE_REL: u128 = 0xE2E5_0000_4042;
+    const BLOCK_REL: u128 = 0xE2E5_0000_4043;
+    const RANK_TYPE_VAL: u128 = 0xE2E5_0000_4044;
+    const ENT_A: u128 = 0xE2E5_0000_4051;
+    const ENT_B: u128 = 0xE2E5_0000_4052;
+
+    let su = |s: &str| Uuid::parse_str(s).unwrap();
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+        "DELETE FROM entities WHERE id = $2",
+    ] {
+        sqlx::query(sql)
+            .bind(u(MEMBER_SPACE))
+            .bind(u(RANK))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id IN ($1, $2)")
+        .bind(u(BLOCK_SPACE))
+        .bind(u(MEMBER_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed prerequisites: a Personal block (no membership check needed,
+    // "All of Geo" admits any submitter) already registered in `ranks`. ----
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'Personal', '0xe2e3')")
+        .bind(u(BLOCK_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ranks.ranking_blocks (id, space_id, name, updated_at) \
+         VALUES ($1, $2, 'Recovered Rank Target', now())",
+    )
+    .bind(u(BLOCK))
+    .bind(u(BLOCK_SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // --- seed the KG as kg-indexer would: the rank's `TYPES -> Rank`
+    // relation, its rank_type value, its `RANK_BLOCK` link, and its entity
+    // row — WITHOUT registering it in `ranks.rankings` — i.e. the exact
+    // state where detect() never saw the type and the entity in one edit. --
+    sqlx::query(
+        "INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block) \
+         VALUES ($1, '1700000000', '42', '1700000100', '43')",
+    )
+    .bind(u(RANK))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+         VALUES ($1, $1, $2, $3, $4, $5)",
+    )
+    .bind(u(TYPE_REL))
+    .bind(su(TYPE_RELATION_TYPE_ID))
+    .bind(u(RANK))
+    .bind(su(RANK_TYPE_ID))
+    .bind(u(MEMBER_SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, text) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(RANK_TYPE_VAL).to_string())
+    .bind(u(RANK))
+    .bind(u(MEMBER_SPACE))
+    .bind(su(RANK_TYPE_PROPERTY_ID))
+    .bind("ORDINAL")
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+         VALUES ($1, $1, $2, $3, $4, $5)",
+    )
+    .bind(u(BLOCK_REL))
+    .bind(su(RANK_BLOCK_RELATION_TYPE_ID))
+    .bind(u(RANK))
+    .bind(u(BLOCK))
+    .bind(u(MEMBER_SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Votes landed via the live path at the time (RANK_VOTES relations are
+    // collected regardless of whether their `from` entity is classified),
+    // so they're already sitting in `ranking_items` — orphaned, since
+    // `ranks.rankings` has no row for RANK to attach them to yet.
+    for (entity, position) in [(ENT_A, "a0"), (ENT_B, "a1")] {
+        sqlx::query(
+            "INSERT INTO ranks.ranking_items (ranking_id, entity_id, space_id, position) \
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(u(RANK))
+        .bind(u(entity))
+        .bind(u(MEMBER_SPACE))
+        .bind(position)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    // --- precondition: the rank is NOT registered in the ranks schema ------
+    let registered: i64 = sqlx::query_scalar("SELECT count(*) FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        registered, 0,
+        "precondition: rank must be unregistered before recovery"
+    );
+
+    // --- the sweep's recovery path: find it, reconstruct it, score it ------
+    let candidates = storage.find_unregistered_ranks().await.unwrap();
+    assert!(
+        candidates.contains(&u(RANK)),
+        "find_unregistered_ranks must surface the orphaned rank"
+    );
+
+    let recovered = storage
+        .get_rank_config_from_kg(u(RANK))
+        .await
+        .unwrap()
+        .expect("rank must be reconstructable from the KG");
+    assert_eq!(recovered.rank_type.as_deref(), Some("ORDINAL"));
+    assert_eq!(
+        recovered.block_id,
+        Some(u(BLOCK)),
+        "block_id must be resolved directly from the RANK_BLOCK relation, \
+         not from ranks.rankings (set_ranking_block silently no-ops against \
+         an unregistered rank)"
+    );
+
+    storage.upsert_ranking(&recovered).await.unwrap();
+    recompute_block(u(BLOCK), BlockMeta::default(), &storage)
+        .await
+        .unwrap();
+
+    let scores: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM ranks.ranking_scores WHERE block_id = $1")
+            .bind(u(BLOCK))
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        scores, 2,
+        "both previously-orphaned items scored once the rank is recovered"
+    );
 }


### PR DESCRIPTION
## Summary
- Ranks have the identical split-edit classification gap as Ranking Blocks (`detect()` only classifies an entity from its own edit's ops) — but unlike blocks, there's no reactive live-path recovery at all. A rank whose `CreateEntity` and `TYPES -> Rank` land in separate edits is never registered, full stop, and nothing has ever retried it.
- Adds `Storage::find_unregistered_ranks` + `Storage::get_rank_config_from_kg`, mirroring `find_unregistered_ranking_blocks`/`get_block_config_from_kg` (issue #738/#739) exactly, and wires both into `backfill_blocks` (from #809/#810) so the existing hourly sweep covers ranks alongside blocks.
- `get_rank_config_from_kg` resolves `block_id` directly from the `RANK_BLOCK` relation in the public graph, rather than depending on `set_ranking_block`'s live path — that path is a bare `UPDATE` that silently touches zero rows against a not-yet-registered rank, so recovering the rank's own existence alone would still leave its block link permanently null.
- `submitted_at`/`updated_at_block` come from `public.entities` rather than a live edit's metadata (a recovery run has no "current edit" to take them from) — this preserves correct dedup ordering relative to genuinely later submissions. `update_index` has no public-schema equivalent; recovered ranks get `0`, a narrow, documented limitation (only matters if two real resubmissions land in the exact same chain block).

## Test plan
- [x] `cargo test -p ranking-indexer --lib` passes
- [x] New e2e test `cross_edit_rank_is_recovered_from_kg_and_scored`, mirroring `cross_edit_block_is_recovered_from_kg_and_scored` — seeds the KG as kg-indexer would (typed, `rank_type` value, `RANK_BLOCK` relation) without registering the rank in `ranks.rankings`, plus already-orphaned `ranking_items` (simulating votes that landed via the live path despite the rank never being registered). Asserts the rank is found, `block_id` resolves correctly from the KG relation (not from `ranks.rankings`, which never got it), and the previously-orphaned items get scored once recovered.
- [x] Ran the full e2e suite (`cargo test -p ranking-indexer --test e2e -- --test-threads=1`) against a real local Postgres (ephemeral container + `api`'s drizzle migrations) — all 6 tests pass, including the new one. Note: the suite is flaky under the default multi-threaded test runner — pre-existing test-isolation fragility unrelated to this change (it's excluded from CI by design, opt-in via `RANKING_INDEXER_E2E_DATABASE_URL`); worth a separate look if anyone's bothered by it.
- [x] `cargo clippy -p ranking-indexer --bins --lib --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean