### PR TITLE
fix(proposal-executor): decode v2 4-field Action tuple in DAOSpaceAbi

### DIFF
--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -111,7 +111,8 @@ export const DAOSpaceAbi = [
 			},
 			{
 				components: [
-					{internalType: "address", name: "to", type: "address"},
+					{internalType: "address", name: "toAddress", type: "address"},
+					{internalType: "bytes16", name: "toSpaceId", type: "bytes16"},
 					{internalType: "uint256", name: "value", type: "uint256"},
 					{internalType: "bytes", name: "data", type: "bytes"},
 				],


### PR DESCRIPTION
## Summary
- Found while reviewing #798 (closed as superseded by the governance-v2 decode work already on `staging`).
- `proposal-executor/src/contracts.ts`'s `DAOSpaceAbi` still declares the legacy 3-field `Action` tuple `(address to, uint256 value, bytes data)` for `getLatestProposalInformation`'s `_actions` return component.
- `geo-contracts-foundry/src/interfaces/IDAOSpace.sol`'s `Action` struct is now the v2 4-field shape: `(address toAddress, bytes16 toSpaceId, uint256 value, bytes data)` — the same shape `hermes-pipeline`/`hermes-substream` already decode (`d619646`, `52e5cca`).
- This file forks its own copy of the ABI independently (see the file's own header comment: "Long-term consolidation: extract a shared @geo/protocol package when a third consumer appears") and was never updated alongside the governance-v2 migration.
- `readProposalTally` (the stage-2 authoritative untouched check used by the membership-accept auto-vote path) ABI-decodes the full `getLatestProposalInformation` return tuple, including `_actions`, even though it doesn't read the decoded action values afterward — a tuple-arity mismatch there will fail the decode for any v2 DAOSpace.

## Changes
- Add the missing `toSpaceId: bytes16` component and rename `to` → `toAddress` in `DAOSpaceAbi.getLatestProposalInformation`'s `_actions` tuple, matching the on-chain v2 struct.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (131 pass)
- No test mocks the raw ABI encoding of `getLatestProposalInformation` (they stub `readContract` at the JS-return-value level), so none needed updating — consistent with why this slipped through unnoticed.