### PR TITLE
fix(api): port GraphQL pool-pressure shedding + query_timeout fuse to staging (#841)

### DIFF
--- a/api/k8s/production/api.yaml
+++ b/api/k8s/production/api.yaml
@@ -94,8 +94,10 @@ spec:
                   key: DATABASE_URL
             - name: PG_CONNECTION_TIMEOUT_MS
               value: "3000"
+            - name: PG_QUERY_TIMEOUT_MS
+              value: "12000"
             - name: PG_POOL_PRESSURE_WAITING_THRESHOLD
-              value: "1"
+              value: "5"
             - name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD
               value: "90"
             - name: PG_POOL_PRESSURE_TIMEOUT_THRESHOLD

--- a/api/k8s/staging/api.yaml
+++ b/api/k8s/staging/api.yaml
@@ -96,8 +96,10 @@ spec:
                   key: DATABASE_URL
             - name: PG_CONNECTION_TIMEOUT_MS
               value: "3000"
+            - name: PG_QUERY_TIMEOUT_MS
+              value: "12000"
             - name: PG_POOL_PRESSURE_WAITING_THRESHOLD
-              value: "1"
+              value: "5"
             - name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD
               value: "90"
             - name: PG_POOL_PRESSURE_TIMEOUT_THRESHOLD

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -58,6 +58,10 @@ const pgPool = new Pool({
 	connectionTimeoutMillis: parseInt(process.env.PG_CONNECTION_TIMEOUT_MS || "3000", 10),
 	// Close idle connections after 30 seconds to free up PgBouncer slots
 	idleTimeoutMillis: parseInt(process.env.PG_IDLE_TIMEOUT_MS || "30000", 10),
+	// Deterministic client-side fuse: destroys a stuck query's connection just above
+	// Postgres' statement_timeout (10s, api/docs/database-configuration.md), so a client
+	// that doesn't get freed server-side is still reclaimed on the Node side.
+	query_timeout: parseInt(process.env.PG_QUERY_TIMEOUT_MS || "12000", 10),
 	// Allow process to exit cleanly when pool is idle (for graceful shutdown)
 	allowExitOnIdle: true,
 })


### PR DESCRIPTION
Cherry-pick of 52676aa7 (#841), on `main` since 2026-07-27 but never on `staging` — so the v2 API has been serving live traffic without it.

## What it changes

Three small things:

- `PG_QUERY_TIMEOUT_MS=12000` added to the k8s manifests
- a client-side `query_timeout` fuse in `postgraphile.ts`, set just above Postgres' `statement_timeout` (10s) so a client that never gets freed server-side is still reclaimed on the Node side
- pool-pressure shedding threshold relaxed from `1` to `5`

The fuse is the substantive part: without it a stuck query can hold a pool connection indefinitely, and the previous threshold of `1` made the API shed requests far too eagerly under load.

## Verification

Applied cleanly (pre-checked with `git merge-tree`). 3 files, +10/−2.

`vitest run` across the api package: **697 passed / 15 failed** — byte-identical to the `staging` baseline I measured immediately before (13 failed files, 15 failed tests, 697 passed). Those failures are pre-existing DB-dependent tests that need a real `DATABASE_URL`, not something this introduces.

## Context

Part of reconciling `main` → `staging`, which diverged 2026-07-08 (17 commits genuinely missing). Being ported one service per PR so each has a clean revert boundary. Companion: #847 (ipfs CID verify + retry).