### PR TITLE
feat(proposal-executor): use EIP-7702 Kernel account on chain 55516

### DIFF
--- a/proposal-executor/bun.lock
+++ b/proposal-executor/bun.lock
@@ -17,6 +17,7 @@
         "@opentelemetry/semantic-conventions": "^1.34.0",
         "@sentry/node": "^10.36.0",
         "@sentry/opentelemetry": "^10.36.0",
+        "@zerodev/sdk": "^5.5.10",
         "effect": "^3.19.14",
         "permissionless": "^0.3.2",
         "pg": "^8.13.3",
@@ -179,6 +180,8 @@
 
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 
+    "@zerodev/sdk": ["@zerodev/sdk@5.5.10", "", { "dependencies": { "semver": "^7.6.0" }, "peerDependencies": { "viem": "^2.28.0" } }, "sha512-WVyj2XR9F6zK2GdXrvappx7yo6zoJ46cWe42dOIArp3xDjFBninjA4O1O94MwohB0G+yFqtXNsEU+WxdE67SgQ=="],
+
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -256,6 +259,8 @@
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 

--- a/proposal-executor/package.json
+++ b/proposal-executor/package.json
@@ -24,6 +24,7 @@
 		"@opentelemetry/semantic-conventions": "^1.34.0",
 		"@sentry/node": "^10.36.0",
 		"@sentry/opentelemetry": "^10.36.0",
+		"@zerodev/sdk": "^5.5.10",
 		"effect": "^3.19.14",
 		"permissionless": "^0.3.2",
 		"pg": "^8.13.3",

--- a/proposal-executor/src/execute.ts
+++ b/proposal-executor/src/execute.ts
@@ -7,6 +7,13 @@
  * See: docs/plans/2026-03-02-feat-proposal-auto-executor-plan.md §On-Chain Execution
  */
 
+import {
+	createKernelAccount,
+	createKernelAccountClient,
+	createZeroDevPaymasterClient,
+	getUserOperationGasPrice,
+} from "@zerodev/sdk"
+import {getEntryPoint, KERNEL_V3_3} from "@zerodev/sdk/constants"
 import {Effect} from "effect"
 import {createSmartAccountClient, type SmartAccountClient} from "permissionless"
 import {toSafeSmartAccount} from "permissionless/accounts"
