### PR TITLE
fix(api): soften GraphQL pool pressure shedding, add query_timeout fuse

### DIFF
--- a/api/k8s/production/api.yaml
+++ b/api/k8s/production/api.yaml
@@ -94,8 +94,10 @@ spec:
                   key: DATABASE_URL
             - name: PG_CONNECTION_TIMEOUT_MS
               value: "3000"
+            - name: PG_QUERY_TIMEOUT_MS
+              value: "12000"
             - name: PG_POOL_PRESSURE_WAITING_THRESHOLD
-              value: "1"
+              value: "5"
             - name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD
               value: "90"
             - name: PG_POOL_PRESSURE_TIMEOUT_THRESHOLD

--- a/api/k8s/staging/api.yaml
+++ b/api/k8s/staging/api.yaml
@@ -96,8 +96,10 @@ spec:
                   key: DATABASE_URL
             - name: PG_CONNECTION_TIMEOUT_MS
               value: "3000"
+            - name: PG_QUERY_TIMEOUT_MS
+              value: "12000"
             - name: PG_POOL_PRESSURE_WAITING_THRESHOLD
-              value: "1"
+              value: "5"
             - name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD
               value: "90"
             - name: PG_POOL_PRESSURE_TIMEOUT_THRESHOLD

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -58,6 +58,10 @@ const pgPool = new Pool({
 	connectionTimeoutMillis: parseInt(process.env.PG_CONNECTION_TIMEOUT_MS || "3000", 10),
 	// Close idle connections after 30 seconds to free up PgBouncer slots
 	idleTimeoutMillis: parseInt(process.env.PG_IDLE_TIMEOUT_MS || "30000", 10),
+	// Deterministic client-side fuse: destroys a stuck query's connection just above
+	// Postgres' statement_timeout (10s, api/docs/database-configuration.md), so a client
+	// that doesn't get freed server-side is still reclaimed on the Node side.
+	query_timeout: parseInt(process.env.PG_QUERY_TIMEOUT_MS || "12000", 10),
 	// Allow process to exit cleanly when pool is idle (for graceful shutdown)
 	allowExitOnIdle: true,
 })


### PR DESCRIPTION
## Summary
Yaniv reported the "Reconnecting" error screen on the root home page. Traced via Sentry to `GEOGENESIS-AM` (1 event, 2026-07-27T21:28:42Z) and `GEOGENESIS-8T` (144 events since 2026-06-29, culprit `POST /root`) — both `Service temporarily unavailable due to database pressure; please retry.` 503s from the GraphQL pool's load-shedding circuit breaker (`api/src/kg/postgraphile.ts`).

Root cause is documented in `api/docs/gql-pool-leak-investigation.md`: a real pg-pool connection leak was fixed in #656 (merged 2026-04-30), but two of that doc's other recommended fixes were never shipped:

- `PG_POOL_PRESSURE_WAITING_THRESHOLD=1` (both prod and staging) trips a shed episode as soon as a single request briefly waits for a pool slot — the doc explicitly said to raise this once the leak was fixed, since brief queuing under normal bursty traffic is expected, not a saturation signal.
- No `query_timeout` on the pg `Pool` — no deterministic client-side fuse if a query doesn't get freed server-side.

## Changes
- `api/src/kg/postgraphile.ts`: add `query_timeout` (default 12s, `PG_QUERY_TIMEOUT_MS`) to the `Pool` config, just above Postgres' 10s `statement_timeout`.
- `api/k8s/production/api.yaml`: `PG_POOL_PRESSURE_WAITING_THRESHOLD` `1 → 5` (matches the code's own default); add `PG_QUERY_TIMEOUT_MS=12000`.
- `api/k8s/staging/api.yaml`: same two changes — staging had the identical `1` override and is equally exposed.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `kubectl apply --dry-run=server` validates cleanly against both production and staging manifests
- [ ] After deploy, confirm `graphql.pool.checked_out_connections` / 503 rate on `/root` drops and no new `GEOGENESIS-8T` events