### PR TITLE
feat(proposal-executor): wire ZERODEV_SPONSORSHIP_RPC_URL into v2 CronJob

### DIFF
--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -80,6 +80,14 @@ spec:
                       key: RPC_URL
                 - name: CHAIN_ID
                   value: "55516"
+                # Required because CHAIN_ID=55516 has no Safe infra deployed — the
+                # executor uses an EIP-7702 Kernel account via ZeroDev's bundler
+                # instead of Safe+Pimlico on this chain (see execute.ts).
+                - name: ZERODEV_SPONSORSHIP_RPC_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: ZERODEV_SPONSORSHIP_RPC_URL
                 # Optional: Sentry error reporting
                 - name: SENTRY_DSN
                   valueFrom:


### PR DESCRIPTION
## Summary
- #833 added a `ZERODEV_SPONSORSHIP_RPC_URL` config requirement for `CHAIN_ID=55516`, but the gaia-namespace v2 manifest never got the env entry — the app reads env vars directly, so adding the key to the `proposal-executor-credentials` secret alone doesn't do anything without a container env entry referencing it.
- Adds the `ZERODEV_SPONSORSHIP_RPC_URL` env entry, sourced from the (already-updated) `proposal-executor-credentials` secret.

## Test plan
- [x] Manifest-only change
- [x] Confirmed the `ZERODEV_SPONSORSHIP_RPC_URL` key already exists in the `proposal-executor-credentials` secret in the `gaia` namespace