### PR TITLE
feat(proposal-executor): point v2 CronJob at chain 55516's SpaceRegistry

### DIFF
--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -72,14 +72,14 @@ spec:
                 - name: MEMBERSHIP_BOT_SPACE_ID
                   value: "0x4612d0863fe0b321052cb8d404a7afac"
                 - name: SPACE_REGISTRY_ADDRESS
-                  value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
+                  value: "0x364231615dcEA33D13C823b13B449DD9F55381E7"
                 - name: RPC_URL
                   valueFrom:
                     secretKeyRef:
                       name: proposal-executor-credentials
                       key: RPC_URL
                 - name: CHAIN_ID
-                  value: "19411"
+                  value: "55516"
                 # Optional: Sentry error reporting
                 - name: SENTRY_DSN
                   valueFrom:


### PR DESCRIPTION
## Summary
- The gaia-namespace v2 CronJob manifest (`proposal-executor/deployment/v2/cronjob.yaml`) still hardcoded `CHAIN_ID=19411` and the old chain's `SPACE_REGISTRY_ADDRESS`, even though the process itself now accepts `CHAIN_ID=55516` as of #831. Without this, the deployed CronJob still couldn't have executed anything on the new testnet.
- Updates `SPACE_REGISTRY_ADDRESS` to `0x364231615dcEA33D13C823b13B449DD9F55381E7` and `CHAIN_ID` to `55516`.

## Not included / open follow-up
- `RPC_URL` is unaffected here — it comes from the `proposal-executor-credentials` k8s Secret, being updated separately (currently a dead Pinax endpoint; needs to point at `https://rpc-geo-testnet-irdc0cgb0w.t.conduit.xyz`).
- `EXECUTOR_SPACE_ID`/`MEMBERSHIP_BOT_SPACE_ID` are left unchanged. `verifyExecutorSetup()` in `execute.ts` checks the executor's Safe against `addressToSpaceId` on the configured SpaceRegistry at startup and fails loudly (not silently) if there's no matching personal space registered on the new chain — this needs confirming/provisioning before the CronJob is unsuspended.

## Test plan
- [x] Manifest-only change, no code touched
- [ ] Verify executor Safe has a registered personal space on chain 55516 before unsuspending