### PR TITLE
fix(ipfs): port CID verification + fetch retry to staging (#823)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1361,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1870,6 +1889,24 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "debugid"
@@ -2786,6 +2823,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -3376,10 +3414,14 @@ name = "ipfs"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bs58",
  "grc-20",
  "reqwest 0.12.28",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -8255,6 +8297,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures 0.3.31",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/hermes-ipfs-cache/Cargo.toml
+++ b/hermes-ipfs-cache/Cargo.toml
@@ -10,6 +10,10 @@ path = "src/lib.rs"
 name = "hermes-ipfs-cache"
 path = "src/main.rs"
 
+[[bin]]
+name = "reconcile_errored"
+path = "src/bin/reconcile_errored.rs"
+
 [dependencies]
 hermes-instrumentation = { path = "../hermes-instrumentation" }
 hermes-relay = { path = "../hermes-relay" }
@@ -34,6 +38,7 @@ sqlx = { version = "0.8", features = [
     "tls-rustls",
 ] }
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 uuid = "1"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/hermes-ipfs-cache/k8s/production/secrets.yaml.template
+++ b/hermes-ipfs-cache/k8s/production/secrets.yaml.template
@@ -4,7 +4,11 @@
 # Required values:
 # - SUBSTREAMS_ENDPOINT: gRPC endpoint (e.g., geotest.substreams.pinax.network:443)
 # - SUBSTREAMS_API_TOKEN: JWT token for substreams authentication
-# - IPFS_GATEWAY_URL: IPFS gateway URL (e.g., https://ipfs.io)
+# - IPFS_GATEWAY_URL: IPFS gateway URL, including the gateway's read path
+#   (e.g., https://ipfs.io/ipfs/ — a bare host with no path, like
+#   https://ipfs.io, will 404: this client appends the CID directly after
+#   whatever's configured here, it doesn't assume any particular gateway's
+#   path convention)
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,4 +18,4 @@ type: Opaque
 stringData:
   SUBSTREAMS_ENDPOINT: "geotest.substreams.pinax.network:443"
   SUBSTREAMS_API_TOKEN: "<your-substreams-api-token>"
-  IPFS_GATEWAY_URL: "https://ipfs.io"
+  IPFS_GATEWAY_URL: "https://ipfs.io/ipfs/"

--- a/hermes-ipfs-cache/src/bin/reconcile_errored.rs
+++ b/hermes-ipfs-cache/src/bin/reconcile_errored.rs
@@ -1,0 +1,142 @@
+//! Re-attempts every `ipfs_cache` row marked `is_errored = true` using the
+//! now-fixed `IpfsClient` (retry-with-backoff + CID verification — see
+//! `ipfs/src/verify.rs` and `ipfs/src/lib.rs::IpfsClient::get_bytes`).
+//!
+//! Before that fix, a single transient fetch failure (a truncated read, a
+//! flaky gateway response) was cached as permanently errored with no retry
+//! anywhere upstream — `hermes-pipeline` then silently and permanently
+//! dropped the edit. A one-time system-wide audit (2026-07-17) found 211 of
+//! 659 errored rows were exactly this: recoverable false positives, not
+//! genuinely invalid content.
+//!
+//! This tool repairs the *cache* row only (`data` + `is_errored = false`).
+//! It does NOT replay the edit into the live knowledge graph — a cache row
+//! being wrong doesn't retroactively make `hermes-pipeline` reprocess an
+//! edit it already dropped. For that, check the target (entity, property,
+//! space) tuples for conflicting later edits by hand, then use
+//! `kg-indexer/src/bin/replay_edit.rs` (mirrors this tool's caution).
+//!
+//! Safe to run repeatedly: only touches rows still marked `is_errored`, and
+//! genuinely invalid content (fails to decode even once correctly fetched
+//! and, where the CID shape is one the `ipfs` crate's internal verification
+//! understands, hash-verified)
+//! is left alone rather than looped on forever.
+//!
+//! Usage:
+//!   DATABASE_URL=... IPFS_GATEWAY_URL=... cargo run -p hermes-ipfs-cache --bin reconcile_errored \
+//!     -- [--dry-run] [--limit N]
+
+use std::env;
+use std::time::Duration;
+
+use grc_20::decode_edit;
+use ipfs::{IpfsClient, IpfsFetcher};
+use sqlx::postgres::PgPoolOptions;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+    let dry_run = args.iter().any(|a| a == "--dry-run");
+    // Distinguish "--limit absent" (limit = None, sweep everything) from
+    // "--limit present but missing/invalid value" (must error, not silently
+    // fall back to sweeping everything).
+    let limit: Option<i64> = args.iter().position(|a| a == "--limit").map(|i| {
+        args.get(i + 1)
+            .unwrap_or_else(|| panic!("--limit requires a value"))
+            .parse()
+            .expect("--limit must be a number")
+    });
+
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let ipfs_gateway = env::var("IPFS_GATEWAY_URL").expect("IPFS_GATEWAY_URL must be set");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await?;
+    let ipfs = IpfsClient::new(&ipfs_gateway);
+
+    let errored: Vec<(String,)> =
+        sqlx::query_as("SELECT uri FROM ipfs_cache WHERE is_errored = true ORDER BY uri LIMIT $1")
+            .bind(limit.unwrap_or(i64::MAX))
+            .fetch_all(&pool)
+            .await?;
+
+    println!(
+        "Found {} errored ipfs_cache row(s){}{}",
+        errored.len(),
+        if dry_run {
+            " (dry run — no writes)"
+        } else {
+            ""
+        },
+        limit
+            .map(|l| format!(" (limited to {l})"))
+            .unwrap_or_default()
+    );
+
+    let mut recovered = 0u32;
+    let mut still_failing = 0u32;
+
+    for (uri,) in errored {
+        match ipfs.get_bytes(&uri).await {
+            Ok(bytes) => match decode_edit(&bytes) {
+                Ok(edit) => {
+                    let name = if edit.name.is_empty() {
+                        None
+                    } else {
+                        Some(edit.name.into_owned())
+                    };
+                    println!(
+                        "RECOVERABLE  {uri}  ({} ops, name={name:?})",
+                        edit.ops.len()
+                    );
+                    recovered += 1;
+                    if !dry_run {
+                        sqlx::query(
+                            "UPDATE ipfs_cache SET data = $1, is_errored = false, name = $2 \
+                             WHERE uri = $3 AND is_errored = true",
+                        )
+                        .bind(&bytes)
+                        .bind(&name)
+                        .bind(&uri)
+                        .execute(&pool)
+                        .await?;
+                    }
+                }
+                Err(decode_error) => {
+                    println!("STILL INVALID  {uri}  (fetched successfully, but: {decode_error})");
+                    still_failing += 1;
+                }
+            },
+            Err(fetch_error) => {
+                println!("STILL UNFETCHABLE  {uri}  ({fetch_error})");
+                still_failing += 1;
+            }
+        }
+        // Be polite to the gateway — this is a batch sweep, not latency-sensitive.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    println!(
+        "\nDone. {recovered} recoverable{}, {still_failing} still failing.",
+        if dry_run {
+            " (not written — dry run)"
+        } else {
+            " (cache row fixed)"
+        }
+    );
+    if recovered > 0 && !dry_run {
+        println!(
+            "Note: cache rows are fixed, but recovered edits are NOT yet in the live KG — \
+             check version history for conflicts, then use kg-indexer's replay_edit tool per edit."
+        );
+    }
+
+    Ok(())
+}

--- a/ipfs/Cargo.toml
+++ b/ipfs/Cargo.toml
@@ -5,7 +5,14 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
+bs58 = "0.5"
 grc-20 = "0.4.1"
 reqwest = "0.12.9"
+sha2 = "0.10"
 thiserror = "2.0.3"
-tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread", "time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread", "time", "test-util"] }
+wiremock = "0.6"

--- a/ipfs/src/lib.rs
+++ b/ipfs/src/lib.rs
@@ -25,13 +25,17 @@
 //! ```
 
 mod mock;
+mod verify;
 
 pub use mock::MockIpfsClient;
