### PR TITLE
fix(api): restrict testnet route to HTTPS listeners

### DIFF
--- a/api/k8s/v2/api.yaml
+++ b/api/k8s/v2/api.yaml
@@ -208,6 +208,8 @@ spec:
 # testnet-api-v2.geobrowser.io and api-testnet.geobrowser.io (HTTP + HTTPS
 # with a cert-manager cert) and allowedRoutes opened to the gaia namespace;
 # DNS for both hosts points at the shared Gateway LB.
+# This backend route attaches only to the HTTPS listeners. The geo-chat
+# Gateway manifest owns the HTTP-to-HTTPS redirect route for both hosts.
 # Note: the old nginx server-snippet gzip and proxy-body-size tuning have no
 # HTTPRoute equivalent — response compression falls to the api process.
 apiVersion: gateway.networking.k8s.io/v1
@@ -219,6 +221,10 @@ spec:
   parentRefs:
     - name: geo-chat-api
       namespace: geo-chat
+      sectionName: gaia-api-https
+    - name: geo-chat-api
+      namespace: geo-chat
+      sectionName: gaia-api-alias-https
   hostnames:
     - testnet-api-v2.geobrowser.io
     - api-testnet.geobrowser.io


### PR DESCRIPTION
## Summary

Gaia's testnet API backend now attaches only to the two HTTPS Gateway listeners, allowing the companion shared-Gateway route to redirect plaintext requests without competing with the application route. Both API hostnames continue to resolve to the same service over HTTPS.

Related: geobrowser/geo-chat#17

## Validation

- `api/k8s/v2/api.yaml` passed server-side dry-run against `do-nyc2-geo-testnet-k8s`.
- The coordinated Gaia and geo-chat diffs passed correctness, security, API-contract, and verification review with no actionable findings.
- Deployment continues to reuse the currently running immutable API tag; no application image change is required.

## Post-Deploy Monitoring & Validation

- Owner/window: deployer, immediately after rollout and again after 15 minutes.
- Confirm `gaia/api` reports `Accepted=True` and `ResolvedRefs=True` for both HTTPS listener parent references.
- After the companion Gateway PR is deployed, confirm both HTTP hostnames return `301` and both HTTPS health endpoints remain healthy.
- Watch for `404`, redirect loops, TLS errors, or rejected HTTPRoute parent references.
- Roll back if HTTPS routing regresses or the redirect cannot be established: redeploy the previous Gaia manifest with the current immutable image tag before reverting the companion Gateway change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
