### PR TITLE
docs(v2-gateway): note the Gateway API CRD upgrade behind the 308 redirect

### DIFF
--- a/api/k8s/v2/api.yaml
+++ b/api/k8s/v2/api.yaml
@@ -209,7 +209,11 @@ spec:
 # with a cert-manager cert) and allowedRoutes opened to the gaia namespace;
 # DNS for both hosts points at the shared Gateway LB.
 # This backend route attaches only to the HTTPS listeners. The geo-chat
-# Gateway manifest owns the HTTP-to-HTTPS redirect route for both hosts.
+# Gateway manifest owns the HTTP-to-HTTPS redirect route for both hosts,
+# using a 308 (method-preserving) redirect — this required upgrading
+# geo-testnet-k8s's Gateway API CRDs from v1.2.1 to v1.6.1, since 308
+# only graduated to Core support in the RequestRedirect filter as of
+# Gateway API v1.6.0.
 # Note: the old nginx server-snippet gzip and proxy-body-size tuning have no
 # HTTPRoute equivalent — response compression falls to the api process.
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
## Summary
Adds a note in the `HTTPRoute/api` comment block cross-referencing the geo-chat-owned redirect route now using a 308 (method-preserving) redirect instead of 301, and the Gateway API CRD upgrade (v1.2.1 → v1.6.1) on `geo-testnet-k8s` that unblocked it — 308 only graduated to Core support in `RequestRedirect` as of Gateway API v1.6.0.

See geo-chat#18 for the actual redirect change.