### PR TITLE
fix(ranking-indexer): backfill stale ranking_type on already-registered blocks

### DIFF
--- a/ranking-indexer/src/bin/backfill_blocks.rs
+++ b/ranking-indexer/src/bin/backfill_blocks.rs
@@ -14,8 +14,13 @@
 //! that's missing from `ranks.ranking_blocks`/`ranks.rankings`, recovers its
 //! config from the same source those tables are meant to reflect, and
 //! recomputes the aggregate for every block touched (directly, or via a
-//! recovered rank that links to one). Idempotent — safe to re-run;
-//! already-registered blocks/ranks are never touched.
+//! recovered rank that links to one). Also finds blocks that already have a
+//! row but are stuck with a stale `ranking_type` — the identical gap one
+//! step later: a block created static and tagged Rolling by a subsequent,
+//! separate edit never gets its existing row updated, since `detect()` only
+//! reads a `CreateEntity`'s own ops (found investigating GEO-2328/PR#821).
+//! Idempotent — safe to re-run; blocks/ranks with nothing stale are never
+//! touched.
 //!
 //! Exits non-zero if anything failed to recover, so a scheduled run (see
 //! `k8s/*/backfill-cronjob.yaml`) surfaces failures as a failed Job instead
@@ -48,17 +53,22 @@ async fn main() -> Result<(), IndexerError> {
     let storage = Storage::new(&database_url).await?;
 
     let block_candidates = storage.find_unregistered_ranking_blocks().await?;
+    let stale_blocks = storage.find_stale_ranking_type_blocks().await?;
     let rank_candidates = storage.find_unregistered_ranks().await?;
     info!(
         blocks = block_candidates.len(),
+        stale_blocks = stale_blocks.len(),
         ranks = rank_candidates.len(),
         dry_run,
-        "found unregistered blocks/ranks"
+        "found unregistered/stale blocks and unregistered ranks"
     );
 
     if dry_run {
         for id in &block_candidates {
             info!(block_id = %id, "would recover block");
+        }
+        for id in &stale_blocks {
+            info!(block_id = %id, "would resync stale ranking_type");
         }
         for id in &rank_candidates {
             info!(rank_id = %id, "would recover rank");
@@ -66,7 +76,7 @@ async fn main() -> Result<(), IndexerError> {
         return Ok(());
     }
 
-    if block_candidates.is_empty() && rank_candidates.is_empty() {
+    if block_candidates.is_empty() && stale_blocks.is_empty() && rank_candidates.is_empty() {
         return Ok(());
     }
 
@@ -75,6 +85,7 @@ async fn main() -> Result<(), IndexerError> {
 
     let mut recovered_blocks = 0;
     let mut still_unregistered_blocks = 0;
+    let mut resynced_stale_blocks = 0;
     let mut recovered_ranks = 0;
     let mut still_unregistered_ranks = 0;
     let mut failed = 0;
@@ -110,6 +121,39 @@ async fn main() -> Result<(), IndexerError> {
             }
             Err(e) => {
                 error!(block_id = %block_id, error = %e, "failed to read block config from kg");
+                failed += 1;
+            }
+        }
+    }
+
+    // Already-registered blocks stuck with a stale `ranking_type` — same
+    // recovery as above (`get_block_config_from_kg` + `upsert_ranking_block`
+    // is already an upsert, so this safely overwrites the stale row), just
+    // starting from a row that already exists.
+    for block_id in stale_blocks {
+        match storage.get_block_config_from_kg(block_id).await {
+            Ok(Some(block)) => {
+                if let Err(e) = storage.upsert_ranking_block(&block).await {
+                    error!(block_id = %block_id, error = %e, "failed to upsert resynced block");
+                    failed += 1;
+                    continue;
+                }
+                if let Err(e) = recompute_block(block_id, meta, now, &storage).await {
+                    error!(block_id = %block_id, error = %e, "resynced block but recompute failed");
+                    failed += 1;
+                    continue;
+                }
+                info!(block_id = %block_id, "resynced stale ranking_type + recomputed block");
+                resynced_stale_blocks += 1;
+            }
+            Ok(None) => {
+                // No longer typed as a Ranking Block at all — leave its
+                // existing row alone; that's a different (currently
+                // unhandled) case, not this gap.
+                warn!(block_id = %block_id, "no longer typed as Ranking Block — skipping resync");
+            }
+            Err(e) => {
+                error!(block_id = %block_id, error = %e, "failed to read block config from kg for resync");
                 failed += 1;
             }
         }
@@ -158,6 +202,7 @@ async fn main() -> Result<(), IndexerError> {
     info!(
         recovered_blocks,
         still_unregistered_blocks,
+        resynced_stale_blocks,
         recovered_ranks,
         still_unregistered_ranks,
         failed,

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -388,6 +388,35 @@ impl Storage {
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
+    /// Already-registered blocks (`ranks.ranking_blocks` row exists) whose
+    /// `ranking_type` is still `NULL` even though the graph now tags them
+    /// Rolling — the same split-edit gap as `find_unregistered_ranking_blocks`,
+    /// one step later: `detect()` only sets `ranking_type` from a
+    /// `CreateEntity`'s own ops, so a block created as static and tagged
+    /// Rolling by a *later*, separate edit never gets its row updated (issue
+    /// found investigating GEO-2328/PR#821 — a real block on a live space sat
+    /// stuck this way until backfilled by hand). Used by `bin/backfill_blocks.rs`
+    /// alongside `find_unregistered_ranking_blocks`; the recovery step is
+    /// identical (`get_block_config_from_kg` + `upsert_ranking_block`), just
+    /// starting from a row that already exists instead of one that doesn't.
+    pub async fn find_stale_ranking_type_blocks(&self) -> Result<Vec<Uuid>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT rb.id FROM ranks.ranking_blocks rb \
+             WHERE rb.ranking_type IS NULL \
+               AND EXISTS ( \
+                 SELECT 1 FROM relations r \
+                 WHERE r.from_entity_id = rb.id AND r.type_id = $1 AND r.to_entity_id = $2 \
+               )",
+        )
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANK_ROLLING_TYPE_ID))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     /// Entities typed `Rank` in the indexed public graph that never made it
     /// into `ranks.rankings` — the identical split-edit gap as
     /// `find_unregistered_ranking_blocks`, but for Rank submissions.


### PR DESCRIPTION
## Summary
- Follow-up to PR #821/#826 (GEO-2328 rolling rankings, Preston's live bug report on https://github.com/geobrowser/gaia/pull/821).
- `find_unregistered_ranking_blocks` only recovers blocks with *no* `ranks.ranking_blocks` row at all. It missed the identical split-edit gap one step later: a block created as static and tagged Rolling by a subsequent, separate edit never gets its **existing** row's `ranking_type`/`submission_frequency` updated, since `detect()` only classifies config from a `CreateEntity`'s own ops.
- Preston's specific block was fixed by hand (manual one-off resync) during the PR #821 rollout. This PR generalizes that fix so any block hitting this gap self-heals on the next scheduled `backfill_blocks` run instead of needing another manual intervention.

## Changes
- `storage.rs`: new `find_stale_ranking_type_blocks()` — registered blocks with `ranking_type IS NULL` where the KG's `TYPES` relation shows they're now tagged Rolling.
- `bin/backfill_blocks.rs`: also pulls these stale blocks and reconciles them through the same recovery path (`get_block_config_from_kg` + `upsert_ranking_block`, already an upsert, + `recompute_block`). Added a `resynced_stale_blocks` counter alongside the existing ones.

No new binary or cron entry — rides the existing scheduled `backfill_blocks` job.

## Test plan
- [x] `cargo build -p ranking-indexer --bin backfill_blocks`
- [x] `cargo test -p ranking-indexer --lib` (34 passed)
- [x] Verified end-to-end in prod during the PR #821 rollout: the same recovery path (`get_block_config_from_kg` + `upsert_ranking_block` + recompute) already fixed Preston's specific block; this PR just makes that path run automatically instead of by hand.