### PR TITLE
ci(ranking-indexer): apply the backfill CronJob on deploy

### DIFF
--- a/.github/workflows/ranking-indexer-deploy-staging.yml
+++ b/.github/workflows/ranking-indexer-deploy-staging.yml
@@ -57,6 +57,8 @@ jobs:
           # Update image tag to use SHA and apply
           sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/staging/ranking-indexer.yaml
           kubectl apply -f ranking-indexer/k8s/staging/ranking-indexer.yaml
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/staging/backfill-cronjob.yaml
+          kubectl apply -f ranking-indexer/k8s/staging/backfill-cronjob.yaml
 
       - name: Restart deployment to pick up new image
         run: |

--- a/.github/workflows/ranking-indexer-deploy.yml
+++ b/.github/workflows/ranking-indexer-deploy.yml
@@ -57,6 +57,8 @@ jobs:
           # Update image tag to use SHA and apply
           sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/production/ranking-indexer.yaml
           kubectl apply -f ranking-indexer/k8s/production/ranking-indexer.yaml
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/production/backfill-cronjob.yaml
+          kubectl apply -f ranking-indexer/k8s/production/backfill-cronjob.yaml
 
       - name: Restart deployment to pick up new image
         run: |


### PR DESCRIPTION
## Summary
`ranking-indexer/k8s/{production,staging}/backfill-cronjob.yaml` (#810, extended in #811 to cover ranks too) were never actually applied by CI — `ranking-indexer-deploy.yml`/`ranking-indexer-deploy-staging.yml`'s `kubectl apply` step only ever referenced `namespace.yaml` and `ranking-indexer.yaml` (the Deployment). Confirmed via `kubectl get cronjob` against both `knowledge` and `knowledge-staging` — neither has ever had this CronJob. Writing the YAML into the repo was necessary but not sufficient; this closes the gap so the hourly sweep actually starts running instead of sitting as an inert file.

Same SHA-tagging treatment as the Deployment manifest, so the CronJob pulls the same pinned image rather than floating `:latest`.

## Note on staging
`ranking-indexer-deploy-staging.yml` triggers on push to `dev`, which has diverged from `main` (independent history, not just behind) — so this fix only takes effect for staging once/if this code actually lands on `dev`. Not attempting that reconciliation here; flagging it as a separate decision.

## Test plan
- [x] YAML-validated both modified workflow files
- [x] Confirmed via `gh run list` that the production deploy workflow already runs successfully on every `ranking-indexer/**` push to `main` (#809, #810, #811 all triggered it) — this only adds one more `kubectl apply` line to an already-working pipeline