### PR TITLE
fix(api): route api-testnet alias to v2 backend

### DIFF
--- a/api/k8s/v2/api.yaml
+++ b/api/k8s/v2/api.yaml
@@ -205,9 +205,9 @@ spec:
 # HTTP routing via the shared Cilium Gateway (`geo-chat-api` in the geo-chat
 # namespace — one LB / IP for the whole cluster, per-service HTTPRoutes).
 # Companion Gateway-side change (geo-chat repo): listeners for
-# testnet-api-v2.geobrowser.io (HTTP + HTTPS with a cert-manager cert) and
-# allowedRoutes opened to the gaia namespace; DNS for the host points at the
-# shared Gateway LB.
+# testnet-api-v2.geobrowser.io and api-testnet.geobrowser.io (HTTP + HTTPS
+# with a cert-manager cert) and allowedRoutes opened to the gaia namespace;
+# DNS for both hosts points at the shared Gateway LB.
 # Note: the old nginx server-snippet gzip and proxy-body-size tuning have no
 # HTTPRoute equivalent — response compression falls to the api process.
 apiVersion: gateway.networking.k8s.io/v1
@@ -221,6 +221,7 @@ spec:
       namespace: geo-chat
   hostnames:
     - testnet-api-v2.geobrowser.io
+    - api-testnet.geobrowser.io
   rules:
     - matches:
         - path:


### PR DESCRIPTION
## Summary

`api-testnet.geobrowser.io` can now reach the same Gaia v2 API backend as `testnet-api-v2.geobrowser.io`. The additional hostname is attached to the existing cross-namespace `HTTPRoute`, so both domains use the same `api:3000` Service without changing the established hostname.

This route depends on the companion `geo-chat` Gateway and certificate change being deployed as well.

Related: geobrowser/geo-chat#16

## Validation

- `kubectl create --dry-run=client --validate=false -f api/k8s/v2/api.yaml -o name`
- `kubectl apply --dry-run=server -f api/k8s/v2/api.yaml`
- `git diff --check`
- Structured correctness, testing, API-contract, and reliability review: no actionable findings

Declarative manifest tests were not added; Kubernetes client parsing and live server-side dry-run provide the relevant pre-deploy validation. End-to-end TLS and routing verification must happen after both companion changes are deployed and cert-manager has reconciled the certificate.

## Post-Deploy Monitoring & Validation

- Owner/window: testnet API operator for 30 minutes after both companion deployments.
- Confirm `HTTPRoute/gaia/api` reports `Accepted=True` and `ResolvedRefs=True`, and that the shared Gateway reports the alias listeners as `Programmed=True`.
- Probe `https://api-testnet.geobrowser.io/` with normal DNS/SNI and confirm it returns the same healthy Gaia API response as `https://testnet-api-v2.geobrowser.io/`.
- Watch Envoy/Cilium request errors for host `api-testnet.geobrowser.io`, public 4xx/5xx rates, and DigitalOcean load-balancer health.
- Failure trigger: TLS errors, an Envoy 404, or sustained alias-only 5xx responses. Roll back this hostname entry and the companion Gateway listener/certificate changes; the established hostname remains unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
