### PR TITLE
feat(proposal-executor): update v2 EXECUTOR/MEMBERSHIP_BOT_SPACE_ID for chain 55516

### DIFF
--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -67,10 +67,21 @@ spec:
                       name: proposal-executor-credentials
                       key: MEMBERSHIP_BOT_PRIVATE_KEY
                 # Config (non-sensitive — plain values)
+                #
+                # EXECUTOR_SPACE_ID/MEMBERSHIP_BOT_SPACE_ID below are specific to THIS
+                # chain (55516) — SpaceRegistry.generateSpaceId() derives the ID from
+                # keccak256("grc20.space", account, nonce, chainId), so it depends on
+                # the calling address and chain ID, not just a fixed constant. The old
+                # 19411 values (0xc669ec5cfd998cb14ca129a0f9838f78 /
+                # 0x4612d0863fe0b321052cb8d404a7afac) belonged to the old chain's
+                # Safe-derived executor address and can't be reused here — the executor
+                # now uses an EIP-7702 account whose address IS the raw EOA, which is a
+                # different address than the old Safe proxy. Registered via
+                # registerSpaceId() against each bot's own address on 55516.
                 - name: EXECUTOR_SPACE_ID
-                  value: "0xc669ec5cfd998cb14ca129a0f9838f78"
+                  value: "0xc6fdd7ccff1b4f5ba5f81dae4e1eb99b"
                 - name: MEMBERSHIP_BOT_SPACE_ID
-                  value: "0x4612d0863fe0b321052cb8d404a7afac"
+                  value: "0xf61e6ac5a54f47898ee23ae48a0729ba"
                 - name: SPACE_REGISTRY_ADDRESS
                   value: "0x364231615dcEA33D13C823b13B449DD9F55381E7"
                 - name: RPC_URL


### PR DESCRIPTION
## Summary
- `EXECUTOR_SPACE_ID`/`MEMBERSHIP_BOT_SPACE_ID` in the v2 manifest were still the old chain's values, registered against the old Safe-derived proxy addresses. `SpaceRegistry.generateSpaceId()` derives the ID from `keccak256("grc20.space", account, nonce, chainId)`, so switching to an EIP-7702 account (raw EOA address, not a Safe proxy) on chain 55516 means neither old ID could ever resolve there.
- Registered fresh personal spaces directly against 55516's SpaceRegistry for both bot identities (`registerSpaceId` is permissionless and reverts harmlessly if already registered):
  - executor `0x0CC9785e958B54D6Ce65f33F2dcC77a33001df13` → `0xc6fdd7ccff1b4f5ba5f81dae4e1eb99b` (tx `0x5d09cd172676ca3a8d042adb728745f3ff3f0524244704407e008daf39edda36`)
  - membership-bot `0x14b3F486aD9a2f5E2a15B54bCa43684C17210e3A` → `0xf61e6ac5a54f47898ee23ae48a0729ba` (tx `0xd7e2c5979b0a49d1f1ee91781e24bd1b3605372f7e896d1d01056ae1943f007c`)
- Updates the manifest to the new IDs.

## Also fixed (secret only, not tracked in git)
- `ZERODEV_SPONSORSHIP_RPC_URL` was `...?selfFunded=true`, whose underlying bundler 500s on `eth_estimateUserOperationGas` for a fresh (nonce=0) EIP-7702 authorization (`"Cannot convert 0x to a BigInt"`) — reproduced consistently regardless of paymaster stub-data wiring. Switched to `...?provider=ULTRA_RELAY`, which handles it correctly. Confirmed via the two registration transactions above, both of which succeeded only after this switch.

## Test plan
- [x] Manifest-only change
- [x] Both space registrations confirmed on-chain (tx hashes above)