### PR TITLE
fix(gaia-v2): set SUBSTREAMS_START_BLOCK to the registry deploy block, not 0

### DIFF
--- a/hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml
@@ -84,9 +84,15 @@ spec:
                   key: SUBSTREAMS_API_TOKEN
             # 0 = stream from genesis — safe on the fresh chain (non-numeric values are
             # silently ignored and fall back to the OLD testnet block 82655).
-            # Tighten to the V2 SpaceRegistry deploy block at deploy time (runbook Step 9).
+            # Deploy block of the self-owned SpaceRegistry (0xcf13491802747e759e1bb8e364bc43045398d1dd)
+            # on chain 55516. MUST NOT be 0: the Substreams server enforces
+            # limit-processed-blocks=10000 per request, so a start block of 0 against a chain
+            # past ~10k blocks never begins streaming. It fails silently — the pod stays Running
+            # and repeats one unchanging "Progress (Jobs: 0, Bytes: [...]) map_actions: 1000
+            # blocks" line, produces nothing to Kafka, and logs no error. Re-tighten this
+            # whenever the registry is redeployed.
             - name: SUBSTREAMS_START_BLOCK
-              value: "0"
+              value: "14339"
             - name: IPFS_GATEWAY_URL
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/v2/atlas.yaml
+++ b/hermes/k8s/v2/atlas.yaml
@@ -62,9 +62,15 @@ spec:
                   optional: true
             # 0 = stream from genesis — safe on the fresh chain (non-numeric values are
             # silently ignored and fall back to the OLD testnet block 82655).
-            # Tighten to the V2 SpaceRegistry deploy block at deploy time (runbook Step 9).
+            # Deploy block of the self-owned SpaceRegistry (0xcf13491802747e759e1bb8e364bc43045398d1dd)
+            # on chain 55516. MUST NOT be 0: the Substreams server enforces
+            # limit-processed-blocks=10000 per request, so a start block of 0 against a chain
+            # past ~10k blocks never begins streaming. It fails silently — the pod stays Running
+            # and repeats one unchanging "Progress (Jobs: 0, Bytes: [...]) map_actions: 1000
+            # blocks" line, produces nothing to Kafka, and logs no error. Re-tighten this
+            # whenever the registry is redeployed.
             - name: SUBSTREAMS_START_BLOCK
-              value: "0"
+              value: "14339"
             - name: ROOT_SPACE_ID
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/v2/hermes-pipeline.yaml
+++ b/hermes/k8s/v2/hermes-pipeline.yaml
@@ -107,9 +107,15 @@ spec:
                   key: SUBSTREAMS_API_TOKEN
             # 0 = stream from genesis — safe on the fresh chain (non-numeric values are
             # silently ignored and fall back to the OLD testnet block 82655).
-            # Tighten to the V2 SpaceRegistry deploy block at deploy time (runbook Step 9).
+            # Deploy block of the self-owned SpaceRegistry (0xcf13491802747e759e1bb8e364bc43045398d1dd)
+            # on chain 55516. MUST NOT be 0: the Substreams server enforces
+            # limit-processed-blocks=10000 per request, so a start block of 0 against a chain
+            # past ~10k blocks never begins streaming. It fails silently — the pod stays Running
+            # and repeats one unchanging "Progress (Jobs: 0, Bytes: [...]) map_actions: 1000
+            # blocks" line, produces nothing to Kafka, and logs no error. Re-tighten this
+            # whenever the registry is redeployed.
             - name: SUBSTREAMS_START_BLOCK
-              value: "0"
+              value: "14339"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The three v2 manifests ship `SUBSTREAMS_START_BLOCK="0"` with a comment saying to tighten it at deploy time. Leaving it at `0` doesn't just waste effort — **it prevents ingestion entirely.**

## The failure

The Substreams server enforces `limit-processed-blocks=10000` per request:

```
rpc error: code = FailedPrecondition desc = request needs to process a total of 14400 blocks
(including 0 to prepare the stores) but only 10000 blocks are allowed according to the
'limit-processed-blocks' request argument
```

Chain 55516 is past 18k blocks, so starting at `0` exceeds the limit and the stream never begins.

**It fails silently.** The pod stays `Running`, logs no error, and repeats one unchanging line while producing nothing to Kafka:

```
Progress (Jobs: 0, Bytes: [R: 45463450, W: 352449]) map_actions: 1000 blocks
```

That reads like healthy progress. It looked fine for ~10 minutes during the registry cutover. The tell was byte counters **identical** across repeated samples plus every Kafka topic offset unchanged from baseline — not anything in the logs.

## The fix

`14339` — the deploy block of the self-owned SpaceRegistry `0xcf13491802747e759e1bb8e364bc43045398d1dd`, found by bisecting `eth_getCode`. From there to head is ~4,100 blocks, well under the limit.

The comment is replaced with the failure mode, so the next person doesn't rediscover it. Re-tighten whenever the registry is redeployed.

## Also removes live drift

The running deployments were patched with `kubectl set env SUBSTREAMS_START_BLOCK=14339` to unblock the cutover in progress. Without this PR, a later `kubectl apply` silently reverts them and re-breaks ingestion — exactly the hand-tuned-drift trap. Merging brings manifests and cluster back into agreement.

YAML validated with `yaml.safe_load_all` on all three files.
