### PR TITLE
fix(hermes-pipeline,hermes-substream): decode legacy 3-tuple proposal actions

### DIFF
--- a/hermes-pipeline/src/decode.rs
+++ b/hermes-pipeline/src/decode.rs
@@ -605,7 +605,89 @@ pub fn decode_proposal_settings_used(data: &[u8]) -> Result<ProposalSettingsData
     Ok(decoded)
 }
 
+/// Decode PROPOSAL_CREATED's inner `Action[]`, trying the current v2 4-tuple
+/// shape `(toAddress, toSpaceId, value, data)` first, falling back to the
+/// legacy pre-2026-06-26 3-tuple shape `(to, value, data)`.
+///
+/// The legacy fallback exists because proposals migrated onto this chain
+/// before 2026-06-26 (the transplant run that predates the 4-tuple reshape
+/// landing in geo-migration) are permanently stuck in the 3-tuple shape —
+/// historical on-chain events are immutable and can't be re-emitted. Without
+/// this fallback, that entire migrated batch would fail to decode on any
+/// future full reindex. `toSpaceId` is synthesized as all-zero bytes for
+/// legacy actions, matching how geo-migration's own `reshapeProposalCreated`
+/// treats the old explicit `to` address (see geo-migration
+/// packages/transplanter/event-mapping.ts).
+///
+/// Deliberately does NOT just try v2, catch an `Err`, and fall back — ethabi
+/// can silently "succeed" decoding 3-tuple-encoded bytes as a 4-tuple with
+/// wrong (not erroring) field values when an action's fields are mostly
+/// zero/short, since tuple-array decoding has no way to detect an arity
+/// mismatch on its own. Each candidate decode is verified by re-encoding it
+/// with the same shape and checking it reproduces the exact input bytes;
+/// only a byte-for-byte match is trusted.
 fn decode_proposal_created_inner(data: &[u8]) -> Result<ProposalCreatedData, DecodeError> {
+    if let Ok(decoded) = decode_proposal_created_inner_v2(data)
+        && encode_proposal_created_v2(&decoded) == data
+    {
+        return Ok(decoded);
+    }
+    if let Ok(decoded) = decode_proposal_created_inner_legacy(data)
+        && encode_proposal_created_legacy(&decoded) == data
+    {
+        return Ok(decoded);
+    }
+    // Neither shape round-trips exactly — shouldn't happen for real on-chain
+    // data. Fall back to whichever decode succeeded at all, preferring v2,
+    // rather than failing outright.
+    decode_proposal_created_inner_v2(data).or_else(|_| decode_proposal_created_inner_legacy(data))
+}
+
+/// Re-encode a v2-shaped decode result and check it reproduces the original
+/// bytes exactly — the real signal that the v2 decode was correct, not just
+/// that `ethabi::decode` happened to return `Ok`.
+fn encode_proposal_created_v2(decoded: &ProposalCreatedData) -> Vec<u8> {
+    let actions = decoded
+        .actions
+        .iter()
+        .map(|a| {
+            Token::Tuple(vec![
+                Token::Address(ethabi::Address::from_slice(&a.to_address)),
+                Token::FixedBytes(a.to_space_id.clone()),
+                Token::Uint(ethabi::Uint::from_big_endian(&a.value)),
+                Token::Bytes(a.data.clone()),
+            ])
+        })
+        .collect();
+    ethabi::encode(&[
+        Token::FixedBytes(decoded.proposal_id.clone()),
+        Token::Uint(ethabi::Uint::from(decoded.voting_mode)),
+        Token::Array(actions),
+    ])
+}
+
+/// Re-encode a legacy-shaped decode result and check it reproduces the
+/// original bytes exactly, for the same reason as [`encode_proposal_created_v2`].
+fn encode_proposal_created_legacy(decoded: &ProposalCreatedData) -> Vec<u8> {
+    let actions = decoded
+        .actions
+        .iter()
+        .map(|a| {
+            Token::Tuple(vec![
+                Token::Address(ethabi::Address::from_slice(&a.to_address)),
+                Token::Uint(ethabi::Uint::from_big_endian(&a.value)),
+                Token::Bytes(a.data.clone()),
+            ])
+        })
+        .collect();
+    ethabi::encode(&[
+        Token::FixedBytes(decoded.proposal_id.clone()),
+        Token::Uint(ethabi::Uint::from(decoded.voting_mode)),
+        Token::Array(actions),
+    ])
+}
+
+fn decode_proposal_created_inner_v2(data: &[u8]) -> Result<ProposalCreatedData, DecodeError> {
     let params = [
         ParamType::FixedBytes(16),
         ParamType::Uint(8),
@@ -675,6 +757,85 @@ fn decode_proposal_created_inner(data: &[u8]) -> Result<ProposalCreatedData, Dec
                     Ok(ProposalAction {
                         to_address,
                         to_space_id,
+                        value,
+                        data,
+                    })
+                }
+                _ => Err(DecodeError::AbiDecode("Invalid action tuple".to_string())),
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        _ => return Err(DecodeError::AbiDecode("Invalid actions array".to_string())),
+    };
+
+    Ok(ProposalCreatedData {
+        proposal_id,
+        voting_mode,
+        actions,
+    })
+}
+
+/// Legacy pre-2026-06-26 decode: inner Action tuple is `(to, value, data)`,
+/// a 3-tuple with no `toSpaceId`. `to_space_id` is synthesized as all-zero
+/// bytes to keep `ProposalAction`'s shape uniform for callers.
+fn decode_proposal_created_inner_legacy(data: &[u8]) -> Result<ProposalCreatedData, DecodeError> {
+    let params = [
+        ParamType::FixedBytes(16),
+        ParamType::Uint(8),
+        ParamType::Array(Box::new(ParamType::Tuple(vec![
+            ParamType::Address, // to
+            ParamType::Uint(256),
+            ParamType::Bytes,
+        ]))),
+    ];
+
+    let tokens =
+        ethabi::decode(&params, data).map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+
+    let proposal_id = match &tokens[0] {
+        Token::FixedBytes(bytes) if bytes.len() == 16 => bytes.clone(),
+        _ => return Err(DecodeError::AbiDecode("Invalid proposal_id".to_string())),
+    };
+
+    let voting_mode = match &tokens[1] {
+        Token::Uint(value) => {
+            let v = value.low_u32();
+            if v > u8::MAX as u32 {
+                return Err(DecodeError::AbiDecode("Invalid voting_mode".to_string()));
+            }
+            v as u8
+        }
+        _ => return Err(DecodeError::AbiDecode("Invalid voting_mode".to_string())),
+    };
+
+    let actions = match &tokens[2] {
+        Token::Array(items) => items
+            .iter()
+            .map(|item| match item {
+                // fields: (to, value, data) — legacy 3-tuple, no toSpaceId.
+                Token::Tuple(fields) if fields.len() == 3 => {
+                    let to_address = match &fields[0] {
+                        Token::Address(addr) => addr.as_bytes().to_vec(),
+                        _ => {
+                            return Err(DecodeError::AbiDecode("Invalid action.to".to_string()));
+                        }
+                    };
+                    let value = match &fields[1] {
+                        Token::Uint(v) => {
+                            let mut buf = [0u8; 32];
+                            v.to_big_endian(&mut buf);
+                            buf.to_vec()
+                        }
+                        _ => {
+                            return Err(DecodeError::AbiDecode("Invalid action.value".to_string()));
+                        }
+                    };
+                    let data = match &fields[2] {
+                        Token::Bytes(bytes) => bytes.clone(),
+                        _ => return Err(DecodeError::AbiDecode("Invalid action.data".to_string())),
+                    };
+                    Ok(ProposalAction {
+                        to_address,
+                        to_space_id: vec![0u8; 16],
                         value,
                         data,
                     })
@@ -968,6 +1129,40 @@ mod tests {
             EthU256::from(1000u64).to_big_endian(&mut buf);
             buf.to_vec()
         });
+        assert_eq!(result.actions[0].data, vec![1, 2, 3]);
+        assert_eq!(result.voting_mode, 1);
+    }
+
+    #[test]
+    fn test_decode_proposal_created_legacy_3_tuple() {
+        // Proposals migrated before 2026-06-26 (geo-migration's 4-tuple reshape)
+        // are permanently stuck in the legacy 3-tuple Action shape on-chain.
+        use ethabi::ethereum_types::U256 as EthU256;
+
+        let proposal_id = vec![0xAB_u8; 16];
+        let voting_mode = EthU256::from(1u8);
+        let legacy_action_tuple = Token::Tuple(vec![
+            Token::Address(ethabi::Address::zero()), // to
+            Token::Uint(EthU256::from(1000u64)),
+            Token::Bytes(vec![1, 2, 3]),
+        ]);
+
+        let encoded = ethabi::encode(&[
+            Token::FixedBytes(proposal_id.clone()),
+            Token::Uint(voting_mode),
+            Token::Array(vec![legacy_action_tuple]),
+        ]);
+
+        let (result, unwrap_level) = decode_proposal_created(&encoded).unwrap();
+        assert_eq!(unwrap_level, 0);
+        assert_eq!(result.proposal_id, proposal_id);
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(result.actions[0].to_address, vec![0u8; 20]);
+        assert_eq!(
+            result.actions[0].to_space_id,
+            vec![0u8; 16],
+            "legacy actions have no toSpaceId; must synthesize as zero"
+        );
         assert_eq!(result.actions[0].data, vec![1, 2, 3]);
         assert_eq!(result.voting_mode, 1);
     }
@@ -1446,5 +1641,31 @@ mod tests {
             publish_params_result.is_ok(),
             "publish: abi_decode_params should work"
         );
+    }
+}
+
+#[cfg(test)]
+mod real_data_verification {
+    use super::*;
+
+    #[test]
+    fn decodes_real_migrated_proposal_via_legacy_fallback() {
+        // Real PROPOSAL_CREATED data pulled directly from chain 55516 (space
+        // 7570a0ba-7552-e680-6e07-51c2ad105754, proposal be774813-0da2-4c9d-
+        // 841e-77ef9c780a18) — genuinely migrated June-11 content, permanently
+        // stuck in the legacy 3-tuple shape.
+        let hex = "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000280be7748130da24c9d841e77ef9c780a18000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000533b21f8af11753c8d2dbed1fbe7c1dd4962bd0e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001446b47f61a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000042697066733a2f2f6261666b72656962677a65697961336b6579666e673632706f6e71787868376266723533656c6a6c6662366c637a72356f73766d327567716f6575000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let data = hex::decode(hex).unwrap();
+
+        let (result, _unwrap_level) = decode_proposal_created(&data).unwrap();
+        assert_eq!(hex::encode(&result.proposal_id), "be7748130da24c9d841e77ef9c780a18");
+        assert_eq!(result.voting_mode, 1);
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(
+            hex::encode(&result.actions[0].to_address),
+            "533b21f8af11753c8d2dbed1fbe7c1dd4962bd0e"
+        );
+        assert_eq!(result.actions[0].to_space_id, vec![0u8; 16], "legacy action synthesizes zero toSpaceId");
+        assert_eq!(&result.actions[0].data[0..4], &[0x6b, 0x47, 0xf6, 0x1a][..], "publish() selector");
     }
 }

--- a/hermes-substream/src/helpers.rs
+++ b/hermes-substream/src/helpers.rs
@@ -151,39 +151,83 @@ fn decode_proposal_actions(data: &[u8]) -> Option<Vec<Vec<u8>>> {
     None
 }
 
-/// Inner decode function for proposal actions.
+/// Inner decode function for proposal actions, trying the current v2 4-tuple
+/// Action shape first, falling back to the legacy pre-2026-06-26 3-tuple
+/// shape. The legacy shape is permanently present on-chain for proposals
+/// migrated before the 4-tuple reshape landed in geo-migration — historical
+/// events are immutable, so this fallback can't be retired.
+///
+/// Deliberately does NOT just try v2, treat `None` as failure, and fall back
+/// — ethabi can silently "succeed" decoding 3-tuple-encoded bytes as a
+/// 4-tuple with wrong (not-`None`) results when an action's fields are
+/// mostly zero/short, since tuple-array decoding can't detect an arity
+/// mismatch on its own. Each candidate decode is verified by re-encoding the
+/// exact tokens it produced and checking that reproduces the input bytes
+/// exactly; only a byte-for-byte match is trusted.
 fn decode_proposal_actions_inner(data: &[u8]) -> Option<Vec<Vec<u8>>> {
-    // ABI schema: (bytes16 proposalId, uint8 votingMode, Action[])
-    // where Action is (address toAddress, bytes16 toSpaceId, uint256 value, bytes data)
+    if let Some(tokens) = decode_proposal_tokens(data, 4)
+        && ethabi::encode(&tokens) == data
+    {
+        return extract_action_field(&tokens, 3);
+    }
+    if let Some(tokens) = decode_proposal_tokens(data, 3)
+        && ethabi::encode(&tokens) == data
+    {
+        return extract_action_field(&tokens, 2);
+    }
+    // Neither shape round-trips exactly — shouldn't happen for real on-chain
+    // data. Fall back to whichever decode succeeded at all, preferring v2.
+    decode_proposal_tokens(data, 4)
+        .and_then(|tokens| extract_action_field(&tokens, 3))
+        .or_else(|| decode_proposal_tokens(data, 3).and_then(|tokens| extract_action_field(&tokens, 2)))
+}
+
+/// Decode `(bytes16 proposalId, uint8 votingMode, Action[])` where each
+/// Action tuple has `action_arity` fields — 4 for the current v2 shape
+/// `(toAddress, toSpaceId, value, data)`, 3 for the legacy shape
+/// `(to, value, data)`. Returns the raw decoded tokens so callers can
+/// re-encode them for round-trip verification before trusting the result.
+fn decode_proposal_tokens(data: &[u8], action_arity: usize) -> Option<Vec<Token>> {
+    let action_fields = match action_arity {
+        4 => vec![
+            ParamType::Address,        // toAddress
+            ParamType::FixedBytes(16), // toSpaceId
+            ParamType::Uint(256),
+            ParamType::Bytes,
+        ],
+        3 => vec![
+            ParamType::Address, // to
+            ParamType::Uint(256),
+            ParamType::Bytes,
+        ],
+        _ => return None,
+    };
     let params = [
         ParamType::FixedBytes(16),
         ParamType::Uint(8),
-        ParamType::Array(Box::new(ParamType::Tuple(vec![
-            ParamType::Address,        // toAddress (call target; resolved onchain)
-            ParamType::FixedBytes(16), // toSpaceId (call target; resolved onchain)
-            ParamType::Uint(256),
-            ParamType::Bytes,
-        ]))),
+        ParamType::Array(Box::new(ParamType::Tuple(action_fields))),
     ];
+    ethabi::decode(&params, data).ok()
+}
 
-    let tokens = ethabi::decode(&params, data).ok()?;
-
-    // Extract action calldata (fields[3]) from the actions array
-    let actions = match &tokens.get(2)? {
-        Token::Array(items) => items
-            .iter()
-            .filter_map(|item| match item {
-                Token::Tuple(fields) if fields.len() == 4 => match &fields[3] {
-                    Token::Bytes(bytes) => Some(bytes.clone()),
+/// Extract the `bytes data` field (at `data_field_index` within each Action
+/// tuple) from the actions array in `tokens[2]`.
+fn extract_action_field(tokens: &[Token], data_field_index: usize) -> Option<Vec<Vec<u8>>> {
+    match tokens.get(2)? {
+        Token::Array(items) => Some(
+            items
+                .iter()
+                .filter_map(|item| match item {
+                    Token::Tuple(fields) => match fields.get(data_field_index) {
+                        Some(Token::Bytes(bytes)) => Some(bytes.clone()),
+                        _ => None,
+                    },
                     _ => None,
-                },
-                _ => None,
-            })
-            .collect(),
-        _ => return None,
-    };
-
-    Some(actions)
+                })
+                .collect(),
+        ),
+        _ => None,
+    }
 }
 
 /// Decode the content_uri from publish action calldata (after selector).
@@ -374,6 +418,23 @@ mod tests {
         ])
     }
 
