### PR TITLE
fix(ranking-indexer): copy rolling_sweep binary into the runtime image

### DIFF
--- a/ranking-indexer/Dockerfile
+++ b/ranking-indexer/Dockerfile
@@ -38,5 +38,6 @@ RUN apt-get update && \
 
 COPY --from=builder /app/ranking-indexer/target/release/ranking-indexer /usr/local/bin/ranking-indexer
 COPY --from=builder /app/ranking-indexer/target/release/backfill_blocks /usr/local/bin/backfill_blocks
+COPY --from=builder /app/ranking-indexer/target/release/rolling_sweep /usr/local/bin/rolling_sweep
 
 CMD ["ranking-indexer"]


### PR DESCRIPTION
## Summary

#821's `rolling_sweep` CronJob crash-looped in production immediately after deploy:

```
exec: "rolling_sweep": executable file not found in $PATH: unknown
```

The Dockerfile's final stage only copies `ranking-indexer` and `backfill_blocks` out of the builder stage — `rolling_sweep` compiles fine but was never added to the `COPY` list, so it doesn't exist in the runtime image at all.

## Test plan
- [x] Mirrors the exact existing `COPY --from=builder` pattern for the other two binaries
- [ ] Verify the CronJob runs successfully after this deploys (will confirm directly against the specific stale ranking block this was blocking)