### PR TITLE
Revert "fix(proposal-executor): point v2 executor at the new SpaceRegistry proxy" (#839)

### DIFF
--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -69,24 +69,21 @@ spec:
                 # Config (non-sensitive — plain values)
                 #
                 # EXECUTOR_SPACE_ID/MEMBERSHIP_BOT_SPACE_ID below are specific to THIS
-                # chain (55516) AND this SpaceRegistry deployment — generateSpaceId()
-                # derives the ID from the calling address, an internal per-account
-                # nonce, and the chain ID, so a new SpaceRegistry proxy (its own,
-                # separate storage) starts each account's nonce independently. These
-                # values were re-registered via registerSpaceId() against the new
-                # proxy below (2026-07-24); nonces landed at 2 and 3 respectively
-                # because both accounts already had earlier registrations on this
-                # same new proxy from prior exploratory work. The old 19411 values
-                # (0xc669ec5cfd998cb14ca129a0f9838f78 / 0x4612d0863fe0b321052cb8d404a7afac)
-                # belonged to the old chain's Safe-derived executor address and can't be
-                # reused here — the executor uses an EIP-7702 account whose address IS
-                # the raw EOA, a different address than the old Safe proxy.
+                # chain (55516) — SpaceRegistry.generateSpaceId() derives the ID from
+                # keccak256("grc20.space", account, nonce, chainId), so it depends on
+                # the calling address and chain ID, not just a fixed constant. The old
+                # 19411 values (0xc669ec5cfd998cb14ca129a0f9838f78 /
+                # 0x4612d0863fe0b321052cb8d404a7afac) belonged to the old chain's
+                # Safe-derived executor address and can't be reused here — the executor
+                # now uses an EIP-7702 account whose address IS the raw EOA, which is a
+                # different address than the old Safe proxy. Registered via
+                # registerSpaceId() against each bot's own address on 55516.
                 - name: EXECUTOR_SPACE_ID
-                  value: "0xa98356cee6be405cae013cd55ef934f7"
+                  value: "0xc6fdd7ccff1b4f5ba5f81dae4e1eb99b"
                 - name: MEMBERSHIP_BOT_SPACE_ID
-                  value: "0x91c83a14d737420abae4ceb3f7b500c5"
+                  value: "0xf61e6ac5a54f47898ee23ae48a0729ba"
                 - name: SPACE_REGISTRY_ADDRESS
-                  value: "0x4ee61966cCd1f6A99656def361e9E6e75bCE5eBa"
+                  value: "0x364231615dcEA33D13C823b13B449DD9F55381E7"
                 - name: RPC_URL
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Why
#839 pointed proposal-executor at the new SpaceRegistry proxy (`0x4ee61966...`), but only the executor's and membership bot's *personal* spaces were re-registered there. Every existing *DAO* governance space — the ones with real, active proposals — has no record in the new proxy at all.

Verified via `spaceIdToAddress`: a real, currently active DAO space (`12197ff1-db64-96c2-e817-149a7413f7c9`) resolves to `0x35b47fa1...` on the old proxy, but returns the zero address on the new one. Since `enter()` (used for proposal execution) is called against whichever registry is configured, pointing at the new proxy breaks execution for every existing DAO space, not just the executor's own identity resolution.

Already rolled back live on `geo-testnet-k8s` ahead of this PR, so this just brings git back in sync with the actual running config.

## Follow-up
Moving to the new proxy for real needs every existing DAO space re-registered there first — a separate, larger piece of work, tracked as a follow-up rather than done here.

## Test plan
- [x] Diff against the commit before #839 is empty — this is an exact revert
- [x] `kubectl apply --dry-run=server` validated cleanly
- [x] Live cluster already rolled back and confirmed matching