### PR TITLE
feat(api): port the Filebase IPFS migration to staging (GEO-2323)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,7 +1,7 @@
 # Required
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/gaia
-IPFS_KEY=                         # Pinata JWT token
-IPFS_GATEWAY_WRITE=https://uploads.pinata.cloud/v3/files
+IPFS_KEY=                         # Filebase IPFS pinning API key (Bearer token, from the Filebase console)
+IPFS_GATEWAY_WRITE=https://rpc.filebase.io/api/v0/add
 
 # Optional — search routes disabled if unset
 # OPENSEARCH_URL=http://localhost:9200

--- a/api/src/ipfs/__tests__/router.test.ts
+++ b/api/src/ipfs/__tests__/router.test.ts
@@ -54,7 +54,7 @@ describe.each(ENDPOINTS)("POST %s", (endpoint) => {
 		expect(uploadFile).not.toHaveBeenCalled()
 	})
 
-	it("returns 400 when the file is empty (size === 0) without calling Pinata", async () => {
+	it("returns 400 when the file is empty (size === 0) without calling the upload service", async () => {
 		const {app, uploadEdit, uploadFile} = setupApp()
 
 		const emptyFile = new File([], "empty.bin", {type: "application/octet-stream"})
@@ -68,12 +68,12 @@ describe.each(ENDPOINTS)("POST %s", (endpoint) => {
 		expect(res.status).toBe(400)
 		expect(await res.text()).toBe("File cannot be empty")
 		// Critical: the upload service MUST NOT be invoked for empty files —
-		// that's the regression this PR fixes (Pinata error → Sentry issue).
+		// that's the regression this guards against (upstream gateway error → Sentry issue).
 		expect(uploadEdit).not.toHaveBeenCalled()
 		expect(uploadFile).not.toHaveBeenCalled()
 	})
 
-	it("returns 400 with no Pinata call when the request body isn't multipart", async () => {
+	it("returns 400 with no upload-service call when the request body isn't multipart", async () => {
 		const {app, uploadEdit, uploadFile} = setupApp()
 
 		// Bare POST: no Content-Type, no body. c.req.formData() throws on this.
@@ -85,7 +85,7 @@ describe.each(ENDPOINTS)("POST %s", (endpoint) => {
 		expect(uploadFile).not.toHaveBeenCalled()
 	})
 
-	it("returns 400 with no Pinata call for a JSON body (wrong content-type)", async () => {
+	it("returns 400 with no upload-service call for a JSON body (wrong content-type)", async () => {
 		const {app, uploadEdit, uploadFile} = setupApp()
 
 		const res = await app.request(endpoint, {

--- a/api/src/ipfs/index.ts
+++ b/api/src/ipfs/index.ts
@@ -7,8 +7,9 @@
  *   - POST /upload-file-alternative-gateway      — deprecated alias for /upload-file
  *
  * Validates that a file is provided and non-empty before delegating to the
- * Pinata-backed IPFS service. Empty/missing files short-circuit with 400 to
- * avoid producing Sentry issues from upstream gateway errors.
+ * Filebase-backed IPFS service (GEO-2323 — migrated off Pinata). Empty/missing
+ * files short-circuit with 400 to avoid producing Sentry issues from upstream
+ * gateway errors.
  */
 
 import {Effect, Either} from "effect"

--- a/api/src/services/ipfs.test.ts
+++ b/api/src/services/ipfs.test.ts
@@ -1,0 +1,98 @@
+import {Effect} from "effect"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+import {Environment, type IEnvironment} from "./environment"
+import {upload} from "./ipfs"
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const TEST_ENV: IEnvironment = {
+	databaseUrl: "postgresql://test" as unknown as IEnvironment["databaseUrl"],
+	debug: null,
+	ipfsKey: "test-key",
+	ipfsGatewayWrite: "https://rpc.filebase.io/api/v0/add",
+}
+
+function runUpload(formData: FormData, url = TEST_ENV.ipfsGatewayWrite) {
+	return Effect.runPromise(upload(formData, url).pipe(Effect.provideService(Environment, TEST_ENV)))
+}
+
+function jsonLines(...entries: Record<string, unknown>[]) {
+	return entries.map((e) => JSON.stringify(e)).join("\n")
+}
+
+function mockFetchOnce(body: string, init?: {status?: number; statusText?: string}) {
+	const response = new Response(body, {status: init?.status ?? 200, statusText: init?.statusText ?? "OK"})
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(() => Promise.resolve(response)),
+	)
+}
+
+beforeEach(() => {
+	vi.stubGlobal("fetch", vi.fn())
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+// =============================================================================
+// Tests — Filebase (Kubo-compatible /api/v0/add) response parsing (GEO-2323)
+// =============================================================================
+
+describe("upload", () => {
+	it("extracts the CID from a single-line NDJSON response", async () => {
+		mockFetchOnce(jsonLines({Name: "file.bin", Hash: "bafkreitestcid123", Size: "11"}))
+
+		const cid = await runUpload(new FormData())
+
+		expect(cid).toBe("ipfs://bafkreitestcid123")
+	})
+
+	it("takes the last Hash when the gateway streams multiple NDJSON lines", async () => {
+		mockFetchOnce(
+			jsonLines(
+				{Name: "dir", Hash: "bafkreidirhash", Size: "0"},
+				{Name: "dir/file.bin", Hash: "bafkreifilehash", Size: "11"},
+			),
+		)
+
+		const cid = await runUpload(new FormData())
+
+		expect(cid).toBe("ipfs://bafkreifilehash")
+	})
+
+	it("ignores blank lines between NDJSON entries", async () => {
+		mockFetchOnce(`${JSON.stringify({Hash: "bafkreitestcid123"})}\n\n`)
+
+		const cid = await runUpload(new FormData())
+
+		expect(cid).toBe("ipfs://bafkreitestcid123")
+	})
+
+	it("fails when the gateway returns a non-2xx status", async () => {
+		mockFetchOnce("Internal Server Error", {status: 500, statusText: "Internal Server Error"})
+
+		await expect(runUpload(new FormData())).rejects.toThrow()
+	})
+
+	it("fails when a streamed line reports a gateway error", async () => {
+		mockFetchOnce(jsonLines({Type: "error", Message: "context deadline exceeded"}))
+
+		await expect(runUpload(new FormData())).rejects.toThrow()
+	})
+
+	it("fails when the response body is not JSON at all", async () => {
+		mockFetchOnce("<html>not json</html>")
+
+		await expect(runUpload(new FormData())).rejects.toThrow()
+	})
+
+	it("fails when the response has no Hash anywhere", async () => {
+		mockFetchOnce(jsonLines({Name: "file.bin", Size: "11"}))
+
+		await expect(runUpload(new FormData())).rejects.toThrow()
+	})
+})

--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -29,9 +29,8 @@ export function uploadEdit(file: File) {
 		const run = Effect.gen(function* () {
 			yield* Ref.update(attemptRef, (n) => n + 1)
 
-			// No Blob wrap — aligns with Pinata's SDK.
+			// No Blob wrap — File is passed directly to FormData.
 			const formData = new FormData()
-			formData.append("network", "public")
 			formData.append("file", file, file.name || "edit.bin")
 
 			const hash = yield* upload(formData, config.ipfsGatewayWrite)
@@ -86,7 +85,6 @@ export function uploadFile(file: File) {
 			yield* Ref.update(attemptRef, (n) => n + 1)
 
 			const formData = new FormData()
-			formData.append("network", "public")
 			// Always provide filename - Bun hangs indefinitely without it
 			formData.append("file", file, file.name || "file.bin")
 
@@ -166,7 +164,7 @@ export function upload(formData: FormData, url: string) {
 			responseTimeMs: Date.now() - requestStart,
 			contentType: response.headers.get("content-type"),
 			contentLength: response.headers.get("content-length"),
-			pinataRequestId: response.headers.get("x-pinata-request-id") ?? response.headers.get("x-request-id"),
+			gatewayRequestId: response.headers.get("x-request-id"),
 			cfRay: response.headers.get("cf-ray"),
 			server: response.headers.get("server"),
 			retryAfter: response.headers.get("retry-after"),
@@ -182,30 +180,49 @@ export function upload(formData: FormData, url: string) {
 			yield* Effect.fail(new IpfsUploadError(`IPFS gateway HTTP ${response.status} ${response.statusText}`))
 		}
 
-		const responseJson = yield* Effect.try({
-			try: () => JSON.parse(responseText) as {error?: unknown; data?: {cid?: string}},
-			catch: () => new IpfsParseResponseError(`Could not parse IPFS JSON response (status=${response.status})`),
-		}).pipe(Effect.tapError(() => Effect.logWarning("[IPFS] gateway returned non-JSON response", diagnostics)))
+		// Filebase's IPFS `add` (Kubo-compatible /api/v0/add) returns
+		// newline-delimited JSON, one entry per added path — `{"Hash": "Qm...", ...}`,
+		// or `{"Type": "error", "Message": "..."}` if something fails mid-stream. A
+		// single-file upload yields one line; parse leniently (ignore blank/non-JSON
+		// lines) and take the last Hash regardless, matching curator-app's reference
+		// implementation for the same gateway.
+		let hash: string | undefined
+		let sawUnparseableLine = false
+		for (const line of responseText.split("\n")) {
+			const trimmed = line.trim()
+			if (!trimmed) continue
 
-		// Handle error responses from gateway
-		if (responseJson.error) {
-			const errorMsg =
-				typeof responseJson.error === "object" && responseJson.error !== null
-					? (responseJson.error as {message?: string}).message || JSON.stringify(responseJson.error)
-					: String(responseJson.error)
-			yield* Effect.logWarning("[IPFS] gateway returned error in body", {
-				...diagnostics,
-				gatewayErrorMessage: errorMsg,
-			})
-			yield* Effect.fail(new IpfsUploadError(`IPFS gateway error: ${errorMsg}`))
+			let entry: {Hash?: string; Type?: string; Message?: string}
+			try {
+				entry = JSON.parse(trimmed)
+			} catch {
+				sawUnparseableLine = true
+				continue
+			}
+
+			if (entry.Type === "error" || entry.Message) {
+				const errorMsg = entry.Message ?? "unknown gateway error"
+				yield* Effect.logWarning("[IPFS] gateway returned error in body", {
+					...diagnostics,
+					gatewayErrorMessage: errorMsg,
+				})
+				yield* Effect.fail(new IpfsUploadError(`IPFS gateway error: ${errorMsg}`))
+			}
+
+			if (entry.Hash) hash = entry.Hash
 		}
 
-		const cid = responseJson.data?.cid
-		if (!cid) {
+		if (!hash) {
+			if (sawUnparseableLine) {
+				yield* Effect.logWarning("[IPFS] gateway returned non-JSON response", diagnostics)
+				yield* Effect.fail(
+					new IpfsParseResponseError(`Could not parse IPFS JSON response (status=${response.status})`),
+				)
+			}
 			yield* Effect.logWarning("[IPFS] gateway returned no CID", diagnostics)
 			return yield* Effect.fail(new IpfsUploadError("IPFS gateway returned no CID"))
 		}
 
-		return `ipfs://${cid}` as const
+		return `ipfs://${hash}` as const
 	}).pipe(Effect.withSpan("ipfs.upload"))
 }


### PR DESCRIPTION
Cherry-pick of 2d96539 (#822), which landed on `main` but **never reached `staging`** — so the v2 cluster, which deploys from `staging`, is still running the fully Pinata-backed uploader.

## Why this matters right now

The API writes fresh content to **Pinata** while `hermes-ipfs-cache` reads from **Filebase**. Different providers, so every fresh publish is unfetchable by the indexer:

```
API  IPFS_GATEWAY_WRITE   → https://uploads.pinata.cloud            (new cluster)
warmer IPFS_GATEWAY_URL   → https://mature-tomato-basilisk.myfilebase.com
```

Verified against a CID from a live e2e publish:

| gateway | result |
|---|---|
| dedicated Filebase (what the warmer reads) | **000** — hangs, doesn't have it |
| Pinata | **200** — content is there |
| dedicated Filebase, *historical* CID | 200 — Filebase itself is healthy |

Consequence: the warmer fetches, fails, writes `is_errored = true`, and hermes-pipeline discards the edit as *"invalid user content"* when it is nothing of the sort. Observed 7 such drops in 20 minutes during an e2e run, and it is why entity-creation e2e tests time out with `{"entity":null}` — the write is gone, so no timeout can help.

This is **separate from #845**. That fixed the pipeline outrunning the warmer ("not found in cache" — now 0 occurrences, with the new wait path confirmed working). This is the second, independent path: "payload errored".

## What the cherry-pick brings

The Kubo-compatible `/api/v0/add` uploader and NDJSON response parser, per the original commit:

> the gaia api service — the actual backend geo-sdk's `Graph.createImage` posts to — was still fully Pinata-backed: `IPFS_GATEWAY_WRITE` defaulted to Pinata's v3/files endpoint, and `upload()`'s response parser only understood Pinata's `{data:{cid}}`/`{error}` JSON shape.

Applied cleanly, no conflicts. 5 files, +147/−31.

## Verification

- `vitest run src/services/ipfs.test.ts src/ipfs` — **22 passed** (15 existing router tests + 7 new NDJSON parsing tests: single-line, multi-line, blank-line-tolerant, non-2xx, embedded error, non-JSON, no-Hash)
- Filebase credentials confirmed working with a real upload against `https://rpc.filebase.io/api/v0/add`, returning the expected Kubo shape `{"Name","Hash","Size"}`

## Deploy ordering matters

The secret rotation is a **separate manual step** (as the original commit notes). It must happen **with or after** this deploy, never before — `staging`'s current Pinata-shaped multipart request would fail outright against Filebase's endpoint.

`api-secrets` on `do-nyc2-geo-testnet-k8s/gaia` needs:
```
IPFS_GATEWAY_WRITE = https://rpc.filebase.io/api/v0/add
IPFS_KEY           = <Filebase pinning key>
```
Both values already exist on the legacy cluster (`do-nyc2-k8s-geo-testnet`, namespaces `api` / `gaia-v2`).

## Worth a follow-up

`is_errored` is treated as a **permanent** verdict, so a transient gateway failure destroys a user's edit for good. That is arguably the same class of bug #845 fixed and deserves a retry path.