### PR TITLE
fix(kg-indexer): tooling for space-misattribution incident and version-chain corruption

### DIFF
--- a/kg-indexer/src/bin/cleanup_value_orphans.rs
+++ b/kg-indexer/src/bin/cleanup_value_orphans.rs
@@ -36,7 +36,7 @@
 //!     --batch-file /path/to/uri_block_wrongspace_lines.txt \
 //!     [--execute]
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 
@@ -74,6 +74,12 @@ async fn main() -> Result<(), IndexerError> {
     let mut decoded = 0usize;
     let mut skipped = 0usize;
 
+    struct BatchLine {
+        uri: String,
+        block: u64,
+        space: Uuid,
+    }
+    let mut batch_lines = Vec::new();
     for line in content.lines().filter(|l| !l.trim().is_empty()) {
         let parts: Vec<&str> = line.split_whitespace().collect();
         if parts.len() < 3 {
@@ -81,43 +87,53 @@ async fn main() -> Result<(), IndexerError> {
                 "malformed batch-file line (expected \"<uri> <block> <space> ...\"): {line:?}"
             )));
         }
-        let (uri, block_str, space_str) = (parts[0], parts[1], parts[2]);
-        let block: u64 = block_str
+        let block: u64 = parts[1]
             .parse()
             .map_err(|e| IndexerError::Config(format!("bad block in line {line:?}: {e}")))?;
-        let space: Uuid = space_str
+        let space: Uuid = parts[2]
             .parse()
             .map_err(|e| IndexerError::Config(format!("bad space in line {line:?}: {e}")))?;
+        batch_lines.push(BatchLine {
+            uri: parts[0].to_string(),
+            block,
+            space,
+        });
+    }
 
