### PR TITLE
ci: port dependency bumps to staging (#783, #784, #785)

### DIFF
--- a/.github/workflows/atlas-e2e-tests.yml
+++ b/.github/workflows/atlas-e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
           pkg-config
 
     - name: Cache cargo registry
-      uses: actions/cache@v5.0.5
+      uses: actions/cache@v6.0.0
       with:
         path: |
           ~/.cargo/registry

--- a/.github/workflows/atlas-unit-tests.yml
+++ b/.github/workflows/atlas-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
           pkg-config
 
     - name: Cache cargo registry
-      uses: actions/cache@v5.0.5
+      uses: actions/cache@v6.0.0
       with:
         path: |
           ~/.cargo/registry

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2
         with:
           tool: cargo-deny
 

--- a/.github/workflows/chain-tip-exporter-check.yml
+++ b/.github/workflows/chain-tip-exporter-check.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: "1.92.0"
           components: rustfmt, clippy

--- a/.github/workflows/delivery-worker-tests.yml
+++ b/.github/workflows/delivery-worker-tests.yml
@@ -44,7 +44,7 @@ jobs:
             pkg-config
 
       - name: Cache cargo registry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/delivery-worker-tests.yml
+++ b/.github/workflows/delivery-worker-tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: "1.92.0"
           components: clippy, rustfmt

--- a/.github/workflows/kg-indexer-unit-tests.yml
+++ b/.github/workflows/kg-indexer-unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
             pkg-config
 
       - name: Cache cargo registry
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@v6.0.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/notification-indexer-tests.yml
+++ b/.github/workflows/notification-indexer-tests.yml
@@ -48,7 +48,7 @@ jobs:
             pkg-config
 
       - name: Cache cargo registry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/notification-indexer-tests.yml
+++ b/.github/workflows/notification-indexer-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: "1.92.0"
           components: clippy, rustfmt

--- a/.github/workflows/notification-service-e2e-tests.yml
+++ b/.github/workflows/notification-service-e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: "1.92.0"
           components: clippy, rustfmt

--- a/.github/workflows/notification-service-e2e-tests.yml
+++ b/.github/workflows/notification-service-e2e-tests.yml
@@ -57,7 +57,7 @@ jobs:
             postgresql-client
 
       - name: Cache cargo registry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/scoring-topology-indexer-tests.yml
+++ b/.github/workflows/scoring-topology-indexer-tests.yml
@@ -46,7 +46,7 @@ jobs:
             pkg-config
 
       - name: Cache cargo registry
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@v6.0.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/scoring-vote-indexer-tests.yml
+++ b/.github/workflows/scoring-vote-indexer-tests.yml
@@ -46,7 +46,7 @@ jobs:
             pkg-config
 
       - name: Cache cargo registry
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@v6.0.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/search-indexer-unit-tests.yml
+++ b/.github/workflows/search-indexer-unit-tests.yml
@@ -51,7 +51,7 @@ jobs:
             pkg-config
 
       - name: Cache cargo registry
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@v6.0.0
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
Batch of three dependabot bumps from `main`, none of which reached `staging`:

- `actions/cache` 5.0.5 → 6.0.0 (#783)
- `taiki-e/install-action` 2.82.0 → 2.82.4 (#784)
- `dtolnay/rust-toolchain` (#785)

11 workflow files, +14/−14. Batched as one PR since they are mechanical and share a single concern; each applied cleanly.

Verified all 11 workflow YAML files still parse.

Completes the low-risk portion of the `main` → `staging` reconciliation.