### PR TITLE
fix(proposal-executor): point v2 executor at the new SpaceRegistry proxy

### DIFF
--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -69,21 +69,24 @@ spec:
                 # Config (non-sensitive — plain values)
                 #
                 # EXECUTOR_SPACE_ID/MEMBERSHIP_BOT_SPACE_ID below are specific to THIS
-                # chain (55516) — SpaceRegistry.generateSpaceId() derives the ID from
-                # keccak256("grc20.space", account, nonce, chainId), so it depends on
-                # the calling address and chain ID, not just a fixed constant. The old
-                # 19411 values (0xc669ec5cfd998cb14ca129a0f9838f78 /
-                # 0x4612d0863fe0b321052cb8d404a7afac) belonged to the old chain's
-                # Safe-derived executor address and can't be reused here — the executor
-                # now uses an EIP-7702 account whose address IS the raw EOA, which is a
-                # different address than the old Safe proxy. Registered via
-                # registerSpaceId() against each bot's own address on 55516.
+                # chain (55516) AND this SpaceRegistry deployment — generateSpaceId()
+                # derives the ID from the calling address, an internal per-account
+                # nonce, and the chain ID, so a new SpaceRegistry proxy (its own,
+                # separate storage) starts each account's nonce independently. These
+                # values were re-registered via registerSpaceId() against the new
+                # proxy below (2026-07-24); nonces landed at 2 and 3 respectively
+                # because both accounts already had earlier registrations on this
+                # same new proxy from prior exploratory work. The old 19411 values
+                # (0xc669ec5cfd998cb14ca129a0f9838f78 / 0x4612d0863fe0b321052cb8d404a7afac)
+                # belonged to the old chain's Safe-derived executor address and can't be
+                # reused here — the executor uses an EIP-7702 account whose address IS
+                # the raw EOA, a different address than the old Safe proxy.
                 - name: EXECUTOR_SPACE_ID
-                  value: "0xc6fdd7ccff1b4f5ba5f81dae4e1eb99b"
+                  value: "0xa98356cee6be405cae013cd55ef934f7"
                 - name: MEMBERSHIP_BOT_SPACE_ID
-                  value: "0xf61e6ac5a54f47898ee23ae48a0729ba"
+                  value: "0x91c83a14d737420abae4ceb3f7b500c5"
                 - name: SPACE_REGISTRY_ADDRESS
-                  value: "0x364231615dcEA33D13C823b13B449DD9F55381E7"
+                  value: "0x4ee61966cCd1f6A99656def361e9E6e75bCE5eBa"
                 - name: RPC_URL
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Summary
`SPACE_REGISTRY_ADDRESS` was still pointed at the pre-PR#82 SpaceRegistry (`0x364231615...`), while the indexer side (hermes-pipeline/hermes-substream) was already decoding the new 4-tuple Action format from the contract deployed after [geo-contracts-foundry#82](https://github.com/geobrowser/geo-contracts-foundry/pull/82) (`0x4ee61966...`, deployed 2026-06-29). Confirmed via `eth_getStorageAt` (EIP-1967 slot) that both addresses are independent UUPS proxies, not a proxy/implementation pair — the new one is a genuine fresh deployment.

- Re-registered the executor's and membership bot's personal spaces against the new proxy via `registerSpaceId()` (same `_type`/`_version` values used in the original registration, decoded from the old proxy's registration tx calldata)
- Updated `EXECUTOR_SPACE_ID`/`MEMBERSHIP_BOT_SPACE_ID` to match the resulting on-chain space IDs (nonces landed at 2/3 since both accounts already had earlier registrations on this new proxy from prior exploratory work)
- Updated `SPACE_REGISTRY_ADDRESS` to the new proxy

## Verification
- `addressToSpaceId()` on the new proxy confirms both accounts resolve to the space IDs now configured
- `kubectl apply --dry-run=server` validated cleanly
- Applied live to `geo-testnet-k8s` and will confirm the next scheduled run picks it up cleanly

## Test plan
- [x] Registration transactions confirmed on-chain (executor: `0x2ac0267b...`, membership bot: `0x1978c600...`)
- [x] `addressToSpaceId` matches configured space IDs post-registration
- [ ] Next cronjob run (every 5 min) executes/skips proposals without reverting due to space resolution