### PR TITLE
fix(api,kg-indexer): proposal status incorrectly REJECTED for passed migrated proposals

### DIFF
--- a/api/src/proposals/__tests__/queries.test.ts
+++ b/api/src/proposals/__tests__/queries.test.ts
@@ -707,6 +707,38 @@ describe("SQL/TypeScript status parity", () => {
 		})
 	})
 
+	describe("execute_by deadline does not override a resolved vote outcome", () => {
+		// Mirrors sqlIsExecutable/sqlIsRejected: execute_by only downgrades a
+		// proposal that's still vote-undecided (sqlVoteOutcomeUndecided) to
+		// REJECTED — it must never override an outcome the votes already
+		// resolved. This is the real-world shape of every migrated historical
+		// proposal, where execute_by is synthesized from long-past timestamps
+		// and is always already expired by the time anyone looks at it.
+		it("stays EXECUTABLE past execute_by when the fast-path threshold was met", () => {
+			const proposal = makeProposal({
+				votingMode: "Fast",
+				threshold: 3n,
+				yesCount: 100n,
+				executeBy: now - 10n,
+				endTime: now + 3600n,
+			})
+			const result = computeProposalStatus(proposal, now)
+			expect(result.status).toBe("EXECUTABLE")
+		})
+
+		it("REJECTS past execute_by when still vote-undecided", () => {
+			const proposal = makeProposal({
+				votingMode: "Fast",
+				threshold: 3n,
+				yesCount: 0n,
+				executeBy: now - 10n,
+				endTime: now + 3600n,
+			})
+			const result = computeProposalStatus(proposal, now)
+			expect(result.status).toBe("REJECTED")
+		})
+	})
+
 	describe("PROPOSED status", () => {
 		it("proposal is PROPOSED when voting not ended and threshold not met (Fast)", () => {
 			const proposal = makeProposal({

--- a/api/src/proposals/__tests__/status.test.ts
+++ b/api/src/proposals/__tests__/status.test.ts
@@ -629,7 +629,12 @@ describe("computeProposalStatus - V2 slow early execution", () => {
 // =============================================================================
 
 describe("computeProposalStatus - V2 executeBy deadline", () => {
-	it("REJECTS an otherwise-executable fast proposal past executeBy", () => {
+	it("stays EXECUTABLE for a fast proposal that passed its vote, even past executeBy", () => {
+		// executeBy must never override an outcome the votes already resolved —
+		// this is exactly the shape of every migrated historical proposal, where
+		// executeBy is synthesized from long-past timestamps and is always
+		// already expired by the time anyone looks at it (see the doc comment
+		// on computeProposalStatus).
 		const now = BigInt(Math.floor(Date.now() / 1000))
 		const proposal = makeProposal({
 			votingMode: "Fast",
@@ -641,10 +646,10 @@ describe("computeProposalStatus - V2 executeBy deadline", () => {
 
 		const result = computeProposalStatus(proposal, now)
 
-		expect(result.status).toBe("REJECTED")
+		expect(result.status).toBe("EXECUTABLE")
 	})
 
-	it("REJECTS an otherwise-early-executable slow proposal past executeBy", () => {
+	it("stays EXECUTABLE for a slow proposal that early-executed, even past executeBy", () => {
 		const now = BigInt(Math.floor(Date.now() / 1000))
 		const proposal = makeProposal({
 			votingMode: "Slow",
@@ -653,6 +658,43 @@ describe("computeProposalStatus - V2 executeBy deadline", () => {
 			partialPercentageSupportThreshold: 5_000_000n,
 			quorum: 1n,
 			yesCount: 2n,
+			executeBy: now - 10n,
+			endTime: now + 3600n,
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		expect(result.status).toBe("EXECUTABLE")
+		expect(result.isEarlyExecutable).toBe(true)
+	})
+
+	it("REJECTS a still-undecided fast proposal once executeBy passes", () => {
+		// This is the case executeBy is actually meant to catch: a proposal that
+		// never resolved (didn't clear its threshold) and whose window to do
+		// anything about it has now also closed.
+		const now = BigInt(Math.floor(Date.now() / 1000))
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			flatSupportThreshold: 3n,
+			yesCount: 0n, // never voted on, still undecided
+			executeBy: now - 10n, // deadline passed
+			endTime: now + 3600n, // voting window technically still open
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		expect(result.status).toBe("REJECTED")
+	})
+
+	it("REJECTS a still-undecided slow proposal once executeBy passes", () => {
+		const now = BigInt(Math.floor(Date.now() / 1000))
+		const proposal = makeProposal({
+			votingMode: "Slow",
+			universalPercentageSupportThreshold: 5_000_000n,
+			totalEditors: 2n,
+			partialPercentageSupportThreshold: 5_000_000n,
+			quorum: 1n,
+			yesCount: 0n, // never voted on, still undecided
 			executeBy: now - 10n,
 			endTime: now + 3600n,
 		})

--- a/api/src/proposals/queries.ts
+++ b/api/src/proposals/queries.ts
@@ -346,19 +346,22 @@ function sqlIsAccepted() {
 }
 
 /**
- * Proposal is EXECUTABLE iff not executed, deadline not passed, the voting
- * window has started (end_time > 0; mirrors the contract's `lastDate != 0`
- * guard in `canExecuteProposal`), and any path produces an executable outcome:
+ * Proposal is EXECUTABLE iff not executed, the voting window has started
+ * (end_time > 0; mirrors the contract's `lastDate != 0` guard in
+ * `canExecuteProposal`), and any path produces an executable outcome:
  *   - Fast: yes_count > effective(flat_support_threshold)
  *   - Slow early: voting ongoing AND total_editors > 0 AND universal > 0
  *                 AND yes_count >= ceil(universal * total_editors / RATIO_BASE)
  *   - Slow late:  voting ended AND quorum met
  *                 AND (RATIO_BASE - partial) * yes > partial * no
+ *
+ * Deliberately does NOT gate on `execute_by` — see the note on `sqlIsRejected`
+ * for why the deadline must never override an outcome the votes already
+ * resolved.
  */
 function sqlIsExecutable(nowSeconds: bigint) {
 	return sql`(
 		p.executed_at IS NULL
-		AND (p.execute_by IS NULL OR ${nowSeconds}::bigint <= p.execute_by)
 		AND p.end_time > 0
 		AND (
 			(p.voting_mode = 'Fast' AND p.yes_count > (CASE WHEN p.flat_support_threshold = 0 THEN 0 ELSE p.flat_support_threshold - 1 END))
@@ -383,28 +386,26 @@ function sqlIsExecutable(nowSeconds: bigint) {
 }
 
 /**
- * Proposal is PROPOSED iff not executed, deadline not passed, and either the
- * voting window has not started yet (end_time = 0 — open, awaiting the first
- * vote) or voting is ongoing with no executable path already matched.
+ * Vote-based "still undecided" condition, independent of the `execute_by`
+ * deadline: either the voting window hasn't started yet (end_time = 0 —
+ * open, awaiting the first vote) or voting is ongoing with no executable
+ * path matched yet. Shared by `sqlIsProposed` and `sqlIsRejected` so the two
+ * stay in sync by construction.
  */
-function sqlIsProposed(nowSeconds: bigint) {
+function sqlVoteOutcomeUndecided(nowSeconds: bigint) {
 	return sql`(
-		p.executed_at IS NULL
-		AND (p.execute_by IS NULL OR ${nowSeconds}::bigint <= p.execute_by)
-		AND (
-			p.end_time = 0
-			OR (
-				${nowSeconds}::bigint <= p.end_time
-				AND NOT (
-					(p.voting_mode = 'Fast' AND p.yes_count > (CASE WHEN p.flat_support_threshold = 0 THEN 0 ELSE p.flat_support_threshold - 1 END))
-					OR (
-						p.voting_mode = 'Slow'
-						AND ${sqlTotalEditors()} > 0
-						AND p.universal_percentage_support_threshold > 0
-						AND p.yes_count::numeric >= CEIL(
-							(p.universal_percentage_support_threshold::numeric * ${sqlTotalEditors()}::numeric)
-							/ ${RATIO_BASE}::numeric
-						)
+		p.end_time = 0
+		OR (
+			${nowSeconds}::bigint <= p.end_time
+			AND NOT (
+				(p.voting_mode = 'Fast' AND p.yes_count > (CASE WHEN p.flat_support_threshold = 0 THEN 0 ELSE p.flat_support_threshold - 1 END))
+				OR (
+					p.voting_mode = 'Slow'
+					AND ${sqlTotalEditors()} > 0
+					AND p.universal_percentage_support_threshold > 0
+					AND p.yes_count::numeric >= CEIL(
+						(p.universal_percentage_support_threshold::numeric * ${sqlTotalEditors()}::numeric)
+						/ ${RATIO_BASE}::numeric
 					)
 				)
 			)
@@ -413,17 +414,44 @@ function sqlIsProposed(nowSeconds: bigint) {
 }
 
 /**
- * Proposal is REJECTED iff not executed and either the executeBy deadline
- * has passed, or the voting window started and ended (end_time > 0 AND now >
- * end_time) without any executable path matching. A zero window (end_time = 0)
- * is never rejected — the proposal is still open (see sqlIsProposed).
+ * Proposal is PROPOSED iff not executed, still vote-undecided (see
+ * `sqlVoteOutcomeUndecided`), and the `execute_by` deadline hasn't passed —
+ * once it does, an undecided proposal downgrades to REJECTED instead (see
+ * `sqlIsRejected`).
+ */
+function sqlIsProposed(nowSeconds: bigint) {
+	return sql`(
+		p.executed_at IS NULL
+		AND ${sqlVoteOutcomeUndecided(nowSeconds)}
+		AND (p.execute_by IS NULL OR ${nowSeconds}::bigint <= p.execute_by)
+	)`
+}
+
+/**
+ * Proposal is REJECTED iff not executed and either:
+ *   - the voting window started and ended (end_time > 0 AND now > end_time)
+ *     without any executable path matching, regardless of `execute_by` — a
+ *     proposal that lost its vote is rejected whether or not its deadline
+ *     also happened to pass, OR
+ *   - it's still vote-undecided (see `sqlVoteOutcomeUndecided`) AND the
+ *     `execute_by` deadline has passed — an open proposal that never got
+ *     resolved lapses once its execution window closes.
+ * A zero window (end_time = 0) is never rejected by the first branch — the
+ * proposal is still open (see `sqlIsProposed`) unless it lapses via the
+ * second branch.
+ *
+ * `execute_by` deliberately never overrides an outcome that already resolved
+ * to EXECUTABLE via the vote-count conditions (see `sqlIsExecutable`) — it
+ * only closes out proposals that were still undecided. This matters for
+ * historical/migrated proposals, where `execute_by` is synthesized from
+ * long-past timestamps and will always appear expired by the time anyone
+ * looks at it.
  */
 function sqlIsRejected(nowSeconds: bigint) {
 	return sql`(
 		p.executed_at IS NULL
 		AND (
-			(p.execute_by IS NOT NULL AND ${nowSeconds}::bigint > p.execute_by)
-			OR (
+			(
 				p.end_time > 0
 				AND ${nowSeconds}::bigint > p.end_time
 				AND NOT (
@@ -434,6 +462,11 @@ function sqlIsRejected(nowSeconds: bigint) {
 						AND (${RATIO_BASE}::numeric - p.partial_percentage_support_threshold::numeric) * p.yes_count::numeric > p.partial_percentage_support_threshold::numeric * p.no_count::numeric
 					)
 				)
+			)
+			OR (
+				${sqlVoteOutcomeUndecided(nowSeconds)}
+				AND p.execute_by IS NOT NULL
+				AND ${nowSeconds}::bigint > p.execute_by
 			)
 		)
 	)`

--- a/api/src/proposals/status.ts
+++ b/api/src/proposals/status.ts
@@ -16,18 +16,26 @@ import {RATIO_BASE} from "./types"
  *
  * Decision order:
  * 1. Already executed → ACCEPTED
- * 2. Past `executeBy` deadline → REJECTED
- * 3. Voting window not started yet (`endTime == 0`) → PROPOSED. In V2 the
+ * 2. Voting window not started yet (`endTime == 0`) → PROPOSED. In V2 the
  *    window (`startDate`/`lastDate`/`executeBy`) stays zero until the first
  *    vote, and the contract's `canExecuteProposal` returns false while
  *    `lastDate == 0`. So a proposal with no votes yet is open, never
  *    executable or rejected on the zero window.
- * 4. Fast path: `yesCount > effective(flatSupportThreshold)` → EXECUTABLE,
+ * 3. Fast path: `yesCount > effective(flatSupportThreshold)` → EXECUTABLE,
  *    where `effective(x) = x == 0 ? 0 : x - 1` (matches the contract).
- * 5. Slow-path early execution (before voting ends): when
+ * 4. Slow-path early execution (before voting ends): when
  *    `yesCount >= ceil(universalPercentageSupportThreshold × totalEditors / RATIO_BASE)`.
- * 6. Slow-path late execution (after voting ends): quorum + the classic
+ * 5. Slow-path late execution (after voting ends): quorum + the classic
  *    `(RATIO_BASE - partial) × yes > partial × no` ratio.
+ * 6. Past `executeBy` deadline → downgrades an otherwise-still-undecided
+ *    (PROPOSED) outcome to REJECTED. Deliberately does NOT override an
+ *    outcome that already resolved to EXECUTABLE (or REJECTED by vote) —
+ *    `executeBy` means "this open proposal lapsed without a decision," not
+ *    "ignore what the votes say." This matters for historical/migrated
+ *    proposals, where `executeBy` is synthesized from long-past timestamps
+ *    and will always appear expired by the time anyone looks at it; treating
+ *    it as an unconditional override would make every migrated proposal that
+ *    actually passed its vote display as REJECTED.
  *
  * Must stay byte-for-byte consistent with the SQL fragments in `queries.ts`
  * (`sqlIsExecutable` / `sqlIsProposed` / `sqlIsRejected`). The parity tests
@@ -51,17 +59,27 @@ export function computeProposalStatus(
 		}
 	}
 
-	// Past the on-chain `executeBy` deadline → REJECTED, regardless of vote outcome.
-	// Null `executeBy` means no deadline (legacy V1 rows).
-	if (proposal.executeBy !== null && nowSeconds > proposal.executeBy) {
+	const result = computeVoteBasedStatus(proposal, nowSeconds)
+
+	// Past the on-chain `executeBy` deadline: only downgrades a proposal that's
+	// still genuinely undecided (PROPOSED) to REJECTED. See the deadline note
+	// above for why this must not override an already-resolved outcome.
+	if (result.status === "PROPOSED" && proposal.executeBy !== null && nowSeconds > proposal.executeBy) {
 		return {
 			status: "REJECTED",
-			isQuorumReached: false,
+			isQuorumReached: result.isQuorumReached,
 			isThresholdReached: false,
 			isEarlyExecutable: false,
 		}
 	}
 
+	return result
+}
+
+function computeVoteBasedStatus(
+	proposal: ProposalWithVotes | ProposalListItem,
+	nowSeconds: bigint,
+): StatusComputationResult {
 	// Voting window not started yet: the V2 contract leaves start/last/executeBy
 	// at zero until the first vote, and `canExecuteProposal` returns false while
 	// `lastDate == 0`. Treat this as an open proposal — not executable, not ended.

--- a/kg-indexer/src/storage.rs
+++ b/kg-indexer/src/storage.rs
@@ -1492,6 +1492,65 @@ impl Storage {
         .execute(&mut *tx)
         .await?;
 
+        // Detect fast-path proposals auto-executed by a YES vote meeting the
+        // effective threshold, and backfill `executed_at` accordingly.
+        //
+        // The DAOSpace contract auto-executes fast-path proposals inline when a
+        // YES vote meets the threshold (_vote -> _executeProposal), but does NOT
+        // emit a PROPOSAL_EXECUTED event in that path — only the explicit
+        // enter(PROPOSAL_EXECUTED) path (slow-path/manual execution) emits it.
+        // So for fast-path proposals we must infer execution from the tally: if
+        // the current version's yes_count clears the effective threshold and
+        // executed_at is still NULL, mark it executed using the timestamp of the
+        // most recent current-version vote.
+        //
+        // `yes_count >= GREATEST(flat_support_threshold, 1)` mirrors
+        // api/src/proposals/status.ts's `effectiveThreshold` (a threshold of 0
+        // stays 0, so a single yes vote clears it via strict `>`; otherwise the
+        // effective bound is `threshold - 1`, so `yes_count >= threshold`).
+        //
+        // This restores logic that existed pre-governance-v2 (see git history,
+        // "remove obsolete Fast-path executed_at inference") and was never
+        // carried forward into the versioned schema — `main`/prod still has an
+        // equivalent unversioned form and runs it correctly today. Without this,
+        // any fast-path proposal that passed its vote but was never explicitly
+        // executed permanently shows as REJECTED once its (synthesized, for
+        // migrated proposals) execute_by deadline lapses, regardless of the
+        // real vote outcome.
+        let auto_executed = sqlx::query(
+            r#"
+            UPDATE proposals p
+            SET executed_at = latest_vote.max_created_at::bigint
+            FROM UNNEST($1::uuid[]) AS queued(proposal_id)
+            JOIN proposal_versions pv
+                ON pv.proposal_id = queued.proposal_id
+            JOIN (
+                SELECT proposal_id, proposal_version, MAX(created_at)::bigint AS max_created_at
+                FROM proposal_votes
+                WHERE proposal_id = ANY($1)
+                GROUP BY proposal_id, proposal_version
+            ) latest_vote
+                ON latest_vote.proposal_id = pv.proposal_id
+                AND latest_vote.proposal_version = pv.proposal_version
+            WHERE p.id = queued.proposal_id
+              AND p.id = pv.proposal_id
+              AND p.current_version = pv.proposal_version
+              AND pv.voting_mode = 'Fast'::"votingMode"
+              AND p.executed_at IS NULL
+              AND pv.yes_count >= GREATEST(pv.flat_support_threshold, 1)
+            "#,
+        )
+        .bind(&proposal_ids)
+        .execute(&mut *tx)
+        .await?;
+
+        if auto_executed.rows_affected() > 0 {
+            info!(
+                count = auto_executed.rows_affected(),
+                "Auto-detected fast-path proposal executions from vote tallies"
+            );
+        }
+
         // Remove processed proposals from the queue
         sqlx::query(
             r#"

--- a/kg-indexer/tests/governance_storage_integration.rs
+++ b/kg-indexer/tests/governance_storage_integration.rs
@@ -857,6 +857,216 @@ async fn test_update_proposal_executed_writes_to_identity() {
     cleanup_proposal(&pool, proposal_id, &[space_id, proposer_id]).await;
 }
 
+// --------------------------------------------------------------------------
+// process_tally_queue backfills executed_at for fast-path proposals whose
+// yes_count clears the effective threshold — restored compensation logic
+// for the DAOSpace contract's silent inline auto-execution (see the comment
+// on process_tally_queue). This is a real regression test: this exact
+// scenario (a migrated fast-path proposal whose vote passed but was never
+// explicitly executed) was displaying REJECTED in production before this
+// fix, because executed_at stayed NULL forever without it.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn test_process_tally_queue_backfills_executed_at_for_passed_fast_path() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+    let space_id = Uuid::new_v4();
+    let proposal_id = Uuid::new_v4();
+    let proposer_id = Uuid::new_v4();
+    let voter_ids: Vec<Uuid> = (0..3).map(|_| Uuid::new_v4()).collect();
+
+    ensure_space(&pool, space_id).await;
+    ensure_space(&pool, proposer_id).await;
+    for voter_id in &voter_ids {
+        ensure_space(&pool, *voter_id).await;
+    }
+
+    // flat_support_threshold = 3 -> effective threshold clears at yes_count >= 3.
+    let v1 = version_fast(3, Some(3_000));
+    seed_proposal_v1(&storage, &pool, proposal_id, space_id, proposer_id, &v1).await;
+
+    let vote_timestamps = [1_700_000_100, 1_700_000_200, 1_700_000_300];
+    let mut tx = pool.begin().await.unwrap();
+    for (voter_id, created_at) in voter_ids.iter().zip(vote_timestamps.iter()) {
+        let vote = ProposalVoteItem {
+            proposal_id,
+            voter_id: *voter_id,
+            space_id,
+            vote: VoteOption::Yes,
+            created_at: *created_at,
+            created_at_block: 1,
+            proposal_version: 1,
+        };
+        storage
+            .insert_proposal_votes(std::slice::from_ref(&vote), &mut tx)
+            .await
+            .unwrap();
+    }
+    tx.commit().await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .queue_tally_update(proposal_id, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    storage
+        .process_tally_queue(10)
+        .await
+        .expect("process_tally_queue failed");
+
+    let (executed_at, yes_count): (Option<i64>, i64) = sqlx::query_as(
+        r#"SELECT p.executed_at, pv.yes_count
+           FROM proposals p
+           JOIN proposal_versions pv ON pv.proposal_id = p.id AND pv.proposal_version = p.current_version
+           WHERE p.id = $1"#,
+    )
+    .bind(proposal_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(yes_count, 3, "tally must reflect all 3 yes votes");
+    assert_eq!(
+        executed_at,
+        Some(1_700_000_300),
+        "executed_at must be backfilled to the latest vote's timestamp once the effective threshold is cleared"
+    );
+
+    cleanup_proposal(&pool, proposal_id, &[space_id, proposer_id, voter_ids[0], voter_ids[1], voter_ids[2]]).await;
+}
+
+// --------------------------------------------------------------------------
+// process_tally_queue must NOT backfill executed_at when the fast-path
+// threshold hasn't actually been cleared yet.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn test_process_tally_queue_does_not_backfill_when_threshold_not_met() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+    let space_id = Uuid::new_v4();
+    let proposal_id = Uuid::new_v4();
+    let proposer_id = Uuid::new_v4();
+    let voter_id = Uuid::new_v4();
+
+    ensure_space(&pool, space_id).await;
+    ensure_space(&pool, proposer_id).await;
+    ensure_space(&pool, voter_id).await;
+
+    // flat_support_threshold = 3 -> needs yes_count >= 3; only 1 yes vote cast.
+    let v1 = version_fast(3, Some(3_000));
+    seed_proposal_v1(&storage, &pool, proposal_id, space_id, proposer_id, &v1).await;
+
+    let vote = ProposalVoteItem {
+        proposal_id,
+        voter_id,
+        space_id,
+        vote: VoteOption::Yes,
+        created_at: 1_700_000_100,
+        created_at_block: 1,
+        proposal_version: 1,
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .insert_proposal_votes(std::slice::from_ref(&vote), &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .queue_tally_update(proposal_id, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    storage
+        .process_tally_queue(10)
+        .await
+        .expect("process_tally_queue failed");
+
+    let (executed_at,): (Option<i64>,) =
+        sqlx::query_as("SELECT executed_at FROM proposals WHERE id = $1")
+            .bind(proposal_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    assert_eq!(
+        executed_at, None,
+        "executed_at must stay NULL when the effective threshold isn't cleared"
+    );
+
+    cleanup_proposal(&pool, proposal_id, &[space_id, proposer_id, voter_id]).await;
+}
+
+// --------------------------------------------------------------------------
+// process_tally_queue must NOT backfill executed_at for Slow-path proposals
+// even when they clearly pass — fast-path auto-execution is a distinct
+// contract behavior; slow-path proposals require an explicit execute() call,
+// which (if it happens) is reflected via a real PROPOSAL_EXECUTED event
+// through update_proposal_executed, not tally-based inference.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn test_process_tally_queue_does_not_backfill_slow_path() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+    let space_id = Uuid::new_v4();
+    let proposal_id = Uuid::new_v4();
+    let proposer_id = Uuid::new_v4();
+    let voter_id = Uuid::new_v4();
+
+    ensure_space(&pool, space_id).await;
+    ensure_space(&pool, proposer_id).await;
+    ensure_space(&pool, voter_id).await;
+
+    let v1 = version_slow(Some("Slow proposal"));
+    seed_proposal_v1(&storage, &pool, proposal_id, space_id, proposer_id, &v1).await;
+
+    let vote = ProposalVoteItem {
+        proposal_id,
+        voter_id,
+        space_id,
+        vote: VoteOption::Yes,
+        created_at: 1_700_000_100,
+        created_at_block: 1,
+        proposal_version: 1,
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .insert_proposal_votes(std::slice::from_ref(&vote), &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .queue_tally_update(proposal_id, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    storage
+        .process_tally_queue(10)
+        .await
+        .expect("process_tally_queue failed");
+
+    let (executed_at,): (Option<i64>,) =
+        sqlx::query_as("SELECT executed_at FROM proposals WHERE id = $1")
+            .bind(proposal_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    assert_eq!(
+        executed_at, None,
+        "slow-path proposals must never be auto-executed by tally inference"
+    );
+
+    cleanup_proposal(&pool, proposal_id, &[space_id, proposer_id, voter_id]).await;
+}
+
 // Silence unused-import warnings for types not exercised in every test.
 #[allow(dead_code)]
 fn _unused(_a: ProposalActionItem, _p: ProposalActionPayload) {}


### PR DESCRIPTION
## Summary

Fixes the bug Preston/Bryan reported: proposals ACCEPTED on prod showing REJECTED on v2 (e.g. `be7748130da24c9d841e77ef9c780a18`). Confirmed **12,517 of ~21,633 migrated proposals (58%)** are currently affected — 99.7% fast-path.

Two independent, complementary fixes, both requested (fix the status display, and get `executed_at` migrated through):

**1. `api/src/proposals/status.ts` + `queries.ts`** — `computeProposalStatus` checked "past `executeBy` deadline" *before* computing the real vote outcome, forcing REJECTED regardless of votes once the deadline passed. For migrated proposals, `executeBy` is synthesized as `lastDate + 7 days` from long-past timestamps, so it's always already expired by the time anyone looks. Reordered so the real vote-based outcome is computed first, and `executeBy` only downgrades a still-undecided (PROPOSED) proposal — never overrides one that already resolved to EXECUTABLE. Applied the equivalent fix to `queries.ts`'s SQL fragments to keep the required parity (factored out a shared `sqlVoteOutcomeUndecided` predicate so `sqlIsProposed`/`sqlIsRejected` can't drift apart).

**2. `kg-indexer/src/storage.rs`** — restores the fast-path `executed_at` inference in `process_tally_queue` that existed pre-governance-v2 (removed in `be8da89`, "remove obsolete Fast-path executed_at inference") and was never carried into the versioned schema. `main`/prod still has an equivalent unversioned form and runs it correctly today (confirmed: that's exactly where the correct `executedAt` in prod's API response comes from — not a real on-chain event, since none exists for fast-path auto-execution). This closes the actual root cause so newly-created fast-path proposals don't hit this same bug once their own window lapses, not just the already-migrated batch.

## Why both, not just one
Fix 1 alone makes the display correct without touching data (covers fast + slow path). Fix 2 makes `executed_at` actually accurate going forward (fast-path only — slow-path execution requires an explicit on-chain call, reflected by a real `PROPOSAL_EXECUTED` event through the existing `update_proposal_executed` path, not tally inference). Both were requested; shipping together closes the loop rather than leaving `executed_at` permanently NULL for passed fast-path proposals.

## Test plan
- [x] `bun test` in `api/` — all existing + 6 new tests pass (2 existing tests updated from asserting the old buggy behavior; 4 new covering the fix)
- [x] `bun run check` (tsc) and `bun run lint` — clean, no new warnings
- [x] Confirmed the 33 pre-existing unrelated test failures in `api/` (GraphQL instrumentation, search, OpenSearch — all DB/service-dependent) are identical on unmodified `staging`, not caused by this change
- [x] `cargo check`/`cargo test` — clean
- [x] **Ran the full `kg-indexer` integration suite against a real Postgres instance** (migrations applied via `api/scripts/setup-test-db.ts`), not just compiled: all existing integration tests pass (one pre-existing, unrelated failure in voting-settings upsert confirmed present on unmodified `staging` too via the same real-DB run), plus 3 new tests: backfill succeeds when the effective threshold is cleared, does *not* backfill when it isn't, and slow-path proposals are never touched
- [ ] **Follow-up after merge/deploy, not included in this PR**: a one-time re-queue of the ~12,480 currently-affected fast-path proposals into `proposal_tally_queue` so the fixed worker backfills their `executed_at`. Existing rows already processed once (before this fix existed) won't get reprocessed automatically — will provide the exact SQL separately once this is live.