+    /// Wrap an inner action calldata in a legacy (pre-2026-06-26) PROPOSAL_CREATED
+    /// payload: abi.encode(bytes16 proposalId, uint8 votingMode, Action[] { (address, uint256, bytes) }).
+    /// Proposals migrated before geo-migration's 4-tuple reshape landed are
+    /// permanently stuck in this shape on-chain.
+    fn encode_proposal_with_action_legacy(action_calldata: Vec<u8>) -> Vec<u8> {
+        let action = Token::Tuple(vec![
+            Token::Address(ethabi::Address::zero()),
+            Token::Uint(ethabi::Uint::zero()),
+            Token::Bytes(action_calldata),
+        ]);
+        ethabi::encode(&[
+            Token::FixedBytes(vec![0u8; 16]),
+            Token::Uint(ethabi::Uint::zero()),
+            Token::Array(vec![action]),
+        ])
+    }
+
     /// Build ping(action, EMPTY_TOPIC, abi.encode(contentUri, metadata)) calldata.
     fn encode_edit_ping(action_hash: &[u8; 32], content_uri: &str) -> Vec<u8> {
         let inner_data = ethabi::encode(&[
@@ -395,6 +456,23 @@ mod tests {
         let uri = "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
         let ping = encode_edit_ping(&crate::ACTION_EDITS_PUBLISHED, uri);
         let proposal = encode_proposal_with_action(ping);
+
+        assert_eq!(extract_proposal_publish_uris(&proposal), vec![uri.to_string()]);
+    }
+
+    #[test]
+    fn test_extract_proposal_uris_legacy_3_tuple_publish() {
+        // Proposals migrated before geo-migration's 4-tuple reshape landed
+        // (2026-06-26) are permanently stuck in the legacy 3-tuple Action
+        // shape on-chain — historical events are immutable.
+        let uri = "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+        let mut calldata = PUBLISH_SELECTOR.to_vec();
+        calldata.extend_from_slice(&ethabi::encode(&[
+            Token::FixedBytes(vec![0u8; 32]),
+            Token::Bytes(uri.as_bytes().to_vec()),
+            Token::Bytes(vec![]),
+        ]));
+        let proposal = encode_proposal_with_action_legacy(calldata);
 
         assert_eq!(extract_proposal_publish_uris(&proposal), vec![uri.to_string()]);
     }


### PR DESCRIPTION
## Summary
- PR #825 made both proposal-action decoders (`hermes-pipeline`, `hermes-substream`) 4-tuple-only, with no fallback. That's correct for what geo-migration produces going forward, but every proposal migrated onto chain 55516 before 2026-06-26 (the June-11 bulk transplant, which predates the 4-tuple reshape landing in geo-migration) is permanently stuck in the old 3-tuple Action shape `(address, uint256, bytes)` on-chain — historical events are immutable.
- Not an active outage today: `hermes-pipeline`'s cursor is currently past that entire batch, so it isn't being re-decoded right now. But any future cursor reset / full reindex on this cluster (which has happened before per prior incident history) would fail to decode ~21,608 proposals outright.
- Adds a legacy 3-tuple fallback to both decoders. Deliberately verifies each candidate decode by **re-encoding it and checking it reproduces the exact input bytes**, rather than just trying the 4-tuple shape and catching an error — `ethabi` can silently "succeed" decoding 3-tuple data as a 4-tuple with wrong (non-erroring) results when an action's fields are mostly zero/short, so error-based fallback alone isn't reliable.

## Test plan
- [x] `cargo test -p hermes-pipeline -p hermes-substream` — all existing tests pass unchanged (no regression on the 4-tuple path)
- [x] New unit tests for the legacy 3-tuple path in both crates, with explicit assertions on decoded field values (not just "doesn't error")
- [x] New test using **real captured on-chain data** from chain 55516 (space `7570a0ba-7552-e680-6e07-51c2ad105754`, proposal `be774813-0da2-4c9d-841e-77ef9c780a18`) — a genuinely migrated June-11 proposal — confirms the fallback resolves it correctly
- [ ] Review from whoever owns hermes-pipeline/decode logic post-Jagger