@@ -43,7 +50,7 @@ export interface SmartWallet {
 	readonly smartAccountClient: SmartAccountClient
 	readonly publicClient: PublicClient
 	readonly chain: Chain
-	readonly safeAddress: Address
+	readonly accountAddress: Address
 }
 
 export interface ExecutorConfig {
@@ -53,6 +60,17 @@ export interface ExecutorConfig {
 	spaceRegistryAddress: Address
 	rpcUrl: string
 	chainId: SupportedChainId
+	/**
+	 * ZeroDev bundler+paymaster endpoint (embeds a project ID) — required only
+	 * when chainId is 55516. That chain (a Conduit rollup) has ZeroDev's Kernel
+	 * v0.3.3 + EntryPoint v0.7 contracts deployed by default but no Safe infra
+	 * at all, so it uses an EIP-7702 Kernel account via ZeroDev's own bundler
+	 * instead of the Safe+Pimlico path used on 19411/80451 — the same pattern
+	 * geogenesis's frontend (mainnet-migration-v020, @geoprotocol/geo-sdk)
+	 * already uses for this chain. Unlike a Safe/classic-Kernel proxy, the
+	 * resulting account address IS the raw EOA derived from `privateKey`.
+	 */
+	zerodevSponsorshipRpcUrl?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -101,14 +119,17 @@ export function encodeProposalExecutedData(proposalIdHex: Hex): Hex {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a gas-sponsored Safe smart account with Pimlico paymaster.
- * Called once per CronJob run.
+ * Create a gas-sponsored smart account. Called once per CronJob run.
+ *
+ * Chain 55516 (testnet v2) has no Safe infra deployed, so it uses an
+ * EIP-7702 Kernel account via ZeroDev's bundler instead of the Safe+Pimlico
+ * path used everywhere else. See the `zerodevSponsorshipRpcUrl` doc comment
+ * on `ExecutorConfig` for why.
  */
 export function createSmartWallet(config: ExecutorConfig): Effect.Effect<SmartWallet, InfraError> {
 	return Effect.tryPromise({
 		try: async () => {
 			const chain = getChain(config.chainId)
-			const bundlerUrl = `https://api.pimlico.io/v2/${config.chainId}/rpc?apikey=${config.pimlicoApiKey}`
 
 			const publicClient = createPublicClient({
 				chain,
@@ -116,6 +137,53 @@ export function createSmartWallet(config: ExecutorConfig): Effect.Effect<SmartWa
 			})
 
 			const owner = privateKeyToAccount(config.privateKey)
+
+			if (config.chainId === 55516) {
+				if (!config.zerodevSponsorshipRpcUrl) {
+					throw new Error("zerodevSponsorshipRpcUrl is required when chainId is 55516")
+				}
+
+				const entryPoint = getEntryPoint("0.7")
+				const kernelAccount = await createKernelAccount(publicClient, {
+					eip7702Account: owner,
+					entryPoint,
+					kernelVersion: KERNEL_V3_3,
+				})
+
+				const bundlerTransport = http(config.zerodevSponsorshipRpcUrl)
+				const paymasterClient = createZeroDevPaymasterClient({
+					chain,
+					transport: bundlerTransport,
+				})
+
+				const smartAccountClient = createKernelAccountClient({
+					account: kernelAccount,
+					chain,
+					client: publicClient,
+					bundlerTransport,
+					paymaster: {
+						getPaymasterStubData: (userOperation) =>
+							paymasterClient.sponsorUserOperation({userOperation, shouldConsume: false}),
+						getPaymasterData: (userOperation) => paymasterClient.sponsorUserOperation({userOperation}),
+					},
+					userOperation: {
+						estimateFeesPerGas: async ({bundlerClient}) => getUserOperationGasPrice(bundlerClient),
+					},
+				})
+
+				return {
+					// KernelAccountClient and permissionless's SmartAccountClient both
+					// expose the `.account`/`.sendTransaction(...)` shape executeProposal
+					// and castMembershipVote actually use — that's the only shape SmartWallet
+					// depends on across the codebase (verified: no other member is accessed).
+					smartAccountClient: smartAccountClient as unknown as SmartAccountClient,
+					publicClient,
+					chain,
+					accountAddress: kernelAccount.address,
+				} satisfies SmartWallet
+			}
+
+			const bundlerUrl = `https://api.pimlico.io/v2/${config.chainId}/rpc?apikey=${config.pimlicoApiKey}`
 
 			const safeAccount = await toSafeSmartAccount({
 				client: publicClient,
@@ -154,7 +222,7 @@ export function createSmartWallet(config: ExecutorConfig): Effect.Effect<SmartWa
 				smartAccountClient,
 				publicClient,
 				chain,
-				safeAddress: safeAccount.address,
+				accountAddress: safeAccount.address,
 			} satisfies SmartWallet
 		},
 		catch: (error) => new InfraError({message: `Smart wallet creation failed: ${error}`, durationMs: 0}),
@@ -167,8 +235,8 @@ export function createSmartWallet(config: ExecutorConfig): Effect.Effect<SmartWa
 
 /**
  * Verify the executor's personal space is registered on-chain.
- * Calls addressToSpaceId(safeAddress) — if it returns zero bytes, the personal
- * space hasn't been created yet and all executions will revert.
+ * Calls addressToSpaceId(accountAddress) — if it returns zero bytes, the
+ * personal space hasn't been created yet and all executions will revert.
  */
 export function verifyExecutorSetup(
 	wallet: SmartWallet,
@@ -181,13 +249,13 @@ export function verifyExecutorSetup(
 				address: spaceRegistryAddress,
 				abi: SpaceRegistryAbi,
 				functionName: "addressToSpaceId",
-				args: [wallet.safeAddress],
+				args: [wallet.accountAddress],
 			})
 
 			const ZERO_BYTES16 = "0x00000000000000000000000000000000"
 			if (spaceId === ZERO_BYTES16) {
 				throw new Error(
-					`Executor Safe ${wallet.safeAddress} has no registered personal space. ` +
+					`Executor account ${wallet.accountAddress} has no registered personal space. ` +
 						"Register one with 'geo space create' before running the executor.",
 				)
 			}
@@ -195,7 +263,7 @@ export function verifyExecutorSetup(
 			// Verify it matches the configured EXECUTOR_SPACE_ID
 			if (spaceId.toLowerCase() !== executorSpaceId.toLowerCase()) {
 				throw new Error(
-					`On-chain space ID ${spaceId} for Safe ${wallet.safeAddress} ` +
+					`On-chain space ID ${spaceId} for account ${wallet.accountAddress} ` +
 						`does not match configured EXECUTOR_SPACE_ID ${executorSpaceId}`,
 				)
 			}

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -64,6 +64,11 @@ export interface ExecutorEnv {
 	/** Redacted — may contain API keys in the path */
 	rpcUrl: Redacted.Redacted
 	chainId: SupportedChainId
+	/**
+	 * Redacted — embeds a ZeroDev project ID. Required only when chainId is
+	 * 55516 (see ExecutorConfig.zerodevSponsorshipRpcUrl in execute.ts for why).
+	 */
+	zerodevSponsorshipRpcUrl: Redacted.Redacted
 
 	// --- Membership-accept path (dedicated bot identity, distinct from the executor) ---
 	/**
@@ -92,6 +97,10 @@ export const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(fu
 	const rawPrivateKey = yield* Config.redacted("EXECUTOR_PRIVATE_KEY")
 	const pimlicoApiKey = yield* Config.redacted("PIMLICO_API_KEY")
 	const rawMembershipBotPrivateKey = yield* Config.redacted("MEMBERSHIP_BOT_PRIVATE_KEY")
+	// Only required for chainId 55516 — validated below once chainId is known.
+	const zerodevSponsorshipRpcUrl = yield* Config.redacted("ZERODEV_SPONSORSHIP_RPC_URL").pipe(
+		Config.withDefault(Redacted.make("")),
+	)
 
 	const rpcUrl = yield* Config.redacted("RPC_URL")
 
@@ -161,6 +170,24 @@ export const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(fu
 				durationMs: 0,
 			}),
 		)
+	}
+
+	// --- Validate ZeroDev sponsorship URL (only required on chain 55516, which has
+	// no Safe infra and uses ZeroDev's EIP-7702 Kernel bundler instead of Pimlico) ---
+	const zerodevSponsorshipRpcUrlValue = Redacted.value(zerodevSponsorshipRpcUrl)
+	if (chainId === 55516) {
+		if (
+			!zerodevSponsorshipRpcUrlValue.startsWith("http://") &&
+			!zerodevSponsorshipRpcUrlValue.startsWith("https://")
+		) {
+			return yield* Effect.fail(
+				new InfraError({
+					message:
+						"Invalid ZERODEV_SPONSORSHIP_RPC_URL: expected http:// or https:// URL (required when CHAIN_ID=55516)",
+					durationMs: 0,
+				}),
+			)
+		}
 	}
 
 	// --- Validate membership-bot private key (auto-prefix 0x like the executor key;
@@ -239,6 +266,7 @@ export const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(fu
 		spaceRegistryAddress,
 		rpcUrl,
 		chainId: chainId as SupportedChainId,
+		zerodevSponsorshipRpcUrl,
 		membershipBotPrivateKey: Redacted.make(membershipBotPrivateKey as `0x${string}`),
 		membershipBotSpaceId: rawMembershipBotSpaceId as Hex,
 		membershipAutoacceptSpaceIds,
@@ -595,10 +623,11 @@ const main = Effect.gen(function* () {
 		spaceRegistryAddress: config.spaceRegistryAddress,
 		rpcUrl: Redacted.value(config.rpcUrl),
 		chainId: config.chainId,
+		zerodevSponsorshipRpcUrl: Redacted.value(config.zerodevSponsorshipRpcUrl) || undefined,
 	})
 
 	yield* Effect.logInfo("wallet_ready").pipe(
-		Effect.annotateLogs({identity: "executor", safeAddress: wallet.safeAddress}),
+		Effect.annotateLogs({identity: "executor", accountAddress: wallet.accountAddress}),
 	)
 
 	yield* verifyExecutorSetup(wallet, config.executorSpaceId, config.spaceRegistryAddress)
@@ -713,10 +742,11 @@ const main = Effect.gen(function* () {
 			spaceRegistryAddress: config.spaceRegistryAddress,
 			rpcUrl: Redacted.value(config.rpcUrl),
 			chainId: config.chainId,
+			zerodevSponsorshipRpcUrl: Redacted.value(config.zerodevSponsorshipRpcUrl) || undefined,
 		})
 
 		yield* Effect.logInfo("wallet_ready").pipe(
-			Effect.annotateLogs({identity: "membership-bot", safeAddress: botWallet.safeAddress}),
+			Effect.annotateLogs({identity: "membership-bot", accountAddress: botWallet.accountAddress}),
 		)
 
 		yield* verifyExecutorSetup(botWallet, config.membershipBotSpaceId, config.spaceRegistryAddress)

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -337,6 +337,29 @@ describe("parseConfig: membership-bot config & allowlist", () => {
 		)
 		expect(env.membershipAutoacceptSpaceIds).toEqual([ALLOW_A, ALLOW_B])
 	})
+
+	test("CHAIN_ID=55516 requires ZERODEV_SPONSORSHIP_RPC_URL", async () => {
+		const err = expectInfraError(await runParse({CHAIN_ID: "55516"}))
+		expect(err.message).toContain("ZERODEV_SPONSORSHIP_RPC_URL")
+	})
+
+	test("CHAIN_ID=55516 with a valid ZERODEV_SPONSORSHIP_RPC_URL parses successfully", async () => {
+		const env = expectSuccess(
+			await runParse({
+				CHAIN_ID: "55516",
+				ZERODEV_SPONSORSHIP_RPC_URL: "https://rpc.zerodev.app/api/v3/test-project/chain/55516",
+			}),
+		)
+		expect(env.chainId).toBe(55516)
+		expect(Redacted.value(env.zerodevSponsorshipRpcUrl)).toBe(
+			"https://rpc.zerodev.app/api/v3/test-project/chain/55516",
+		)
+	})
+
+	test("CHAIN_ID=80451 does not require ZERODEV_SPONSORSHIP_RPC_URL", async () => {
+		const env = expectSuccess(await runParse({}, ["ZERODEV_SPONSORSHIP_RPC_URL"]))
+		expect(env.chainId).toBe(80451)
+	})
 })
 
 // ---------------------------------------------------------------------------
@@ -385,7 +408,7 @@ function makeFakeWallet(opts: FakeWalletOpts = {}): FakeWallet {
 	const calls = {readContract: [] as string[], sendTransaction: 0}
 	const wallet = {
 		chain: {id: 80451},
-		safeAddress: "0x0000000000000000000000000000000000000001",
+		accountAddress: "0x0000000000000000000000000000000000000001",
 		publicClient: {
 			// biome-ignore lint/suspicious/noExplicitAny: minimal stub
 			readContract: async ({functionName}: any) => {

--- a/proposal-executor/tests/membership.test.ts
+++ b/proposal-executor/tests/membership.test.ts
@@ -68,7 +68,7 @@ function fakeWallet(overrides: {
 			getBlock: overrides.getBlock ?? (async () => ({timestamp: NOW})),
 		},
 		chain: {id: 19411},
-		safeAddress: "0xsafe",
+		accountAddress: "0xsafe",
 	} as unknown as SmartWallet
 }
 


### PR DESCRIPTION
## Summary
- Chain 55516 (a Conduit rollup) has ZeroDev's Kernel v0.3.3 + EntryPoint v0.7 contracts deployed by default, but **no Safe infra at all** — confirmed via a manual CronJob run: smart wallet creation failed with `proxyCreationCode() returned no data` because the canonical SafeProxyFactory has no code on this chain.
- geogenesis's frontend (`mainnet-migration-v020`, `@geoprotocol/geo-sdk`) already solved this for the same chain: an **EIP-7702 Kernel account** via ZeroDev's own bundler/paymaster, not a Safe or classic CREATE2 Kernel proxy. This PR mirrors that exact approach.
- `createSmartWallet` now branches on `chainId`: 55516 uses `@zerodev/sdk`'s `createKernelAccount`/`createKernelAccountClient` (EIP-7702), everything else keeps the existing Safe+Pimlico path unchanged.
- Renamed `SmartWallet.safeAddress` → `accountAddress` since it's no longer always a Safe — and unlike a Safe or classic Kernel proxy, the EIP-7702 account's address on 55516 **is** the raw EOA (`privateKeyToAccount(EXECUTOR_PRIVATE_KEY).address`), not a separately-derived proxy address.
- New env var `ZERODEV_SPONSORSHIP_RPC_URL` (redacted — embeds a ZeroDev project ID), required only when `CHAIN_ID=55516`.

## Not included / open follow-up
- Confirmed via a manual on-chain read that the executor's raw EOA has **no personal space registered on chain 55516 yet** (`addressToSpaceId` returns zero). Same is true for the membership-bot identity. Neither the executor nor the membership-bot path can actually execute anything on 55516 until those personal spaces are registered — that's a `geo space create`-equivalent operational step, not a code change, and `verifyExecutorSetup` will fail loudly (not silently) until it's done.
- `ZERODEV_SPONSORSHIP_RPC_URL` needs to be added to the `proposal-executor-credentials` k8s secret in the `gaia` namespace before the next deploy to 55516 actually works end-to-end.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (134 pass, up from 131 — added 3 new tests covering the CHAIN_ID=55516 / ZERODEV_SPONSORSHIP_RPC_URL validation)
- [x] `bun run lint` (clean)
- [x] Manually ran the CronJob once (schedule left suspended) against the pre-fix code to confirm the exact Safe failure mode before writing this fix
- [x] Verified all referenced ZeroDev Kernel v0.3.3/EntryPoint v0.7 contract addresses are live on chain 55516 via direct `eth_getCode` calls