### PR TITLE
feat(proposal-executor): add chain 55516 (testnet v2) support

### DIFF
--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -149,11 +149,21 @@ export const testnetChain: Chain = {
 	},
 }
 
-export type SupportedChainId = 80451 | 19411
+export const testnetV2Chain: Chain = {
+	id: 55516,
+	name: "Geo Testnet",
+	nativeCurrency: {name: "Ethereum", symbol: "ETH", decimals: 18},
+	rpcUrls: {
+		default: {http: ["https://rpc-geo-testnet-irdc0cgb0w.t.conduit.xyz"]},
+	},
+}
+
+export type SupportedChainId = 80451 | 19411 | 55516
 
 export function getChain(chainId: SupportedChainId): Chain {
 	if (chainId === 80451) return mainnetChain
 	if (chainId === 19411) return testnetChain
+	if (chainId === 55516) return testnetV2Chain
 	// Exhaustiveness check — TypeScript will error here if a new chain ID is added
 	// to SupportedChainId without a corresponding branch above.
 	const _exhaustive: never = chainId

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -154,10 +154,10 @@ export const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(fu
 	}
 
 	// --- Validate chain ID ---
-	if (chainId !== 80451 && chainId !== 19411) {
+	if (chainId !== 80451 && chainId !== 19411 && chainId !== 55516) {
 		return yield* Effect.fail(
 			new InfraError({
-				message: `Invalid CHAIN_ID: ${chainId}. Expected 80451 (mainnet) or 19411 (testnet).`,
+				message: `Invalid CHAIN_ID: ${chainId}. Expected 80451 (mainnet), 19411 (testnet), or 55516 (testnet v2).`,
 				durationMs: 0,
 			}),
 		)

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -162,10 +162,11 @@ describe("config validation contracts", () => {
 		expect(validKey.startsWith("0x")).toBe(true)
 	})
 
-	test("chain ID must be 80451 (mainnet) or 19411 (testnet)", () => {
-		const validChainIds = [80451, 19411]
+	test("chain ID must be 80451 (mainnet), 19411 (testnet), or 55516 (testnet v2)", () => {
+		const validChainIds = [80451, 19411, 55516]
 		expect(validChainIds).toContain(80451)
 		expect(validChainIds).toContain(19411)
+		expect(validChainIds).toContain(55516)
 		expect(validChainIds).not.toContain(1) // Ethereum mainnet
 		expect(validChainIds).not.toContain(0)
 	})


### PR DESCRIPTION
## Summary
- `proposal-executor` currently hard-rejects any `CHAIN_ID` other than `80451`/`19411` (`SupportedChainId` type + `parseConfig`'s validation gate in `index.ts`), so it can't run against the new testnet (chain 55516) at all today.
- This adds `55516` as a supported chain ID, address-agnostic — `SPACE_REGISTRY_ADDRESS` and `RPC_URL` are already fully env-driven (`Config.string`/`Config.redacted` in `parseConfig`), so this doesn't wire up or commit to any particular SpaceRegistry deployment. It only makes `CHAIN_ID=55516` a valid config value.
- Deliberately not included: updating the actual CronJob deployment env (still `CHAIN_ID=19411` on the new cluster) — holding off on picking a SpaceRegistry address for testnet v2 until that's settled.

## Changes
- `contracts.ts`: add `testnetV2Chain` (id 55516), widen `SupportedChainId`, add the `getChain()` branch (exhaustiveness check still enforced).
- `index.ts`: widen the `CHAIN_ID` validation gate to accept 55516.
- `tests/index.test.ts`: update the chain-ID test to reflect the third supported value.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (131 pass)
- [x] `bun run lint` (clean — one pre-existing, unrelated biome schema-version notice)