### PR TITLE
fix(hermes-ipfs-cache): copy reconcile_errored into the runtime image

### DIFF
--- a/hermes-ipfs-cache/Dockerfile
+++ b/hermes-ipfs-cache/Dockerfile
@@ -35,6 +35,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/hermes-ipfs-cache/target/release/hermes-ipfs-cache /usr/local/bin/hermes-ipfs-cache
+# reconcile_errored re-attempts ipfs_cache rows marked is_errored (#823). `cargo
+# build --release` already produces it, but without this COPY it is discarded with
+# the builder stage and the tool cannot be run in-cluster — same omission #826 hit
+# with ranking-indexer's rolling_sweep.
+COPY --from=builder /app/hermes-ipfs-cache/target/release/reconcile_errored /usr/local/bin/reconcile_errored
 COPY --from=builder /app/hermes-substream/hermes-substream-v0.1.0.spkg /hermes-substream/hermes-substream-v0.1.0.spkg
 
 WORKDIR /


### PR DESCRIPTION
#847 shipped `reconcile_errored` — the recovery half of #823, and the only way to reclaim edits already lost to a transient IPFS fetch failure. **It is not in the deployed image.**

```
$ kubectl exec deploy/hermes-ipfs-cache -n gaia -- ls /usr/local/bin
hermes-ipfs-cache
```

`cargo build --release` does produce it (it lives in `src/bin/`), but the runtime stage only copied the main binary, so it was discarded with the builder stage. One `COPY` line fixes it.

This is the same omission **#826** hit with ranking-indexer's `rolling_sweep`, fixed the same way — worth noting as a recurring shape in these multi-binary crates.

## Why it matters now

A prior system-wide audit recovered **211 of 659** `is_errored` rows as false positives. We also have 7 edits dropped during tonight's e2e run, before the Filebase/Pinata mismatch was fixed, that this tool should be able to reclaim. Without it, #823's retry logic only prevents *future* loss and there is no path to recover what is already marked errored.

## Verification

`cargo build --release -p hermes-ipfs-cache --bin reconcile_errored` — builds clean, 11.2 MB binary produced. The tool takes `--dry-run` and `--limit N`, and needs `DATABASE_URL` + `IPFS_GATEWAY_URL`, both already present in the deployment's env.

After this deploys I will run it with `--dry-run` first and report the count before doing anything real.