-        let row: (Option<Vec<u8>>, bool) =
-            sqlx::query_as("SELECT data, is_errored FROM ipfs_cache WHERE uri = $1")
-                .bind(uri)
-                .fetch_one(&storage.pool)
-                .await
-                .map_err(|e| match e {
-                    sqlx::Error::RowNotFound => {
-                        IndexerError::Config(format!("uri not found in ipfs_cache: {uri}"))
-                    }
-                    other => IndexerError::Database(other),
-                })?;
-        let (data, is_errored) = row;
-        if is_errored {
-            println!("SKIP {uri}: ipfs_cache row still marked is_errored");
+    let uris: Vec<&str> = batch_lines.iter().map(|l| l.uri.as_str()).collect();
+    let cache_rows: Vec<(String, Option<Vec<u8>>, bool)> =
+        sqlx::query_as("SELECT uri, data, is_errored FROM ipfs_cache WHERE uri = ANY($1::text[])")
+            .bind(&uris)
+            .fetch_all(&storage.pool)
+            .await?;
+    let cache_by_uri: HashMap<String, (Option<Vec<u8>>, bool)> = cache_rows
+        .into_iter()
+        .map(|(uri, data, errored)| (uri, (data, errored)))
+        .collect();
+
+    for line in &batch_lines {
+        let Some((data, is_errored)) = cache_by_uri.get(&line.uri) else {
+            println!("SKIP {}: uri not found in ipfs_cache", line.uri);
+            skipped += 1;
+            continue;
+        };
+        if *is_errored {
+            println!("SKIP {}: ipfs_cache row still marked is_errored", line.uri);
             skipped += 1;
             continue;
         }
         let payload = match data {
             Some(p) => p,
             None => {
-                println!("SKIP {uri}: no data");
+                println!("SKIP {}: no data", line.uri);
                 skipped += 1;
                 continue;
             }
         };
-        let decoded_edit = match decode_edit(&payload) {
+        let decoded_edit = match decode_edit(payload) {
             Ok(d) => d,
             Err(e) => {
-                println!("SKIP {uri}: decode failed: {e}");
+                println!("SKIP {}: decode failed: {e}", line.uri);
                 skipped += 1;
                 continue;
             }
@@ -126,15 +142,15 @@ async fn main() -> Result<(), IndexerError> {
         let edit = HermesEdit {
             id: decoded_edit.id.to_vec(),
             name: decoded_edit.name.to_string(),
-            payload: payload.clone(),
+            payload: payload.to_vec(),
             authors: decoded_edit.authors.iter().map(|a| a.to_vec()).collect(),
             language: None,
-            space_id: space.as_bytes().to_vec(),
+            space_id: line.space.as_bytes().to_vec(),
             is_canonical: true,
             meta: Some(BlockchainMetadata {
                 created_at: 0,
                 created_by: vec![],
-                block_number: block,
+                block_number: line.block,
                 cursor: String::new(),
                 sequence: 0,
                 is_last: false,

--- a/kg-indexer/src/bin/cleanup_value_orphans.rs
+++ b/kg-indexer/src/bin/cleanup_value_orphans.rs
@@ -1,0 +1,227 @@
+//! One-off retroactive cleanup for the 2026-07-21 space-misattribution
+//! incident: `fix_misattribution`'s original live-sync logic decided which
+//! row to sync a live `values` row to using a snapshot of "now open" state
+//! taken *before* the version-table deletes ran. When a target's only
+//! wrong-space history was the row being deleted, that snapshot pointed at
+//! exactly the row about to be deleted — so the sync silently affected zero
+//! rows (the JOIN found nothing), leaving a stale orphan live `values` row
+//! behind with no backing `value_versions` history at all. Confirmed via a
+//! Copilot review finding + direct DB check. Fixed properly in
+//! `fix_misattribution` (now re-derives "now open" after the mutations run,
+//! inside a transaction), but that fix doesn't retroactively clean up
+//! orphans left behind by the buggy first pass — hence this tool.
+//!
+//! Scoped to `values` only (not `relations`): a value's live id is derived
+//! from (entity_id, property_id, space_id), so an orphan check is entirely
+//! self-contained per exact triple — no risk of only checking one space's
+//! data and wrongly concluding a relation with legitimate history in a
+//! *different* space is an orphan (which is exactly why the general-purpose
+//! `repair_version_chains`, when pointed at only the wrong space, is NOT
+//! safe to use for this — its relation-orphan logic aggregates by relation_id
+//! across every space it was asked to check, and wrongly flags relations
+//! whose live row correctly lives in a space this batch never queries).
+//! Also does NOT touch `edit_versions` — these edits have already been
+//! successfully replayed into their correct space, and re-deriving/deleting
+//! their edit_versions rows here would undo that.
+//!
+//! For every (entity_id, property_id, wrong_space) target derived from the
+//! given batch: if a live `values` row exists with the corresponding
+//! deterministic id, and there is NO `value_versions` row at all for that
+//! exact (entity_id, property_id, space_id) triple, delete the live row.
+//!
+//! Defaults to `--dry-run`. Pass `--execute` to actually apply.
+//!
+//! Usage:
+//!   DATABASE_URL=... cargo run -p kg-indexer --bin cleanup_value_orphans -- \
+//!     --batch-file /path/to/uri_block_wrongspace_lines.txt \
+//!     [--execute]
+
+use std::collections::HashSet;
+use std::env;
+use std::fs;
+
+use grc_20::decode_edit;
+use hermes_schema::pb::blockchain_metadata::BlockchainMetadata;
+use hermes_schema::pb::knowledge::HermesEdit;
+use kg_indexer::error::IndexerError;
+use kg_indexer::handlers;
+use kg_indexer::storage::Storage;
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+    let batch_file = args
+        .iter()
+        .position(|a| a == "--batch-file")
+        .and_then(|i| args.get(i + 1))
+        .expect("--batch-file is required");
+    let execute = args.iter().any(|a| a == "--execute");
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let storage = Storage::new(&database_url).await?;
+
+    let content = fs::read_to_string(batch_file)
+        .map_err(|e| IndexerError::Config(format!("could not read batch file: {e}")))?;
+
+    let mut value_targets: HashSet<(Uuid, Uuid, Uuid)> = HashSet::new();
+    let mut decoded = 0usize;
+    let mut skipped = 0usize;
+
+    for line in content.lines().filter(|l| !l.trim().is_empty()) {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 3 {
+            return Err(IndexerError::Config(format!(
+                "malformed batch-file line (expected \"<uri> <block> <space> ...\"): {line:?}"
+            )));
+        }
+        let (uri, block_str, space_str) = (parts[0], parts[1], parts[2]);
+        let block: u64 = block_str
+            .parse()
+            .map_err(|e| IndexerError::Config(format!("bad block in line {line:?}: {e}")))?;
+        let space: Uuid = space_str
+            .parse()
+            .map_err(|e| IndexerError::Config(format!("bad space in line {line:?}: {e}")))?;
+
+        let row: (Option<Vec<u8>>, bool) =
+            sqlx::query_as("SELECT data, is_errored FROM ipfs_cache WHERE uri = $1")
+                .bind(uri)
+                .fetch_one(&storage.pool)
+                .await
+                .map_err(|e| match e {
+                    sqlx::Error::RowNotFound => {
+                        IndexerError::Config(format!("uri not found in ipfs_cache: {uri}"))
+                    }
+                    other => IndexerError::Database(other),
+                })?;
+        let (data, is_errored) = row;
+        if is_errored {
+            println!("SKIP {uri}: ipfs_cache row still marked is_errored");
+            skipped += 1;
+            continue;
+        }
+        let payload = match data {
+            Some(p) => p,
+            None => {
+                println!("SKIP {uri}: no data");
+                skipped += 1;
+                continue;
+            }
+        };
+        let decoded_edit = match decode_edit(&payload) {
+            Ok(d) => d,
+            Err(e) => {
+                println!("SKIP {uri}: decode failed: {e}");
+                skipped += 1;
+                continue;
+            }
+        };
+
+        let edit = HermesEdit {
+            id: decoded_edit.id.to_vec(),
+            name: decoded_edit.name.to_string(),
+            payload: payload.clone(),
+            authors: decoded_edit.authors.iter().map(|a| a.to_vec()).collect(),
+            language: None,
+            space_id: space.as_bytes().to_vec(),
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                created_at: 0,
+                created_by: vec![],
+                block_number: block,
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let result = handlers::edits::handle_edit(&edit)?;
+        decoded += 1;
+        for v in &result.values {
+            value_targets.insert((v.entity_id, v.property_id, v.space_id));
+        }
+    }
+
+    println!(
+        "Decoded {decoded} edit(s), {skipped} skipped. {} distinct value target(s) to check.",
+        value_targets.len()
+    );
+
+    let targets: Vec<(Uuid, Uuid, Uuid)> = value_targets.into_iter().collect();
+    let (e, p, s): (Vec<Uuid>, Vec<Uuid>, Vec<Uuid>) =
+        targets
+            .iter()
+            .fold((vec![], vec![], vec![]), |mut acc, &(e, p, s)| {
+                acc.0.push(e);
+                acc.1.push(p);
+                acc.2.push(s);
+                acc
+            });
+
+    // Which of these targets still have ANY value_versions row at all
+    // (open or closed) — those are NOT orphans, leave them alone.
+    let backed: Vec<(Uuid, Uuid, Uuid)> = if targets.is_empty() {
+        Vec::new()
+    } else {
+        sqlx::query_as(
+            "SELECT DISTINCT entity_id, property_id, space_id FROM value_versions \
+             WHERE (entity_id, property_id, space_id) IN ( \
+               SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::uuid[]) \
+             )",
+        )
+        .bind(&e)
+        .bind(&p)
+        .bind(&s)
+        .fetch_all(&storage.pool)
+        .await?
+    };
+    let backed_set: HashSet<(Uuid, Uuid, Uuid)> = backed.into_iter().collect();
+
+    let live_ids: Vec<String> = targets
+        .iter()
+        .map(|&(e, p, s)| handlers::edits::derive_value_id(&e, &p, &s).to_string())
+        .collect();
+    let existing_live: Vec<String> =
+        sqlx::query_scalar("SELECT id FROM values WHERE id = ANY($1::text[])")
+            .bind(&live_ids)
+            .fetch_all(&storage.pool)
+            .await?;
+    let existing_live_set: HashSet<String> = existing_live.into_iter().collect();
+
+    let mut delete_live_ids: Vec<String> = Vec::new();
+    for &target @ (e, p, s) in &targets {
+        if backed_set.contains(&target) {
+            continue; // has real history, not an orphan
+        }
+        let live_id = handlers::edits::derive_value_id(&e, &p, &s).to_string();
+        if existing_live_set.contains(&live_id) {
+            delete_live_ids.push(live_id);
+        }
+    }
+
+    println!(
+        "\n{} orphaned live value row(s) found (zero backing value_versions history).",
+        delete_live_ids.len()
+    );
+
+    if !execute {
+        println!("\nDry run — no changes made. Pass --execute to apply.");
+        return Ok(());
+    }
+
+    if !delete_live_ids.is_empty() {
+        sqlx::query("DELETE FROM values WHERE id = ANY($1::text[])")
+            .bind(&delete_live_ids)
+            .execute(&storage.pool)
+            .await?;
+    }
+    println!("\nExecuted successfully.");
+
+    Ok(())
+}

--- a/kg-indexer/src/bin/fix_misattribution.rs
+++ b/kg-indexer/src/bin/fix_misattribution.rs
@@ -406,6 +406,21 @@ async fn main() -> Result<(), IndexerError> {
     let mut delete_relation_version_ids: Vec<Uuid> = Vec::new();
     let mut update_relation_version_valid_to: Vec<(Uuid, Option<i64>)> = Vec::new();
 
+    // Whether THIS run found any actual wrong-space version-table footprint
+    // for each plan. An edit whose every target shows "no trace" likely
+    // pre-existed from before the incident — `insert_edit_version` no-op'd
+    // (ON CONFLICT DO NOTHING) so its edit_versions row is from whatever
+    // legitimately indexed it earlier, not from this bad replay. Deleting
+    // that row would remove replay_edit's idempotency guard for an edit
+    // that was never actually broken, and re-processing it would re-close
+    // currently-open versions and reintroduce backfill-style corruption.
+    // Edits with zero targets at all have nothing to find a trace of, so
+    // there's nothing at risk — treat them as safe to clear.
+    let mut has_footprint: Vec<bool> = plans
+        .iter()
+        .map(|p| p.value_targets.is_empty() && p.relation_targets.is_empty())
+        .collect();
+
     for t in &value_touches {
         let opened = opened_value_map.get(&t.opened_id).copied();
         let closed = closed_value_map
@@ -419,6 +434,7 @@ async fn main() -> Result<(), IndexerError> {
                 plans[t.plan_idx].uri, t.entity_id, t.property_id, t.version_key
             );
         } else {
+            has_footprint[t.plan_idx] = true;
             let new_valid_to = opened.and_then(|(_, to)| to);
             if let Some((closed_id, closed_from)) = closed {
                 println!(
@@ -449,6 +465,7 @@ async fn main() -> Result<(), IndexerError> {
                 plans[t.plan_idx].uri, t.relation_id, t.version_key
             );
         } else {
+            has_footprint[t.plan_idx] = true;
             let new_valid_to = opened.and_then(|(_, to)| to);
             if let Some((closed_id, closed_from)) = closed {
                 println!(
@@ -467,12 +484,23 @@ async fn main() -> Result<(), IndexerError> {
         }
     }
 
-    let edit_ids: Vec<Uuid> = plans.iter().map(|p| p.edit_id).collect();
-    for plan in &plans {
-        println!(
-            "  [edit {}] WOULD DELETE edit_versions WHERE edit_id = {} ({:?})",
-            plan.uri, plan.edit_id, plan.edit_name
-        );
+    let mut edit_ids: Vec<Uuid> = Vec::new();
+    for (plan_idx, plan) in plans.iter().enumerate() {
+        if has_footprint[plan_idx] {
+            edit_ids.push(plan.edit_id);
+            println!(
+                "  [edit {}] WOULD DELETE edit_versions WHERE edit_id = {} ({:?})",
+                plan.uri, plan.edit_id, plan.edit_name
+            );
+        } else {
+            println!(
+                "  [edit {}] SKIP edit_versions delete for edit_id = {} ({:?}) — no wrong-space \
+                 footprint found for any of its targets, so it likely pre-existed from before the \
+                 incident; deleting would remove replay_edit's idempotency guard for an edit that \
+                 was never actually broken",
+                plan.uri, plan.edit_id, plan.edit_name
+            );
+        }
     }
 
     // Capture counts before these vecs are consumed below.
@@ -695,7 +723,7 @@ async fn main() -> Result<(), IndexerError> {
              space_id = rv.space_id, verified = rv.verified \
              FROM UNNEST($1::uuid[], $2::uuid[]) AS u(relation_id, source_id) \
              JOIN relation_versions rv ON rv.id = u.source_id \
-             WHERE r.id = u.relation_id",
+             WHERE r.id = u.relation_id AND r.is_system = false",
         )
         .bind(&rel_ids)
         .bind(&source_ids)

--- a/kg-indexer/src/bin/fix_misattribution.rs
+++ b/kg-indexer/src/bin/fix_misattribution.rs
@@ -153,6 +153,43 @@ async fn main() -> Result<(), IndexerError> {
         }
     }
 
+    // The original bad replay's version_key is whatever `replay_edit` was
+    // actually invoked with — `(block << 32) | sequence`, not necessarily
+    // `sequence = 0`. Rather than assume, read it back from each edit's
+    // still-present (wrong-space) `edit_versions` row, which is exactly the
+    // value the opened/closed rows in value_versions/relation_versions were
+    // written with.
+    let plan_edit_ids: Vec<Uuid> = plans.iter().map(|p| p.edit_id).collect();
+    let edit_version_keys: Vec<(Uuid, i64)> = if plan_edit_ids.is_empty() {
+        Vec::new()
+    } else {
+        sqlx::query_as(
+            "SELECT edit_id, version_key FROM edit_versions WHERE edit_id = ANY($1::uuid[])",
+        )
+        .bind(&plan_edit_ids)
+        .fetch_all(&storage.pool)
+        .await?
+    };
+    let version_key_by_edit_id: HashMap<Uuid, i64> = edit_version_keys.into_iter().collect();
+
+    let mut resolved_plans = Vec::with_capacity(plans.len());
+    for mut plan in plans {
+        match version_key_by_edit_id.get(&plan.edit_id) {
+            Some(&version_key) => {
+                plan.version_key = version_key;
+                resolved_plans.push(plan);
+            }
+            None => {
+                println!(
+                    "SKIP {}: no edit_versions row for edit_id {} — already cleaned up, or never replayed?",
+                    plan.uri, plan.edit_id
+                );
+                skipped += 1;
+            }
+        }
+    }
+    let plans = resolved_plans;
+
     println!(
         "Decoded {} edit(s), {} skipped. Collecting targets...",
         plans.len(),
@@ -276,33 +313,12 @@ async fn main() -> Result<(), IndexerError> {
             })
             .collect()
     };
-    let (nve, nvp, nvs): (Vec<Uuid>, Vec<Uuid>, Vec<Uuid>) = distinct_value_targets
-        .iter()
-        .map(|&(e, p, s)| (e, p, s))
-        .fold(
-            (Vec::new(), Vec::new(), Vec::new()),
-            |mut acc, (e, p, s)| {
-                acc.0.push(e);
-                acc.1.push(p);
-                acc.2.push(s);
-                acc
-            },
-        );
-    let now_open_values: Vec<(Uuid, Uuid, Uuid, Uuid)> = sqlx::query_as(
-        "SELECT entity_id, property_id, space_id, id FROM value_versions \
-         WHERE (entity_id, property_id, space_id) IN (\
-           SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::uuid[])\
-         ) AND valid_to_key IS NULL",
-    )
-    .bind(&nve)
-    .bind(&nvp)
-    .bind(&nvs)
-    .fetch_all(&storage.pool)
-    .await?;
-    let now_open_value_map: HashMap<(Uuid, Uuid, Uuid), Uuid> = now_open_values
-        .into_iter()
-        .map(|(e, p, s, id)| ((e, p, s), id))
-        .collect();
+    // `now_open` state (which row is currently the latest for each target)
+    // is deliberately NOT fetched here. It's read fresh after the
+    // version-table mutations run (see Phase 5) — a target's "now open" row
+    // can be exactly the row this tool is about to delete, and syncing the
+    // live row to a snapshot taken before that delete would point it at a
+    // row that no longer exists by the time the sync statement runs.
 
     let live_value_ids: Vec<String> = value_touches.iter().map(|t| t.live_id.clone()).collect();
     let live_values: Vec<String> =
@@ -362,28 +378,6 @@ async fn main() -> Result<(), IndexerError> {
             })
             .collect()
     };
-    let (nrr, nrs): (Vec<Uuid>, Vec<Uuid>) = distinct_relation_targets
-        .iter()
-        .map(|&(r, s)| (r, s))
-        .fold((Vec::new(), Vec::new()), |mut acc, (r, s)| {
-            acc.0.push(r);
-            acc.1.push(s);
-            acc
-        });
-    let now_open_relations: Vec<(Uuid, Uuid, Uuid)> = sqlx::query_as(
-        "SELECT relation_id, space_id, id FROM relation_versions \
-         WHERE (relation_id, space_id) IN (SELECT * FROM UNNEST($1::uuid[], $2::uuid[])) \
-         AND valid_to_key IS NULL",
-    )
-    .bind(&nrr)
-    .bind(&nrs)
-    .fetch_all(&storage.pool)
-    .await?;
-    let now_open_relation_map: HashMap<(Uuid, Uuid), Uuid> = now_open_relations
-        .into_iter()
-        .map(|(r, s, id)| ((r, s), id))
-        .collect();
-
     let relation_ids: Vec<Uuid> = relation_touches.iter().map(|t| t.relation_id).collect();
     let current_relations: Vec<(Uuid, Uuid)> =
         sqlx::query_as("SELECT id, space_id FROM relations WHERE id = ANY($1::uuid[])")
@@ -394,16 +388,11 @@ async fn main() -> Result<(), IndexerError> {
 
     println!("Batch fetch complete. Computing plan...");
 
-    // ---- Phase 4: compute the plan in memory (no more queries needed) ----
+    // ---- Phase 4: compute version-table mutations in memory ----
     let mut delete_value_version_ids: Vec<Uuid> = Vec::new();
     let mut update_value_version_valid_to: Vec<(Uuid, Option<i64>)> = Vec::new();
-    let mut sync_live_value: Vec<(String, Uuid)> = Vec::new(); // (live_id, source_version_id)
-    let mut delete_live_value_ids: Vec<String> = Vec::new();
-
     let mut delete_relation_version_ids: Vec<Uuid> = Vec::new();
     let mut update_relation_version_valid_to: Vec<(Uuid, Option<i64>)> = Vec::new();
-    let mut sync_live_relation: Vec<(Uuid, Uuid)> = Vec::new(); // (relation_id, source_version_id)
-    let mut delete_live_relation_ids: Vec<Uuid> = Vec::new();
 
     for t in &value_touches {
         let opened = opened_value_map.get(&t.opened_id).copied();
@@ -433,25 +422,6 @@ async fn main() -> Result<(), IndexerError> {
                 );
                 delete_value_version_ids.push(t.opened_id);
             }
-        }
-
-        let now_open = now_open_value_map
-            .get(&(t.entity_id, t.property_id, t.wrong_space))
-            .copied();
-        let live_exists = live_value_set.contains(&t.live_id);
-        match (now_open, live_exists) {
-            (Some(open_id), _) => {
-                println!(
-                    "  [edit {}] VALUE live sync: set values id={} to match now-open row {open_id}",
-                    plans[t.plan_idx].uri, t.live_id
-                );
-                sync_live_value.push((t.live_id.clone(), open_id));
-            }
-            (None, true) => {
-                println!("  [edit {}] VALUE live sync: delete orphaned values id={} (no version history backs it)", plans[t.plan_idx].uri, t.live_id);
-                delete_live_value_ids.push(t.live_id.clone());
-            }
-            (None, false) => {}
         }
     }
 
@@ -483,28 +453,6 @@ async fn main() -> Result<(), IndexerError> {
                 delete_relation_version_ids.push(t.opened_id);
             }
         }
-
-        let current_space = current_relation_space_map.get(&t.relation_id).copied();
-        if current_space != Some(t.wrong_space) {
-            println!(
-                "  [edit {}] RELATION live sync: not needed (relations id={} current space_id={:?} is not the wrong space)",
-                plans[t.plan_idx].uri, t.relation_id, current_space
-            );
-            continue;
-        }
-        match now_open_relation_map
-            .get(&(t.relation_id, t.wrong_space))
-            .copied()
-        {
-            Some(open_id) => {
-                println!("  [edit {}] RELATION live sync: set relations id={} to match now-open row {open_id}", plans[t.plan_idx].uri, t.relation_id);
-                sync_live_relation.push((t.relation_id, open_id));
-            }
-            None => {
-                println!("  [edit {}] RELATION live sync: delete relations id={} (currently wrong-space, nothing precedes it)", plans[t.plan_idx].uri, t.relation_id);
-                delete_live_relation_ids.push(t.relation_id);
-            }
-        }
     }
 
     let edit_ids: Vec<Uuid> = plans.iter().map(|p| p.edit_id).collect();
@@ -515,27 +463,20 @@ async fn main() -> Result<(), IndexerError> {
         );
     }
 
-    println!(
-        "\nPlan: delete {} value_version row(s), update {} value_version row(s), sync {} live value row(s), \
-         delete {} orphaned live value row(s); delete {} relation_version row(s), update {} relation_version row(s), \
-         sync {} live relation row(s), delete {} live relation row(s); delete {} edit_versions row(s).",
-        delete_value_version_ids.len(),
-        update_value_version_valid_to.len(),
-        sync_live_value.len(),
-        delete_live_value_ids.len(),
-        delete_relation_version_ids.len(),
-        update_relation_version_valid_to.len(),
-        sync_live_relation.len(),
-        delete_live_relation_ids.len(),
-        edit_ids.len(),
-    );
+    // Capture counts before these vecs are consumed below.
+    let delete_value_version_count = delete_value_version_ids.len();
+    let update_value_version_count = update_value_version_valid_to.len();
+    let delete_relation_version_count = delete_relation_version_ids.len();
+    let update_relation_version_count = update_relation_version_valid_to.len();
 
-    if !execute {
-        println!("\nDry run — no changes made. Pass --execute to apply.");
-        return Ok(());
-    }
-
-    // ---- Phase 5: execute, batched ----
+    // ---- Phase 5: mutate version tables, THEN decide live-row sync from
+    // the post-mutation state. Always runs inside a transaction — a
+    // target's "now open" row can be exactly the row we just deleted, so
+    // computing that from a pre-mutation snapshot (like Phase 3's queries
+    // would if reused here) risks syncing a live row to something that no
+    // longer exists by the time the sync statement runs. Dry-run rolls the
+    // transaction back at the end, so the printed plan is always exactly
+    // what --execute would do.
     let mut tx = storage.pool.begin().await?;
 
     if !delete_value_version_ids.is_empty() {
@@ -556,6 +497,154 @@ async fn main() -> Result<(), IndexerError> {
         .execute(&mut *tx)
         .await?;
     }
+    if !delete_relation_version_ids.is_empty() {
+        sqlx::query("DELETE FROM relation_versions WHERE id = ANY($1::uuid[])")
+            .bind(&delete_relation_version_ids)
+            .execute(&mut *tx)
+            .await?;
+    }
+    if !update_relation_version_valid_to.is_empty() {
+        let (ids, valid_tos): (Vec<Uuid>, Vec<Option<i64>>) =
+            update_relation_version_valid_to.into_iter().unzip();
+        sqlx::query(
+            "UPDATE relation_versions rv SET valid_to_key = u.valid_to_key \
+             FROM UNNEST($1::uuid[], $2::bigint[]) AS u(id, valid_to_key) WHERE rv.id = u.id",
+        )
+        .bind(&ids)
+        .bind(&valid_tos)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    // Fresh post-mutation "now open" lookups, read inside the same
+    // transaction (READ COMMITTED sees this transaction's own prior writes).
+    let (nve, nvp, nvs): (Vec<Uuid>, Vec<Uuid>, Vec<Uuid>) = distinct_value_targets
+        .iter()
+        .map(|&(e, p, s)| (e, p, s))
+        .fold(
+            (Vec::new(), Vec::new(), Vec::new()),
+            |mut acc, (e, p, s)| {
+                acc.0.push(e);
+                acc.1.push(p);
+                acc.2.push(s);
+                acc
+            },
+        );
+    let now_open_values: Vec<(Uuid, Uuid, Uuid, Uuid)> = sqlx::query_as(
+        "SELECT entity_id, property_id, space_id, id FROM value_versions \
+         WHERE (entity_id, property_id, space_id) IN (\
+           SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::uuid[])\
+         ) AND valid_to_key IS NULL",
+    )
+    .bind(&nve)
+    .bind(&nvp)
+    .bind(&nvs)
+    .fetch_all(&mut *tx)
+    .await?;
+    let now_open_value_map: HashMap<(Uuid, Uuid, Uuid), Uuid> = now_open_values
+        .into_iter()
+        .map(|(e, p, s, id)| ((e, p, s), id))
+        .collect();
+
+    let (nrr, nrs): (Vec<Uuid>, Vec<Uuid>) = distinct_relation_targets
+        .iter()
+        .map(|&(r, s)| (r, s))
+        .fold((Vec::new(), Vec::new()), |mut acc, (r, s)| {
+            acc.0.push(r);
+            acc.1.push(s);
+            acc
+        });
+    let now_open_relations: Vec<(Uuid, Uuid, Uuid)> = sqlx::query_as(
+        "SELECT relation_id, space_id, id FROM relation_versions \
+         WHERE (relation_id, space_id) IN (SELECT * FROM UNNEST($1::uuid[], $2::uuid[])) \
+         AND valid_to_key IS NULL",
+    )
+    .bind(&nrr)
+    .bind(&nrs)
+    .fetch_all(&mut *tx)
+    .await?;
+    let now_open_relation_map: HashMap<(Uuid, Uuid), Uuid> = now_open_relations
+        .into_iter()
+        .map(|(r, s, id)| ((r, s), id))
+        .collect();
+
+    let mut sync_live_value: Vec<(String, Uuid)> = Vec::new(); // (live_id, source_version_id)
+    let mut delete_live_value_ids: Vec<String> = Vec::new();
+    let mut seen_value_targets: HashSet<(Uuid, Uuid, Uuid)> = HashSet::new();
+
+    for t in &value_touches {
+        let key = (t.entity_id, t.property_id, t.wrong_space);
+        if !seen_value_targets.insert(key) {
+            continue; // already decided for this target by an earlier touch
+        }
+        let now_open = now_open_value_map.get(&key).copied();
+        let live_exists = live_value_set.contains(&t.live_id);
+        match (now_open, live_exists) {
+            (Some(open_id), _) => {
+                println!(
+                    "  [edit {}] VALUE live sync: set values id={} to match now-open row {open_id}",
+                    plans[t.plan_idx].uri, t.live_id
+                );
+                sync_live_value.push((t.live_id.clone(), open_id));
+            }
+            (None, true) => {
+                println!("  [edit {}] VALUE live sync: delete orphaned values id={} (no version history backs it)", plans[t.plan_idx].uri, t.live_id);
+                delete_live_value_ids.push(t.live_id.clone());
+            }
+            (None, false) => {}
+        }
+    }
+
+    let mut sync_live_relation: Vec<(Uuid, Uuid)> = Vec::new(); // (relation_id, source_version_id)
+    let mut delete_live_relation_ids: Vec<Uuid> = Vec::new();
+    let mut seen_relation_targets: HashSet<(Uuid, Uuid)> = HashSet::new();
+
+    for t in &relation_touches {
+        let key = (t.relation_id, t.wrong_space);
+        if !seen_relation_targets.insert(key) {
+            continue;
+        }
+        let current_space = current_relation_space_map.get(&t.relation_id).copied();
+        if current_space != Some(t.wrong_space) {
+            println!(
+                "  [edit {}] RELATION live sync: not needed (relations id={} current space_id={:?} is not the wrong space)",
+                plans[t.plan_idx].uri, t.relation_id, current_space
+            );
+            continue;
+        }
+        match now_open_relation_map.get(&key).copied() {
+            Some(open_id) => {
+                println!("  [edit {}] RELATION live sync: set relations id={} to match now-open row {open_id}", plans[t.plan_idx].uri, t.relation_id);
+                sync_live_relation.push((t.relation_id, open_id));
+            }
+            None => {
+                println!("  [edit {}] RELATION live sync: delete relations id={} (currently wrong-space, nothing precedes it)", plans[t.plan_idx].uri, t.relation_id);
+                delete_live_relation_ids.push(t.relation_id);
+            }
+        }
+    }
+
+    println!(
+        "\nPlan: delete {} value_version row(s), update {} value_version row(s), sync {} live value row(s), \
+         delete {} orphaned live value row(s); delete {} relation_version row(s), update {} relation_version row(s), \
+         sync {} live relation row(s), delete {} live relation row(s); delete {} edit_versions row(s).",
+        delete_value_version_count,
+        update_value_version_count,
+        sync_live_value.len(),
+        delete_live_value_ids.len(),
+        delete_relation_version_count,
+        update_relation_version_count,
+        sync_live_relation.len(),
+        delete_live_relation_ids.len(),
+        edit_ids.len(),
+    );
+
+    if !execute {
+        tx.rollback().await?;
+        println!("\nDry run — no changes made. Pass --execute to apply.");
+        return Ok(());
+    }
+
     if !sync_live_value.is_empty() {
         let (live_ids, source_ids): (Vec<String>, Vec<Uuid>) = sync_live_value.into_iter().unzip();
         sqlx::query(
@@ -584,25 +673,6 @@ async fn main() -> Result<(), IndexerError> {
             .bind(&delete_live_value_ids)
             .execute(&mut *tx)
             .await?;
-    }
-
-    if !delete_relation_version_ids.is_empty() {
-        sqlx::query("DELETE FROM relation_versions WHERE id = ANY($1::uuid[])")
-            .bind(&delete_relation_version_ids)
-            .execute(&mut *tx)
-            .await?;
-    }
-    if !update_relation_version_valid_to.is_empty() {
-        let (ids, valid_tos): (Vec<Uuid>, Vec<Option<i64>>) =
-            update_relation_version_valid_to.into_iter().unzip();
-        sqlx::query(
-            "UPDATE relation_versions rv SET valid_to_key = u.valid_to_key \
-             FROM UNNEST($1::uuid[], $2::bigint[]) AS u(id, valid_to_key) WHERE rv.id = u.id",
-        )
-        .bind(&ids)
-        .bind(&valid_tos)
-        .execute(&mut *tx)
-        .await?;
     }
     if !sync_live_relation.is_empty() {
         let (rel_ids, source_ids): (Vec<Uuid>, Vec<Uuid>) = sync_live_relation.into_iter().unzip();
@@ -692,7 +762,10 @@ fn build_plan(
     Ok(EditPlan {
         uri: line.uri.clone(),
         wrong_space: line.wrong_space,
-        version_key: (line.block as i64) << 32,
+        // Placeholder — overwritten from the edit's actual `edit_versions`
+        // row (see main()) once every plan's edit_id is known, since the
+        // true version_key may include a non-zero sequence.
+        version_key: 0,
         edit_id: result.edit_id,
         edit_name: decoded.name.to_string(),
         value_targets,

--- a/kg-indexer/src/bin/fix_misattribution.rs
+++ b/kg-indexer/src/bin/fix_misattribution.rs
@@ -112,12 +112,12 @@ async fn main() -> Result<(), IndexerError> {
             block: parts[1]
                 .parse()
                 .map_err(|e| IndexerError::Config(format!("bad block in line {line:?}: {e}")))?,
-            wrong_space: parts[2]
-                .parse()
-                .map_err(|e| IndexerError::Config(format!("bad wrong_space in line {line:?}: {e}")))?,
-            correct_space: parts[3]
-                .parse()
-                .map_err(|e| IndexerError::Config(format!("bad correct_space in line {line:?}: {e}")))?,
+            wrong_space: parts[2].parse().map_err(|e| {
+                IndexerError::Config(format!("bad wrong_space in line {line:?}: {e}"))
+            })?,
+            correct_space: parts[3].parse().map_err(|e| {
+                IndexerError::Config(format!("bad correct_space in line {line:?}: {e}"))
+            })?,
         });
     }
     lines.sort_by_key(|l| l.block);
@@ -130,12 +130,11 @@ async fn main() -> Result<(), IndexerError> {
 
     // ---- Phase 1: fetch + decode every edit, collect its targets ----
     let uris: Vec<&str> = lines.iter().map(|l| l.uri.as_str()).collect();
-    let cache_rows: Vec<(String, Option<Vec<u8>>, bool)> = sqlx::query_as(
-        "SELECT uri, data, is_errored FROM ipfs_cache WHERE uri = ANY($1::text[])",
-    )
-    .bind(&uris)
-    .fetch_all(&storage.pool)
-    .await?;
+    let cache_rows: Vec<(String, Option<Vec<u8>>, bool)> =
+        sqlx::query_as("SELECT uri, data, is_errored FROM ipfs_cache WHERE uri = ANY($1::text[])")
+            .bind(&uris)
+            .fetch_all(&storage.pool)
+            .await?;
     let cache_by_uri: HashMap<String, (Option<Vec<u8>>, bool)> = cache_rows
         .into_iter()
         .map(|(uri, data, errored)| (uri, (data, errored)))
@@ -203,8 +202,11 @@ async fn main() -> Result<(), IndexerError> {
             });
         }
         for &relation_id in &plan.relation_targets {
-            let opened_id =
-                Storage::derive_relation_version_id(&relation_id, &plan.wrong_space, plan.version_key);
+            let opened_id = Storage::derive_relation_version_id(
+                &relation_id,
+                &plan.wrong_space,
+                plan.version_key,
+            );
             relation_touches.push(RelationTouch {
                 plan_idx,
                 relation_id,
@@ -277,12 +279,15 @@ async fn main() -> Result<(), IndexerError> {
     let (nve, nvp, nvs): (Vec<Uuid>, Vec<Uuid>, Vec<Uuid>) = distinct_value_targets
         .iter()
         .map(|&(e, p, s)| (e, p, s))
-        .fold((Vec::new(), Vec::new(), Vec::new()), |mut acc, (e, p, s)| {
-            acc.0.push(e);
-            acc.1.push(p);
-            acc.2.push(s);
-            acc
-        });
+        .fold(
+            (Vec::new(), Vec::new(), Vec::new()),
+            |mut acc, (e, p, s)| {
+                acc.0.push(e);
+                acc.1.push(p);
+                acc.2.push(s);
+                acc
+            },
+        );
     let now_open_values: Vec<(Uuid, Uuid, Uuid, Uuid)> = sqlx::query_as(
         "SELECT entity_id, property_id, space_id, id FROM value_versions \
          WHERE (entity_id, property_id, space_id) IN (\
@@ -430,11 +435,16 @@ async fn main() -> Result<(), IndexerError> {
             }
         }
 
-        let now_open = now_open_value_map.get(&(t.entity_id, t.property_id, t.wrong_space)).copied();
+        let now_open = now_open_value_map
+            .get(&(t.entity_id, t.property_id, t.wrong_space))
+            .copied();
         let live_exists = live_value_set.contains(&t.live_id);
         match (now_open, live_exists) {
             (Some(open_id), _) => {
-                println!("  [edit {}] VALUE live sync: set values id={} to match now-open row {open_id}", plans[t.plan_idx].uri, t.live_id);
+                println!(
+                    "  [edit {}] VALUE live sync: set values id={} to match now-open row {open_id}",
+                    plans[t.plan_idx].uri, t.live_id
+                );
                 sync_live_value.push((t.live_id.clone(), open_id));
             }
             (None, true) => {
@@ -482,7 +492,10 @@ async fn main() -> Result<(), IndexerError> {
             );
             continue;
         }
-        match now_open_relation_map.get(&(t.relation_id, t.wrong_space)).copied() {
+        match now_open_relation_map
+            .get(&(t.relation_id, t.wrong_space))
+            .copied()
+        {
             Some(open_id) => {
                 println!("  [edit {}] RELATION live sync: set relations id={} to match now-open row {open_id}", plans[t.plan_idx].uri, t.relation_id);
                 sync_live_relation.push((t.relation_id, open_id));
@@ -629,9 +642,9 @@ fn build_plan(
     line: &BatchLine,
     cache_by_uri: &HashMap<String, (Option<Vec<u8>>, bool)>,
 ) -> Result<EditPlan, IndexerError> {
-    let (data, is_errored) = cache_by_uri
-        .get(&line.uri)
-        .ok_or_else(|| IndexerError::Config(format!("uri not found in ipfs_cache: {}", line.uri)))?;
+    let (data, is_errored) = cache_by_uri.get(&line.uri).ok_or_else(|| {
+        IndexerError::Config(format!("uri not found in ipfs_cache: {}", line.uri))
+    })?;
     if *is_errored {
         return Err(IndexerError::Config("ipfs_cache row is_errored".into()));
     }

--- a/kg-indexer/src/bin/fix_misattribution.rs
+++ b/kg-indexer/src/bin/fix_misattribution.rs
@@ -1,0 +1,688 @@
+//! Fixes the 2026-07-21 space-misattribution incident: the batch-replay tool
+//! (`replay_edit`) was called with the wrong `--space` for edits that had a
+//! governing proposal — it used `ipfs_cache.space` (populated from the
+//! on-chain action's `from_id`, i.e. the *proposer's* space) instead of the
+//! proposal's actual `space_id` (`to_id`, the space the proposal executed
+//! in). See the incident report for full context; see
+//! `hermes-pipeline/src/pipelines/governance.rs` for the correct
+//! attribution the real pipeline uses.
+//!
+//! For each misattributed edit this:
+//! 1. Re-decodes the edit and re-derives exactly which (entity, property,
+//!    space) / (relation, space) targets it touched, in the *wrong* space —
+//!    same extraction `replay_edit` itself used.
+//! 2. For each target, finds the row(s) the original bad replay wrote there:
+//!    - a row it *opened* (`valid_from_key == this edit's version_key`) —
+//!      exists only for Set/Create ops.
+//!    - a row it *closed* (`valid_to_key == this edit's version_key`) —
+//!      exists for any op type that touched a target with prior history in
+//!      the wrong space, since closing happens unconditionally.
+//! 3. Removes the opened row (if any) and un-closes / re-links the closed
+//!    row (if any), bridging the wrong space's version chain around the
+//!    removed node (same invariant `audit_batch_replay` checks).
+//! 4. Reconciles the live `values`/`relations` row for each target against
+//!    whatever is now open in the wrong space — including the case where
+//!    `insert_edit_version` no-op'd (edit_id pre-existed from *before* the
+//!    incident, e.g. already correctly indexed once) but the unconditional
+//!    `insert_values`/`insert_relations` call still ran, leaving an orphan
+//!    live row backed by zero version history. For relations specifically,
+//!    `insert_relations`' `ON CONFLICT` never touches `space_id`, so a
+//!    relation whose *current* space_id isn't the wrong one was already
+//!    protected by an earlier legitimate write and is left untouched.
+//! 5. Deletes the `edit_versions` row for this edit, so `replay_edit` can
+//!    cleanly re-insert it under the correct space afterward.
+//!
+//! Performance: all data fetching is batched into a handful of bulk queries
+//! (one pass to decode every edit and collect its targets, then one query
+//! per lookup type across *all* targets at once) rather than several
+//! queries per individual target — the latter took hours across a few
+//! hundred edits with many targets each.
+//!
+//! Defaults to `--dry-run`. Pass `--execute` to actually apply. This tool
+//! does NOT re-replay into the correct space — run `replay_edit` for each
+//! entry afterward, in block order.
+//!
+//! Usage:
+//!   DATABASE_URL=... cargo run -p kg-indexer --bin fix_misattribution -- \
+//!     --batch-file /path/to/uri_block_wrongspace_correctspace_lines.txt \
+//!     [--execute]
+
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::fs;
+
+use grc_20::decode_edit;
+use hermes_schema::pb::blockchain_metadata::BlockchainMetadata;
+use hermes_schema::pb::knowledge::HermesEdit;
+use kg_indexer::error::IndexerError;
+use kg_indexer::handlers;
+use kg_indexer::storage::Storage;
+use uuid::Uuid;
+
+struct BatchLine {
+    uri: String,
+    block: u64,
+    wrong_space: Uuid,
+    #[allow(dead_code)]
+    correct_space: Uuid,
+}
+
+struct EditPlan {
+    uri: String,
+    wrong_space: Uuid,
+    version_key: i64,
+    edit_id: Uuid,
+    edit_name: String,
+    value_targets: Vec<(Uuid, Uuid)>,
+    relation_targets: Vec<Uuid>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+    let batch_file = args
+        .iter()
+        .position(|a| a == "--batch-file")
+        .and_then(|i| args.get(i + 1))
+        .expect("--batch-file is required");
+    let execute = args.iter().any(|a| a == "--execute");
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let storage = Storage::new(&database_url).await?;
+
+    let content = fs::read_to_string(batch_file)
+        .map_err(|e| IndexerError::Config(format!("could not read batch file: {e}")))?;
+
+    let mut lines = Vec::new();
+    for line in content.lines().filter(|l| !l.trim().is_empty()) {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() != 4 {
+            return Err(IndexerError::Config(format!(
+                "malformed line (expected \"<uri> <block> <wrong_space> <correct_space>\"): {line:?}"
+            )));
+        }
+        lines.push(BatchLine {
+            uri: parts[0].to_string(),
+            block: parts[1]
+                .parse()
+                .map_err(|e| IndexerError::Config(format!("bad block in line {line:?}: {e}")))?,
+            wrong_space: parts[2]
+                .parse()
+                .map_err(|e| IndexerError::Config(format!("bad wrong_space in line {line:?}: {e}")))?,
+            correct_space: parts[3]
+                .parse()
+                .map_err(|e| IndexerError::Config(format!("bad correct_space in line {line:?}: {e}")))?,
+        });
+    }
+    lines.sort_by_key(|l| l.block);
+
+    println!(
+        "{} edit(s) to fix. Mode: {}",
+        lines.len(),
+        if execute { "EXECUTE" } else { "DRY RUN" }
+    );
+
+    // ---- Phase 1: fetch + decode every edit, collect its targets ----
+    let uris: Vec<&str> = lines.iter().map(|l| l.uri.as_str()).collect();
+    let cache_rows: Vec<(String, Option<Vec<u8>>, bool)> = sqlx::query_as(
+        "SELECT uri, data, is_errored FROM ipfs_cache WHERE uri = ANY($1::text[])",
+    )
+    .bind(&uris)
+    .fetch_all(&storage.pool)
+    .await?;
+    let cache_by_uri: HashMap<String, (Option<Vec<u8>>, bool)> = cache_rows
+        .into_iter()
+        .map(|(uri, data, errored)| (uri, (data, errored)))
+        .collect();
+
+    let mut plans: Vec<EditPlan> = Vec::with_capacity(lines.len());
+    let mut skipped = 0u32;
+
+    for line in &lines {
+        match build_plan(line, &cache_by_uri) {
+            Ok(plan) => plans.push(plan),
+            Err(e) => {
+                println!("SKIP {}: {e}", line.uri);
+                skipped += 1;
+            }
+        }
+    }
+
+    println!(
+        "Decoded {} edit(s), {} skipped. Collecting targets...",
+        plans.len(),
+        skipped
+    );
+
+    // ---- Phase 2: flatten all targets across all edits ----
+    struct ValueTouch {
+        plan_idx: usize,
+        entity_id: Uuid,
+        property_id: Uuid,
+        wrong_space: Uuid,
+        version_key: i64,
+        opened_id: Uuid,
+        live_id: String,
+    }
+    struct RelationTouch {
+        plan_idx: usize,
+        relation_id: Uuid,
+        wrong_space: Uuid,
+        version_key: i64,
+        opened_id: Uuid,
+    }
+
+    let mut value_touches = Vec::new();
+    let mut relation_touches = Vec::new();
+
+    for (plan_idx, plan) in plans.iter().enumerate() {
+        for &(entity_id, property_id) in &plan.value_targets {
+            let opened_id = Storage::derive_value_version_id(
+                &entity_id,
+                &property_id,
+                &plan.wrong_space,
+                plan.version_key,
+            );
+            let live_id =
+                handlers::edits::derive_value_id(&entity_id, &property_id, &plan.wrong_space)
+                    .to_string();
+            value_touches.push(ValueTouch {
+                plan_idx,
+                entity_id,
+                property_id,
+                wrong_space: plan.wrong_space,
+                version_key: plan.version_key,
+                opened_id,
+                live_id,
+            });
+        }
+        for &relation_id in &plan.relation_targets {
+            let opened_id =
+                Storage::derive_relation_version_id(&relation_id, &plan.wrong_space, plan.version_key);
+            relation_touches.push(RelationTouch {
+                plan_idx,
+                relation_id,
+                wrong_space: plan.wrong_space,
+                version_key: plan.version_key,
+                opened_id,
+            });
+        }
+    }
+
+    println!(
+        "{} value target(s), {} relation target(s) across all edits. Batch-fetching current state...",
+        value_touches.len(),
+        relation_touches.len()
+    );
+
+    // ---- Phase 3: batch-fetch everything needed, in a handful of queries ----
+    let opened_value_ids: Vec<Uuid> = value_touches.iter().map(|t| t.opened_id).collect();
+    let opened_values: Vec<(Uuid, i64, Option<i64>)> = sqlx::query_as(
+        "SELECT id, valid_from_key, valid_to_key FROM value_versions WHERE id = ANY($1::uuid[])",
+    )
+    .bind(&opened_value_ids)
+    .fetch_all(&storage.pool)
+    .await?;
+    let opened_value_map: HashMap<Uuid, (i64, Option<i64>)> = opened_values
+        .into_iter()
+        .map(|(id, from, to)| (id, (from, to)))
+        .collect();
+
+    let (ve, vp, vs, vk): (Vec<Uuid>, Vec<Uuid>, Vec<Uuid>, Vec<i64>) = {
+        let mut ve = Vec::new();
+        let mut vp = Vec::new();
+        let mut vs = Vec::new();
+        let mut vk = Vec::new();
+        for t in &value_touches {
+            ve.push(t.entity_id);
+            vp.push(t.property_id);
+            vs.push(t.wrong_space);
+            vk.push(t.version_key);
+        }
+        (ve, vp, vs, vk)
+    };
+    let closed_values: Vec<(Uuid, Uuid, Uuid, i64, Uuid, i64)> = sqlx::query_as(
+        "SELECT vv.entity_id, vv.property_id, vv.space_id, u.version_key, vv.id, vv.valid_from_key \
+         FROM UNNEST($1::uuid[], $2::uuid[], $3::uuid[], $4::bigint[]) AS u(entity_id, property_id, space_id, version_key) \
+         JOIN value_versions vv ON vv.entity_id = u.entity_id AND vv.property_id = u.property_id \
+           AND vv.space_id = u.space_id AND vv.valid_to_key = u.version_key",
+    )
+    .bind(&ve)
+    .bind(&vp)
+    .bind(&vs)
+    .bind(&vk)
+    .fetch_all(&storage.pool)
+    .await?;
+    let closed_value_map: HashMap<(Uuid, Uuid, Uuid, i64), (Uuid, i64)> = closed_values
+        .into_iter()
+        .map(|(e, p, s, k, id, from)| ((e, p, s, k), (id, from)))
+        .collect();
+
+    let distinct_value_targets: Vec<(Uuid, Uuid, Uuid)> = {
+        let mut seen = HashSet::new();
+        value_touches
+            .iter()
+            .filter_map(|t| {
+                let key = (t.entity_id, t.property_id, t.wrong_space);
+                seen.insert(key).then_some(key)
+            })
+            .collect()
+    };
+    let (nve, nvp, nvs): (Vec<Uuid>, Vec<Uuid>, Vec<Uuid>) = distinct_value_targets
+        .iter()
+        .map(|&(e, p, s)| (e, p, s))
+        .fold((Vec::new(), Vec::new(), Vec::new()), |mut acc, (e, p, s)| {
+            acc.0.push(e);
+            acc.1.push(p);
+            acc.2.push(s);
+            acc
+        });
+    let now_open_values: Vec<(Uuid, Uuid, Uuid, Uuid)> = sqlx::query_as(
+        "SELECT entity_id, property_id, space_id, id FROM value_versions \
+         WHERE (entity_id, property_id, space_id) IN (\
+           SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::uuid[])\
+         ) AND valid_to_key IS NULL",
+    )
+    .bind(&nve)
+    .bind(&nvp)
+    .bind(&nvs)
+    .fetch_all(&storage.pool)
+    .await?;
+    let now_open_value_map: HashMap<(Uuid, Uuid, Uuid), Uuid> = now_open_values
+        .into_iter()
+        .map(|(e, p, s, id)| ((e, p, s), id))
+        .collect();
+
+    let live_value_ids: Vec<String> = value_touches.iter().map(|t| t.live_id.clone()).collect();
+    let live_values: Vec<String> =
+        sqlx::query_scalar("SELECT id FROM values WHERE id = ANY($1::text[])")
+            .bind(&live_value_ids)
+            .fetch_all(&storage.pool)
+            .await?;
+    let live_value_set: HashSet<String> = live_values.into_iter().collect();
+
+    // Relations
+    let opened_relation_ids: Vec<Uuid> = relation_touches.iter().map(|t| t.opened_id).collect();
+    let opened_relations: Vec<(Uuid, i64, Option<i64>)> = sqlx::query_as(
+        "SELECT id, valid_from_key, valid_to_key FROM relation_versions WHERE id = ANY($1::uuid[])",
+    )
+    .bind(&opened_relation_ids)
+    .fetch_all(&storage.pool)
+    .await?;
+    let opened_relation_map: HashMap<Uuid, (i64, Option<i64>)> = opened_relations
+        .into_iter()
+        .map(|(id, from, to)| (id, (from, to)))
+        .collect();
+
+    let (rr, rs, rk): (Vec<Uuid>, Vec<Uuid>, Vec<i64>) = {
+        let mut rr = Vec::new();
+        let mut rs = Vec::new();
+        let mut rk = Vec::new();
+        for t in &relation_touches {
+            rr.push(t.relation_id);
+            rs.push(t.wrong_space);
+            rk.push(t.version_key);
+        }
+        (rr, rs, rk)
+    };
+    let closed_relations: Vec<(Uuid, Uuid, i64, Uuid, i64)> = sqlx::query_as(
+        "SELECT rv.relation_id, u.space_id, u.version_key, rv.id, rv.valid_from_key \
+         FROM UNNEST($1::uuid[], $2::uuid[], $3::bigint[]) AS u(relation_id, space_id, version_key) \
+         JOIN relation_versions rv ON rv.relation_id = u.relation_id AND rv.space_id = u.space_id \
+           AND rv.valid_to_key = u.version_key",
+    )
+    .bind(&rr)
+    .bind(&rs)
+    .bind(&rk)
+    .fetch_all(&storage.pool)
+    .await?;
+    let closed_relation_map: HashMap<(Uuid, Uuid, i64), (Uuid, i64)> = closed_relations
+        .into_iter()
+        .map(|(r, s, k, id, from)| ((r, s, k), (id, from)))
+        .collect();
+
+    let distinct_relation_targets: Vec<(Uuid, Uuid)> = {
+        let mut seen = HashSet::new();
+        relation_touches
+            .iter()
+            .filter_map(|t| {
+                let key = (t.relation_id, t.wrong_space);
+                seen.insert(key).then_some(key)
+            })
+            .collect()
+    };
+    let (nrr, nrs): (Vec<Uuid>, Vec<Uuid>) = distinct_relation_targets
+        .iter()
+        .map(|&(r, s)| (r, s))
+        .fold((Vec::new(), Vec::new()), |mut acc, (r, s)| {
+            acc.0.push(r);
+            acc.1.push(s);
+            acc
+        });
+    let now_open_relations: Vec<(Uuid, Uuid, Uuid)> = sqlx::query_as(
+        "SELECT relation_id, space_id, id FROM relation_versions \
+         WHERE (relation_id, space_id) IN (SELECT * FROM UNNEST($1::uuid[], $2::uuid[])) \
+         AND valid_to_key IS NULL",
+    )
+    .bind(&nrr)
+    .bind(&nrs)
+    .fetch_all(&storage.pool)
+    .await?;
+    let now_open_relation_map: HashMap<(Uuid, Uuid), Uuid> = now_open_relations
+        .into_iter()
+        .map(|(r, s, id)| ((r, s), id))
+        .collect();
+
+    let relation_ids: Vec<Uuid> = relation_touches.iter().map(|t| t.relation_id).collect();
+    let current_relations: Vec<(Uuid, Uuid)> =
+        sqlx::query_as("SELECT id, space_id FROM relations WHERE id = ANY($1::uuid[])")
+            .bind(&relation_ids)
+            .fetch_all(&storage.pool)
+            .await?;
+    let current_relation_space_map: HashMap<Uuid, Uuid> = current_relations.into_iter().collect();
+
+    println!("Batch fetch complete. Computing plan...");
+
+    // ---- Phase 4: compute the plan in memory (no more queries needed) ----
+    let mut delete_value_version_ids: Vec<Uuid> = Vec::new();
+    let mut update_value_version_valid_to: Vec<(Uuid, Option<i64>)> = Vec::new();
+    let mut sync_live_value: Vec<(String, Uuid)> = Vec::new(); // (live_id, source_version_id)
+    let mut delete_live_value_ids: Vec<String> = Vec::new();
+
+    let mut delete_relation_version_ids: Vec<Uuid> = Vec::new();
+    let mut update_relation_version_valid_to: Vec<(Uuid, Option<i64>)> = Vec::new();
+    let mut sync_live_relation: Vec<(Uuid, Uuid)> = Vec::new(); // (relation_id, source_version_id)
+    let mut delete_live_relation_ids: Vec<Uuid> = Vec::new();
+
+    for t in &value_touches {
+        let opened = opened_value_map.get(&t.opened_id).copied();
+        let closed = closed_value_map
+            .get(&(t.entity_id, t.property_id, t.wrong_space, t.version_key))
+            .copied();
+
+        if opened.is_none() && closed.is_none() {
+            println!(
+                "  [edit {}] VALUE (entity={}, property={}): no version_versions trace at version_key={} \
+                 (edit_id likely pre-existed from before the incident)",
+                plans[t.plan_idx].uri, t.entity_id, t.property_id, t.version_key
+            );
+        } else {
+            let new_valid_to = opened.and_then(|(_, to)| to);
+            if let Some((closed_id, closed_from)) = closed {
+                println!(
+                    "  [edit {}] VALUE (entity={}, property={}): un-close row {closed_id} (valid_from={closed_from}) -> new valid_to={new_valid_to:?}",
+                    plans[t.plan_idx].uri, t.entity_id, t.property_id
+                );
+                update_value_version_valid_to.push((closed_id, new_valid_to));
+            }
+            if opened.is_some() {
+                println!(
+                    "  [edit {}] VALUE (entity={}, property={}): delete opened row {}",
+                    plans[t.plan_idx].uri, t.entity_id, t.property_id, t.opened_id
+                );
+                delete_value_version_ids.push(t.opened_id);
+            }
+        }
+
+        let now_open = now_open_value_map.get(&(t.entity_id, t.property_id, t.wrong_space)).copied();
+        let live_exists = live_value_set.contains(&t.live_id);
+        match (now_open, live_exists) {
+            (Some(open_id), _) => {
+                println!("  [edit {}] VALUE live sync: set values id={} to match now-open row {open_id}", plans[t.plan_idx].uri, t.live_id);
+                sync_live_value.push((t.live_id.clone(), open_id));
+            }
+            (None, true) => {
+                println!("  [edit {}] VALUE live sync: delete orphaned values id={} (no version history backs it)", plans[t.plan_idx].uri, t.live_id);
+                delete_live_value_ids.push(t.live_id.clone());
+            }
+            (None, false) => {}
+        }
+    }
+
+    for t in &relation_touches {
+        let opened = opened_relation_map.get(&t.opened_id).copied();
+        let closed = closed_relation_map
+            .get(&(t.relation_id, t.wrong_space, t.version_key))
+            .copied();
+
+        if opened.is_none() && closed.is_none() {
+            println!(
+                "  [edit {}] RELATION (id={}): no relation_versions trace at version_key={}",
+                plans[t.plan_idx].uri, t.relation_id, t.version_key
+            );
+        } else {
+            let new_valid_to = opened.and_then(|(_, to)| to);
+            if let Some((closed_id, closed_from)) = closed {
+                println!(
+                    "  [edit {}] RELATION (id={}): un-close row {closed_id} (valid_from={closed_from}) -> new valid_to={new_valid_to:?}",
+                    plans[t.plan_idx].uri, t.relation_id
+                );
+                update_relation_version_valid_to.push((closed_id, new_valid_to));
+            }
+            if opened.is_some() {
+                println!(
+                    "  [edit {}] RELATION (id={}): delete opened row {}",
+                    plans[t.plan_idx].uri, t.relation_id, t.opened_id
+                );
+                delete_relation_version_ids.push(t.opened_id);
+            }
+        }
+
+        let current_space = current_relation_space_map.get(&t.relation_id).copied();
+        if current_space != Some(t.wrong_space) {
+            println!(
+                "  [edit {}] RELATION live sync: not needed (relations id={} current space_id={:?} is not the wrong space)",
+                plans[t.plan_idx].uri, t.relation_id, current_space
+            );
+            continue;
+        }
+        match now_open_relation_map.get(&(t.relation_id, t.wrong_space)).copied() {
+            Some(open_id) => {
+                println!("  [edit {}] RELATION live sync: set relations id={} to match now-open row {open_id}", plans[t.plan_idx].uri, t.relation_id);
+                sync_live_relation.push((t.relation_id, open_id));
+            }
+            None => {
+                println!("  [edit {}] RELATION live sync: delete relations id={} (currently wrong-space, nothing precedes it)", plans[t.plan_idx].uri, t.relation_id);
+                delete_live_relation_ids.push(t.relation_id);
+            }
+        }
+    }
+
+    let edit_ids: Vec<Uuid> = plans.iter().map(|p| p.edit_id).collect();
+    for plan in &plans {
+        println!(
+            "  [edit {}] WOULD DELETE edit_versions WHERE edit_id = {} ({:?})",
+            plan.uri, plan.edit_id, plan.edit_name
+        );
+    }
+
+    println!(
+        "\nPlan: delete {} value_version row(s), update {} value_version row(s), sync {} live value row(s), \
+         delete {} orphaned live value row(s); delete {} relation_version row(s), update {} relation_version row(s), \
+         sync {} live relation row(s), delete {} live relation row(s); delete {} edit_versions row(s).",
+        delete_value_version_ids.len(),
+        update_value_version_valid_to.len(),
+        sync_live_value.len(),
+        delete_live_value_ids.len(),
+        delete_relation_version_ids.len(),
+        update_relation_version_valid_to.len(),
+        sync_live_relation.len(),
+        delete_live_relation_ids.len(),
+        edit_ids.len(),
+    );
+
+    if !execute {
+        println!("\nDry run — no changes made. Pass --execute to apply.");
+        return Ok(());
+    }
+
+    // ---- Phase 5: execute, batched ----
+    let mut tx = storage.pool.begin().await?;
+
+    if !delete_value_version_ids.is_empty() {
+        sqlx::query("DELETE FROM value_versions WHERE id = ANY($1::uuid[])")
+            .bind(&delete_value_version_ids)
+            .execute(&mut *tx)
+            .await?;
+    }
+    if !update_value_version_valid_to.is_empty() {
+        let (ids, valid_tos): (Vec<Uuid>, Vec<Option<i64>>) =
+            update_value_version_valid_to.into_iter().unzip();
+        sqlx::query(
+            "UPDATE value_versions vv SET valid_to_key = u.valid_to_key \
+             FROM UNNEST($1::uuid[], $2::bigint[]) AS u(id, valid_to_key) WHERE vv.id = u.id",
+        )
+        .bind(&ids)
+        .bind(&valid_tos)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if !sync_live_value.is_empty() {
+        let (live_ids, source_ids): (Vec<String>, Vec<Uuid>) = sync_live_value.into_iter().unzip();
+        sqlx::query(
+            "INSERT INTO values (id, entity_id, property_id, space_id, text, language, unit, boolean, \
+             decimal, point, time, integer, float, bytes, date, datetime, schedule, embedding, \
+             time_utc, datetime_utc, rect) \
+             SELECT u.live_id, vv.entity_id, vv.property_id, vv.space_id, vv.text, vv.language, vv.unit, \
+             vv.boolean, vv.decimal, vv.point, vv.time, vv.integer, vv.float, vv.bytes, vv.date, \
+             vv.datetime, vv.schedule, vv.embedding, vv.time_utc, vv.datetime_utc, vv.rect \
+             FROM UNNEST($1::text[], $2::uuid[]) AS u(live_id, source_id) \
+             JOIN value_versions vv ON vv.id = u.source_id \
+             ON CONFLICT (id) DO UPDATE SET text = EXCLUDED.text, language = EXCLUDED.language, \
+             unit = EXCLUDED.unit, boolean = EXCLUDED.boolean, decimal = EXCLUDED.decimal, \
+             point = EXCLUDED.point, time = EXCLUDED.time, integer = EXCLUDED.integer, \
+             float = EXCLUDED.float, bytes = EXCLUDED.bytes, date = EXCLUDED.date, \
+             datetime = EXCLUDED.datetime, schedule = EXCLUDED.schedule, embedding = EXCLUDED.embedding, \
+             time_utc = EXCLUDED.time_utc, datetime_utc = EXCLUDED.datetime_utc, rect = EXCLUDED.rect",
+        )
+        .bind(&live_ids)
+        .bind(&source_ids)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if !delete_live_value_ids.is_empty() {
+        sqlx::query("DELETE FROM values WHERE id = ANY($1::text[])")
+            .bind(&delete_live_value_ids)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    if !delete_relation_version_ids.is_empty() {
+        sqlx::query("DELETE FROM relation_versions WHERE id = ANY($1::uuid[])")
+            .bind(&delete_relation_version_ids)
+            .execute(&mut *tx)
+            .await?;
+    }
+    if !update_relation_version_valid_to.is_empty() {
+        let (ids, valid_tos): (Vec<Uuid>, Vec<Option<i64>>) =
+            update_relation_version_valid_to.into_iter().unzip();
+        sqlx::query(
+            "UPDATE relation_versions rv SET valid_to_key = u.valid_to_key \
+             FROM UNNEST($1::uuid[], $2::bigint[]) AS u(id, valid_to_key) WHERE rv.id = u.id",
+        )
+        .bind(&ids)
+        .bind(&valid_tos)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if !sync_live_relation.is_empty() {
+        let (rel_ids, source_ids): (Vec<Uuid>, Vec<Uuid>) = sync_live_relation.into_iter().unzip();
+        sqlx::query(
+            "UPDATE relations r SET entity_id = rv.entity_id, type_id = rv.type_id, \
+             from_entity_id = rv.from_entity_id, from_space_id = rv.from_space_id, \
+             to_entity_id = rv.to_entity_id, to_space_id = rv.to_space_id, position = rv.position, \
+             space_id = rv.space_id, verified = rv.verified \
+             FROM UNNEST($1::uuid[], $2::uuid[]) AS u(relation_id, source_id) \
+             JOIN relation_versions rv ON rv.id = u.source_id \
+             WHERE r.id = u.relation_id",
+        )
+        .bind(&rel_ids)
+        .bind(&source_ids)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if !delete_live_relation_ids.is_empty() {
+        sqlx::query("DELETE FROM relations WHERE id = ANY($1::uuid[])")
+            .bind(&delete_live_relation_ids)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    sqlx::query("DELETE FROM edit_versions WHERE edit_id = ANY($1::uuid[])")
+        .bind(&edit_ids)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+    println!("\nExecuted successfully.");
+
+    Ok(())
+}
+
+fn build_plan(
+    line: &BatchLine,
+    cache_by_uri: &HashMap<String, (Option<Vec<u8>>, bool)>,
+) -> Result<EditPlan, IndexerError> {
+    let (data, is_errored) = cache_by_uri
+        .get(&line.uri)
+        .ok_or_else(|| IndexerError::Config(format!("uri not found in ipfs_cache: {}", line.uri)))?;
+    if *is_errored {
+        return Err(IndexerError::Config("ipfs_cache row is_errored".into()));
+    }
+    let payload = data
+        .clone()
+        .ok_or_else(|| IndexerError::Config("no data".into()))?;
+    let decoded =
+        decode_edit(&payload).map_err(|e| IndexerError::Config(format!("decode failed: {e}")))?;
+
+    let edit = HermesEdit {
+        id: decoded.id.to_vec(),
+        name: decoded.name.to_string(),
+        payload: payload.clone(),
+        authors: decoded.authors.iter().map(|a| a.to_vec()).collect(),
+        language: None,
+        space_id: line.wrong_space.as_bytes().to_vec(),
+        is_canonical: true,
+        meta: Some(BlockchainMetadata {
+            created_at: 0,
+            created_by: vec![],
+            block_number: line.block,
+            cursor: String::new(),
+            sequence: 0,
+            is_last: false,
+        }),
+    };
+
+    let result = handlers::edits::handle_edit(&edit)?;
+
+    let mut value_targets: Vec<(Uuid, Uuid)> = Vec::new();
+    for v in &result.values {
+        let t = (v.entity_id, v.property_id);
+        if !value_targets.contains(&t) {
+            value_targets.push(t);
+        }
+    }
+    let mut relation_targets: Vec<Uuid> = Vec::new();
+    for r in &result.relations {
+        let id = r.id();
+        if !relation_targets.contains(&id) {
+            relation_targets.push(id);
+        }
+    }
+
+    Ok(EditPlan {
+        uri: line.uri.clone(),
+        wrong_space: line.wrong_space,
+        version_key: (line.block as i64) << 32,
+        edit_id: result.edit_id,
+        edit_name: decoded.name.to_string(),
+        value_targets,
+        relation_targets,
+    })
+}

--- a/kg-indexer/src/bin/fix_misattribution.rs
+++ b/kg-indexer/src/bin/fix_misattribution.rs
@@ -329,7 +329,10 @@ async fn main() -> Result<(), IndexerError> {
     // live row to a snapshot taken before that delete would point it at a
     // row that no longer exists by the time the sync statement runs.
 
-    let live_value_ids: Vec<String> = value_touches.iter().map(|t| t.live_id.clone()).collect();
+    let live_value_ids: Vec<String> = distinct_value_targets
+        .iter()
+        .map(|&(e, p, s)| handlers::edits::derive_value_id(&e, &p, &s).to_string())
+        .collect();
     let live_values: Vec<String> =
         sqlx::query_scalar("SELECT id FROM values WHERE id = ANY($1::text[])")
             .bind(&live_value_ids)
@@ -387,7 +390,7 @@ async fn main() -> Result<(), IndexerError> {
             })
             .collect()
     };
-    let relation_ids: Vec<Uuid> = relation_touches.iter().map(|t| t.relation_id).collect();
+    let relation_ids: Vec<Uuid> = distinct_relation_targets.iter().map(|&(r, _)| r).collect();
     let current_relations: Vec<(Uuid, Uuid)> =
         sqlx::query_as("SELECT id, space_id FROM relations WHERE id = ANY($1::uuid[])")
             .bind(&relation_ids)

--- a/kg-indexer/src/bin/fix_misattribution.rs
+++ b/kg-indexer/src/bin/fix_misattribution.rs
@@ -107,17 +107,26 @@ async fn main() -> Result<(), IndexerError> {
                 "malformed line (expected \"<uri> <block> <wrong_space> <correct_space>\"): {line:?}"
             )));
         }
+        let wrong_space: Uuid = parts[2]
+            .parse()
+            .map_err(|e| IndexerError::Config(format!("bad wrong_space in line {line:?}: {e}")))?;
+        let correct_space: Uuid = parts[3].parse().map_err(|e| {
+            IndexerError::Config(format!("bad correct_space in line {line:?}: {e}"))
+        })?;
+        if wrong_space == correct_space {
+            return Err(IndexerError::Config(format!(
+                "wrong_space == correct_space in line {line:?} — this tool deletes/relinks \
+                 history in wrong_space, so a malformed line here would corrupt the correct \
+                 space instead of fixing it"
+            )));
+        }
         lines.push(BatchLine {
             uri: parts[0].to_string(),
             block: parts[1]
                 .parse()
                 .map_err(|e| IndexerError::Config(format!("bad block in line {line:?}: {e}")))?,
-            wrong_space: parts[2].parse().map_err(|e| {
-                IndexerError::Config(format!("bad wrong_space in line {line:?}: {e}"))
-            })?,
-            correct_space: parts[3].parse().map_err(|e| {
-                IndexerError::Config(format!("bad correct_space in line {line:?}: {e}"))
-            })?,
+            wrong_space,
+            correct_space,
         });
     }
     lines.sort_by_key(|l| l.block);

--- a/kg-indexer/src/bin/fix_misattribution.rs
+++ b/kg-indexer/src/bin/fix_misattribution.rs
@@ -414,7 +414,7 @@ async fn main() -> Result<(), IndexerError> {
 
         if opened.is_none() && closed.is_none() {
             println!(
-                "  [edit {}] VALUE (entity={}, property={}): no version_versions trace at version_key={} \
+                "  [edit {}] VALUE (entity={}, property={}): no value_versions trace at version_key={} \
                  (edit_id likely pre-existed from before the incident)",
                 plans[t.plan_idx].uri, t.entity_id, t.property_id, t.version_key
             );

--- a/kg-indexer/src/bin/fix_misattribution.rs
+++ b/kg-indexer/src/bin/fix_misattribution.rs
@@ -785,16 +785,18 @@ fn build_plan(
     let result = handlers::edits::handle_edit(&edit)?;
 
     let mut value_targets: Vec<(Uuid, Uuid)> = Vec::new();
+    let mut seen_value_targets: HashSet<(Uuid, Uuid)> = HashSet::new();
     for v in &result.values {
         let t = (v.entity_id, v.property_id);
-        if !value_targets.contains(&t) {
+        if seen_value_targets.insert(t) {
             value_targets.push(t);
         }
     }
     let mut relation_targets: Vec<Uuid> = Vec::new();
+    let mut seen_relation_targets: HashSet<Uuid> = HashSet::new();
     for r in &result.relations {
         let id = r.id();
-        if !relation_targets.contains(&id) {
+        if seen_relation_targets.insert(id) {
             relation_targets.push(id);
         }
     }

--- a/kg-indexer/src/bin/repair_version_chains.rs
+++ b/kg-indexer/src/bin/repair_version_chains.rs
@@ -67,11 +67,13 @@ async fn main() -> Result<(), IndexerError> {
     let lines = fs::read_to_string(batch_file)
         .map_err(|e| IndexerError::Config(format!("could not read batch file: {e}")))?;
 
-    // ---- Phase 1: decode every edit, collect its distinct targets ----
-    let mut targets: HashSet<Target> = HashSet::new();
-    let mut decoded_count = 0usize;
-    let mut skipped = 0usize;
-
+    // ---- Phase 1: parse lines, batch-fetch ipfs_cache, decode every edit ----
+    struct BatchLine {
+        uri: String,
+        block: u64,
+        space: Uuid,
+    }
+    let mut batch_lines = Vec::new();
     for line in lines.lines().filter(|l| !l.trim().is_empty()) {
         let parts: Vec<&str> = line.split_whitespace().collect();
         if parts.len() != 3 {
@@ -79,43 +81,57 @@ async fn main() -> Result<(), IndexerError> {
                 "malformed batch-file line (expected \"<uri> <block> <space>\"): {line:?}"
             )));
         }
-        let (uri, block_str, space_str) = (parts[0], parts[1], parts[2]);
-        let block: u64 = block_str
+        let block: u64 = parts[1]
             .parse()
             .map_err(|e| IndexerError::Config(format!("bad block number in line {line:?}: {e}")))?;
-        let space: Uuid = space_str
+        let space: Uuid = parts[2]
             .parse()
             .map_err(|e| IndexerError::Config(format!("bad space UUID in line {line:?}: {e}")))?;
+        batch_lines.push(BatchLine {
+            uri: parts[0].to_string(),
+            block,
+            space,
+        });
+    }
 
-        let row: (Option<Vec<u8>>, bool) =
-            sqlx::query_as("SELECT data, is_errored FROM ipfs_cache WHERE uri = $1")
-                .bind(uri)
-                .fetch_one(&storage.pool)
-                .await
-                .map_err(|e| match e {
-                    sqlx::Error::RowNotFound => {
-                        IndexerError::Config(format!("uri not found in ipfs_cache: {uri}"))
-                    }
-                    other => IndexerError::Database(other),
-                })?;
-        let (data, is_errored) = row;
-        if is_errored {
-            println!("SKIP {uri}: ipfs_cache row still marked is_errored");
+    let uris: Vec<&str> = batch_lines.iter().map(|l| l.uri.as_str()).collect();
+    let cache_rows: Vec<(String, Option<Vec<u8>>, bool)> =
+        sqlx::query_as("SELECT uri, data, is_errored FROM ipfs_cache WHERE uri = ANY($1::text[])")
+            .bind(&uris)
+            .fetch_all(&storage.pool)
+            .await?;
+    let cache_by_uri: HashMap<String, (Option<Vec<u8>>, bool)> = cache_rows
+        .into_iter()
+        .map(|(uri, data, errored)| (uri, (data, errored)))
+        .collect();
+
+    let mut targets: HashSet<Target> = HashSet::new();
+    let mut decoded_count = 0usize;
+    let mut skipped = 0usize;
+
+    for line in &batch_lines {
+        let Some((data, is_errored)) = cache_by_uri.get(&line.uri) else {
+            println!("SKIP {}: uri not found in ipfs_cache", line.uri);
+            skipped += 1;
+            continue;
+        };
+        if *is_errored {
+            println!("SKIP {}: ipfs_cache row still marked is_errored", line.uri);
             skipped += 1;
             continue;
         }
         let payload = match data {
             Some(p) => p,
             None => {
-                println!("SKIP {uri}: no data");
+                println!("SKIP {}: no data", line.uri);
                 skipped += 1;
                 continue;
             }
         };
-        let decoded = match decode_edit(&payload) {
+        let decoded = match decode_edit(payload) {
             Ok(d) => d,
             Err(e) => {
-                println!("SKIP {uri}: decode failed: {e}");
+                println!("SKIP {}: decode failed: {e}", line.uri);
                 skipped += 1;
                 continue;
             }
@@ -127,12 +143,12 @@ async fn main() -> Result<(), IndexerError> {
             payload: payload.clone(),
             authors: decoded.authors.iter().map(|a| a.to_vec()).collect(),
             language: None,
-            space_id: space.as_bytes().to_vec(),
+            space_id: line.space.as_bytes().to_vec(),
             is_canonical: true,
             meta: Some(BlockchainMetadata {
                 created_at: 0,
                 created_by: vec![],
-                block_number: block,
+                block_number: line.block,
                 cursor: String::new(),
                 sequence: 0,
                 is_last: false,
@@ -258,12 +274,38 @@ async fn main() -> Result<(), IndexerError> {
     for ((entity_id, property_id, space_id), mut rows) in value_chains {
         rows.sort_by_key(|(_, vf, _)| *vf);
         let mut was_corrupt = false;
+        // Post-fix valid_to per row, applied below — used afterward to
+        // find whichever row is genuinely open once these fixes land,
+        // rather than assuming it's always `rows.last()`.
+        let mut fixed_valid_to: Vec<Option<i64>> = rows.iter().map(|(_, _, vt)| *vt).collect();
         for i in 0..rows.len() {
-            let (id, _vf, vt) = rows[i];
-            let correct_vt = rows.get(i + 1).map(|(_, next_vf, _)| *next_vf);
-            if vt != correct_vt {
-                was_corrupt = true;
-                update_value_valid_to.push((id, correct_vt));
+            let (id, vf, vt) = rows[i];
+            match rows.get(i + 1) {
+                Some((_, next_vf, _)) => {
+                    // A real next row exists for this target — the
+                    // hand-off must match it exactly.
+                    if vt != Some(*next_vf) {
+                        was_corrupt = true;
+                        update_value_valid_to.push((id, Some(*next_vf)));
+                        fixed_valid_to[i] = Some(*next_vf);
+                    }
+                }
+                None => {
+                    // No successor exists in this target's history. That's
+                    // not evidence of anything on its own — the last touch
+                    // may have legitimately been an Unset/Delete, which
+                    // closes a version without opening a new one (see
+                    // audit_batch_replay's identical invariant). Only a
+                    // genuine inversion (closed before it opened) is
+                    // corruption here.
+                    if let Some(actual_vt) = vt {
+                        if actual_vt < vf {
+                            was_corrupt = true;
+                            update_value_valid_to.push((id, None));
+                            fixed_valid_to[i] = None;
+                        }
+                    }
+                }
             }
         }
         if was_corrupt {
@@ -272,12 +314,22 @@ async fn main() -> Result<(), IndexerError> {
         // Always resync regardless of `was_corrupt`, not just when the
         // chain needed relinking — the live row can still be stale even
         // when its own version chain is already correctly ordered (e.g. it
-        // was never resynced by whatever wrote the version rows).
+        // was never resynced by whatever wrote the version rows). The row
+        // to sync to is whichever one is genuinely open (valid_to IS NULL)
+        // after the fixes above — not simply the row with the largest
+        // valid_from, since that row may be legitimately closed (Unset)
+        // with nothing currently valid for this target at all.
         let live_id =
             handlers::edits::derive_value_id(&entity_id, &property_id, &space_id).to_string();
-        match rows.last() {
-            Some((open_id, _, _)) => {
-                sync_live_value.push((live_id, *open_id));
+        let currently_open = rows
+            .iter()
+            .zip(fixed_valid_to.iter())
+            .rev()
+            .find(|(_, vt)| vt.is_none())
+            .map(|((id, _, _), _)| *id);
+        match currently_open {
+            Some(open_id) => {
+                sync_live_value.push((live_id, open_id));
             }
             None => {
                 delete_live_value_ids.push(live_id);
@@ -308,22 +360,47 @@ async fn main() -> Result<(), IndexerError> {
     for ((relation_id, space_id), mut rows) in relation_chains {
         rows.sort_by_key(|(_, vf, _)| *vf);
         let mut was_corrupt = false;
+        let mut fixed_valid_to: Vec<Option<i64>> = rows.iter().map(|(_, _, vt)| *vt).collect();
         for i in 0..rows.len() {
-            let (id, _vf, vt) = rows[i];
-            let correct_vt = rows.get(i + 1).map(|(_, next_vf, _)| *next_vf);
-            if vt != correct_vt {
-                was_corrupt = true;
-                update_relation_valid_to.push((id, correct_vt));
+            let (id, vf, vt) = rows[i];
+            match rows.get(i + 1) {
+                Some((_, next_vf, _)) => {
+                    if vt != Some(*next_vf) {
+                        was_corrupt = true;
+                        update_relation_valid_to.push((id, Some(*next_vf)));
+                        fixed_valid_to[i] = Some(*next_vf);
+                    }
+                }
+                None => {
+                    // No successor — only a genuine inversion is
+                    // corruption; a legitimate Unset/Delete closes a
+                    // version without opening a new one and is not itself
+                    // evidence of anything (same invariant as values,
+                    // above, and as audit_batch_replay).
+                    if let Some(actual_vt) = vt {
+                        if actual_vt < vf {
+                            was_corrupt = true;
+                            update_relation_valid_to.push((id, None));
+                            fixed_valid_to[i] = None;
+                        }
+                    }
+                }
             }
         }
         if was_corrupt {
             corrupt_relation_targets += 1;
         }
-        if let Some((open_id, _, _)) = rows.last() {
+        let currently_open = rows
+            .iter()
+            .zip(fixed_valid_to.iter())
+            .rev()
+            .find(|(_, vt)| vt.is_none())
+            .map(|((id, _, _), _)| *id);
+        if let Some(open_id) = currently_open {
             open_per_relation
                 .entry(relation_id)
                 .or_default()
-                .push((space_id, *open_id));
+                .push((space_id, open_id));
         }
     }
 

--- a/kg-indexer/src/bin/repair_version_chains.rs
+++ b/kg-indexer/src/bin/repair_version_chains.rs
@@ -228,13 +228,20 @@ async fn main() -> Result<(), IndexerError> {
     );
 
     // ---- Phase 3: in-memory relink ----
-    let mut value_chains: HashMap<(Uuid, Uuid, Uuid), Vec<(Uuid, i64, Option<i64>)>> = HashMap::new();
+    let mut value_chains: HashMap<(Uuid, Uuid, Uuid), Vec<(Uuid, i64, Option<i64>)>> =
+        HashMap::new();
     for (e, p, s, id, vf, vt) in value_rows {
-        value_chains.entry((e, p, s)).or_default().push((id, vf, vt));
+        value_chains
+            .entry((e, p, s))
+            .or_default()
+            .push((id, vf, vt));
     }
     let mut relation_chains: HashMap<(Uuid, Uuid), Vec<(Uuid, i64, Option<i64>)>> = HashMap::new();
     for (r, s, id, vf, vt) in relation_rows {
-        relation_chains.entry((r, s)).or_default().push((id, vf, vt));
+        relation_chains
+            .entry((r, s))
+            .or_default()
+            .push((id, vf, vt));
     }
 
     let mut update_value_valid_to: Vec<(Uuid, Option<i64>)> = Vec::new();
@@ -256,7 +263,8 @@ async fn main() -> Result<(), IndexerError> {
         if was_corrupt {
             corrupt_value_targets += 1;
         }
-        let live_id = handlers::edits::derive_value_id(&entity_id, &property_id, &space_id).to_string();
+        let live_id =
+            handlers::edits::derive_value_id(&entity_id, &property_id, &space_id).to_string();
         match rows.last() {
             Some((open_id, _, _)) if was_corrupt => {
                 sync_live_value.push((live_id, *open_id));

--- a/kg-indexer/src/bin/repair_version_chains.rs
+++ b/kg-indexer/src/bin/repair_version_chains.rs
@@ -245,7 +245,7 @@ async fn main() -> Result<(), IndexerError> {
 
     // ---- Phase 3: in-memory relink ----
     // Seeded from every decoded target (not just ones with query results) so
-    // a target backed by zero version_versions rows still gets checked —
+    // a target backed by zero value_versions rows still gets checked —
     // that's exactly the "live row is a pure orphan" case: no chain to
     // relink, but a stale live row may still need deleting.
     type ChainRow = (Uuid, i64, Option<i64>); // (id, valid_from_key, valid_to_key)

--- a/kg-indexer/src/bin/repair_version_chains.rs
+++ b/kg-indexer/src/bin/repair_version_chains.rs
@@ -228,15 +228,21 @@ async fn main() -> Result<(), IndexerError> {
     );
 
     // ---- Phase 3: in-memory relink ----
+    // Seeded from every decoded target (not just ones with query results) so
+    // a target backed by zero version_versions rows still gets checked —
+    // that's exactly the "live row is a pure orphan" case: no chain to
+    // relink, but a stale live row may still need deleting.
     type ChainRow = (Uuid, i64, Option<i64>); // (id, valid_from_key, valid_to_key)
-    let mut value_chains: HashMap<(Uuid, Uuid, Uuid), Vec<ChainRow>> = HashMap::new();
+    let mut value_chains: HashMap<(Uuid, Uuid, Uuid), Vec<ChainRow>> =
+        value_targets.iter().map(|&t| (t, Vec::new())).collect();
     for (e, p, s, id, vf, vt) in value_rows {
         value_chains
             .entry((e, p, s))
             .or_default()
             .push((id, vf, vt));
     }
-    let mut relation_chains: HashMap<(Uuid, Uuid), Vec<ChainRow>> = HashMap::new();
+    let mut relation_chains: HashMap<(Uuid, Uuid), Vec<ChainRow>> =
+        relation_targets.iter().map(|&t| (t, Vec::new())).collect();
     for (r, s, id, vf, vt) in relation_rows {
         relation_chains
             .entry((r, s))
@@ -263,16 +269,19 @@ async fn main() -> Result<(), IndexerError> {
         if was_corrupt {
             corrupt_value_targets += 1;
         }
+        // Always resync regardless of `was_corrupt`, not just when the
+        // chain needed relinking — the live row can still be stale even
+        // when its own version chain is already correctly ordered (e.g. it
+        // was never resynced by whatever wrote the version rows).
         let live_id =
             handlers::edits::derive_value_id(&entity_id, &property_id, &space_id).to_string();
         match rows.last() {
-            Some((open_id, _, _)) if was_corrupt => {
+            Some((open_id, _, _)) => {
                 sync_live_value.push((live_id, *open_id));
             }
             None => {
                 delete_live_value_ids.push(live_id);
             }
-            _ => {}
         }
     }
 
@@ -288,7 +297,13 @@ async fn main() -> Result<(), IndexerError> {
     // in the linking sense. So live sync must be decided globally per
     // relation_id (which space currently has the open/latest row), not
     // gated on whether any single space's chain needed relinking.
-    let mut open_per_relation: HashMap<Uuid, Vec<(Uuid, Uuid)>> = HashMap::new(); // relation_id -> [(space_id, open_version_id)]
+    // Seeded from every distinct relation_id so one with zero backing rows
+    // in any space still surfaces below (as an empty `opens` list) instead
+    // of silently never appearing at all.
+    let mut open_per_relation: HashMap<Uuid, Vec<(Uuid, Uuid)>> = relation_targets
+        .iter()
+        .map(|&(r, _)| (r, Vec::new()))
+        .collect();
 
     for ((relation_id, space_id), mut rows) in relation_chains {
         rows.sort_by_key(|(_, vf, _)| *vf);

--- a/kg-indexer/src/bin/repair_version_chains.rs
+++ b/kg-indexer/src/bin/repair_version_chains.rs
@@ -557,7 +557,8 @@ async fn main() -> Result<(), IndexerError> {
              ON CONFLICT (id) DO UPDATE SET entity_id = EXCLUDED.entity_id, type_id = EXCLUDED.type_id, \
              from_entity_id = EXCLUDED.from_entity_id, from_space_id = EXCLUDED.from_space_id, \
              to_entity_id = EXCLUDED.to_entity_id, to_space_id = EXCLUDED.to_space_id, \
-             position = EXCLUDED.position, space_id = EXCLUDED.space_id, verified = EXCLUDED.verified",
+             position = EXCLUDED.position, space_id = EXCLUDED.space_id, verified = EXCLUDED.verified \
+             WHERE relations.is_system = false",
         )
         .bind(&rel_ids)
         .bind(&source_ids)

--- a/kg-indexer/src/bin/repair_version_chains.rs
+++ b/kg-indexer/src/bin/repair_version_chains.rs
@@ -228,15 +228,15 @@ async fn main() -> Result<(), IndexerError> {
     );
 
     // ---- Phase 3: in-memory relink ----
-    let mut value_chains: HashMap<(Uuid, Uuid, Uuid), Vec<(Uuid, i64, Option<i64>)>> =
-        HashMap::new();
+    type ChainRow = (Uuid, i64, Option<i64>); // (id, valid_from_key, valid_to_key)
+    let mut value_chains: HashMap<(Uuid, Uuid, Uuid), Vec<ChainRow>> = HashMap::new();
     for (e, p, s, id, vf, vt) in value_rows {
         value_chains
             .entry((e, p, s))
             .or_default()
             .push((id, vf, vt));
     }
-    let mut relation_chains: HashMap<(Uuid, Uuid), Vec<(Uuid, i64, Option<i64>)>> = HashMap::new();
+    let mut relation_chains: HashMap<(Uuid, Uuid), Vec<ChainRow>> = HashMap::new();
     for (r, s, id, vf, vt) in relation_rows {
         relation_chains
             .entry((r, s))

--- a/kg-indexer/src/bin/repair_version_chains.rs
+++ b/kg-indexer/src/bin/repair_version_chains.rs
@@ -1,0 +1,426 @@
+//! Generic version-chain repair for the 2026-07-21 backfill-corruption
+//! incident: `replay_edit` (and any backfill tool built on
+//! `insert_value_versions`/`insert_relation_versions`) always assumes the
+//! version it's inserting is the newest for its target, and unconditionally
+//! closes whatever's currently open. If a target already has a version with
+//! a *larger* valid_from_key (e.g. backfilling an old block after real-time
+//! indexing has already moved past it — see the shared "latest batch"
+//! entities the news-worker keeps updating), this corrupts the linked list:
+//! the wrong row gets closed, and the new backfilled row is left open even
+//! though it's actually the *oldest*. Confirmed via `audit_batch_replay`.
+//!
+//! This is independent of how the corruption happened — the fix is a pure
+//! invariant restoration: for each target, fetch its full chain, sort by
+//! valid_from_key, and relink (each row's valid_to_key = next row's
+//! valid_from_key; the last row is open). Then resync the live
+//! `values`/`relations` row to whichever version is genuinely open
+//! afterward, since `insert_values`/`insert_relations` unconditionally
+//! overwrite live data with whatever was most recently *processed*
+//! (regardless of temporal order), so live data may currently reflect a
+//! stale backfilled row instead of newer legitimate content.
+//!
+//! Safe to run on an already-correct chain (no-op). Defaults to
+//! `--dry-run`; pass `--execute` to apply.
+//!
+//! Usage:
+//!   DATABASE_URL=... cargo run -p kg-indexer --bin repair_version_chains -- \
+//!     --batch-file /path/to/uri_block_space_lines.txt \
+//!     [--execute]
+
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::fs;
+
+use grc_20::decode_edit;
+use hermes_schema::pb::blockchain_metadata::BlockchainMetadata;
+use hermes_schema::pb::knowledge::HermesEdit;
+use kg_indexer::error::IndexerError;
+use kg_indexer::handlers;
+use kg_indexer::storage::Storage;
+use uuid::Uuid;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum Target {
+    Value(Uuid, Uuid, Uuid),
+    Relation(Uuid, Uuid),
+}
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+    let batch_file = args
+        .iter()
+        .position(|a| a == "--batch-file")
+        .and_then(|i| args.get(i + 1))
+        .expect("--batch-file is required");
+    let execute = args.iter().any(|a| a == "--execute");
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let storage = Storage::new(&database_url).await?;
+
+    let lines = fs::read_to_string(batch_file)
+        .map_err(|e| IndexerError::Config(format!("could not read batch file: {e}")))?;
+
+    // ---- Phase 1: decode every edit, collect its distinct targets ----
+    let mut targets: HashSet<Target> = HashSet::new();
+    let mut decoded_count = 0usize;
+    let mut skipped = 0usize;
+
+    for line in lines.lines().filter(|l| !l.trim().is_empty()) {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() != 3 {
+            return Err(IndexerError::Config(format!(
+                "malformed batch-file line (expected \"<uri> <block> <space>\"): {line:?}"
+            )));
+        }
+        let (uri, block_str, space_str) = (parts[0], parts[1], parts[2]);
+        let block: u64 = block_str
+            .parse()
+            .map_err(|e| IndexerError::Config(format!("bad block number in line {line:?}: {e}")))?;
+        let space: Uuid = space_str
+            .parse()
+            .map_err(|e| IndexerError::Config(format!("bad space UUID in line {line:?}: {e}")))?;
+
+        let row: (Option<Vec<u8>>, bool) =
+            sqlx::query_as("SELECT data, is_errored FROM ipfs_cache WHERE uri = $1")
+                .bind(uri)
+                .fetch_one(&storage.pool)
+                .await
+                .map_err(|e| match e {
+                    sqlx::Error::RowNotFound => {
+                        IndexerError::Config(format!("uri not found in ipfs_cache: {uri}"))
+                    }
+                    other => IndexerError::Database(other),
+                })?;
+        let (data, is_errored) = row;
+        if is_errored {
+            println!("SKIP {uri}: ipfs_cache row still marked is_errored");
+            skipped += 1;
+            continue;
+        }
+        let payload = match data {
+            Some(p) => p,
+            None => {
+                println!("SKIP {uri}: no data");
+                skipped += 1;
+                continue;
+            }
+        };
+        let decoded = match decode_edit(&payload) {
+            Ok(d) => d,
+            Err(e) => {
+                println!("SKIP {uri}: decode failed: {e}");
+                skipped += 1;
+                continue;
+            }
+        };
+
+        let edit = HermesEdit {
+            id: decoded.id.to_vec(),
+            name: decoded.name.to_string(),
+            payload: payload.clone(),
+            authors: decoded.authors.iter().map(|a| a.to_vec()).collect(),
+            language: None,
+            space_id: space.as_bytes().to_vec(),
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                created_at: 0,
+                created_by: vec![],
+                block_number: block,
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let result = handlers::edits::handle_edit(&edit)?;
+        decoded_count += 1;
+
+        for v in &result.values {
+            targets.insert(Target::Value(v.entity_id, v.property_id, v.space_id));
+        }
+        for r in &result.relations {
+            targets.insert(Target::Relation(r.id(), r.space_id()));
+        }
+    }
+
+    println!(
+        "Decoded {decoded_count} edit(s), {skipped} skipped. {} distinct target(s) to check.",
+        targets.len()
+    );
+
+    let value_targets: Vec<(Uuid, Uuid, Uuid)> = targets
+        .iter()
+        .filter_map(|t| match t {
+            Target::Value(e, p, s) => Some((*e, *p, *s)),
+            Target::Relation(..) => None,
+        })
+        .collect();
+    let relation_targets: Vec<(Uuid, Uuid)> = targets
+        .iter()
+        .filter_map(|t| match t {
+            Target::Relation(r, s) => Some((*r, *s)),
+            Target::Value(..) => None,
+        })
+        .collect();
+
+    // ---- Phase 2: batch-fetch the FULL chain for every target ----
+    let (v_entity, v_property, v_space): (Vec<Uuid>, Vec<Uuid>, Vec<Uuid>) = value_targets
+        .iter()
+        .map(|(e, p, s)| (*e, *p, *s))
+        .fold((vec![], vec![], vec![]), |mut acc, (e, p, s)| {
+            acc.0.push(e);
+            acc.1.push(p);
+            acc.2.push(s);
+            acc
+        });
+    let value_rows: Vec<(Uuid, Uuid, Uuid, Uuid, i64, Option<i64>)> = if value_targets.is_empty() {
+        Vec::new()
+    } else {
+        sqlx::query_as(
+            "SELECT entity_id, property_id, space_id, id, valid_from_key, valid_to_key \
+             FROM value_versions \
+             WHERE (entity_id, property_id, space_id) IN ( \
+               SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::uuid[]) \
+             )",
+        )
+        .bind(&v_entity)
+        .bind(&v_property)
+        .bind(&v_space)
+        .fetch_all(&storage.pool)
+        .await?
+    };
+
+    let (r_relation, r_space): (Vec<Uuid>, Vec<Uuid>) = relation_targets
+        .iter()
+        .map(|(r, s)| (*r, *s))
+        .fold((vec![], vec![]), |mut acc, (r, s)| {
+            acc.0.push(r);
+            acc.1.push(s);
+            acc
+        });
+    let relation_rows: Vec<(Uuid, Uuid, Uuid, i64, Option<i64>)> = if relation_targets.is_empty() {
+        Vec::new()
+    } else {
+        sqlx::query_as(
+            "SELECT relation_id, space_id, id, valid_from_key, valid_to_key \
+             FROM relation_versions \
+             WHERE (relation_id, space_id) IN ( \
+               SELECT * FROM UNNEST($1::uuid[], $2::uuid[]) \
+             )",
+        )
+        .bind(&r_relation)
+        .bind(&r_space)
+        .fetch_all(&storage.pool)
+        .await?
+    };
+
+    println!(
+        "Fetched {} value_version row(s), {} relation_version row(s) across all targets.",
+        value_rows.len(),
+        relation_rows.len()
+    );
+
+    // ---- Phase 3: in-memory relink ----
+    let mut value_chains: HashMap<(Uuid, Uuid, Uuid), Vec<(Uuid, i64, Option<i64>)>> = HashMap::new();
+    for (e, p, s, id, vf, vt) in value_rows {
+        value_chains.entry((e, p, s)).or_default().push((id, vf, vt));
+    }
+    let mut relation_chains: HashMap<(Uuid, Uuid), Vec<(Uuid, i64, Option<i64>)>> = HashMap::new();
+    for (r, s, id, vf, vt) in relation_rows {
+        relation_chains.entry((r, s)).or_default().push((id, vf, vt));
+    }
+
+    let mut update_value_valid_to: Vec<(Uuid, Option<i64>)> = Vec::new();
+    let mut sync_live_value: Vec<(String, Uuid)> = Vec::new(); // (live_id, source_version_id)
+    let mut delete_live_value_ids: Vec<String> = Vec::new();
+    let mut corrupt_value_targets = 0usize;
+
+    for ((entity_id, property_id, space_id), mut rows) in value_chains {
+        rows.sort_by_key(|(_, vf, _)| *vf);
+        let mut was_corrupt = false;
+        for i in 0..rows.len() {
+            let (id, _vf, vt) = rows[i];
+            let correct_vt = rows.get(i + 1).map(|(_, next_vf, _)| *next_vf);
+            if vt != correct_vt {
+                was_corrupt = true;
+                update_value_valid_to.push((id, correct_vt));
+            }
+        }
+        if was_corrupt {
+            corrupt_value_targets += 1;
+        }
+        let live_id = handlers::edits::derive_value_id(&entity_id, &property_id, &space_id).to_string();
+        match rows.last() {
+            Some((open_id, _, _)) if was_corrupt => {
+                sync_live_value.push((live_id, *open_id));
+            }
+            None => {
+                delete_live_value_ids.push(live_id);
+            }
+            _ => {}
+        }
+    }
+
+    let mut update_relation_valid_to: Vec<(Uuid, Option<i64>)> = Vec::new();
+    let mut corrupt_relation_targets = 0usize;
+    // relation_versions is partitioned by (relation_id, space_id), but the
+    // live `relations` row is keyed globally by relation_id alone — and
+    // `insert_relations`'s ON CONFLICT never updates `space_id` (by design,
+    // to keep a relation's home space stable across ordinary updates). That
+    // means once a relation's live row is created in the wrong space,
+    // replaying it into the correct space's version chain does NOT fix the
+    // live row on its own, even though that per-space chain isn't "corrupt"
+    // in the linking sense. So live sync must be decided globally per
+    // relation_id (which space currently has the open/latest row), not
+    // gated on whether any single space's chain needed relinking.
+    let mut open_per_relation: HashMap<Uuid, Vec<(Uuid, Uuid)>> = HashMap::new(); // relation_id -> [(space_id, open_version_id)]
+
+    for ((relation_id, space_id), mut rows) in relation_chains {
+        rows.sort_by_key(|(_, vf, _)| *vf);
+        let mut was_corrupt = false;
+        for i in 0..rows.len() {
+            let (id, _vf, vt) = rows[i];
+            let correct_vt = rows.get(i + 1).map(|(_, next_vf, _)| *next_vf);
+            if vt != correct_vt {
+                was_corrupt = true;
+                update_relation_valid_to.push((id, correct_vt));
+            }
+        }
+        if was_corrupt {
+            corrupt_relation_targets += 1;
+        }
+        if let Some((open_id, _, _)) = rows.last() {
+            open_per_relation
+                .entry(relation_id)
+                .or_default()
+                .push((space_id, *open_id));
+        }
+    }
+
+    let mut sync_live_relation: Vec<(Uuid, Uuid)> = Vec::new(); // (relation_id, source_version_id)
+    let mut delete_live_relation_ids: Vec<Uuid> = Vec::new();
+    for (relation_id, mut opens) in open_per_relation {
+        match opens.len() {
+            0 => delete_live_relation_ids.push(relation_id),
+            1 => sync_live_relation.push((relation_id, opens.remove(0).1)),
+            _ => {
+                println!(
+                    "  WARNING: relation {relation_id} has an open version in {} different spaces \
+                     ({opens:?}) — ambiguous, leaving live row untouched.",
+                    opens.len()
+                );
+            }
+        }
+    }
+
+    println!(
+        "\n{corrupt_value_targets} value target(s) and {corrupt_relation_targets} relation target(s) had a corrupt chain.\n\
+         Plan: update {} value_version row(s), resync {} live value row(s), delete {} live value row(s); \
+         update {} relation_version row(s), resync {} live relation row(s), delete {} live relation row(s).",
+        update_value_valid_to.len(),
+        sync_live_value.len(),
+        delete_live_value_ids.len(),
+        update_relation_valid_to.len(),
+        sync_live_relation.len(),
+        delete_live_relation_ids.len(),
+    );
+
+    if !execute {
+        println!("\nDry run — no changes made. Pass --execute to apply.");
+        return Ok(());
+    }
+
+    let mut tx = storage.pool.begin().await?;
+
+    if !update_value_valid_to.is_empty() {
+        let (ids, valid_tos): (Vec<Uuid>, Vec<Option<i64>>) =
+            update_value_valid_to.into_iter().unzip();
+        sqlx::query(
+            "UPDATE value_versions vv SET valid_to_key = u.valid_to_key \
+             FROM UNNEST($1::uuid[], $2::bigint[]) AS u(id, valid_to_key) WHERE vv.id = u.id",
+        )
+        .bind(&ids)
+        .bind(&valid_tos)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if !sync_live_value.is_empty() {
+        let (live_ids, source_ids): (Vec<String>, Vec<Uuid>) = sync_live_value.into_iter().unzip();
+        sqlx::query(
+            "INSERT INTO values (id, entity_id, property_id, space_id, text, language, unit, boolean, \
+             decimal, point, time, integer, float, bytes, date, datetime, schedule, embedding, \
+             time_utc, datetime_utc, rect) \
+             SELECT u.live_id, vv.entity_id, vv.property_id, vv.space_id, vv.text, vv.language, vv.unit, \
+             vv.boolean, vv.decimal, vv.point, vv.time, vv.integer, vv.float, vv.bytes, vv.date, \
+             vv.datetime, vv.schedule, vv.embedding, vv.time_utc, vv.datetime_utc, vv.rect \
+             FROM UNNEST($1::text[], $2::uuid[]) AS u(live_id, source_id) \
+             JOIN value_versions vv ON vv.id = u.source_id \
+             ON CONFLICT (id) DO UPDATE SET text = EXCLUDED.text, language = EXCLUDED.language, \
+             unit = EXCLUDED.unit, boolean = EXCLUDED.boolean, decimal = EXCLUDED.decimal, \
+             point = EXCLUDED.point, time = EXCLUDED.time, integer = EXCLUDED.integer, \
+             float = EXCLUDED.float, bytes = EXCLUDED.bytes, date = EXCLUDED.date, \
+             datetime = EXCLUDED.datetime, schedule = EXCLUDED.schedule, embedding = EXCLUDED.embedding, \
+             time_utc = EXCLUDED.time_utc, datetime_utc = EXCLUDED.datetime_utc, rect = EXCLUDED.rect",
+        )
+        .bind(&live_ids)
+        .bind(&source_ids)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if !delete_live_value_ids.is_empty() {
+        sqlx::query("DELETE FROM values WHERE id = ANY($1::text[])")
+            .bind(&delete_live_value_ids)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    if !update_relation_valid_to.is_empty() {
+        let (ids, valid_tos): (Vec<Uuid>, Vec<Option<i64>>) =
+            update_relation_valid_to.into_iter().unzip();
+        sqlx::query(
+            "UPDATE relation_versions rv SET valid_to_key = u.valid_to_key \
+             FROM UNNEST($1::uuid[], $2::bigint[]) AS u(id, valid_to_key) WHERE rv.id = u.id",
+        )
+        .bind(&ids)
+        .bind(&valid_tos)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if !sync_live_relation.is_empty() {
+        let (rel_ids, source_ids): (Vec<Uuid>, Vec<Uuid>) = sync_live_relation.into_iter().unzip();
+        sqlx::query(
+            "INSERT INTO relations (id, entity_id, type_id, from_entity_id, from_space_id, \
+             to_entity_id, to_space_id, position, space_id, verified) \
+             SELECT u.relation_id, rv.entity_id, rv.type_id, rv.from_entity_id, rv.from_space_id, \
+             rv.to_entity_id, rv.to_space_id, rv.position, rv.space_id, rv.verified \
+             FROM UNNEST($1::uuid[], $2::uuid[]) AS u(relation_id, source_id) \
+             JOIN relation_versions rv ON rv.id = u.source_id \
+             ON CONFLICT (id) DO UPDATE SET entity_id = EXCLUDED.entity_id, type_id = EXCLUDED.type_id, \
+             from_entity_id = EXCLUDED.from_entity_id, from_space_id = EXCLUDED.from_space_id, \
+             to_entity_id = EXCLUDED.to_entity_id, to_space_id = EXCLUDED.to_space_id, \
+             position = EXCLUDED.position, space_id = EXCLUDED.space_id, verified = EXCLUDED.verified",
+        )
+        .bind(&rel_ids)
+        .bind(&source_ids)
+        .execute(&mut *tx)
+        .await?;
+    }
+    if !delete_live_relation_ids.is_empty() {
+        sqlx::query("DELETE FROM relations WHERE id = ANY($1::uuid[])")
+            .bind(&delete_live_relation_ids)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    tx.commit().await?;
+    println!("\nExecuted successfully.");
+
+    Ok(())
+}

--- a/kg-indexer/src/bin/repair_version_chains.rs
+++ b/kg-indexer/src/bin/repair_version_chains.rs
@@ -327,11 +327,23 @@ async fn main() -> Result<(), IndexerError> {
         }
     }
 
+    // Which spaces this run actually queried relation_versions for, per
+    // relation_id — needed below to tell "confirmed no history anywhere" (0
+    // opens found here would be conclusive if this were the only space)
+    // apart from "we just didn't check the space this relation currently
+    // lives in".
+    let mut checked_spaces_by_relation: HashMap<Uuid, HashSet<Uuid>> = HashMap::new();
+    for &(r, s) in &relation_targets {
+        checked_spaces_by_relation.entry(r).or_default().insert(s);
+    }
+
     let mut sync_live_relation: Vec<(Uuid, Uuid)> = Vec::new(); // (relation_id, source_version_id)
     let mut delete_live_relation_ids: Vec<Uuid> = Vec::new();
+    let mut zero_open_relation_ids: Vec<Uuid> = Vec::new();
+
     for (relation_id, mut opens) in open_per_relation {
         match opens.len() {
-            0 => delete_live_relation_ids.push(relation_id),
+            0 => zero_open_relation_ids.push(relation_id),
             1 => sync_live_relation.push((relation_id, opens.remove(0).1)),
             _ => {
                 println!(
@@ -339,6 +351,46 @@ async fn main() -> Result<(), IndexerError> {
                      ({opens:?}) — ambiguous, leaving live row untouched.",
                     opens.len()
                 );
+            }
+        }
+    }
+
+    // A relation with zero opens among the spaces this run checked is only
+    // a confirmed orphan if its CURRENT live space_id is one of those we
+    // actually queried. If it currently lives in some other space this run
+    // never looked at, deleting it would drop valid history purely because
+    // we didn't check — so leave it untouched instead of guessing.
+    if !zero_open_relation_ids.is_empty() {
+        let current_relation_spaces: Vec<(Uuid, Option<Uuid>)> =
+            sqlx::query_as("SELECT id, space_id FROM relations WHERE id = ANY($1::uuid[])")
+                .bind(&zero_open_relation_ids)
+                .fetch_all(&storage.pool)
+                .await?;
+        let current_space_by_relation: HashMap<Uuid, Option<Uuid>> =
+            current_relation_spaces.into_iter().collect();
+
+        for relation_id in zero_open_relation_ids {
+            let current_space = current_space_by_relation
+                .get(&relation_id)
+                .copied()
+                .flatten();
+            match current_space {
+                None => {} // no live row exists at all — nothing to delete
+                Some(space) => {
+                    let checked = checked_spaces_by_relation
+                        .get(&relation_id)
+                        .is_some_and(|spaces| spaces.contains(&space));
+                    if checked {
+                        delete_live_relation_ids.push(relation_id);
+                    } else {
+                        println!(
+                            "  WARNING: relation {relation_id} has no open version in the \
+                             space(s) this run checked, but its live row currently sits in \
+                             {space}, which wasn't checked — leaving it untouched rather than \
+                             risk deleting valid history this run never queried."
+                        );
+                    }
+                }
             }
         }
     }

--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -837,6 +837,11 @@ fn extract_relations(edit: &Grc20Edit, space_id: &Uuid) -> Vec<RelationOp> {
     relation_ops
 }
 
+/// Derive the deterministic id of a live `values` row from its
+/// (entity, property, space) triple. Must stay in exact lockstep with the
+/// production write path — standalone remediation binaries (e.g.
+/// `fix_misattribution`, `repair_version_chains`) rely on recomputing this
+/// same id to locate/resync a live row without reading it back first.
 pub fn derive_value_id(entity_id: &Uuid, property_id: &Uuid, space_id: &Uuid) -> Uuid {
     let mut hasher = DefaultHasher::new();
     entity_id.hash(&mut hasher);

--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -837,7 +837,7 @@ fn extract_relations(edit: &Grc20Edit, space_id: &Uuid) -> Vec<RelationOp> {
     relation_ops
 }
 
-pub(crate) fn derive_value_id(entity_id: &Uuid, property_id: &Uuid, space_id: &Uuid) -> Uuid {
+pub fn derive_value_id(entity_id: &Uuid, property_id: &Uuid, space_id: &Uuid) -> Uuid {
     let mut hasher = DefaultHasher::new();
     entity_id.hash(&mut hasher);
     property_id.hash(&mut hasher);

--- a/kg-indexer/src/storage.rs
+++ b/kg-indexer/src/storage.rs
@@ -1323,7 +1323,7 @@ impl Storage {
 
     /// Derive a deterministic version ID from entity, property, space, and version_key.
     /// This ensures idempotency - the same inputs always produce the same ID.
-    fn derive_value_version_id(
+    pub fn derive_value_version_id(
         entity_id: &Uuid,
         property_id: &Uuid,
         space_id: &Uuid,
@@ -1347,7 +1347,11 @@ impl Storage {
     }
 
     /// Derive a deterministic version ID for relation versions.
-    fn derive_relation_version_id(relation_id: &Uuid, space_id: &Uuid, version_key: i64) -> Uuid {
+    pub fn derive_relation_version_id(
+        relation_id: &Uuid,
+        space_id: &Uuid,
+        version_key: i64,
+    ) -> Uuid {
         let mut hasher = DefaultHasher::new();
         relation_id.hash(&mut hasher);
         space_id.hash(&mut hasher);


### PR DESCRIPTION
## Summary

Adds the three one-off tools used to remediate the 2026-07-21 backlog-replay space-misattribution incident, and the visibility changes they needed:

- **`fix_misattribution`**: removes an edit's wrong-space footprint (version rows it opened/closed, live row sync or cleanup) and clears its `edit_versions` row so it can be cleanly re-replayed into the correct space. Batches all data fetching (a handful of bulk queries) instead of querying per-target, which is what made the full remediation run in ~1 minute instead of ~4-5 hours.
- **`repair_version_chains`**: relinks any target's `valid_to_key` chain into correct `valid_from_key` order and resyncs live `values`/`relations` rows to whichever version is genuinely open. This fixes a related, separately-discovered bug: `replay_edit` always assumes the version it's writing is the newest and unconditionally closes whatever's currently open, which corrupts the chain (and leaves live tables showing stale content) when backfilling old blocks into a target that already has newer real-time data. Also handles a subtler case where a relation's live row can go stale even when its own version chain looks fine, because `insert_relations`' `ON CONFLICT` never updates `space_id`.
- **`cleanup_value_orphans`**: one-off retroactive cleanup for orphaned live `values` rows left behind by an earlier bug in `fix_misattribution` (fixed in this PR — see review thread) — rows with zero backing version history that the buggy live-sync logic silently failed to clean up. Found and removed 50,004 of them across the 293 remediated edits.
- `derive_value_id`/`derive_value_version_id`/`derive_relation_version_id` made `pub` so these standalone bin targets can recompute the same deterministic IDs as the real write path.

No production write-path code changed — only new one-off tooling plus the visibility bump needed to compile it as separate bin targets.

## Test plan
- [x] `fix_misattribution` dry-run validated against a 6-edit sample, confirmed byte-for-byte decision parity with an earlier hand-validated sequential version
- [x] Ran against all 247 originally-identified misattributed edits + 46 additionally-identified relation-only edits (293 total), executed, spot-checked several examples directly in the DB
- [x] `repair_version_chains` re-run afterward found and fixed 501 value chains + 641 relation chains + 155,924 stale relation live rows; re-verified 0 corruption remains
- [x] `cleanup_value_orphans` found and removed 50,004 orphaned live value rows left behind by a bug caught in Copilot review; re-verified 0 remain
- [x] Three rounds of Copilot review addressed: version_key derivation, stale live-sync references (values + relations), operator-error validation, N+1 query patterns, and a relation-orphan false-positive I'd independently caught by hand; plus a self-caught correctness bug (legitimate Unset/Delete closes were being misidentified as corruption) found during regression testing after this round's changes
