### PR TITLE
fix(search): port canonical-only toggle fix for root-space searches to staging (#817)

### DIFF
--- a/api/src/services/search/opensearch.test.ts
+++ b/api/src/services/search/opensearch.test.ts
@@ -791,7 +791,31 @@ describe("OpenSearchClient", () => {
 			vi.restoreAllMocks()
 		})
 
-		it("uses in_canonical_graph filter when space is root", async () => {
+		it("uses in_canonical_graph filter when space is root and canonical-only is requested", async () => {
+			const spaceId = "abcd1234-abcd-1234-abcd-1234abcd0001"
+			vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+				new Response(JSON.stringify({subspaces: [spaceId, "child-1"], is_root: true}), {
+					status: 200,
+					headers: {"Content-Type": "application/json"},
+				}),
+			)
+
+			const query = await topologyClient.buildSearchBody({
+				query: "blockchain",
+				scope: "SPACE",
+				space_id: spaceId,
+				include_non_canonical: false,
+			})
+			const queryStr = JSON.stringify(query)
+
+			expect(queryStr).toContain("in_canonical_graph")
+			expect(queryStr).not.toContain(spaceId)
+		})
+
+		it("does NOT force in_canonical_graph when space is root and non-canonical is included (regression)", async () => {
+			// Root-space membership must not silently collapse to canonical-only —
+			// the include_non_canonical toggle (default true) has to actually widen
+			// results, or non-canonical entities become unsearchable from root.
 			const spaceId = "abcd1234-abcd-1234-abcd-1234abcd0001"
 			vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
 				new Response(JSON.stringify({subspaces: [spaceId, "child-1"], is_root: true}), {
@@ -807,8 +831,7 @@ describe("OpenSearchClient", () => {
 			})
 			const queryStr = JSON.stringify(query)
 
-			expect(queryStr).toContain("in_canonical_graph")
-			expect(queryStr).not.toContain(spaceId)
+			expect(queryStr).not.toContain("in_canonical_graph")
 		})
 
 		it("uses space_id terms filter when space is not root", async () => {
@@ -905,6 +928,7 @@ describe("OpenSearchClient", () => {
 				query: "blockchain",
 				scope: "SPACE",
 				space_id: rootId,
+				include_non_canonical: false,
 			})
 			const queryStr = JSON.stringify(query)
 
@@ -969,6 +993,7 @@ describe("OpenSearchClient", () => {
 				query: "test",
 				scope: "SPACE",
 				space_id: rootId,
+				include_non_canonical: false,
 			})
 			expect(JSON.stringify(query1)).toContain("in_canonical_graph")
 
@@ -979,6 +1004,7 @@ describe("OpenSearchClient", () => {
 				query: "test2",
 				scope: "SPACE",
 				space_id: rootId,
+				include_non_canonical: false,
 			})
 			expect(JSON.stringify(query2)).toContain("in_canonical_graph")
 			expect(fetchSpy).not.toHaveBeenCalled()

--- a/api/src/services/search/opensearch.ts
+++ b/api/src/services/search/opensearch.ts
@@ -826,16 +826,15 @@ export class OpenSearchClient implements SearchClient {
 				return buildBoolQuery()
 
 			case "SPACE":
-				if (space_id) {
-					if (this.isRootSpace(space_id)) {
-						filters.push({term: {in_canonical_graph: true}})
-					} else {
-						const {subspaces, isRoot} = await this.fetchSubspaces(space_id)
-						if (isRoot) {
-							filters.push({term: {in_canonical_graph: true}})
-						} else {
-							filters.push({terms: {space_id: subspaces.flatMap(uuidTermVariants)}})
-						}
+				// Root-space membership already collapses to the canonical filter,
+				// which the shared `!includeNonCanonical` push above already applies —
+				// don't force it here too, or the canonical-only toggle has no effect
+				// for root-space searches (see e.g. buildMultiSpaceQuery for the same
+				// pattern applied to text search).
+				if (space_id && !this.isRootSpace(space_id)) {
+					const {subspaces, isRoot} = await this.fetchSubspaces(space_id)
+					if (!isRoot) {
+						filters.push({terms: {space_id: subspaces.flatMap(uuidTermVariants)}})
 					}
 				}
 				return buildBoolQuery()
@@ -945,16 +944,15 @@ export class OpenSearchClient implements SearchClient {
 				}
 
 			case "SPACE":
-				if (space_id) {
-					if (this.isRootSpace(space_id)) {
-						filters.push({term: {in_canonical_graph: true}})
-					} else {
-						const {subspaces, isRoot} = await this.fetchSubspaces(space_id)
-						if (isRoot) {
-							filters.push({term: {in_canonical_graph: true}})
-						} else {
-							filters.push({terms: {space_id: subspaces.flatMap(uuidTermVariants)}})
-						}
+				// Root-space membership already collapses to the canonical filter,
+				// which the shared `!includeNonCanonical` push above already applies —
+				// don't force it here too, or the canonical-only toggle has no effect
+				// for root-space searches (see e.g. buildMultiSpaceQuery for the same
+				// pattern applied to text search).
+				if (space_id && !this.isRootSpace(space_id)) {
+					const {subspaces, isRoot} = await this.fetchSubspaces(space_id)
+					if (!isRoot) {
+						filters.push({terms: {space_id: subspaces.flatMap(uuidTermVariants)}})
 					}
 				}
 				return {
@@ -1420,10 +1418,12 @@ export class OpenSearchClient implements SearchClient {
 	): object {
 		const typeFilter = this.buildTypeFilter(typeIds)
 		const typeExclusionFilter = this.buildTypeExclusionFilter(excludeTypeIds)
-		const spaceFilter = isRoot
-			? {term: {in_canonical_graph: true}}
-			: {terms: {space_id: spaceIds.flatMap(uuidTermVariants)}}
-		const filters: object[] = [spaceFilter]
+		// Root-space membership already collapses to the canonical filter, which
+		// the `!includeNonCanonical` push below already applies — don't force it
+		// here too, or the canonical-only toggle has no effect for root-space
+		// searches. When non-canonical entities are requested for a root space,
+		// there's no bounded space set to filter by, so leave it unfiltered.
+		const filters: object[] = isRoot ? [] : [{terms: {space_id: spaceIds.flatMap(uuidTermVariants)}}]
 		const mustNot: object[] = []
 		if (!includeDeleted) filters.push(this.buildNonDeletedFilter())
 		if (!includeNonCanonical) filters.push(this.buildCanonicalFilter())

--- a/search-indexer/tests/e2e-kafka-search-api/typescript/validate-search.ts
+++ b/search-indexer/tests/e2e-kafka-search-api/typescript/validate-search.ts
@@ -2594,23 +2594,30 @@ class SearchValidator {
   }
 
   /**
-   * Test 40: SPACE scope on topo_root (canonical root) returns all 5 canonical entities.
+   * Test 40: SPACE scope on topo_root (canonical root), canonical-only requested,
+   * returns all 5 canonical entities.
    *
-   * topo_root is the canonical root → the API must use {term:{in_canonical_graph:true}}
-   * which matches ALL entities across all canonical spaces (root + children + grandchild).
+   * topo_root is the canonical root → with include_non_canonical=false the API
+   * must use {term:{in_canonical_graph:true}}, matching ALL entities across all
+   * canonical spaces (root + children + grandchild) and excluding topo_remove_me.
+   *
+   * Root-space membership only collapses to the canonical filter when the caller
+   * actually asks for canonical-only — the toggle is NOT ignored for root-space
+   * queries (see test40b for the include_non_canonical=true / default case).
    *
    * After all three diffs the canonical set is:
    *   topo_root, topo_child_a, topo_child_b, topo_grandchild, topo_moveable (5 spaces)
    * So we expect 5 entities in the result (topo_remove_me was removed).
    */
   async test40_SpaceScopeRootUsesCanonicalFilter(): Promise<void> {
-    console.log(`\n${BLUE}Test 40: SPACE scope on canonical root returns entities from all canonical subspaces${NC}`);
+    console.log(`\n${BLUE}Test 40: SPACE scope on canonical root, canonical-only requested, returns entities from all canonical subspaces${NC}`);
 
     const response = await this.search({
       query: 'TopoEntity',
       scope: 'SPACE',
       space_id: TEST_ENTITIES.TOPO_ROOT_SPACE_ID,
       limit: 20,
+      include_non_canonical: false,
     });
 
     // topo_remove_me was removed in diff 2 → its entity should not appear
@@ -2638,6 +2645,37 @@ class SearchValidator {
     } else {
       const missing = [...expectedCanonical].filter(id => !foundIds.has(id));
       this.addResult('test40_canonical_entities_present', false, `Missing canonical TopoEntity entities: ${missing.join(', ')}`);
+    }
+  }
+
+  /**
+   * Test 40b: SPACE scope on topo_root, include_non_canonical=true (the default —
+   * i.e. the caller never sent the param at all), does NOT force the canonical
+   * filter — topo_remove_me (in_canonical_graph=false) must be reachable.
+   *
+   * Regression coverage for a real bug: root-space search used to hardcode
+   * {term:{in_canonical_graph:true}} unconditionally, so a "canonical only" UI
+   * toggle turned off had no effect for any consumer scoped to the root space —
+   * non-canonical entities were unsearchable by name no matter what. Root-space
+   * membership must only collapse to canonical when canonical-only is actually
+   * requested (test40); the default (unset / true) must leave it unfiltered.
+   */
+  async test40b_SpaceScopeRootIncludesNonCanonicalByDefault(): Promise<void> {
+    console.log(`\n${BLUE}Test 40b: SPACE scope on canonical root, include_non_canonical default (true), includes non-canonical entities${NC}`);
+
+    const response = await this.search({
+      query: 'TopoEntity',
+      scope: 'SPACE',
+      space_id: TEST_ENTITIES.TOPO_ROOT_SPACE_ID,
+      limit: 20,
+    });
+
+    const foundIds = new Set(response.results.map(r => r.entityId));
+    const removeMePresent = foundIds.has(TEST_ENTITIES.TOPO_REMOVE_ME_ENTITY_ID);
+    if (removeMePresent) {
+      this.addResult('test40b_remove_me_included', true, 'topo_remove_me entity (non-canonical) found in root SPACE scope when canonical-only is not requested');
+    } else {
+      this.addResult('test40b_remove_me_included', false, 'topo_remove_me entity missing from root SPACE scope — canonical-only toggle has no effect (regression)');
     }
   }
 
@@ -2705,9 +2743,11 @@ class SearchValidator {
   /**
    * Test 42: Removed node loses in_canonical_graph flag (diff 2).
    *
-   * topo_remove_me was removed in diff 2.  Its entity must NOT appear in a SPACE
-   * scope search on topo_root (which uses the in_canonical_graph filter).  We
-   * also confirm that the topology endpoint no longer knows about topo_remove_me.
+   * topo_remove_me was removed in diff 2.  With canonical-only explicitly
+   * requested (include_non_canonical=false), its entity must NOT appear in a
+   * SPACE scope search on topo_root (which uses the in_canonical_graph filter).
+   * We also confirm that the topology endpoint no longer knows about
+   * topo_remove_me.
    */
   async test42_RemovedNodeLosesCanonicalFlag(): Promise<void> {
     console.log(`\n${BLUE}Test 42: Removed node loses in_canonical_graph flag (diff 2 removal)${NC}`);
@@ -2720,12 +2760,13 @@ class SearchValidator {
       this.addResult('test42_topology_404', false, `Expected 404 for topo_remove_me, got subspaces: ${JSON.stringify(subResp)}`);
     }
 
-    // Root SPACE scope must exclude topo_remove_me_entity (in_canonical_graph=false)
+    // Root SPACE scope with canonical-only requested must exclude topo_remove_me_entity (in_canonical_graph=false)
     const response = await this.search({
       query: 'TopoEntity',
       scope: 'SPACE',
       space_id: TEST_ENTITIES.TOPO_ROOT_SPACE_ID,
       limit: 20,
+      include_non_canonical: false,
     });
 
     const foundIds = response.results.map(r => r.entityId);
@@ -3827,6 +3868,7 @@ async function main() {
     await validator.test38_TopologyRootIsSet();
     await validator.test39_CanonicalEntitiesIndexed();
     await validator.test40_SpaceScopeRootUsesCanonicalFilter();
+    await validator.test40b_SpaceScopeRootIncludesNonCanonicalByDefault();
     await validator.test41_SpaceScopeNonRootUsesSubspaceList();
     await validator.test42_RemovedNodeLosesCanonicalFlag();
     await validator.test43_SubtreeCascadeAndRejoin();


### PR DESCRIPTION
Cherry-pick of 697e52e7 (#817), on `main` since 2026-07-16 but never on `staging`.

## The bug

`buildMultiSpaceQuery`, `buildUuidQuery` and `buildTopRankedQuery` all hardcoded `{term: {in_canonical_graph: true}}` for root-space (SPACE scope) queries, ignoring `include_non_canonical` entirely. The toggle already behaved correctly for GLOBAL scope — root-space search never got the same treatment, so **"canonical only" off had no effect in the main site search bar**.

User-visible on the v2 cluster today: the toggle silently does nothing for root-space searches.

## Verification

Applied cleanly (pre-checked with `git merge-tree`). 3 files, +101/−33.

`vitest run src/services/search` — **82 passed**, including the 28 lines of new assertions this commit adds for the toggle behaviour.

## Deploy note

Touches `api` (query builders) and the search validation script, so it needs an `api` redeploy. Does not touch the `search-indexer` service itself, so no reindex is required — this only changes how queries are built.

Part of the `main` → `staging` reconciliation (diverged 2026-07-08). Companions: #847, #848, #849.