+pub use verify::Verification;
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use reqwest::Client as ReqwestClient;
+use tracing::warn;
 
 #[derive(Debug, thiserror::Error)]
 pub enum IpfsError {
@@ -45,6 +49,8 @@ pub enum IpfsError {
     NetworkError(String),
     #[error("timeout")]
     Timeout,
+    #[error("content did not hash to the requested CID after {attempts} attempt(s): {cid}")]
+    VerificationFailed { cid: String, attempts: u32 },
 }
 
 pub type Result<T> = std::result::Result<T, IpfsError>;
@@ -85,27 +91,55 @@ pub trait IpfsFetcher: Send + Sync {
 pub struct IpfsClient {
     url: String,
     client: ReqwestClient,
+    max_attempts: u32,
+    base_backoff: Duration,
 }
 
 impl IpfsClient {
+    /// Max fetch attempts before giving up on a URI. Applies to both
+    /// transport failures (timeouts, non-2xx) and content that fails CID
+    /// verification (see [`Verification`]) — either is treated as "this
+    /// attempt didn't get the real content," not "this content is invalid."
+    const DEFAULT_MAX_ATTEMPTS: u32 = 3;
+    const DEFAULT_BASE_BACKOFF: Duration = Duration::from_millis(250);
+    /// Upper bound on any single retry's backoff, regardless of attempt
+    /// count or configured base — keeps a large `max_attempts` from ever
+    /// producing an absurd (if not overflowing) wait.
+    const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
     pub fn new(url: &str) -> Self {
         IpfsClient {
             url: url.to_string(),
             client: ReqwestClient::new(),
+            max_attempts: Self::DEFAULT_MAX_ATTEMPTS,
+            base_backoff: Self::DEFAULT_BASE_BACKOFF,
         }
     }
-}
 
-#[async_trait]
-impl IpfsFetcher for IpfsClient {
-    async fn get_bytes(&self, uri: &str) -> Result<Vec<u8>> {
-        // Strip ipfs:// prefix if present
-        let cid = uri.strip_prefix("ipfs://").unwrap_or(uri);
+    /// Same as [`Self::new`] but with a configurable attempt count and base
+    /// backoff (doubled each retry). Exposed mainly so tests can run a full
+    /// retry sequence without real delays.
+    pub fn with_retry_config(url: &str, max_attempts: u32, base_backoff: Duration) -> Self {
+        IpfsClient {
+            url: url.to_string(),
+            client: ReqwestClient::new(),
+            max_attempts: max_attempts.max(1),
+            base_backoff,
+        }
+    }
 
-        let url = format!("{}{}", self.url, cid);
+    async fn fetch_once(&self, cid: &str) -> Result<Vec<u8>> {
+        // Normalize exactly one separating slash regardless of whether the
+        // configured gateway URL ends with one, so a trailing-slash typo in
+        // config doesn't turn into a malformed `https://hostQm...` URL. This
+        // does NOT guess at a gateway's path convention (e.g. `/ipfs/` vs
+        // `/files/`) — the configured URL must already include whatever
+        // path segment that specific gateway needs; see
+        // `hermes-ipfs-cache/k8s/production/secrets.yaml.template`.
+        let base = self.url.trim_end_matches('/');
+        let url = format!("{base}/{cid}");
         let res = self.client.get(&url).send().await?;
 
-        // Check for HTTP errors before returning bytes
         if !res.status().is_success() {
             let status = res.status();
             let body = res.text().await.unwrap_or_default();
@@ -118,6 +152,78 @@ impl IpfsFetcher for IpfsClient {
 
         let bytes = res.bytes().await?;
         Ok(bytes.to_vec())
+    }
+}
+
+#[async_trait]
+impl IpfsFetcher for IpfsClient {
+    /// Fetch `uri`, retrying transient failures and re-fetching (rather than
+    /// trusting) content whose hash doesn't match the requested CID.
+    ///
+    /// Without this, a single truncated/corrupted gateway response — still
+    /// HTTP 200 — used to be indistinguishable from genuinely invalid
+    /// content, and got cached as permanently errored with no retry
+    /// anywhere upstream (`hermes-ipfs-cache` → `hermes-pipeline` silently
+    /// dropping the edit for good). See the "Encoding error" incidents this
+    /// was built to stop recurring.
+    async fn get_bytes(&self, uri: &str) -> Result<Vec<u8>> {
+        let cid = uri.strip_prefix("ipfs://").unwrap_or(uri);
+
+        // Tracks whatever happened on the most recent attempt, so the final
+        // error accurately reflects that attempt's actual failure mode
+        // (transport error vs. hash mismatch) rather than conflating the
+        // two across a mixed sequence of retries.
+        let mut last_error: Option<IpfsError> = None;
+
+        for attempt in 1..=self.max_attempts {
+            match self.fetch_once(cid).await {
+                Ok(bytes) => match verify::verify(cid, &bytes) {
+                    Verification::Verified | Verification::Unsupported => return Ok(bytes),
+                    Verification::Mismatch => {
+                        warn!(
+                            cid = %cid,
+                            attempt,
+                            max_attempts = self.max_attempts,
+                            bytes = bytes.len(),
+                            "fetched bytes did not hash to the requested CID, retrying"
+                        );
+                        last_error = Some(IpfsError::VerificationFailed {
+                            cid: cid.to_string(),
+                            attempts: attempt,
+                        });
+                    }
+                },
+                Err(err) => {
+                    warn!(
+                        cid = %cid,
+                        attempt,
+                        max_attempts = self.max_attempts,
+                        error = %err,
+                        "IPFS fetch failed, retrying"
+                    );
+                    last_error = Some(err);
+                }
+            }
+
+            if attempt < self.max_attempts {
+                // `checked_pow`/`saturating_mul` (rather than plain `*`) so a
+                // large `max_attempts` via `with_retry_config` can't overflow
+                // `u32`/`Duration` arithmetic; `.min(MAX_BACKOFF)` caps the
+                // wait at something sane regardless.
+                let multiplier = 2u32.checked_pow(attempt - 1).unwrap_or(u32::MAX);
+                let backoff = self
+                    .base_backoff
+                    .saturating_mul(multiplier)
+                    .min(Self::MAX_BACKOFF);
+                tokio::time::sleep(backoff).await;
+            }
+        }
+
+        // Every loop iteration sets last_error before falling through to
+        // here (the only early return is the Ok(bytes) success path above),
+        // so this is always Some by the time max_attempts is exhausted.
+        Err(last_error
+            .expect("get_bytes retry loop always records an error before exhausting attempts"))
     }
 }
 
@@ -204,5 +310,198 @@ impl IpfsSource {
             Self::MockBytes(data) => Box::new(MockIpfsClient::with_bytes(data)),
             Self::Live { gateway_url } => Box::new(IpfsClient::new(&gateway_url)),
         }
+    }
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::*;
+    use crate::verify::fixtures::{GOLDEN_SMALL_BYTES, GOLDEN_SMALL_CID};
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    fn test_client(server: &MockServer) -> IpfsClient {
+        IpfsClient::with_retry_config(&format!("{}/", server.uri()), 3, Duration::from_millis(1))
+    }
+
+    /// Fails with a 500 for the first `fail_times` requests, then returns
+    /// `good_body` on every request after that.
+    struct FlakyThenGood {
+        fail_times: u32,
+        calls: AtomicU32,
+        good_body: Vec<u8>,
+    }
+
+    impl Respond for FlakyThenGood {
+        fn respond(&self, _req: &Request) -> ResponseTemplate {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            if n < self.fail_times {
+                ResponseTemplate::new(500)
+            } else {
+                ResponseTemplate::new(200).set_body_bytes(self.good_body.clone())
+            }
+        }
+    }
+
+    /// Always returns 200 with `body`, regardless of what's requested —
+    /// used to simulate a gateway that returns wrong/corrupted content for
+    /// a CID it claims to be serving.
+    struct AlwaysBody {
+        calls: Arc<AtomicU32>,
+        body: Vec<u8>,
+    }
+
+    impl Respond for AlwaysBody {
+        fn respond(&self, _req: &Request) -> ResponseTemplate {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(200).set_body_bytes(self.body.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn succeeds_when_base_url_has_no_trailing_slash() {
+        // A trailing-slash typo in config shouldn't produce a malformed URL.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{GOLDEN_SMALL_CID}")))
+            .respond_with(AlwaysBody {
+                calls: Arc::new(AtomicU32::new(0)),
+                body: GOLDEN_SMALL_BYTES.to_vec(),
+            })
+            .mount(&server)
+            .await;
+
+        let no_trailing_slash = server.uri();
+        assert!(!no_trailing_slash.ends_with('/'));
+        let client = IpfsClient::with_retry_config(&no_trailing_slash, 3, Duration::from_millis(1));
+
+        let bytes = client.get_bytes(GOLDEN_SMALL_CID).await.unwrap();
+        assert_eq!(bytes, GOLDEN_SMALL_BYTES);
+    }
+
+    #[tokio::test]
+    async fn succeeds_immediately_on_valid_content() {
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicU32::new(0));
+        Mock::given(method("GET"))
+            .and(path(format!("/{GOLDEN_SMALL_CID}")))
+            .respond_with(AlwaysBody {
+                calls: Arc::clone(&calls),
+                body: GOLDEN_SMALL_BYTES.to_vec(),
+            })
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let bytes = client.get_bytes(GOLDEN_SMALL_CID).await.unwrap();
+
+        assert_eq!(bytes, GOLDEN_SMALL_BYTES);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "should not retry on success"
+        );
+    }
+
+    #[tokio::test]
+    async fn retries_transient_http_failures_then_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{GOLDEN_SMALL_CID}")))
+            .respond_with(FlakyThenGood {
+                fail_times: 2,
+                calls: AtomicU32::new(0),
+                good_body: GOLDEN_SMALL_BYTES.to_vec(),
+            })
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let bytes = client.get_bytes(GOLDEN_SMALL_CID).await.unwrap();
+
+        assert_eq!(bytes, GOLDEN_SMALL_BYTES);
+    }
+
+    #[tokio::test]
+    async fn gives_up_after_max_attempts_on_persistent_http_failure() {
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicU32::new(0));
+        Mock::given(method("GET"))
+            .and(path(format!("/{GOLDEN_SMALL_CID}")))
+            .respond_with({
+                let calls = Arc::clone(&calls);
+                move |_req: &Request| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    ResponseTemplate::new(500)
+                }
+            })
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let result = client.get_bytes(GOLDEN_SMALL_CID).await;
+
+        assert!(matches!(result, Err(IpfsError::NetworkError(_))));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "should try exactly max_attempts times"
+        );
+    }
+
+    #[tokio::test]
+    async fn retries_and_ultimately_rejects_content_that_never_matches_the_cid() {
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicU32::new(0));
+        Mock::given(method("GET"))
+            .and(path(format!("/{GOLDEN_SMALL_CID}")))
+            .respond_with(AlwaysBody {
+                calls: Arc::clone(&calls),
+                // Wrong content for this CID on every attempt — simulates a
+                // gateway that deterministically serves corrupted bytes.
+                body: b"definitely not the real content".to_vec(),
+            })
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let result = client.get_bytes(GOLDEN_SMALL_CID).await;
+
+        assert!(matches!(
+            result,
+            Err(IpfsError::VerificationFailed { attempts: 3, .. })
+        ));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "should retry a hash mismatch, not trust it"
+        );
+    }
+
+    #[tokio::test]
+    async fn passes_through_unverifiable_content_without_retrying() {
+        // A CID shape verify() can't check should be returned as-is on the
+        // first successful fetch, not retried. Not valid base32 (doesn't
+        // start with 'b') and not valid base58 either (contains characters
+        // base58 excludes) — genuinely unparseable, not a real CID shape.
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicU32::new(0));
+        let cid = "not-a-real-cid-0O0Il";
+        Mock::given(method("GET"))
+            .and(path(format!("/{cid}")))
+            .respond_with(AlwaysBody {
+                calls: Arc::clone(&calls),
+                body: b"unverifiable but should pass through".to_vec(),
+            })
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let bytes = client.get_bytes(cid).await.unwrap();
+
+        assert_eq!(bytes, b"unverifiable but should pass through");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/ipfs/src/verify.rs
+++ b/ipfs/src/verify.rs
@@ -1,0 +1,573 @@
+//! CID verification for content fetched from an IPFS gateway.
+//!
+//! Real GRC-20 edit CIDs observed in production come in two shapes:
+//!
+//! - **CIDv0** (`Qm...`, base58btc): always sha2-256 over a UnixFS `File`
+//!   node wrapped in a dag-pb block — never a hash of the raw bytes
+//!   directly. Produced by `ipfs add` with default settings (e.g. Filebase's
+//!   Kubo-compatible endpoint — see `api/src/services/ipfs.ts`).
+//! - **CIDv1** (`bafkrei...`, base32 multibase 'b'): observed in production
+//!   almost exclusively with the `raw` codec, where the multihash digest
+//!   *is* directly `sha2-256(raw_bytes)` — no wrapping at all. CIDv1 with
+//!   the `dag-pb` codec is also supported here for completeness, using the
+//!   same UnixFS reconstruction as CIDv0, in case an older or differently
+//!   configured client ever produces one.
+//!
+//! Both codec/version combinations were validated against real production
+//! (CID, bytes) pairs during development — see this module's tests.
+//!
+//! Every GRC-20 edit observed in production is well under the 256 KiB
+//! default UnixFS chunk size, so single-chunk (no `Links`) dag-pb
+//! reconstruction covers the entire real dag-pb workload. `raw` codec CIDs
+//! have no such limit — a raw-codec CID is by construction never chunked
+//! (a chunked/multi-block file's root CID is always a linking dag-pb node).
+//! Anything this module can't confidently parse is reported as
+//! [`Verification::Unsupported`] rather than guessed at.
+
+use sha2::{Digest, Sha256};
+
+/// Kubo's default max chunk size — content at or under this fits in a single
+/// UnixFS leaf with no `Links`, the only shape this module can reconstruct
+/// for the dag-pb codec.
+const MAX_SINGLE_CHUNK_BYTES: usize = 256 * 1024;
+
+/// sha2-256 multihash function code (see the multiformats multihash table).
+const MULTIHASH_SHA2_256: u64 = 0x12;
+/// Digest length in bytes for sha2-256.
+const MULTIHASH_SHA2_256_LEN: u64 = 0x20;
+
+/// Multicodec code for raw binary (content-addressed directly, no wrapping).
+const CODEC_RAW: u64 = 0x55;
+/// Multicodec code for a dag-pb (MerkleDAG protobuf / UnixFS) node.
+const CODEC_DAG_PB: u64 = 0x70;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verification {
+    /// The bytes hash to exactly the content this CID identifies.
+    Verified,
+    /// The bytes were successfully reconstructed into the block shape this
+    /// CID's codec implies, but its digest does not match. The fetch
+    /// returned the wrong (or corrupted) content.
+    Mismatch,
+    /// This CID isn't one of the shapes this module understands (see module
+    /// docs), or the content is larger than a single dag-pb chunk —
+    /// verification isn't implemented for that case, so no claim is made
+    /// either way.
+    Unsupported,
+}
+
+/// A parsed, not-yet-verified CID: which block shape to expect, and the
+/// multihash digest it should hash to.
+struct ParsedCid {
+    codec: u64,
+    digest: Vec<u8>,
+}
+
+/// Verify that `bytes` are the actual content identified by `cid`.
+///
+/// `cid` may be given with or without an `ipfs://` prefix.
+pub fn verify(cid: &str, bytes: &[u8]) -> Verification {
+    let cid = cid.strip_prefix("ipfs://").unwrap_or(cid);
+
+    let Some(parsed) = parse_cid(cid) else {
+        return Verification::Unsupported;
+    };
+
+    let actual_digest = match parsed.codec {
+        CODEC_RAW => Sha256::digest(bytes).to_vec(),
+        CODEC_DAG_PB => {
+            if bytes.len() > MAX_SINGLE_CHUNK_BYTES {
+                return Verification::Unsupported;
+            }
+            Sha256::digest(unixfs_file_block(bytes)).to_vec()
+        }
+        _ => return Verification::Unsupported,
+    };
+
+    if actual_digest == parsed.digest {
+        Verification::Verified
+    } else {
+        Verification::Mismatch
+    }
+}
+
+/// Parse a CIDv0 or CIDv1 string into its codec and expected sha2-256
+/// digest. Returns `None` for anything not in one of those two shapes, or
+/// using a hash function other than sha2-256.
+fn parse_cid(cid: &str) -> Option<ParsedCid> {
+    // Multibase 'b' (lowercase) and 'B' (uppercase) both denote base32
+    // (RFC4648, no padding) — 'b' is by far the most common CIDv1 string
+    // encoding in practice, but 'B' is equally valid per the multibase spec.
+    // `base32_decode_nopad` itself is already case-insensitive, so only the
+    // prefix check needs to accept both.
+    if cid.starts_with('b') || cid.starts_with('B') {
+        let rest = &cid[1..];
+        let bytes = base32_decode_nopad(rest)?;
+        let mut pos = 0;
+        let (version, n) = read_varint(&bytes[pos..])?;
+        pos += n;
+        if version != 1 {
+            return None;
+        }
+        let (codec, n) = read_varint(&bytes[pos..])?;
+        pos += n;
+        let (mh_code, n) = read_varint(&bytes[pos..])?;
+        pos += n;
+        let (mh_len, n) = read_varint(&bytes[pos..])?;
+        pos += n;
+        if mh_code != MULTIHASH_SHA2_256 || mh_len != MULTIHASH_SHA2_256_LEN {
+            return None;
+        }
+        let digest_end = pos.checked_add(mh_len as usize)?;
+        // Reject trailing bytes past the digest — a canonical CIDv1 multihash
+        // ends exactly here; anything left over is a malformed or
+        // non-canonical encoding we shouldn't guess about.
+        if digest_end != bytes.len() {
+            return None;
+        }
+        let digest = bytes[pos..digest_end].to_vec();
+        return Some(ParsedCid { codec, digest });
+    }
+
+    // CIDv0: base58btc encoding of exactly a 34-byte sha2-256 multihash
+    // (<code=0x12><len=0x20><32-byte digest>), always implicitly dag-pb.
+    let decoded = bs58::decode(cid).into_vec().ok()?;
+    if decoded.len() != 34
+        || decoded[0] != MULTIHASH_SHA2_256 as u8
+        || decoded[1] != MULTIHASH_SHA2_256_LEN as u8
+    {
+        return None;
+    }
+    Some(ParsedCid {
+        codec: CODEC_DAG_PB,
+        digest: decoded[2..].to_vec(),
+    })
+}
+
+/// Decode RFC4648 base32 (lowercase alphabet, no padding) — the encoding
+/// multibase prefix `b` denotes.
+fn base32_decode_nopad(s: &str) -> Option<Vec<u8>> {
+    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz234567";
+
+    let mut bits: u64 = 0;
+    let mut bit_count: u32 = 0;
+    let mut out = Vec::with_capacity(s.len() * 5 / 8);
+
+    for ch in s.bytes() {
+        let value = ALPHABET
+            .iter()
+            .position(|&c| c == ch.to_ascii_lowercase())? as u64;
+        bits = (bits << 5) | value;
+        bit_count += 5;
+        if bit_count >= 8 {
+            bit_count -= 8;
+            out.push(((bits >> bit_count) & 0xff) as u8);
+        }
+    }
+
+    // Canonical RFC4648 no-pad base32 requires the leftover (non-byte-
+    // aligned) bits at the end to be zero — they're unused padding, not
+    // data. A non-canonical encoding could set them to anything and still
+    // decode to the same bytes; reject rather than silently accept it.
+    let leftover_mask = (1u64 << bit_count) - 1;
+    if bits & leftover_mask != 0 {
+        return None;
+    }
+
+    Some(out)
+}
+
+/// Read an unsigned LEB128 varint, returning `(value, bytes_consumed)`.
+fn read_varint(bytes: &[u8]) -> Option<(u64, usize)> {
+    // A u64 needs at most 10 groups of 7 bits (70 > 64). Bounding the loop
+    // (rather than trusting the continuation bit alone) keeps a malformed
+    // CID with an unbroken run of continuation bytes from shifting past the
+    // width of `value` — `checked_shl` would otherwise return `None` there
+    // and this function would just report a bogus-but-harmless failure, but
+    // bounding it up front makes that guarantee explicit rather than
+    // incidental.
+    let mut value: u64 = 0;
+    for (i, &byte) in bytes.iter().take(10).enumerate() {
+        let shifted = ((byte & 0x7f) as u64).checked_shl(7 * i as u32)?;
+        value |= shifted;
+        if byte & 0x80 == 0 {
+            return Some((value, i + 1));
+        }
+    }
+    None
+}
+
+/// Reconstruct the dag-pb block Kubo produces for a single-chunk UnixFS file
+/// (no `Links`), given the raw file content.
+///
+/// Wire shapes (proto2, from go-ipfs's `unixfs.pb.go` / `merkledag.pb.go`):
+/// ```proto
+/// message Data { required DataType Type = 1; optional bytes Data = 2; optional uint64 filesize = 3; ... }
+/// message PBNode { repeated PBLink Links = 2; optional bytes Data = 1; }
+/// ```
+/// `DataType::File = 2`. Validated against real production CIDs during
+/// development — see `ipfs/src/verify.rs` tests.
+fn unixfs_file_block(content: &[u8]) -> Vec<u8> {
+    const TYPE_FILE: u64 = 2;
+
+    let mut unixfs_data = Vec::with_capacity(content.len() + 16);
+    write_varint_field(&mut unixfs_data, 1, TYPE_FILE);
+    write_bytes_field(&mut unixfs_data, 2, content);
+    write_varint_field(&mut unixfs_data, 3, content.len() as u64);
+
+    let mut node = Vec::with_capacity(unixfs_data.len() + 8);
+    write_bytes_field(&mut node, 1, &unixfs_data);
+    node
+}
+
+/// Encode a protobuf varint (LEB128, unsigned) field: `(field_num << 3) | 0`.
+fn write_varint_field(out: &mut Vec<u8>, field_num: u32, value: u64) {
+    write_varint(out, (field_num as u64) << 3);
+    write_varint(out, value);
+}
+
+/// Encode a protobuf length-delimited field: `(field_num << 3) | 2`.
+fn write_bytes_field(out: &mut Vec<u8>, field_num: u32, value: &[u8]) {
+    write_varint(out, ((field_num as u64) << 3) | 2);
+    write_varint(out, value.len() as u64);
+    out.extend_from_slice(value);
+}
+
+fn write_varint(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            out.push(byte | 0x80);
+        } else {
+            out.push(byte);
+            break;
+        }
+    }
+}
+
+/// Real production (CID, bytes) fixtures, reused by this module's tests and
+/// by `lib.rs`'s retry tests.
+#[cfg(test)]
+pub(crate) mod fixtures {
+    // Real production payload + CID (space 7570a0ba7552e6806e0751c2ad105754,
+    // proposal 4d514f70a1114cf78c2c5a4e20c09f39 — the "Encoding error"
+    // incident this module was built to prevent). 123 bytes; single-byte
+    // varint for the UnixFS `Data` length field.
+    pub(crate) const GOLDEN_SMALL_CID: &str = "QmYdCDY6MQe9ve1HbUiwo3fLLB9eXdCUiWb9bYL8PJ2LXS";
+    pub(crate) const GOLDEN_SMALL_BYTES: &[u8] = &[
+        0x47, 0x52, 0x43, 0x32, 0x00, 0x76, 0x2f, 0xb5, 0x48, 0x7b, 0x43, 0x42, 0x50, 0x95, 0x28,
+        0x60, 0x55, 0x3b, 0x58, 0xbb, 0x32, 0x07, 0x50, 0x55, 0x62, 0x6c, 0x69, 0x73, 0x68, 0x01,
+        0xf3, 0xda, 0xb7, 0x9c, 0xb5, 0xa3, 0xd9, 0xd1, 0x75, 0x96, 0x56, 0xdd, 0x53, 0x61, 0xd1,
+        0xc6, 0x80, 0xbb, 0xd8, 0xab, 0x94, 0xc3, 0xab, 0x06, 0x01, 0xa1, 0x26, 0xca, 0x53, 0x0c,
+        0x8e, 0x48, 0xd5, 0xb8, 0x88, 0x82, 0xc7, 0x34, 0xc3, 0x89, 0x35, 0x05, 0x00, 0x01, 0x09,
+        0x0a, 0xda, 0xc0, 0xfc, 0xa4, 0x82, 0x2e, 0x8e, 0x71, 0x92, 0x63, 0xe6, 0x76, 0x20, 0xec,
+        0x00, 0x01, 0xe5, 0x23, 0x28, 0x89, 0xff, 0x85, 0x49, 0x45, 0xb5, 0xb7, 0xbb, 0x5d, 0x20,
+        0x77, 0x92, 0x11, 0x00, 0x00, 0x01, 0x02, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0xff, 0xff,
+        0xff, 0xff, 0x0f,
+    ];
+
+    // Second real production payload + CID (space 7570a0ba7552e6806e0751c2ad105754,
+    // "Create debates page type", from the 07-17 Preston incident). 248 bytes;
+    // exercises the 2-byte varint length-field path the 123-byte fixture above
+    // doesn't reach.
+    pub(crate) const GOLDEN_LARGE_CID: &str = "QmXEpL18P3gkBdgcm4obxQQfVAEWTYCJV8pmT4KVfmJ5Xo";
+    pub(crate) const GOLDEN_LARGE_BYTES: &[u8] = &[
+        0x47, 0x52, 0x43, 0x32, 0x00, 0x9a, 0x43, 0x71, 0xd5, 0x9e, 0x1c, 0x44, 0xd2, 0xba, 0xd1,
+        0x9e, 0x66, 0x8d, 0xec, 0x09, 0x60, 0x18, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x20, 0x64,
+        0x65, 0x62, 0x61, 0x74, 0x65, 0x73, 0x20, 0x70, 0x61, 0x67, 0x65, 0x20, 0x74, 0x79, 0x70,
+        0x65, 0x01, 0xf3, 0xda, 0xb7, 0x9c, 0xb5, 0xa3, 0xd9, 0xd1, 0x75, 0x96, 0x56, 0xdd, 0x53,
+        0x61, 0xd1, 0xc6, 0xf0, 0xe3, 0xee, 0xbd, 0x9a, 0xb5, 0xab, 0x06, 0x01, 0xa1, 0x26, 0xca,
+        0x53, 0x0c, 0x8e, 0x48, 0xd5, 0xb8, 0x88, 0x82, 0xc7, 0x34, 0xc3, 0x89, 0x35, 0x05, 0x01,
+        0x8f, 0x15, 0x1b, 0xa4, 0xde, 0x20, 0x4e, 0x3c, 0x9c, 0xb4, 0x99, 0xdd, 0xf9, 0x6f, 0x48,
+        0xf1, 0x01, 0x09, 0x0a, 0xda, 0xc0, 0xfc, 0xa4, 0x82, 0x2e, 0x8e, 0x71, 0x92, 0x63, 0xe6,
+        0x76, 0x20, 0xec, 0x00, 0x02, 0xde, 0xc3, 0xc8, 0xca, 0xe0, 0x71, 0x48, 0x23, 0x94, 0xf1,
+        0xdc, 0x4d, 0xe1, 0x1e, 0x7f, 0xb6, 0xe7, 0xd7, 0x37, 0xc5, 0x36, 0x76, 0x4c, 0x60, 0x9f,
+        0xa1, 0x6a, 0xa6, 0x4a, 0x8c, 0x90, 0xad, 0x00, 0x00, 0x02, 0x05, 0x91, 0xe3, 0xb1, 0x48,
+        0x52, 0x7a, 0x47, 0x93, 0xbf, 0x50, 0x4a, 0x46, 0x08, 0x81, 0xda, 0x0a, 0x00, 0x34, 0x00,
+        0x01, 0xa1, 0x9c, 0x34, 0x5a, 0xb9, 0x86, 0x66, 0x79, 0xb0, 0x01, 0xd7, 0xd2, 0x13, 0x8d,
+        0x88, 0xa1, 0x28, 0x71, 0x5c, 0xac, 0x33, 0xc6, 0x40, 0x6d, 0xa2, 0xdb, 0x0b, 0x03, 0x7b,
+        0x89, 0xcc, 0x7a, 0x05, 0x61, 0x30, 0x33, 0x7a, 0x50, 0xff, 0xff, 0xff, 0xff, 0x0f, 0x02,
+        0x00, 0x01, 0x01, 0x00, 0x0c, 0x44, 0x65, 0x62, 0x61, 0x74, 0x65, 0x73, 0x20, 0x70, 0x61,
+        0x67, 0x65, 0x01, 0xff, 0xff, 0xff, 0xff, 0x0f,
+    ];
+
+    // Real CIDv1 (raw codec, base32 multibase) production payload + CID
+    // ("Create payout") — the dominant real-world shape found once the
+    // 2026-07-20 backlog audit ran: unlike the CIDv0 fixtures above, this
+    // codec's digest is a direct sha2-256 of the raw bytes, no dag-pb/UnixFS
+    // wrapping involved.
+    pub(crate) const GOLDEN_CIDV1_RAW_CID: &str =
+        "bafkreiaexy7lean2gu56wdy6wonpfcvmrxqduqwtx3bsgionxx3v4ugc5y";
+    pub(crate) const GOLDEN_CIDV1_RAW_BYTES: &[u8] = &[
+        0x47, 0x52, 0x43, 0x32, 0x00, 0x06, 0x09, 0x67, 0xe3, 0xf1, 0x64, 0x46, 0xe1, 0xbe, 0x68,
+        0xd9, 0x76, 0xb3, 0xbe, 0x38, 0x39, 0x0d, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x20, 0x70,
+        0x61, 0x79, 0x6f, 0x75, 0x74, 0x01, 0x07, 0x84, 0x28, 0x62, 0xd2, 0xc3, 0x65, 0x4c, 0x03,
+        0x24, 0xa0, 0x7b, 0xc7, 0xcc, 0xe1, 0xa4, 0xf0, 0x8f, 0xd7, 0x81, 0x97, 0x96, 0xa6, 0x06,
+        0x02, 0xa1, 0x26, 0xca, 0x53, 0x0c, 0x8e, 0x48, 0xd5, 0xb8, 0x88, 0x82, 0xc7, 0x34, 0xc3,
+        0x89, 0x35, 0x05, 0x97, 0x28, 0xa6, 0xaa, 0xd7, 0xd7, 0x5a, 0x48, 0x29, 0xbb, 0x41, 0x18,
+        0xad, 0x28, 0xb6, 0xc0, 0x04, 0x03, 0xfd, 0xda, 0xca, 0xae, 0x85, 0x13, 0x8a, 0x43, 0xec,
+        0x1a, 0x50, 0xff, 0x71, 0x56, 0x4d, 0x42, 0x8f, 0x15, 0x1b, 0xa4, 0xde, 0x20, 0x4e, 0x3c,
+        0x9c, 0xb4, 0x99, 0xdd, 0xf9, 0x6f, 0x48, 0xf1, 0x1b, 0x59, 0x5a, 0x8b, 0x81, 0xfc, 0x25,
+        0x85, 0x6a, 0x9b, 0x50, 0x3e, 0x3e, 0x99, 0x33, 0x31, 0x01, 0x09, 0x0a, 0xda, 0xc0, 0xfc,
+        0xa4, 0x82, 0x2e, 0x8e, 0x71, 0x92, 0x63, 0xe6, 0x76, 0x20, 0xec, 0x00, 0x05, 0x4e, 0x6d,
+        0x70, 0xbd, 0xe6, 0x72, 0xf7, 0xac, 0x25, 0x69, 0x39, 0xeb, 0xa8, 0x2c, 0x26, 0xc3, 0x40,
+        0x70, 0x49, 0xae, 0xd8, 0x01, 0x48, 0x03, 0x9d, 0xfd, 0x52, 0x8d, 0xaf, 0x89, 0x80, 0x81,
+        0xbf, 0x99, 0xb1, 0x79, 0xf2, 0xcf, 0x4b, 0x1a, 0xb1, 0xa3, 0xcd, 0x05, 0xe8, 0x03, 0x24,
+        0xc6, 0xf5, 0x13, 0x2d, 0xeb, 0x10, 0x2d, 0x64, 0x55, 0x30, 0x49, 0xf1, 0xe9, 0xcb, 0x66,
+        0x2f, 0x50, 0x33, 0x0f, 0x72, 0xc7, 0xd0, 0xee, 0x4e, 0xd5, 0xbf, 0xa7, 0x34, 0xa1, 0x4f,
+        0xc7, 0x85, 0x32, 0x00, 0x00, 0x04, 0x05, 0x2f, 0xb9, 0xca, 0x0d, 0x0d, 0x50, 0x43, 0x83,
+        0xa4, 0xfc, 0x29, 0xbf, 0x0a, 0xb4, 0x04, 0xe6, 0x00, 0x10, 0x00, 0x01, 0xbf, 0x99, 0xb1,
+        0x79, 0xf2, 0xcf, 0x4b, 0x1a, 0xb1, 0xa3, 0xcd, 0x05, 0xe8, 0x03, 0x24, 0xc6, 0xff, 0xff,
+        0xff, 0xff, 0x0f, 0x01, 0xbf, 0x99, 0xb1, 0x79, 0xf2, 0xcf, 0x4b, 0x1a, 0xb1, 0xa3, 0xcd,
+        0x05, 0xe8, 0x03, 0x24, 0xc6, 0x02, 0x00, 0x11, 0x50, 0x61, 0x79, 0x6f, 0x75, 0x74, 0x20,
+        0x74, 0x6f, 0x20, 0x4e, 0x69, 0x6b, 0x20, 0x39, 0x30, 0x32, 0x01, 0x01, 0x00, 0x00, 0x14,
+        0x00, 0xff, 0xff, 0xff, 0xff, 0x0f, 0x05, 0x8e, 0x3e, 0xc7, 0x70, 0x25, 0x05, 0x4d, 0x20,
+        0x8a, 0xf4, 0x2e, 0x91, 0x96, 0xb9, 0x94, 0xe7, 0x01, 0x10, 0x02, 0x03, 0x01, 0x1a, 0xd1,
+        0x35, 0xba, 0xa9, 0x4f, 0x97, 0xaf, 0x82, 0x2e, 0x22, 0x7d, 0x6d, 0x49, 0xc6, 0xff, 0xff,
+        0xff, 0xff, 0x0f, 0x05, 0xd0, 0x2e, 0xe6, 0xf6, 0xe0, 0x22, 0x49, 0xa0, 0xa9, 0xa2, 0x69,
+        0x03, 0x68, 0x8b, 0x2a, 0x78, 0x02, 0x10, 0x02, 0x04, 0x22, 0xd5, 0xc6, 0xa0, 0x8d, 0xa4,
+        0x4c, 0x96, 0xb6, 0xa1, 0x20, 0xca, 0x84, 0x05, 0x55, 0x37, 0xff, 0xff, 0xff, 0xff, 0x0f,
+    ];
+
+    // Second real CIDv1 raw-codec fixture ("test 2") — different length,
+    // independent confirmation of the raw-codec path.
+    pub(crate) const GOLDEN_CIDV1_RAW_CID_2: &str =
+        "bafkreiaez5vauo6q2wk5pqun3itvkq6clvjfxjtcdcgawtknodo6ouzihu";
+    pub(crate) const GOLDEN_CIDV1_RAW_BYTES_2: &[u8] = &[
+        0x47, 0x52, 0x43, 0x32, 0x00, 0xd7, 0x72, 0x72, 0xcd, 0xa1, 0x8e, 0x46, 0x4e, 0x8a, 0x06,
+        0x7a, 0x54, 0x23, 0xa5, 0x4c, 0x73, 0x06, 0x74, 0x65, 0x73, 0x74, 0x20, 0x32, 0x01, 0x1d,
+        0x01, 0x46, 0x98, 0xe7, 0x4b, 0xb2, 0xd9, 0x6f, 0xdb, 0x77, 0xdd, 0x08, 0x6f, 0x3a, 0x03,
+        0xd0, 0x8d, 0xf4, 0xd8, 0xf1, 0xa9, 0xa5, 0x06, 0x03, 0xa1, 0x26, 0xca, 0x53, 0x0c, 0x8e,
+        0x48, 0xd5, 0xb8, 0x88, 0x82, 0xc7, 0x34, 0xc3, 0x89, 0x35, 0x05, 0x36, 0x1d, 0xe8, 0xfa,
+        0xd0, 0xe4, 0x44, 0xdc, 0xa2, 0xd2, 0x69, 0x39, 0x88, 0x45, 0x80, 0x98, 0x04, 0xcd, 0xbc,
+        0x35, 0xe8, 0xd0, 0x22, 0x41, 0xd1, 0x8d, 0xa2, 0xa5, 0x4a, 0x96, 0x87, 0x0b, 0xe9, 0x04,
+        0x02, 0x6d, 0x29, 0xd5, 0x78, 0x49, 0xbb, 0x49, 0x59, 0xba, 0xf7, 0x2c, 0xc6, 0x96, 0xb1,
+        0x67, 0x1a, 0x8f, 0x15, 0x1b, 0xa4, 0xde, 0x20, 0x4e, 0x3c, 0x9c, 0xb4, 0x99, 0xdd, 0xf9,
+        0x6f, 0x48, 0xf1, 0x01, 0x09, 0x0a, 0xda, 0xc0, 0xfc, 0xa4, 0x82, 0x2e, 0x8e, 0x71, 0x92,
+        0x63, 0xe6, 0x76, 0x20, 0xec, 0x00, 0x04, 0xcd, 0xbc, 0x35, 0xe8, 0xd0, 0x22, 0x41, 0xd1,
+        0x8d, 0xa2, 0xa5, 0x4a, 0x96, 0x87, 0x0b, 0xe9, 0xa3, 0x28, 0x8c, 0x22, 0xa0, 0x56, 0x4f,
+        0x6f, 0xb4, 0x09, 0xfb, 0xcc, 0xcb, 0x2c, 0x11, 0x8c, 0x80, 0x8a, 0x04, 0xce, 0xb2, 0x1c,
+        0x4d, 0x88, 0x8a, 0xd1, 0x2e, 0x24, 0x06, 0x13, 0xe5, 0xca, 0xbc, 0x63, 0xe4, 0x2b, 0xc0,
+        0xde, 0x4c, 0x2c, 0xb2, 0x79, 0x3a, 0x98, 0x4a, 0xfe, 0xc0, 0x20, 0x00, 0x00, 0x04, 0x05,
+        0xe7, 0x51, 0xfa, 0x32, 0xdd, 0x10, 0x41, 0x49, 0xb3, 0x7a, 0x4f, 0xe7, 0xe2, 0x88, 0x38,
+        0xbb, 0x00, 0x30, 0x00, 0x01, 0xee, 0x31, 0x41, 0x93, 0x0f, 0xe0, 0x47, 0x62, 0xb3, 0x69,
+        0x81, 0x8c, 0xbe, 0x05, 0x99, 0x03, 0x05, 0x61, 0x30, 0x39, 0x4a, 0x52, 0xff, 0xff, 0xff,
+        0xff, 0x0f, 0x05, 0x84, 0xce, 0xf0, 0x14, 0x54, 0x72, 0x4d, 0xcb, 0x97, 0xe1, 0xb1, 0xd5,
+        0x72, 0x91, 0xcf, 0x88, 0x01, 0x30, 0x00, 0x02, 0x84, 0xfc, 0xe8, 0x27, 0x09, 0x70, 0x43,
+        0xb7, 0x82, 0xa8, 0x20, 0x70, 0x29, 0x1e, 0xbf, 0x27, 0x05, 0x61, 0x30, 0x31, 0x43, 0x43,
+        0xff, 0xff, 0xff, 0xff, 0x0f, 0x02, 0x00, 0x01, 0x01, 0x00, 0x0e, 0x54, 0x65, 0x73, 0x74,
+        0x20, 0x64, 0x65, 0x63, 0x69, 0x6d, 0x61, 0x6c, 0x20, 0x32, 0x01, 0xff, 0xff, 0xff, 0xff,
+        0x0f, 0x02, 0x03, 0x01, 0x02, 0x01, 0x03, 0x00, 0xe4, 0x0f, 0x00, 0x02, 0x03, 0x00, 0xe4,
+        0x0f, 0x00, 0xff, 0xff, 0xff, 0xff, 0x0f,
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fixtures::*;
+
+    #[test]
+    fn verifies_known_good_content() {
+        assert_eq!(
+            verify(GOLDEN_SMALL_CID, GOLDEN_SMALL_BYTES),
+            Verification::Verified
+        );
+    }
+
+    #[test]
+    fn verifies_a_multi_byte_varint_length_field() {
+        assert_eq!(
+            verify(GOLDEN_LARGE_CID, GOLDEN_LARGE_BYTES),
+            Verification::Verified
+        );
+    }
+
+    #[test]
+    fn rejects_mismatched_content() {
+        let mut tampered = GOLDEN_SMALL_BYTES.to_vec();
+        tampered.push(0x00);
+        assert_eq!(verify(GOLDEN_SMALL_CID, &tampered), Verification::Mismatch);
+    }
+
+    #[test]
+    fn rejects_truncated_content() {
+        let truncated = &GOLDEN_SMALL_BYTES[..GOLDEN_SMALL_BYTES.len() - 1];
+        assert_eq!(verify(GOLDEN_SMALL_CID, truncated), Verification::Mismatch);
+    }
+
+    #[test]
+    fn reports_unrecognized_hash_function_as_unsupported() {
+        // CIDv1, raw codec, but blake2b-256 (mh code 0xb220) instead of
+        // sha2-256 — a shape this module deliberately doesn't attempt to
+        // verify rather than mis-hash.
+        let mut bytes = vec![1u8, CODEC_RAW as u8];
+        write_varint(&mut bytes, 0xb220);
+        bytes.push(32); // digest length
+        bytes.extend_from_slice(&[0u8; 32]);
+        let cid = format!("b{}", base32_encode_nopad(&bytes));
+
+        assert_eq!(verify(&cid, b"anything"), Verification::Unsupported);
+    }
+
+    #[test]
+    fn reports_non_base32_cidv1_as_unsupported() {
+        // Doesn't start with 'b' (base32) and isn't valid base58 either
+        // (contains characters base58 excludes) — genuinely unparseable,
+        // not a shape we quietly mis-verify.
+        let result = verify("not-a-real-cid-0O0Il", b"anything");
+        assert_eq!(result, Verification::Unsupported);
+    }
+
+    #[test]
+    fn verifies_uppercase_multibase_prefix() {
+        // 'B' (uppercase) is the multibase code for base32-upper — equally
+        // valid per the multibase spec, just far rarer in practice than
+        // lowercase 'b'. Uppercasing everything after the prefix on a known
+        // real CID should still verify.
+        let uppercased = format!("B{}", GOLDEN_CIDV1_RAW_CID[1..].to_ascii_uppercase());
+        assert_eq!(
+            verify(&uppercased, GOLDEN_CIDV1_RAW_BYTES),
+            Verification::Verified
+        );
+    }
+
+    #[test]
+    fn rejects_cidv1_with_trailing_bytes_after_the_digest() {
+        // A well-formed header + digest followed by extra bytes is not a
+        // canonical CIDv1 multihash — reject rather than silently ignoring
+        // the trailing bytes.
+        let mut bytes = vec![1u8, CODEC_RAW as u8, MULTIHASH_SHA2_256 as u8, 32];
+        bytes.extend_from_slice(&[0u8; 32]);
+        bytes.push(0xFF); // trailing garbage past the digest
+        let cid = format!("b{}", base32_encode_nopad(&bytes));
+
+        assert_eq!(verify(&cid, b"anything"), Verification::Unsupported);
+    }
+
+    #[test]
+    fn reports_oversized_content_as_unsupported() {
+        let big = vec![0u8; 256 * 1024 + 1];
+        assert_eq!(verify(GOLDEN_SMALL_CID, &big), Verification::Unsupported);
+    }
+
+    #[test]
+    fn strips_ipfs_prefix() {
+        let uri = format!("ipfs://{GOLDEN_SMALL_CID}");
+        // Wrong bytes on purpose — just checking the prefix is stripped and
+        // we get a real verdict (Mismatch), not silently treated as
+        // Unsupported due to a malformed decode from the un-stripped prefix.
+        assert_eq!(verify(&uri, b"wrong"), Verification::Mismatch);
+    }
+
+    #[test]
+    fn verifies_known_good_cidv1_raw_content() {
+        assert_eq!(
+            verify(GOLDEN_CIDV1_RAW_CID, GOLDEN_CIDV1_RAW_BYTES),
+            Verification::Verified
+        );
+        assert_eq!(
+            verify(GOLDEN_CIDV1_RAW_CID_2, GOLDEN_CIDV1_RAW_BYTES_2),
+            Verification::Verified
+        );
+    }
+
+    #[test]
+    fn rejects_mismatched_cidv1_raw_content() {
+        let mut tampered = GOLDEN_CIDV1_RAW_BYTES.to_vec();
+        tampered.push(0x00);
+        assert_eq!(
+            verify(GOLDEN_CIDV1_RAW_CID, &tampered),
+            Verification::Mismatch
+        );
+    }
+
+    #[test]
+    fn rejects_content_swapped_between_two_real_cidv1_uris() {
+        // GOLDEN_CIDV1_RAW_BYTES_2 is real, valid content for a *different*
+        // CID — make sure verify() doesn't just check "is this decodable",
+        // it checks "does this match *this* CID".
+        assert_eq!(
+            verify(GOLDEN_CIDV1_RAW_CID, GOLDEN_CIDV1_RAW_BYTES_2),
+            Verification::Mismatch
+        );
+    }
+
+    #[test]
+    fn cidv1_raw_has_no_single_chunk_size_limit() {
+        // Unlike dag-pb, a raw-codec CID is never chunked by construction —
+        // large content should still be checked directly, not bailed out to
+        // Unsupported the way an oversized dag-pb payload is.
+        let big = vec![0xABu8; 256 * 1024 + 1];
+        let digest = Sha256::digest(&big);
+        let cid = cidv1_raw_string(&digest);
+        assert_eq!(verify(&cid, &big), Verification::Verified);
+    }
+
+    /// Build a CIDv1 raw-codec string for a given sha2-256 digest, for use
+    /// as a test fixture (encodes: version=1, codec=raw, mh-code=sha2-256,
+    /// mh-len=32, digest).
+    fn cidv1_raw_string(digest: &[u8]) -> String {
+        let mut bytes = vec![
+            1u8,
+            CODEC_RAW as u8,
+            MULTIHASH_SHA2_256 as u8,
+            digest.len() as u8,
+        ];
+        bytes.extend_from_slice(digest);
+        format!("b{}", base32_encode_nopad(&bytes))
+    }
+
+    fn base32_encode_nopad(bytes: &[u8]) -> String {
+        const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz234567";
+        let mut bits: u64 = 0;
+        let mut bit_count: u32 = 0;
+        let mut out = String::new();
+        for &b in bytes {
+            bits = (bits << 8) | b as u64;
+            bit_count += 8;
+            while bit_count >= 5 {
+                bit_count -= 5;
+                out.push(ALPHABET[((bits >> bit_count) & 0x1f) as usize] as char);
+            }
+        }
+        if bit_count > 0 {
+            out.push(ALPHABET[((bits << (5 - bit_count)) & 0x1f) as usize] as char);
+        }
+        out
+    }
+
+    /// Same encoding as `base32_encode_nopad`, but deliberately sets the
+    /// final group's padding bit to 1 instead of 0 — a non-canonical
+    /// encoding that decodes to identical bytes but must still be rejected.
+    fn base32_encode_nonzero_padding(bytes: &[u8]) -> String {
+        const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz234567";
+        let mut bits: u64 = 0;
+        let mut bit_count: u32 = 0;
+        let mut out = String::new();
+        for &b in bytes {
+            bits = (bits << 8) | b as u64;
+            bit_count += 8;
+            while bit_count >= 5 {
+                bit_count -= 5;
+                out.push(ALPHABET[((bits >> bit_count) & 0x1f) as usize] as char);
+            }
+        }
+        assert!(
+            bit_count > 0,
+            "test input must need padding to be meaningful"
+        );
+        let value = (((bits << (5 - bit_count)) & 0x1f) | 0b1) as usize;
+        out.push(ALPHABET[value] as char);
+        out
+    }
+
+    #[test]
+    fn rejects_non_canonical_base32_padding() {
+        let mut bytes = vec![1u8, CODEC_RAW as u8, MULTIHASH_SHA2_256 as u8, 32];
+        bytes.extend_from_slice(&[0xABu8; 32]);
+        let cid = format!("b{}", base32_encode_nonzero_padding(&bytes));
+        assert_eq!(verify(&cid, b"anything"), Verification::Unsupported);
+    }
+}

--- a/kg-indexer/src/bin/audit_batch_replay.rs
+++ b/kg-indexer/src/bin/audit_batch_replay.rs
@@ -1,0 +1,264 @@
+//! One-off audit for the 2026-07-20 batch-replay-ordering incident: a batch
+//! of recovered edits was replayed via `replay_edit` in alphabetical-URI
+//! order rather than chronological block order. `replay_edit`'s write path
+//! (mirroring the real Kafka consumer) always closes whatever version is
+//! *currently open* for a touched target and treats its own edit as the new
+//! latest — it has no awareness of other edits in the same batch. Any
+//! target touched by more than one edit in a batch that wasn't replayed in
+//! block order ends up with a corrupted `valid_to_key` chain.
+//!
+//! Given a list of (uri, block, space) triples (one per line, space-
+//! separated, same format as the batch that was replayed), this:
+//! 1. Decodes each edit and collects every (entity, property, space) and
+//!    (relation, space) target it touches, same extraction as
+//!    `check_replay_safety`.
+//! 2. Groups by target. Every target the batch touches is checked — not
+//!    just ones shared between 2+ batch edits, since a single batch edit
+//!    can also corrupt or resurrect data over an *independent*, non-batch
+//!    edit that touched the same target (see `check_replay_safety`'s
+//!    Unset/Delete handling for why "no open row" doesn't mean "nothing
+//!    else touched this").
+//! 3. For each target, fetches the *entire* current version chain (not
+//!    just the open row) and checks whether `valid_to_key` on each row
+//!    equals the `valid_from_key` of the next row in ascending order (and
+//!    the last row is open, i.e. `valid_to_key IS NULL`).
+//! 4. Reports any chain that's out of order, with the exact corrected
+//!    `valid_to_key` for each affected row. Read-only — prints proposed
+//!    fixes, does not apply them.
+//!
+//! Usage:
+//!   DATABASE_URL=... cargo run -p kg-indexer --bin audit_batch_replay -- \
+//!     --batch-file /path/to/uri_block_space_lines.txt
+
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::fs;
+
+use grc_20::decode_edit;
+use hermes_schema::pb::blockchain_metadata::BlockchainMetadata;
+use hermes_schema::pb::knowledge::HermesEdit;
+use kg_indexer::error::IndexerError;
+use kg_indexer::handlers;
+use kg_indexer::storage::Storage;
+use uuid::Uuid;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum Target {
+    Value(Uuid, Uuid, Uuid),
+    Relation(Uuid, Uuid),
+}
+
+struct BatchEdit {
+    uri: String,
+    block: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+    let batch_file = args
+        .iter()
+        .position(|a| a == "--batch-file")
+        .and_then(|i| args.get(i + 1))
+        .expect("--batch-file is required");
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let storage = Storage::new(&database_url).await?;
+
+    let lines = fs::read_to_string(batch_file)
+        .map_err(|e| IndexerError::Config(format!("could not read batch file: {e}")))?;
+
+    // target -> list of (uri, block, version_key) that touch it
+    let mut target_edits: HashMap<Target, Vec<BatchEdit>> = HashMap::new();
+
+    for line in lines.lines().filter(|l| !l.trim().is_empty()) {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() != 3 {
+            return Err(IndexerError::Config(format!(
+                "malformed batch-file line (expected \"<uri> <block> <space>\"): {line:?}"
+            )));
+        }
+        let (uri, block_str, space_str) = (parts[0], parts[1], parts[2]);
+        let block: u64 = block_str
+            .parse()
+            .map_err(|e| IndexerError::Config(format!("bad block number in line {line:?}: {e}")))?;
+        let space: Uuid = space_str
+            .parse()
+            .map_err(|e| IndexerError::Config(format!("bad space UUID in line {line:?}: {e}")))?;
+
+        let row: (Option<Vec<u8>>, bool) =
+            sqlx::query_as("SELECT data, is_errored FROM ipfs_cache WHERE uri = $1")
+                .bind(uri)
+                .fetch_one(&storage.pool)
+                .await
+                .map_err(|e| match e {
+                    sqlx::Error::RowNotFound => {
+                        IndexerError::Config(format!("uri not found in ipfs_cache: {uri}"))
+                    }
+                    other => IndexerError::Database(other),
+                })?;
+        let (data, is_errored) = row;
+        if is_errored {
+            return Err(IndexerError::Config(format!(
+                "{uri}: ipfs_cache row is still marked is_errored — fix that first"
+            )));
+        }
+        let payload = data.ok_or_else(|| IndexerError::Config("no data".into()))?;
+        let decoded = decode_edit(&payload)
+            .map_err(|e| IndexerError::Config(format!("decode failed: {e}")))?;
+
+        let edit = HermesEdit {
+            id: decoded.id.to_vec(),
+            name: decoded.name.to_string(),
+            payload: payload.clone(),
+            authors: decoded.authors.iter().map(|a| a.to_vec()).collect(),
+            language: None,
+            space_id: space.as_bytes().to_vec(),
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                created_at: 0,
+                created_by: vec![],
+                block_number: block,
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let result = handlers::edits::handle_edit(&edit)?;
+
+        // Dedup this edit's own targets before recording them — a single
+        // edit can touch the same target more than once (e.g. set then
+        // later unset), which would otherwise inflate memory and make the
+        // "touched by batch edits" output list the same edit repeatedly.
+        let mut edit_targets: HashSet<Target> = HashSet::new();
+        for v in &result.values {
+            edit_targets.insert(Target::Value(v.entity_id, v.property_id, v.space_id));
+        }
+        for r in &result.relations {
+            edit_targets.insert(Target::Relation(r.id(), r.space_id()));
+        }
+        for target in edit_targets {
+            target_edits.entry(target).or_default().push(BatchEdit {
+                uri: uri.to_string(),
+                block,
+            });
+        }
+    }
+
+    // Check the full chain for every target the batch touched, not just
+    // ones shared between 2+ batch edits — a single batch edit can also
+    // silently resurrect data over an independent, non-batch edit that
+    // later unset/deleted it (that edit closes a version without opening a
+    // new one, so it wouldn't otherwise show up as a "shared target").
+    println!(
+        "Checking full version chain for {} target(s) touched by this batch.",
+        target_edits.len()
+    );
+
+    let mut any_corrupt = false;
+
+    for (target, edits) in target_edits.iter() {
+        match target {
+            Target::Value(entity_id, property_id, space_id) => {
+                let rows: Vec<(Uuid, i64, Option<i64>)> = sqlx::query_as(
+                    "SELECT id, valid_from_key, valid_to_key FROM value_versions \
+                     WHERE entity_id = $1 AND property_id = $2 AND space_id = $3 \
+                     ORDER BY valid_from_key",
+                )
+                .bind(entity_id)
+                .bind(property_id)
+                .bind(space_id)
+                .fetch_all(&storage.pool)
+                .await?;
+
+                report_chain(
+                    &format!(
+                        "VALUE (entity={entity_id}, property={property_id}, space={space_id})"
+                    ),
+                    &rows,
+                    edits,
+                    &mut any_corrupt,
+                );
+                continue;
+            }
+            Target::Relation(relation_id, space_id) => {
+                let rows: Vec<(Uuid, i64, Option<i64>)> = sqlx::query_as(
+                    "SELECT id, valid_from_key, valid_to_key FROM relation_versions \
+                     WHERE relation_id = $1 AND space_id = $2 ORDER BY valid_from_key",
+                )
+                .bind(relation_id)
+                .bind(space_id)
+                .fetch_all(&storage.pool)
+                .await?;
+
+                report_chain(
+                    &format!("RELATION (relation={relation_id}, space={space_id})"),
+                    &rows,
+                    edits,
+                    &mut any_corrupt,
+                );
+            }
+        }
+    }
+
+    if !any_corrupt {
+        println!("No out-of-order chains found among any of the batch's targets.");
+    }
+
+    Ok(())
+}
+
+fn report_chain(
+    label: &str,
+    rows: &[(Uuid, i64, Option<i64>)],
+    batch_edits: &[BatchEdit],
+    any_corrupt: &mut bool,
+) {
+    // A target's *last* row legitimately has no successor whenever the
+    // final touch was an Unset/Delete — those close a version without
+    // opening a new one (see Storage::insert_relation_versions/
+    // insert_value_versions, which only insert new rows for Create/Set).
+    // So the only real invariants are: (1) no row's valid_to is earlier
+    // than its own valid_from (closed before it opened), and (2) every row
+    // that *does* have a successor must hand off to it exactly (this row's
+    // valid_to == the next row's valid_from). Whether the last row is open
+    // or closed is not itself evidence of anything.
+    let mut corrupt = false;
+    let mut lines = Vec::new();
+    for i in 0..rows.len() {
+        let (id, valid_from, valid_to) = &rows[i];
+        if let Some(vt) = valid_to {
+            if vt < valid_from {
+                corrupt = true;
+            }
+        }
+        let expected_valid_to = rows.get(i + 1).map(|(_, next_from, _)| *next_from);
+        if expected_valid_to.is_some() && *valid_to != expected_valid_to {
+            corrupt = true;
+        }
+        lines.push(format!(
+            "  row {id}: valid_from={valid_from} valid_to={valid_to:?} (expected {expected_valid_to:?})"
+        ));
+    }
+    if corrupt {
+        *any_corrupt = true;
+        println!(
+            "CORRUPT CHAIN: {label} — touched by batch edits: {}",
+            batch_edits
+                .iter()
+                .map(|e| format!("{}(block {})", e.uri, e.block))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        for line in &lines {
+            println!("{line}");
+        }
+    }
+}

--- a/kg-indexer/src/bin/check_replay_safety.rs
+++ b/kg-indexer/src/bin/check_replay_safety.rs
@@ -1,0 +1,268 @@
+//! Checks whether a recovered `ipfs_cache` edit is safe to replay with
+//! `replay_edit` — i.e. whether any *later* real edit has already touched
+//! the same (entity, property, space) or (relation, space) targets.
+//!
+//! `replay_edit`'s underlying write path (`Storage::insert_value_versions` /
+//! `insert_relation_versions`) unconditionally closes whatever version is
+//! *currently open* for a touched target, setting its `valid_to_key` to this
+//! edit's own `version_key` — regardless of chronological order. If a newer
+//! edit already opened a version for that same target, replaying an older
+//! edit would set `valid_to_key` to a value *earlier* than that version's
+//! own `valid_from_key`, corrupting the version range and effectively
+//! back-dating a stomp over legitimately newer data.
+//!
+//! This tool decodes the edit, runs it through the exact same `handle_edit`
+//! extraction `replay_edit` uses (so the target set matches precisely what
+//! would actually be written), and batch-queries the currently open version
+//! for every touched target in one round trip per table — essential for
+//! edits with tens of thousands of ops, where a per-target query would be
+//! far too slow.
+//!
+//! Read-only: makes no writes. Exit code is 0 if safe to replay, 1 if any
+//! conflict was found (details printed either way).
+//!
+//! Usage:
+//!   DATABASE_URL=... cargo run -p kg-indexer --bin check_replay_safety -- \
+//!     --uri ipfs://Qm... \
+//!     --space <uuid> \
+//!     --block <n> \
+//!     [--sequence 0]
+
+use std::collections::HashSet;
+use std::env;
+
+use grc_20::decode_edit;
+use hermes_schema::pb::blockchain_metadata::BlockchainMetadata;
+use hermes_schema::pb::knowledge::HermesEdit;
+use kg_indexer::error::IndexerError;
+use kg_indexer::handlers;
+use kg_indexer::storage::Storage;
+use uuid::Uuid;
+
+struct Args {
+    uri: String,
+    space: Uuid,
+    block: u64,
+    sequence: u32,
+}
+
+fn parse_args() -> Args {
+    let args: Vec<String> = env::args().collect();
+    let get = |flag: &str| -> Option<String> {
+        args.iter()
+            .position(|a| a == flag)
+            .and_then(|i| args.get(i + 1))
+            .cloned()
+    };
+
+    let uri = get("--uri").expect("--uri is required");
+    let space = get("--space")
+        .expect("--space is required")
+        .parse()
+        .expect("--space must be a valid UUID");
+    let block: u64 = get("--block")
+        .expect("--block is required")
+        .parse()
+        .expect("--block must be a number");
+    let sequence: u32 = get("--sequence")
+        .map(|s| s.parse().expect("--sequence must be a number"))
+        .unwrap_or(0);
+
+    Args {
+        uri,
+        space,
+        block,
+        sequence,
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args = parse_args();
+    let version_key = ((args.block as i64) << 32) | args.sequence as i64;
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let storage = Storage::new(&database_url).await?;
+
+    let row: (Option<Vec<u8>>, bool) =
+        sqlx::query_as("SELECT data, is_errored FROM ipfs_cache WHERE uri = $1")
+            .bind(&args.uri)
+            .fetch_one(&storage.pool)
+            .await
+            .map_err(|e| match e {
+                sqlx::Error::RowNotFound => {
+                    IndexerError::Config(format!("uri not found in ipfs_cache: {}", args.uri))
+                }
+                other => IndexerError::Database(other),
+            })?;
+    let (data, is_errored) = row;
+    if is_errored {
+        return Err(IndexerError::Config(
+            "ipfs_cache row is still marked is_errored — fix that first".into(),
+        ));
+    }
+    let payload = data.ok_or_else(|| IndexerError::Config("ipfs_cache row has no data".into()))?;
+
+    let decoded = decode_edit(&payload)
+        .map_err(|e| IndexerError::Config(format!("payload does not decode: {e}")))?;
+
+    let edit = HermesEdit {
+        id: decoded.id.to_vec(),
+        name: decoded.name.to_string(),
+        payload: payload.clone(),
+        authors: decoded.authors.iter().map(|a| a.to_vec()).collect(),
+        language: None,
+        space_id: args.space.as_bytes().to_vec(),
+        is_canonical: true,
+        meta: Some(BlockchainMetadata {
+            created_at: 0,
+            created_by: vec![],
+            block_number: args.block,
+            cursor: String::new(),
+            sequence: args.sequence,
+            is_last: false,
+        }),
+    };
+
+    let result = handlers::edits::handle_edit(&edit)?;
+
+    println!(
+        "Edit {:?}: {} ops touching {} value targets, {} relation targets. version_key={version_key}",
+        decoded.name,
+        decoded.ops.len(),
+        result.values.len(),
+        result.relations.len(),
+    );
+
+    // Dedup targets — the same (entity, property, space) can be touched by
+    // multiple ops (e.g. set then later unset within the same edit). Kept as
+    // a single Vec<tuple> (not three parallel Vecs each derived from a
+    // separate HashSet::iter() pass) so the three per-column arrays bound
+    // below are built from one aligned iteration — `UNNEST` zips its
+    // argument arrays by index, so any independent derivation risks
+    // misaligning them and silently checking the wrong tuples.
+    let mut seen_values = HashSet::new();
+    let value_targets: Vec<(Uuid, Uuid, Uuid)> = result
+        .values
+        .iter()
+        .map(|v| (v.entity_id, v.property_id, v.space_id))
+        .filter(|t| seen_values.insert(*t))
+        .collect();
+
+    let mut seen_relations = HashSet::new();
+    let relation_targets: Vec<(Uuid, Uuid)> = result
+        .relations
+        .iter()
+        .map(|r| (r.id(), r.space_id()))
+        .filter(|t| seen_relations.insert(*t))
+        .collect();
+
+    let mut conflicts: Vec<String> = Vec::new();
+
+    if !value_targets.is_empty() {
+        let mut entity_ids = Vec::with_capacity(value_targets.len());
+        let mut property_ids = Vec::with_capacity(value_targets.len());
+        let mut space_ids = Vec::with_capacity(value_targets.len());
+        for (entity_id, property_id, space_id) in &value_targets {
+            entity_ids.push(*entity_id);
+            property_ids.push(*property_id);
+            space_ids.push(*space_id);
+        }
+
+        // DISTINCT ON + ORDER BY ... valid_from_key DESC gets the *latest*
+        // version per target regardless of whether it's still open —
+        // an Unset/Delete op closes a version without opening a new one
+        // (see Storage::insert_value_versions, which only inserts new rows
+        // for the Set subset), so a target's most recent touch can leave no
+        // open row at all. Checking only `valid_to_key IS NULL` would miss
+        // that and let a replay silently resurrect data a later edit
+        // deliberately removed.
+        let latest_versions: Vec<(Uuid, Uuid, Uuid, i64)> = sqlx::query_as(
+            r#"
+            SELECT DISTINCT ON (entity_id, property_id, space_id)
+                entity_id, property_id, space_id, valid_from_key
+            FROM value_versions
+            WHERE (entity_id, property_id, space_id) IN (
+                SELECT entity_id, property_id, space_id
+                FROM UNNEST($1::uuid[], $2::uuid[], $3::uuid[])
+                AS t(entity_id, property_id, space_id)
+              )
+            ORDER BY entity_id, property_id, space_id, valid_from_key DESC
+            "#,
+        )
+        .bind(&entity_ids)
+        .bind(&property_ids)
+        .bind(&space_ids)
+        .fetch_all(&storage.pool)
+        .await?;
+
+        for (entity_id, property_id, space_id, latest_from_key) in latest_versions {
+            if latest_from_key > version_key {
+                conflicts.push(format!(
+                    "VALUE CONFLICT: (entity={entity_id}, property={property_id}, space={space_id}) \
+                     already has a later version from key {latest_from_key} > this edit's {version_key} \
+                     — replaying would corrupt or resurrect over that row"
+                ));
+            }
+        }
+    }
+
+    if !relation_targets.is_empty() {
+        let mut relation_ids = Vec::with_capacity(relation_targets.len());
+        let mut space_ids = Vec::with_capacity(relation_targets.len());
+        for (relation_id, space_id) in &relation_targets {
+            relation_ids.push(*relation_id);
+            space_ids.push(*space_id);
+        }
+
+        // Same rationale as the value-target query above: check the latest
+        // version regardless of open/closed status.
+        let latest_versions: Vec<(Uuid, Uuid, i64)> = sqlx::query_as(
+            r#"
+            SELECT DISTINCT ON (relation_id, space_id)
+                relation_id, space_id, valid_from_key
+            FROM relation_versions
+            WHERE (relation_id, space_id) IN (
+                SELECT relation_id, space_id
+                FROM UNNEST($1::uuid[], $2::uuid[])
+                AS t(relation_id, space_id)
+              )
+            ORDER BY relation_id, space_id, valid_from_key DESC
+            "#,
+        )
+        .bind(&relation_ids)
+        .bind(&space_ids)
+        .fetch_all(&storage.pool)
+        .await?;
+
+        for (relation_id, space_id, latest_from_key) in latest_versions {
+            if latest_from_key > version_key {
+                conflicts.push(format!(
+                    "RELATION CONFLICT: (relation={relation_id}, space={space_id}) already has a \
+                     later version from key {latest_from_key} > this edit's {version_key} — \
+                     replaying would corrupt or resurrect over that row"
+                ));
+            }
+        }
+    }
+
+    if conflicts.is_empty() {
+        println!(
+            "SAFE — no later edit has touched any of this edit's {} targets.",
+            value_targets.len() + relation_targets.len()
+        );
+        Ok(())
+    } else {
+        println!("UNSAFE — {} conflict(s) found:", conflicts.len());
+        for c in &conflicts {
+            println!("  {c}");
+        }
+        std::process::exit(1);
+    }
+}

--- a/kg-indexer/src/bin/replay_edit.rs
+++ b/kg-indexer/src/bin/replay_edit.rs
@@ -1,0 +1,266 @@
+//! One-off manual replay for a single edit that `hermes-pipeline` permanently
+//! dropped due to a false-positive `ipfs_cache.is_errored` (see
+//! `ipfs::IpfsClient::get_bytes` — no CID-hash verification on fetch, so a
+//! transient truncated/corrupted read gets marked errored forever with no
+//! retry). Once the cache row is corrected (real payload + `is_errored =
+//! false`), the edit itself still never reaches `kg-indexer` on its own —
+//! `hermes-pipeline` is a one-shot, event-driven consumer with no backfill
+//! path for edits it already dropped.
+//!
+//! This bypasses Kafka entirely: it reads the (now-fixed) cached payload
+//! directly, decodes it, and runs it through the exact same `handle_edit` +
+//! storage-write sequence `kg-indexer`'s real Kafka consumer uses for a
+//! `KgMessage::Edit`, in one transaction.
+//!
+//! Idempotency is keyed on `edit_id` (embedded in the edit payload itself,
+//! not on block/sequence), via `edit_versions`'s `ON CONFLICT (edit_id) DO
+//! NOTHING` — so re-running this for an edit that already landed is a safe
+//! no-op, not a duplicate.
+//!
+//! CAUTION — this does NOT check whether the edit's target (entity,
+//! property, space) tuples have been touched by later, real edits since the
+//! original block. Blindly replaying a stale edit can incorrectly stomp on
+//! more-recent legitimate state (the versioned-write path always closes
+//! whatever version is currently open, regardless of chronological order).
+//! Verify the target values/version history by hand before running this for
+//! any edit that *sets* or *unsets* values on a pre-existing entity —
+//! creation-only edits (new entities/relations with no prior state) are safe
+//! by construction.
+//!
+//! Usage (a single DATABASE_URL is correct here — `ipfs_cache` and the KG
+//! tables this replays into are defined in the same migration/schema, see
+//! `api/drizzle/0000_handy_omega_red.sql`):
+//!   DATABASE_URL=... cargo run -p kg-indexer --bin replay_edit -- \
+//!     --uri ipfs://Qm... \
+//!     --space f3dab79c-b5a3-d9d1-7596-56dd5361d1c6 \
+//!     --block 162685 \
+//!     [--sequence 0] \
+//!     [--created-at 1752781200]
+
+use std::env;
+
+use grc_20::decode_edit;
+use hermes_schema::pb::blockchain_metadata::BlockchainMetadata;
+use hermes_schema::pb::knowledge::HermesEdit;
+use kg_indexer::error::IndexerError;
+use kg_indexer::handlers;
+use kg_indexer::models::values::ValueChangeType;
+use kg_indexer::storage::Storage;
+use uuid::Uuid;
+
+/// Must match `main.rs`'s `MAX_EDIT_NAME_LENGTH` — this tool mirrors the real
+/// Kafka consumer's storage-write behavior exactly, name truncation included.
+const MAX_EDIT_NAME_LENGTH: usize = 256;
+
+struct Args {
+    uri: String,
+    space: Uuid,
+    block: u64,
+    sequence: u32,
+    created_at: u64,
+}
+
+fn parse_args() -> Args {
+    let args: Vec<String> = env::args().collect();
+    let get = |flag: &str| -> Option<String> {
+        args.iter()
+            .position(|a| a == flag)
+            .and_then(|i| args.get(i + 1))
+            .cloned()
+    };
+
+    let uri = get("--uri").expect("--uri is required");
+    let space = get("--space")
+        .expect("--space is required")
+        .parse()
+        .expect("--space must be a valid UUID");
+    let block: u64 = get("--block")
+        .expect("--block is required")
+        .parse()
+        .expect("--block must be a number");
+    let sequence: u32 = get("--sequence")
+        .map(|s| s.parse().expect("--sequence must be a number"))
+        .unwrap_or(0);
+    let created_at: u64 = match get("--created-at") {
+        Some(s) => s.parse().expect("--created-at must be a unix timestamp"),
+        None => std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    };
+
+    Args {
+        uri,
+        space,
+        block,
+        sequence,
+        created_at,
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args = parse_args();
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let storage = Storage::new(&database_url).await?;
+
+    // 1. Read the (already-fixed) cached payload directly — this must be a
+    //    valid, non-errored row, or something upstream is still broken.
+    let row: (Option<Vec<u8>>, bool) =
+        sqlx::query_as("SELECT data, is_errored FROM ipfs_cache WHERE uri = $1")
+            .bind(&args.uri)
+            .fetch_one(&storage.pool)
+            .await
+            .map_err(|e| match e {
+                sqlx::Error::RowNotFound => {
+                    IndexerError::Config(format!("uri not found in ipfs_cache: {}", args.uri))
+                }
+                other => IndexerError::Database(other),
+            })?;
+    let (data, is_errored) = row;
+    if is_errored {
+        return Err(IndexerError::Config(
+            "ipfs_cache row is still marked is_errored — fix that first".into(),
+        ));
+    }
+    let payload = data.ok_or_else(|| IndexerError::Config("ipfs_cache row has no data".into()))?;
+
+    // 2. Decode once here to fail fast with a clear error before touching the
+    //    DB, and to log what we're about to replay.
+    let decoded = decode_edit(&payload)
+        .map_err(|e| IndexerError::Config(format!("payload does not decode: {e}")))?;
+    println!(
+        "Replaying edit {:?} ({} ops) into space {}",
+        decoded.name,
+        decoded.ops.len(),
+        args.space
+    );
+
+    // 3. Build the exact HermesEdit hermes-pipeline would have produced.
+    let edit = HermesEdit {
+        id: decoded.id.to_vec(),
+        name: decoded.name.to_string(),
+        payload: payload.clone(),
+        authors: decoded.authors.iter().map(|a| a.to_vec()).collect(),
+        language: None,
+        space_id: args.space.as_bytes().to_vec(),
+        is_canonical: true,
+        meta: Some(BlockchainMetadata {
+            created_at: args.created_at,
+            created_by: vec![],
+            block_number: args.block,
+            cursor: String::new(),
+            sequence: args.sequence,
+            is_last: false,
+        }),
+    };
+
+    // 4. Replicate kg-indexer's real process_message(KgMessage::Edit) path
+    //    exactly (see main.rs), in one transaction.
+    let mut tx = storage.pool.begin().await?;
+    sqlx::query("SET CONSTRAINTS ALL DEFERRED")
+        .execute(&mut *tx)
+        .await?;
+
+    let result = handlers::edits::handle_edit(&edit)?;
+
+    let values_for_versioning = result.values.clone();
+    let relations_for_versioning = result.relations.clone();
+
+    let (set_values, delete_values): (Vec<_>, Vec<_>) = result
+        .values
+        .into_iter()
+        .partition(|v| matches!(v.change_type, ValueChangeType::Set));
+    let delete_value_ids: Vec<_> = delete_values
+        .into_iter()
+        .map(|v| (v.id, v.space_id))
+        .collect();
+
+    let mut set_relations = Vec::new();
+    let mut update_relations = Vec::new();
+    let mut unset_relations = Vec::new();
+    let mut delete_relations = Vec::new();
+    for op in result.relations {
+        match op {
+            kg_indexer::models::relations::RelationOp::Create(r) => set_relations.push(r),
+            kg_indexer::models::relations::RelationOp::Update(r) => update_relations.push(r),
+            kg_indexer::models::relations::RelationOp::Unset(r) => unset_relations.push(r),
+            kg_indexer::models::relations::RelationOp::Delete(r) => {
+                delete_relations.push((r.id, r.space_id))
+            }
+        }
+    }
+
+    let ops = result.entities.len()
+        + set_values.len()
+        + delete_value_ids.len()
+        + set_relations.len()
+        + update_relations.len()
+        + unset_relations.len()
+        + delete_relations.len();
+
+    storage.insert_entities(&result.entities, &mut tx).await?;
+    storage.insert_values(&set_values, &mut tx).await?;
+    storage.delete_values(&delete_value_ids, &mut tx).await?;
+    storage.insert_relations(&set_relations, &mut tx).await?;
+    storage.update_relations(&update_relations, &mut tx).await?;
+    storage
+        .unset_relation_fields(&unset_relations, &mut tx)
+        .await?;
+    storage.delete_relations(&delete_relations, &mut tx).await?;
+
+    if let Some(meta) = edit.meta.as_ref() {
+        // Mirror main.rs's extract_edit_metadata exactly, so a replayed
+        // edit's stored name matches what the real Kafka consumer would
+        // have written for the same payload.
+        let name = if edit.name.is_empty() {
+            None
+        } else if edit.name.len() > MAX_EDIT_NAME_LENGTH {
+            Some(&edit.name[..edit.name.floor_char_boundary(MAX_EDIT_NAME_LENGTH)])
+        } else {
+            Some(edit.name.as_str())
+        };
+        let created_by_id = edit.authors.first().and_then(|a| Uuid::from_slice(a).ok());
+
+        if let Some(version_key) = storage
+            .insert_edit_version(
+                result.edit_id,
+                meta.block_number as i64,
+                meta.sequence as i64,
+                meta.created_at as i64,
+                name,
+                created_by_id,
+                &mut tx,
+            )
+            .await?
+        {
+            storage
+                .insert_value_versions(&values_for_versioning, version_key, &mut tx)
+                .await?;
+            storage
+                .insert_relation_versions(&relations_for_versioning, version_key, &mut tx)
+                .await?;
+            println!("Wrote {ops} operations, version_key={version_key}");
+        } else {
+            // The entities/values/relations upserts above already ran in
+            // this transaction (idempotent no-ops if this edit was replayed
+            // before) — only the version-tracking rows are skipped here, so
+            // "nothing written" would overstate what this branch means.
+            println!(
+                "edit_id {} already has a version — skipped value/relation version rows (live-table writes above already ran, idempotently)",
+                result.edit_id
+            );
+        }
+    }
+
+    tx.commit().await?;
+    println!("Done.");
+    Ok(())
+}

--- a/kg-indexer/src/lib.rs
+++ b/kg-indexer/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod error;
+pub mod handlers;
 pub mod models;
 pub mod storage;


### PR DESCRIPTION
Cherry-pick of b4e369c8 (#823), on `main` since 2026-07-20 but never on `staging` — so the v2 cluster has been running without it.

## Why this matters

This is the **third and last** silent data-loss path in the IPFS chain, in the original commit's own words:

> `get_bytes()` trusted whatever bytes an IPFS gateway returned with a 200, with no check that they actually hashed to the requested CID and no retry on failure. A single truncated read or flaky response was indistinguishable from genuinely invalid content, and got cached as permanently errored (hermes-ipfs-cache → hermes-pipeline), **silently and permanently dropping the edit with no way to recover it later**.

That is exactly what cost us 7 edits during an e2e run tonight: a transient fetch failure became a permanent `is_errored` verdict, and hermes-pipeline discarded the edits as "invalid user content".

It composes with the two fixes already on staging rather than overlapping them:

| path | fix |
|---|---|
| pipeline outruns the warmer → "not found in cache" | #845 (waits on the warmer's cursor) |
| writes to Pinata, reads Filebase → "payload errored" | #846 + secret rotation |
| **transient fetch failure → permanent `is_errored`** | **this PR** |

## What it adds

- CID verification for CIDv0 (dag-pb/UnixFS) and CIDv1 (raw + dag-pb) — both shapes seen in production
- Retry on transport failure or hash mismatch (3 attempts, exponential backoff) before giving up
- `hermes-ipfs-cache/src/bin/reconcile_errored.rs` — re-attempts existing `is_errored` rows. A prior audit recovered **211 of 659** false positives with it
- `kg-indexer` diagnostic binaries: `audit_batch_replay`, `check_replay_safety`, `replay_edit`

## Scope note

Despite the title, this commit spans **three crates** — `ipfs`, `hermes-ipfs-cache`, `kg-indexer`. So it is **not** a single-service deploy: both `hermes-ipfs-cache` and `kg-indexer` need rebuilding. Flagging because the rest of the main→staging backlog is being ported one service per PR.

## Verification

Applied cleanly (verified with `git merge-tree` before cherry-picking; no conflicts).

- `cargo check -p ipfs -p hermes-ipfs-cache -p kg-indexer` — clean
- `cargo test -p ipfs` — **26 passed** (the new CID verification suite)
- `cargo test -p hermes-ipfs-cache` — 13 passed
- `cargo test -p kg-indexer --lib` — 89 passed

## After deploy

Run `reconcile_errored` and check the count it reports — it should recover tonight's 7 dropped edits plus any historical false positives. Worth reading the number rather than assuming it worked.