### PR TITLE
feat(ranking-indexer): port datetime bounds, block backfill and rolling rankings to staging (#808, #809, #810, #811, #821, #826, #827)

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -90,7 +90,9 @@ jobs:
             proposal-executor) manifests="proposal-executor/deployment/v2/cronjob.yaml";    rollout="" ;;
             notification-indexer) manifests="notification-service/deployment/v2/notification-indexer.yaml"; rollout="deployment/notification-indexer" ;;
             delivery-worker)   manifests="notification-service/deployment/v2/delivery-worker.yaml"; rollout="deployment/delivery-worker" ;;
-            ranking-indexer)   manifests="ranking-indexer/k8s/v2/ranking-indexer.yaml";     rollout="deployment/ranking-indexer" ;;
+            # The two CronJobs ship with the Deployment: both run the same image
+            # and are only useful at the same version as the consumer.
+            ranking-indexer)   manifests="ranking-indexer/k8s/v2/ranking-indexer.yaml ranking-indexer/k8s/v2/backfill-cronjob.yaml ranking-indexer/k8s/v2/rolling-sweep-cronjob.yaml"; rollout="deployment/ranking-indexer" ;;
             *) echo "unknown service"; exit 1 ;;
           esac
           echo "manifests=$manifests" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ranking-indexer-deploy-staging.yml
+++ b/.github/workflows/ranking-indexer-deploy-staging.yml
@@ -57,6 +57,10 @@ jobs:
           # Update image tag to use SHA and apply
           sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/staging/ranking-indexer.yaml
           kubectl apply -f ranking-indexer/k8s/staging/ranking-indexer.yaml
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/staging/backfill-cronjob.yaml
+          kubectl apply -f ranking-indexer/k8s/staging/backfill-cronjob.yaml
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/staging/rolling-sweep-cronjob.yaml
+          kubectl apply -f ranking-indexer/k8s/staging/rolling-sweep-cronjob.yaml
 
       - name: Restart deployment to pick up new image
         run: |

--- a/.github/workflows/ranking-indexer-deploy.yml
+++ b/.github/workflows/ranking-indexer-deploy.yml
@@ -57,6 +57,10 @@ jobs:
           # Update image tag to use SHA and apply
           sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/production/ranking-indexer.yaml
           kubectl apply -f ranking-indexer/k8s/production/ranking-indexer.yaml
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/production/backfill-cronjob.yaml
+          kubectl apply -f ranking-indexer/k8s/production/backfill-cronjob.yaml
+          sed -i 's|image: registry.digitalocean.com/geo/ranking-indexer:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' ranking-indexer/k8s/production/rolling-sweep-cronjob.yaml
+          kubectl apply -f ranking-indexer/k8s/production/rolling-sweep-cronjob.yaml
 
       - name: Restart deployment to pick up new image
         run: |

--- a/api/drizzle/0068_rolling_rankings.sql
+++ b/api/drizzle/0068_rolling_rankings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "ranks"."ranking_blocks" ADD COLUMN "ranking_type" uuid;--> statement-breakpoint
+ALTER TABLE "ranks"."ranking_blocks" ADD COLUMN "submission_frequency" integer;

--- a/api/drizzle/meta/0068_snapshot.json
+++ b/api/drizzle/meta/0068_snapshot.json
@@ -1,0 +1,4210 @@
+{
+  "id": "f846cd7b-47c2-433a-8aca-d2d0144b0007",
+  "prevId": "273891cc-8b0a-4b2e-871f-d21a2c7a4c8e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_types": {
+          "name": "notification_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_ids": {
+          "name": "space_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_poll_cursors": {
+      "name": "notification_poll_cursors",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor_updated_at": {
+          "name": "cursor_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_version": {
+          "name": "proposal_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partial_percentage_support_threshold": {
+          "name": "partial_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "universal_percentage_support_threshold": {
+          "name": "universal_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flat_support_threshold": {
+          "name": "flat_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disable_fast_path_access_for_new_members": {
+          "name": "disable_fast_path_access_for_new_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_grace_period": {
+          "name": "execution_grace_period",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_version_fk": {
+          "name": "proposal_actions_version_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposal_versions",
+          "columnsFrom": [
+            "proposal_id",
+            "proposal_version"
+          ],
+          "columnsTo": [
+            "proposal_id",
+            "proposal_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_actions_proposal_id_proposal_version_index_pk": {
+          "name": "proposal_actions_proposal_id_proposal_version_index_pk",
+          "columns": [
+            "proposal_id",
+            "proposal_version",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_versions": {
+      "name": "proposal_versions",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_version": {
+          "name": "proposal_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partial_percentage_support_threshold": {
+          "name": "partial_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "universal_percentage_support_threshold": {
+          "name": "universal_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flat_support_threshold": {
+          "name": "flat_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execute_by": {
+          "name": "execute_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_created_at_block": {
+          "name": "version_created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_versions_proposal_version_desc_idx": {
+          "name": "proposal_versions_proposal_version_desc_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposal_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_versions_end_time_idx": {
+          "name": "proposal_versions_end_time_idx",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_versions_start_time_idx": {
+          "name": "proposal_versions_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_versions_proposal_id_proposals_id_fk": {
+          "name": "proposal_versions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_versions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_versions_proposal_id_proposal_version_pk": {
+          "name": "proposal_versions_proposal_id_proposal_version_pk",
+          "columns": [
+            "proposal_id",
+            "proposal_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "proposal_versions_idempotency_key": {
+          "name": "proposal_versions_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proposal_id",
+            "version_created_at_block"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_version": {
+          "name": "proposal_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_version_fk": {
+          "name": "proposal_votes_version_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposal_versions",
+          "columnsFrom": [
+            "proposal_id",
+            "proposal_version"
+          ],
+          "columnsTo": [
+            "proposal_id",
+            "proposal_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_proposal_version_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_proposal_version_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "proposal_version",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_blocks": {
+      "name": "ranking_blocks",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restriction_id": {
+          "name": "restriction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranking_type": {
+          "name": "ranking_type",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_frequency": {
+          "name": "submission_frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_blocks_id_space_id_pk": {
+          "name": "ranking_blocks_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_items": {
+      "name": "ranking_items",
+      "schema": "ranks",
+      "columns": {
+        "ranking_id": {
+          "name": "ranking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_items_ranking_id_entity_id_space_id_pk": {
+          "name": "ranking_items_ranking_id_entity_id_space_id_pk",
+          "columns": [
+            "ranking_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_scores": {
+      "name": "ranking_scores",
+      "schema": "ranks",
+      "columns": {
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranking_scores_block_position_idx": {
+          "name": "ranking_scores_block_position_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_scores_block_id_entity_id_space_id_pk": {
+          "name": "ranking_scores_block_id_entity_id_space_id_pk",
+          "columns": [
+            "block_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.rankings": {
+      "name": "rankings",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank_type": {
+          "name": "rank_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "update_index": {
+          "name": "update_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rankings_block_id_idx": {
+          "name": "rankings_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rankings_block_space_idx": {
+          "name": "rankings_block_space_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rankings_space_id_idx": {
+          "name": "rankings_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rankings_id_space_id_pk": {
+          "name": "rankings_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.editors": {
+      "name": "editors",
+      "schema": "ranks",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranks_editors_space_id_idx": {
+          "name": "ranks_editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.members": {
+      "name": "members",
+      "schema": "ranks",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranks_members_space_id_idx": {
+          "name": "ranks_members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_last_to_entity_id": {
+          "name": "context_last_to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_blocks_to_entity_idx": {
+          "name": "relation_versions_blocks_to_entity_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"type_id\" = 'beaba5cb-a677-41a8-b353-77030613fc70'::uuid",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_context_root_idx": {
+          "name": "relation_versions_context_root_idx",
+          "columns": [
+            {
+              "expression": "context_root_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"context_root_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_voting_settings": {
+      "name": "space_voting_settings",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "partial_percentage_support_threshold": {
+          "name": "partial_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "universal_percentage_support_threshold": {
+          "name": "universal_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flat_support_threshold": {
+          "name": "flat_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disable_fast_path_access_for_new_members": {
+          "name": "disable_fast_path_access_for_new_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_grace_period": {
+          "name": "execution_grace_period",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_voting_settings_space_id_spaces_id_fk": {
+          "name": "space_voting_settings_space_id_spaces_id_fk",
+          "tableFrom": "space_voting_settings",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_last_to_entity_id": {
+          "name": "context_last_to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_context_root_idx": {
+          "name": "value_versions_context_root_idx",
+          "columns": [
+            {
+              "expression": "context_root_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"context_root_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_count_updated_at": {
+          "name": "idx_votes_count_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "object_type = 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {
+    "ranks": "ranks"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.proposals_current": {
+      "columns": {},
+      "definition": "select \"proposals\".\"id\", \"proposals\".\"space_id\", \"proposals\".\"proposed_by\", \"proposals\".\"created_at\", \"proposals\".\"created_at_block\", \"proposals\".\"current_version\", \"proposals\".\"executed_at\", \"proposal_versions\".\"proposal_id\", \"proposal_versions\".\"proposal_version\", \"proposal_versions\".\"voting_mode\", \"proposal_versions\".\"start_time\", \"proposal_versions\".\"end_time\", \"proposal_versions\".\"quorum\", \"proposal_versions\".\"threshold\", \"proposal_versions\".\"partial_percentage_support_threshold\", \"proposal_versions\".\"universal_percentage_support_threshold\", \"proposal_versions\".\"flat_support_threshold\", \"proposal_versions\".\"execute_by\", \"proposal_versions\".\"name\", \"proposal_versions\".\"yes_count\", \"proposal_versions\".\"no_count\", \"proposal_versions\".\"abstain_count\", \"proposal_versions\".\"version_created_at\", \"proposal_versions\".\"version_created_at_block\" from \"proposals\" inner join \"proposal_versions\" on \"proposal_versions\".\"proposal_id\" = \"proposals\".\"id\" AND \"proposal_versions\".\"proposal_version\" = \"proposals\".\"current_version\"",
+      "name": "proposals_current",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.space_editor_counts": {
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_editors": {
+          "name": "total_editors",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "SELECT space_id, COUNT(*)::bigint AS total_editors FROM editors GROUP BY space_id",
+      "name": "space_editor_counts",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1783089645264,
       "tag": "0067_governance_v2",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1785416524168,
+      "tag": "0068_rolling_rankings",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -1215,6 +1215,10 @@ export const rankingBlocks = ranks.table(
 		startDate: timestamp("start_date", {withTimezone: true, mode: "date"}),
 		endDate: timestamp("end_date", {withTimezone: true, mode: "date"}),
 		restrictionId: uuid("restriction_id"),
+		/** Value-entity id of the block's `Ranking type` relation (e.g. the "Rolling" value); `null` = static (default). */
+		rankingType: uuid("ranking_type"),
+		/** GEO-2328: hours a submission stays eligible before a rolling block requires resubmission. `null` for static blocks. */
+		submissionFrequency: integer("submission_frequency"),
 		updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull().defaultNow(),
 	},
 	(table) => [primaryKey({columns: [table.id, table.spaceId]})],

--- a/ranking-indexer/Cargo.toml
+++ b/ranking-indexer/Cargo.toml
@@ -8,6 +8,14 @@ description = "Aggregates GEO rank submissions into ranking results and projects
 name = "ranking-indexer"
 path = "src/main.rs"
 
+[[bin]]
+name = "backfill_blocks"
+path = "src/bin/backfill_blocks.rs"
+
+[[bin]]
+name = "rolling_sweep"
+path = "src/bin/rolling_sweep.rs"
+
 [dependencies]
 hermes-schema = { path = "../hermes-schema" }
 hermes-instrumentation = { path = "../hermes-instrumentation" }

--- a/ranking-indexer/Dockerfile
+++ b/ranking-indexer/Dockerfile
@@ -37,5 +37,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/ranking-indexer/target/release/ranking-indexer /usr/local/bin/ranking-indexer
+COPY --from=builder /app/ranking-indexer/target/release/backfill_blocks /usr/local/bin/backfill_blocks
+COPY --from=builder /app/ranking-indexer/target/release/rolling_sweep /usr/local/bin/rolling_sweep
 
 CMD ["ranking-indexer"]

--- a/ranking-indexer/k8s/production/backfill-cronjob.yaml
+++ b/ranking-indexer/k8s/production/backfill-cronjob.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ranking-indexer-backfill
+  namespace: knowledge
+  labels:
+    app: ranking-indexer-backfill
+spec:
+  # Self-heals blocks the live recovery path (issue #738/#739) missed because
+  # kg-indexer hadn't yet indexed the block's type/config at the moment a rank
+  # linked to it — that recovery only ever gets one shot. Hourly is plenty;
+  # this is a safety net, not a latency-sensitive path.
+  schedule: "0 * * * *"
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: geo
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+          containers:
+            - name: ranking-indexer-backfill
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command: ["backfill_blocks"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              env:
+                - name: PGSSLROOTCERT
+                  value: /ssl/ca.crt
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_URL
+                - name: RUST_LOG
+                  value: "backfill_blocks=info,ranking_indexer=info"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "250m"

--- a/ranking-indexer/k8s/production/rolling-sweep-cronjob.yaml
+++ b/ranking-indexer/k8s/production/rolling-sweep-cronjob.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ranking-indexer-rolling-sweep
+  namespace: knowledge
+  labels:
+    app: ranking-indexer-rolling-sweep
+spec:
+  # GEO-2328: the actual timing mechanism Rolling ranking blocks need — without
+  # this, a submission ageing past its `submission_frequency` never triggers a
+  # recompute (nothing on-chain happens when a submission just expires).
+  # Cadence is a product question, not an engineering one: how stale an
+  # expired ranking is allowed to look. PLACEHOLDER at ship time — no Rolling
+  # blocks exist yet, so there's no real submission_frequency distribution to
+  # tune against. Retune to roughly the shortest submission_frequency in use
+  # once that's known; this is a plain schedule edit, no code change needed.
+  schedule: "0 * * * *"
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: geo
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+          containers:
+            - name: ranking-indexer-rolling-sweep
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command: ["rolling_sweep"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              env:
+                - name: PGSSLROOTCERT
+                  value: /ssl/ca.crt
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_URL
+                - name: RUST_LOG
+                  value: "rolling_sweep=info,ranking_indexer=info"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "250m"

--- a/ranking-indexer/k8s/staging/backfill-cronjob.yaml
+++ b/ranking-indexer/k8s/staging/backfill-cronjob.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ranking-indexer-backfill
+  namespace: knowledge-staging
+  labels:
+    app: ranking-indexer-backfill
+    environment: staging
+spec:
+  # Self-heals blocks the live recovery path (issue #738/#739) missed because
+  # kg-indexer hadn't yet indexed the block's type/config at the moment a rank
+  # linked to it — that recovery only ever gets one shot. Hourly is plenty;
+  # this is a safety net, not a latency-sensitive path.
+  schedule: "0 * * * *"
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            environment: staging
+        spec:
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: geo
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+          containers:
+            - name: ranking-indexer-backfill
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command: ["backfill_blocks"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              env:
+                - name: PGSSLROOTCERT
+                  value: /ssl/ca.crt
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_URL
+                - name: RUST_LOG
+                  value: "backfill_blocks=info,ranking_indexer=info"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "250m"

--- a/ranking-indexer/k8s/staging/rolling-sweep-cronjob.yaml
+++ b/ranking-indexer/k8s/staging/rolling-sweep-cronjob.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ranking-indexer-rolling-sweep
+  namespace: knowledge-staging
+  labels:
+    app: ranking-indexer-rolling-sweep
+    environment: staging
+spec:
+  # GEO-2328: the actual timing mechanism Rolling ranking blocks need — without
+  # this, a submission ageing past its `submission_frequency` never triggers a
+  # recompute (nothing on-chain happens when a submission just expires).
+  # Cadence is a product question, not an engineering one: how stale an
+  # expired ranking is allowed to look. PLACEHOLDER at ship time — no Rolling
+  # blocks exist yet, so there's no real submission_frequency distribution to
+  # tune against. Retune to roughly the shortest submission_frequency in use
+  # once that's known; this is a plain schedule edit, no code change needed.
+  schedule: "0 * * * *"
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            environment: staging
+        spec:
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: geo
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+          containers:
+            - name: ranking-indexer-rolling-sweep
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command: ["rolling_sweep"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              env:
+                - name: PGSSLROOTCERT
+                  value: /ssl/ca.crt
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_URL
+                - name: RUST_LOG
+                  value: "rolling_sweep=info,ranking_indexer=info"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "250m"

--- a/ranking-indexer/k8s/v2/backfill-cronjob.yaml
+++ b/ranking-indexer/k8s/v2/backfill-cronjob.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ranking-indexer-backfill
+  namespace: gaia
+  labels:
+    app: ranking-indexer-backfill
+    environment: testnet
+spec:
+  # Self-heals blocks the live recovery path (issue #738/#739) missed because
+  # kg-indexer hadn't yet indexed the block's type/config at the moment a rank
+  # linked to it — that recovery only ever gets one shot. Hourly is plenty;
+  # this is a safety net, not a latency-sensitive path.
+  #
+  # Modeled on k8s/staging/backfill-cronjob.yaml; v2 conventions applied
+  # (namespace gaia, `regcred` pull secret, non-root pod securityContext) to
+  # match k8s/v2/ranking-indexer.yaml. Needs only DATABASE_URL — no Kafka.
+  schedule: "0 * * * *"
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            environment: testnet
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            fsGroup: 1001
+          imagePullSecrets:
+            - name: regcred
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+          containers:
+            - name: ranking-indexer-backfill
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command: ["backfill_blocks"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              env:
+                - name: PGSSLROOTCERT
+                  value: /ssl/ca.crt
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_URL
+                - name: RUST_LOG
+                  value: "backfill_blocks=info,ranking_indexer=info"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "250m"

--- a/ranking-indexer/k8s/v2/rolling-sweep-cronjob.yaml
+++ b/ranking-indexer/k8s/v2/rolling-sweep-cronjob.yaml
@@ -1,0 +1,98 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ranking-indexer-rolling-sweep
+  namespace: gaia
+  labels:
+    app: ranking-indexer-rolling-sweep
+    environment: testnet
+spec:
+  # GEO-2328: the actual timing mechanism Rolling ranking blocks need — without
+  # this, a submission ageing past its `submission_frequency` never triggers a
+  # recompute (nothing on-chain happens when a submission just expires).
+  # Cadence is a product question, not an engineering one: how stale an
+  # expired ranking is allowed to look. PLACEHOLDER at ship time — no Rolling
+  # blocks exist yet, so there's no real submission_frequency distribution to
+  # tune against. Retune to roughly the shortest submission_frequency in use
+  # once that's known; this is a plain schedule edit, no code change needed.
+  #
+  # Until a Rolling block exists the sweep finds nothing and is a no-op, so
+  # shipping it on v2 ahead of product costs nothing.
+  #
+  # Modeled on k8s/staging/rolling-sweep-cronjob.yaml; v2 conventions applied
+  # (namespace gaia, `regcred` pull secret, non-root pod securityContext) to
+  # match k8s/v2/ranking-indexer.yaml. Needs only DATABASE_URL — no Kafka.
+  schedule: "0 * * * *"
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            environment: testnet
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            fsGroup: 1001
+          imagePullSecrets:
+            - name: regcred
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+          containers:
+            - name: ranking-indexer-rolling-sweep
+              image: registry.digitalocean.com/geo/ranking-indexer:latest
+              imagePullPolicy: Always
+              command: ["rolling_sweep"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              env:
+                - name: PGSSLROOTCERT
+                  value: /ssl/ca.crt
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: api-secrets
+                      key: DATABASE_URL
+                - name: RUST_LOG
+                  value: "rolling_sweep=info,ranking_indexer=info"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "250m"

--- a/ranking-indexer/src/bin/backfill_blocks.rs
+++ b/ranking-indexer/src/bin/backfill_blocks.rs
@@ -1,0 +1,215 @@
+//! One-off/scheduled backfill for Ranking Block and Rank entities that never
+//! made it into the `ranks` schema because their `TYPES` relation arrived in
+//! a different edit than their own creation (`detect()` only classifies an
+//! entity from the current edit's own ops).
+//!
+//! For blocks, the live consumer has a reactive one-shot recovery (issue
+//! #738/#739, `get_block_config_from_kg`) that runs the moment a rank links
+//! to an unregistered block — but it never retries, so anything that raced
+//! ahead of kg-indexer indexing the type, or that nothing has linked to
+//! since, is stuck forever. For ranks, there is no reactive recovery at all;
+//! this binary is the only thing that ever finds them.
+//!
+//! Finds every entity typed `Ranking Block`/`Rank` in the public graph
+//! that's missing from `ranks.ranking_blocks`/`ranks.rankings`, recovers its
+//! config from the same source those tables are meant to reflect, and
+//! recomputes the aggregate for every block touched (directly, or via a
+//! recovered rank that links to one). Also finds blocks that already have a
+//! row but are stuck with a stale `ranking_type` — the identical gap one
+//! step later: a block created static and tagged Rolling by a subsequent,
+//! separate edit never gets its existing row updated, since `detect()` only
+//! reads a `CreateEntity`'s own ops (found investigating GEO-2328/PR#821).
+//! Idempotent — safe to re-run; blocks/ranks with nothing stale are never
+//! touched.
+//!
+//! Exits non-zero if anything failed to recover, so a scheduled run (see
+//! `k8s/*/backfill-cronjob.yaml`) surfaces failures as a failed Job instead
+//! of a silently-green one.
+//!
+//! Usage: `DATABASE_URL=... cargo run -p ranking-indexer --bin backfill_blocks`
+//! Add `DRY_RUN=true` to list candidates without writing anything.
+
+use std::collections::HashSet;
+use std::env;
+
+use chrono::Utc;
+use tracing::{error, info, warn};
+
+use ranking_indexer::error::IndexerError;
+use ranking_indexer::recompute::recompute_block;
+use ranking_indexer::storage::Storage;
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+    let dry_run = env::var("DRY_RUN").is_ok_and(|v| v == "true" || v == "1");
+
+    let storage = Storage::new(&database_url).await?;
+
+    let block_candidates = storage.find_unregistered_ranking_blocks().await?;
+    let stale_blocks = storage.find_stale_ranking_type_blocks().await?;
+    let rank_candidates = storage.find_unregistered_ranks().await?;
+    info!(
+        blocks = block_candidates.len(),
+        stale_blocks = stale_blocks.len(),
+        ranks = rank_candidates.len(),
+        dry_run,
+        "found unregistered/stale blocks and unregistered ranks"
+    );
+
+    if dry_run {
+        for id in &block_candidates {
+            info!(block_id = %id, "would recover block");
+        }
+        for id in &stale_blocks {
+            info!(block_id = %id, "would resync stale ranking_type");
+        }
+        for id in &rank_candidates {
+            info!(rank_id = %id, "would recover rank");
+        }
+        return Ok(());
+    }
+
+    if block_candidates.is_empty() && stale_blocks.is_empty() && rank_candidates.is_empty() {
+        return Ok(());
+    }
+
+    let meta = storage.current_chain_meta().await?;
+    let now = Utc::now();
+
+    let mut recovered_blocks = 0;
+    let mut still_unregistered_blocks = 0;
+    let mut resynced_stale_blocks = 0;
+    let mut recovered_ranks = 0;
+    let mut still_unregistered_ranks = 0;
+    let mut failed = 0;
+
+    // Blocks first: a recovered rank's block_id is guaranteed to already be
+    // registered by the time we get to it below, since this scan already
+    // covers every currently-unregistered block, not just ones ranks
+    // happen to point at.
+    for block_id in block_candidates {
+        // Re-check under get_block_config_from_kg rather than trusting the
+        // earlier scan — the two queries aren't in the same transaction, and
+        // this mirrors exactly what the live recovery path does.
+        match storage.get_block_config_from_kg(block_id).await {
+            Ok(Some(block)) => {
+                if let Err(e) = storage.upsert_ranking_block(&block).await {
+                    error!(block_id = %block_id, error = %e, "failed to upsert recovered block");
+                    failed += 1;
+                    continue;
+                }
+                if let Err(e) = recompute_block(block_id, meta, now, &storage).await {
+                    error!(block_id = %block_id, error = %e, "recovered block but recompute failed");
+                    failed += 1;
+                    continue;
+                }
+                info!(block_id = %block_id, "recovered + recomputed block");
+                recovered_blocks += 1;
+            }
+            Ok(None) => {
+                // Typed in `relations` a moment ago, not typed now — a
+                // concurrent edit removed the type between the scan and here.
+                warn!(block_id = %block_id, "no longer typed as Ranking Block — skipping");
+                still_unregistered_blocks += 1;
+            }
+            Err(e) => {
+                error!(block_id = %block_id, error = %e, "failed to read block config from kg");
+                failed += 1;
+            }
+        }
+    }
+
+    // Already-registered blocks stuck with a stale `ranking_type` — same
+    // recovery as above (`get_block_config_from_kg` + `upsert_ranking_block`
+    // is already an upsert, so this safely overwrites the stale row), just
+    // starting from a row that already exists.
+    for block_id in stale_blocks {
+        match storage.get_block_config_from_kg(block_id).await {
+            Ok(Some(block)) => {
+                if let Err(e) = storage.upsert_ranking_block(&block).await {
+                    error!(block_id = %block_id, error = %e, "failed to upsert resynced block");
+                    failed += 1;
+                    continue;
+                }
+                if let Err(e) = recompute_block(block_id, meta, now, &storage).await {
+                    error!(block_id = %block_id, error = %e, "resynced block but recompute failed");
+                    failed += 1;
+                    continue;
+                }
+                info!(block_id = %block_id, "resynced stale ranking_type + recomputed block");
+                resynced_stale_blocks += 1;
+            }
+            Ok(None) => {
+                // No longer typed as a Ranking Block at all — leave its
+                // existing row alone; that's a different (currently
+                // unhandled) case, not this gap.
+                warn!(block_id = %block_id, "no longer typed as Ranking Block — skipping resync");
+            }
+            Err(e) => {
+                error!(block_id = %block_id, error = %e, "failed to read block config from kg for resync");
+                failed += 1;
+            }
+        }
+    }
+
+    let mut affected_blocks: HashSet<uuid::Uuid> = HashSet::new();
+    for rank_id in rank_candidates {
+        match storage.get_rank_config_from_kg(rank_id).await {
+            Ok(Some(rank)) => {
+                let block_id = rank.block_id;
+                if let Err(e) = storage.upsert_ranking(&rank).await {
+                    error!(rank_id = %rank_id, error = %e, "failed to upsert recovered rank");
+                    failed += 1;
+                    continue;
+                }
+                info!(rank_id = %rank_id, block_id = ?block_id, "recovered rank");
+                recovered_ranks += 1;
+                if let Some(block_id) = block_id {
+                    affected_blocks.insert(block_id);
+                }
+            }
+            Ok(None) => {
+                warn!(rank_id = %rank_id, "no longer typed as Rank — skipping");
+                still_unregistered_ranks += 1;
+            }
+            Err(e) => {
+                error!(rank_id = %rank_id, error = %e, "failed to read rank config from kg");
+                failed += 1;
+            }
+        }
+    }
+
+    // Recompute every block a recovered rank links to — its aggregate needs
+    // to include the rank that just appeared.
+    for block_id in affected_blocks {
+        if let Err(e) = recompute_block(block_id, meta, now, &storage).await {
+            error!(
+                block_id = %block_id,
+                error = %e,
+                "recompute failed for block affected by a recovered rank"
+            );
+            failed += 1;
+        }
+    }
+
+    info!(
+        recovered_blocks,
+        still_unregistered_blocks,
+        resynced_stale_blocks,
+        recovered_ranks,
+        still_unregistered_ranks,
+        failed,
+        "backfill complete"
+    );
+    if failed > 0 {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/ranking-indexer/src/bin/rolling_sweep.rs
+++ b/ranking-indexer/src/bin/rolling_sweep.rs
@@ -1,0 +1,84 @@
+//! Periodic sweep for Rolling ranking blocks (GEO-2328).
+//!
+//! Recompute is otherwise purely event-driven (design §7, `recompute.rs`) —
+//! it only runs in reaction to an edit or a membership event. A Rolling
+//! block's aggregate needs to change purely from elapsed time too: once a
+//! submission ages past its `submission_frequency`, nothing on-chain happens,
+//! so without this the block's projection stays frozen at whatever it was
+//! the last time an edit happened to touch it (see `eligibility::rolling_admits`).
+//! This binary is that missing time-based trigger: find every registered
+//! Rolling block and recompute it against the current instant.
+//!
+//! Structurally mirrors `backfill_blocks.rs`'s one-shot-per-invocation
+//! CronJob wiring, but a different purpose: that one is a data-integrity
+//! self-heal for split-edit races (#738/#739), this one is the actual timing
+//! mechanism Rolling rankings need to function at all.
+//!
+//! Cadence is intentionally NOT hardcoded here — how often this needs to run
+//! is a product question (how stale an expired Rolling ranking is allowed to
+//! look, confirmed dynamic-with-`submission_frequency` and easily
+//! configurable per the GEO-2328 spec discussion), not an engineering one.
+//! Tune it via the CronJob's `schedule` field (see
+//! `k8s/*/rolling-sweep-cronjob.yaml`) to roughly track the shortest
+//! `submission_frequency` in use across Rolling blocks — no code change
+//! required to retune it.
+//!
+//! Cost scales with (# Rolling blocks × ticks/day), independent of edit
+//! volume — unlike everything else in this indexer today.
+//!
+//! Usage: `DATABASE_URL=... cargo run -p ranking-indexer --bin rolling_sweep`
+
+use std::env;
+
+use chrono::Utc;
+use tracing::{error, info};
+
+use ranking_indexer::error::IndexerError;
+use ranking_indexer::recompute::recompute_block;
+use ranking_indexer::storage::Storage;
+
+#[tokio::main]
+async fn main() -> Result<(), IndexerError> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let database_url = env::var("DATABASE_URL")
+        .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
+
+    let storage = Storage::new(&database_url).await?;
+
+    let blocks = storage.find_rolling_ranking_blocks().await?;
+    info!(blocks = blocks.len(), "rolling sweep: found Rolling blocks");
+
+    if blocks.is_empty() {
+        return Ok(());
+    }
+
+    // Same stamping convention as backfill_blocks: this recompute isn't
+    // reacting to a specific edit, so there's no natural block/timestamp to
+    // attach to whatever the projection mints — use the chain tip the
+    // indexer has actually caught up to, and the wall-clock instant this
+    // sweep is evaluating expiry against.
+    let meta = storage.current_chain_meta().await?;
+    let now = Utc::now();
+
+    let mut recomputed = 0;
+    let mut failed = 0;
+    for block_id in blocks {
+        match recompute_block(block_id, meta, now, &storage).await {
+            Ok(()) => recomputed += 1,
+            Err(e) => {
+                error!(block_id = %block_id, error = %e, "rolling sweep: recompute failed");
+                failed += 1;
+            }
+        }
+    }
+
+    info!(recomputed, failed, "rolling sweep complete");
+    if failed > 0 {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/ranking-indexer/src/detect.rs
+++ b/ranking-indexer/src/detect.rs
@@ -33,7 +33,11 @@ struct DetectIds {
     filter_property: Uuid,
     start_date_property: Uuid,
     end_date_property: Uuid,
+    start_datetime_property: Uuid,
+    end_datetime_property: Uuid,
     aggregation_restriction_relation: Uuid,
+    rolling_type: Uuid,
+    submission_frequency_property: Uuid,
 }
 
 static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
@@ -51,7 +55,11 @@ static IDS: LazyLock<DetectIds> = LazyLock::new(|| {
         filter_property: uid(RANK_FILTER_PROPERTY_ID),
         start_date_property: uid(RANK_START_DATE_PROPERTY_ID),
         end_date_property: uid(RANK_END_DATE_PROPERTY_ID),
+        start_datetime_property: uid(RANK_START_DATETIME_PROPERTY_ID),
+        end_datetime_property: uid(RANK_END_DATETIME_PROPERTY_ID),
         aggregation_restriction_relation: uid(RANK_AGGREGATION_RESTRICTION_PROPERTY_ID),
+        rolling_type: uid(RANK_ROLLING_TYPE_ID),
+        submission_frequency_property: uid(RANK_SUBMISSION_FREQUENCY_PROPERTY_ID),
     }
 });
 
@@ -78,6 +86,20 @@ fn float_value(values: &[PropertyValue], property: Uuid) -> Option<f64> {
         }
         match &pv.value {
             Grc20Value::Float { value, .. } => Some(*value),
+            _ => None,
+        }
+    })
+}
+
+/// Read an `Integer` property value, truncated to `i32` (the column type;
+/// `submission_frequency` is a small number of hours, never near i64's range).
+fn int_value(values: &[PropertyValue], property: Uuid) -> Option<i32> {
+    values.iter().find_map(|pv| {
+        if id_to_uuid(&pv.property) != property {
+            return None;
+        }
+        match &pv.value {
+            Grc20Value::Integer { value, .. } => i32::try_from(*value).ok(),
             _ => None,
         }
     })
@@ -110,6 +132,28 @@ fn parse_date(s: &str) -> Option<DateTime<Utc>> {
             .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
     }
     None
+}
+
+/// Resolve one submission-window bound of a block: the datetime property
+/// (GEO-2253) wins; the legacy date property is the fallback. When a block
+/// authors both, the legacy value is ignored (even if it differs).
+fn window_bound(
+    values: &[PropertyValue],
+    block: Uuid,
+    bound: &'static str,
+    datetime_property: Uuid,
+    date_property: Uuid,
+) -> Option<DateTime<Utc>> {
+    let new = date_value(values, datetime_property);
+    let old = date_value(values, date_property);
+    if new.is_some() && old.is_some() {
+        tracing::debug!(
+            block = %block,
+            bound,
+            "block authors both the datetime and legacy date property; using the datetime one"
+        );
+    }
+    new.or(old)
 }
 
 /// The rank-relevant ops extracted from a single edit.
@@ -212,9 +256,30 @@ pub fn detect(
                         space_id,
                         name: text_value(&entity.values, ids.name_property),
                         filter: text_value(&entity.values, ids.filter_property),
-                        start_date: date_value(&entity.values, ids.start_date_property),
-                        end_date: date_value(&entity.values, ids.end_date_property),
+                        start_date: window_bound(
+                            &entity.values,
+                            entity_id,
+                            "start",
+                            ids.start_datetime_property,
+                            ids.start_date_property,
+                        ),
+                        end_date: window_bound(
+                            &entity.values,
+                            entity_id,
+                            "end",
+                            ids.end_datetime_property,
+                            ids.end_date_property,
+                        ),
                         restriction_id: restriction_of.get(&entity_id).copied(),
+                        // Rolling is a second TYPES tag on the block (GEO-2328), not a
+                        // dedicated property — see RANK_ROLLING_TYPE_ID's doc comment.
+                        ranking_type: entity_types
+                            .is_some_and(|t| t.contains(&ids.rolling_type))
+                            .then_some(ids.rolling_type),
+                        submission_frequency: int_value(
+                            &entity.values,
+                            ids.submission_frequency_property,
+                        ),
                     });
                 }
             }
@@ -444,6 +509,105 @@ mod tests {
         assert_eq!(
             b.restriction_id,
             Some(Uuid::parse_str(RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID).unwrap())
+        );
+    }
+
+    /// A `Ranking Block` typed entity whose values are set by `configure`.
+    fn block_edit(
+        configure: impl FnOnce(
+            grc_20::model::builder::EntityBuilder<'static>,
+        ) -> grc_20::model::builder::EntityBuilder<'static>,
+    ) -> grc_20::Edit<'static> {
+        EditBuilder::new(gid(0))
+            .create_relation(|r| {
+                r.id(gid(20))
+                    .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                    .from(gid(BLOCK))
+                    .to(sid(RANKING_BLOCK_TYPE_ID))
+            })
+            .create_entity(gid(BLOCK), configure)
+            .build()
+    }
+
+    #[test]
+    fn legacy_date_props_accept_datetime_values() {
+        use chrono::TimeZone;
+        let edit = block_edit(|e| {
+            e.value(
+                sid(RANK_START_DATE_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-01T12:30:00Z".into()),
+            )
+            .value(
+                sid(RANK_END_DATE_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-30T18:00:00+02:00".into()),
+            )
+        });
+
+        let b = &detect(&edit, space_uuid(), 100, 0).blocks[0];
+        assert_eq!(
+            b.start_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 1, 12, 30, 0).unwrap())
+        );
+        // offsets normalize to UTC
+        assert_eq!(
+            b.end_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 30, 16, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn detects_new_datetime_props() {
+        use chrono::TimeZone;
+        let edit = block_edit(|e| {
+            e.value(
+                sid(RANK_START_DATETIME_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-01T12:30:00Z".into()),
+            )
+            .value(
+                sid(RANK_END_DATETIME_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-30T18:00:00Z".into()),
+            )
+        });
+
+        let b = &detect(&edit, space_uuid(), 100, 0).blocks[0];
+        assert_eq!(
+            b.start_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 1, 12, 30, 0).unwrap())
+        );
+        assert_eq!(
+            b.end_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 30, 18, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn new_datetime_props_win_over_legacy_per_bound() {
+        use chrono::TimeZone;
+        // start: both authored, values disagree -> the datetime property wins;
+        // end: only the legacy date -> falls back per-bound.
+        let edit = block_edit(|e| {
+            e.value(
+                sid(RANK_START_DATE_PROPERTY_ID),
+                Grc20Value::Date("2026-06-01".into()),
+            )
+            .value(
+                sid(RANK_START_DATETIME_PROPERTY_ID),
+                Grc20Value::Datetime("2026-06-02T09:00:00Z".into()),
+            )
+            .value(
+                sid(RANK_END_DATE_PROPERTY_ID),
+                Grc20Value::Date("2026-06-30".into()),
+            )
+        });
+
+        let b = &detect(&edit, space_uuid(), 100, 0).blocks[0];
+        assert_eq!(
+            b.start_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 2, 9, 0, 0).unwrap())
+        );
+        assert_eq!(
+            b.end_date,
+            Some(Utc.with_ymd_and_hms(2026, 6, 30, 0, 0, 0).unwrap())
         );
     }
 

--- a/ranking-indexer/src/eligibility.rs
+++ b/ranking-indexer/src/eligibility.rs
@@ -9,8 +9,11 @@
 //!   - Personal-space block: "All of Geo" for now — admit every submitter. (This
 //!     will narrow to verified users once verification ships.)
 //!
-//! Window: the submission timestamp must fall within the block's optional
-//! `[start, end]` bounds; an absent bound imposes no limit.
+//! Window: for a static block, the submission timestamp must fall within the
+//! block's optional `[start, end]` bounds; an absent bound imposes no limit.
+//! For a Rolling block (GEO-2328), instead a submission stays eligible only
+//! while `now - submitted_at < submission_frequency` — it ages out and
+//! requires resubmission rather than being bounded by a fixed window.
 
 use std::collections::HashSet;
 
@@ -62,21 +65,48 @@ pub fn window_admits(
     after_start && before_end
 }
 
+/// Does a Rolling-type block's submission remain eligible?
+///
+/// Valid while `now - submitted_at < submission_frequency` (hours); once a
+/// submission ages past its frequency it requires resubmission. `now` is a
+/// parameter (never read via an inline `Utc::now()` call here) so callers —
+/// tests and the periodic sweep alike — control it deterministically.
+///
+/// An absent frequency or unknown submission time can't be evaluated, so (like
+/// `window_admits`) we admit rather than silently drop.
+pub fn rolling_admits(
+    submitted_at: Option<DateTime<Utc>>,
+    frequency_hours: Option<i32>,
+    now: DateTime<Utc>,
+) -> bool {
+    let (Some(submitted_at), Some(frequency_hours)) = (submitted_at, frequency_hours) else {
+        return true;
+    };
+    now - submitted_at < chrono::Duration::hours(frequency_hours.into())
+}
+
 /// Filter deduped submissions to those eligible for `block`.
 ///
 /// `eligible_member_spaces` is the set of member/editor space ids of the
-/// block's space (ignored for personal-space blocks).
+/// block's space (ignored for personal-space blocks). `now` is the instant
+/// used to evaluate a Rolling block's per-submission expiry.
 pub fn filter_eligible(
     block: &RankingBlock,
     space_kind: SpaceKind,
     eligible_member_spaces: &HashSet<Uuid>,
     submissions: Vec<Ranking>,
+    now: DateTime<Utc>,
 ) -> Vec<Ranking> {
+    let is_rolling = block.ranking_type.is_some();
     submissions
         .into_iter()
         .filter(|s| {
             restriction_admits(space_kind, s.space_id, eligible_member_spaces)
-                && window_admits(s.submitted_at, block.start_date, block.end_date)
+                && if is_rolling {
+                    rolling_admits(s.submitted_at, block.submission_frequency, now)
+                } else {
+                    window_admits(s.submitted_at, block.start_date, block.end_date)
+                }
         })
         .collect()
 }
@@ -94,6 +124,16 @@ mod tests {
             start_date: start,
             end_date: end,
             restriction_id: None,
+            ranking_type: None,
+            submission_frequency: None,
+        }
+    }
+
+    fn rolling_block(frequency_hours: Option<i32>) -> RankingBlock {
+        RankingBlock {
+            ranking_type: Some(Uuid::from_u128(2)), // any value marks it Rolling
+            submission_frequency: frequency_hours,
+            ..block(None, None)
         }
     }
 
@@ -162,9 +202,45 @@ mod tests {
             submission(2, t(50)),  // non-member -> drop
             submission(1, t(200)), // member, out of window -> drop
         ];
-        let kept = filter_eligible(&b, SpaceKind::Dao, &members, subs);
+        let kept = filter_eligible(&b, SpaceKind::Dao, &members, subs, t(50).unwrap());
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0].space_id, Uuid::from_u128(1));
         assert_eq!(kept[0].submitted_at, t(50));
+    }
+
+    #[test]
+    fn rolling_admits_window() {
+        let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0).unwrap();
+        let hour = 3600;
+        // within: 1 hour old, 2-hour frequency
+        assert!(rolling_admits(Some(t(0)), Some(2), t(hour)));
+        // exactly-at-boundary: elapsed == frequency is expired, not admitted
+        assert!(!rolling_admits(Some(t(0)), Some(1), t(hour)));
+        // just past the boundary
+        assert!(!rolling_admits(Some(t(0)), Some(1), t(hour + 1)));
+        // just before the boundary
+        assert!(rolling_admits(Some(t(0)), Some(1), t(hour - 1)));
+        // absent frequency imposes no limit
+        assert!(rolling_admits(Some(t(0)), None, t(hour * 1000)));
+        // unknown submission time can't be rejected
+        assert!(rolling_admits(None, Some(1), t(hour * 1000)));
+    }
+
+    #[test]
+    fn filter_eligible_uses_rolling_admits_for_rolling_blocks() {
+        let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0).unwrap();
+        let hour = 3600;
+        let b = rolling_block(Some(1)); // 1-hour frequency
+        let mut members = HashSet::new();
+        members.insert(Uuid::from_u128(1));
+
+        let subs = vec![
+            submission(1, Some(t(0))),         // member, still within frequency -> keep
+            submission(1, Some(t(-2 * hour))), // member, expired -> drop
+            submission(2, Some(t(0))),         // non-member -> drop
+        ];
+        let kept = filter_eligible(&b, SpaceKind::Dao, &members, subs, t(hour / 2));
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].submitted_at, Some(t(0)));
     }
 }

--- a/ranking-indexer/src/membership.rs
+++ b/ranking-indexer/src/membership.rs
@@ -6,6 +6,7 @@
 //! event recomputes the blocks where the change can matter: blocks in the
 //! affected space that hold a submission from the member's personal space.
 
+use chrono::Utc;
 use hermes_schema::pb::membership::{HermesRoleGranted, HermesRoleRevoked, MembershipRole};
 use uuid::Uuid;
 
@@ -129,8 +130,9 @@ pub async fn apply_membership_event(
     let blocks = storage
         .blocks_with_rankings_from(change.space_id, change.member_space_id)
         .await?;
+    let now = Utc::now();
     for block_id in &blocks {
-        recompute_block(*block_id, meta, storage).await?;
+        recompute_block(*block_id, meta, now, storage).await?;
     }
 
     tracing::debug!(

--- a/ranking-indexer/src/models.rs
+++ b/ranking-indexer/src/models.rs
@@ -24,6 +24,14 @@ pub struct RankingBlock {
     pub end_date: Option<DateTime<Utc>>,
     /// Aggregation restriction value entity; `None` => default "Members and editors".
     pub restriction_id: Option<Uuid>,
+    /// `Ranking type` value entity (GEO-2328), e.g. `RANK_ROLLING_TYPE_VALUE_ID`;
+    /// `None` => default (static, the only kind that existed before GEO-2328).
+    pub ranking_type: Option<Uuid>,
+    /// Hours a submission stays eligible after `submitted_at` before requiring
+    /// resubmission. Only meaningful when `ranking_type` is Rolling; `None`
+    /// otherwise (static blocks use the block-wide `[start_date, end_date]`
+    /// window instead — see `eligibility::filter_eligible`).
+    pub submission_frequency: Option<i32>,
 }
 
 /// A `ranks.rankings` row — one per Rank submission.

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::dedup::dedup_latest;
@@ -53,9 +54,17 @@ pub async fn affected_blocks(
 }
 
 /// Recompute a single block's aggregate end to end.
+///
+/// `now` is the instant used to evaluate a Rolling block's per-submission
+/// expiry (see `eligibility::rolling_admits`) — a parameter, not an inline
+/// `Utc::now()` call, so a test can recompute the same block twice with an
+/// advanced `now` to simulate a submission aging out between two sweeps
+/// without a real sleep. Live callers (the edit consumer, membership events)
+/// pass `Utc::now()` at their own boundary.
 pub async fn recompute_block(
     block_id: Uuid,
     meta: BlockMeta,
+    now: DateTime<Utc>,
     storage: &Storage,
 ) -> Result<(), IndexerError> {
     let block = match storage.get_ranking_block(block_id).await? {
@@ -90,7 +99,7 @@ pub async fn recompute_block(
         SpaceKind::Dao => storage.member_and_editor_spaces(block.space_id).await?,
         SpaceKind::Personal => HashSet::new(), // unused under "All of Geo"
     };
-    let eligible = filter_eligible(&block, space_kind, &eligible_member_spaces, deduped);
+    let eligible = filter_eligible(&block, space_kind, &eligible_member_spaces, deduped, now);
 
     // 3. Scoring: normalize each ballot to [0.5, 1] and aggregate per (entity, space).
     let eligible_ids: Vec<Uuid> = eligible.iter().map(|r| r.id).collect();
@@ -173,8 +182,9 @@ pub async fn apply_detected_edit(
             .await?;
     }
 
+    let now = Utc::now();
     for block_id in affected_blocks(detected, storage).await? {
-        recompute_block(block_id, detected.meta, storage).await?;
+        recompute_block(block_id, detected.meta, now, storage).await?;
     }
 
     Ok(())

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -18,6 +18,26 @@ use crate::models::{BlockMeta, Ranking, RankingBlock, RankingItem};
 use crate::publish::{provenance_ids, RankPositionRow};
 use crate::scoring::ScoreRow;
 
+/// Resolve one submission-window bound from separately queried legacy/datetime
+/// columns: the datetime property (GEO-2253) wins per-bound; the legacy date
+/// property is the fallback. Mirrors `detect::window_bound`'s precedence so
+/// the live and KG-recovery paths never disagree on a block that authors both.
+fn resolve_window_bound(
+    block: Uuid,
+    bound: &'static str,
+    datetime_value: Option<DateTime<Utc>>,
+    date_value: Option<DateTime<Utc>>,
+) -> Option<DateTime<Utc>> {
+    if datetime_value.is_some() && date_value.is_some() {
+        tracing::debug!(
+            block = %block,
+            bound,
+            "block authors both the datetime and legacy date property; using the datetime one"
+        );
+    }
+    datetime_value.or(date_value)
+}
+
 #[derive(Clone)]
 pub struct Storage {
     pool: PgPool,
@@ -193,7 +213,8 @@ impl Storage {
         block_id: Uuid,
     ) -> Result<Option<RankingBlock>, IndexerError> {
         let block = sqlx::query_as::<_, RankingBlock>(
-            "SELECT id, space_id, name, filter, start_date, end_date, restriction_id \
+            "SELECT id, space_id, name, filter, start_date, end_date, restriction_id, \
+                    ranking_type, submission_frequency \
              FROM ranks.ranking_blocks WHERE id = $1",
         )
         .bind(block_id)
@@ -235,32 +256,59 @@ impl Storage {
             return Ok(None);
         };
 
-        // Config properties: Name/Filter as text, Start/End as datetime. One row
-        // is always returned (aggregates over zero matching values yield NULLs).
+        // Config properties: Name/Filter as text, Start/End as datetime (both
+        // the legacy date property and its GEO-2253 datetime successor — see
+        // `resolve_window_bound`), Submission frequency (GEO-2328) as integer
+        // hours. One row is always returned (aggregates over zero matching
+        // values yield NULLs).
         type ConfigRow = (
             Option<String>,
             Option<String>,
             Option<DateTime<Utc>>,
             Option<DateTime<Utc>>,
+            Option<DateTime<Utc>>,
+            Option<DateTime<Utc>>,
+            Option<i64>,
         );
         // Scope to the block's home space: the same entity may be perspectived
         // into other spaces with different config, keyed on (id, space_id).
-        let (name, filter, start_date, end_date): ConfigRow = sqlx::query_as(
+        let (
+            name,
+            filter,
+            legacy_start_date,
+            legacy_end_date,
+            start_datetime,
+            end_datetime,
+            submission_frequency,
+        ): ConfigRow = sqlx::query_as(
             "SELECT \
-               max(text)         FILTER (WHERE property_id = $2) AS name, \
-               max(text)         FILTER (WHERE property_id = $3) AS filter, \
-               max(datetime_utc) FILTER (WHERE property_id = $4) AS start_date, \
-               max(datetime_utc) FILTER (WHERE property_id = $5) AS end_date \
-             FROM values WHERE entity_id = $1 AND space_id = $6",
+                   max(text)         FILTER (WHERE property_id = $2) AS name, \
+                   max(text)         FILTER (WHERE property_id = $3) AS filter, \
+                   max(datetime_utc) FILTER (WHERE property_id = $4) AS start_date, \
+                   max(datetime_utc) FILTER (WHERE property_id = $5) AS end_date, \
+                   max(datetime_utc) FILTER (WHERE property_id = $6) AS start_datetime, \
+                   max(datetime_utc) FILTER (WHERE property_id = $7) AS end_datetime, \
+                   max(integer)      FILTER (WHERE property_id = $8) AS submission_frequency \
+                 FROM values WHERE entity_id = $1 AND space_id = $9",
         )
         .bind(block_id)
         .bind(pid(ids::NAME_PROPERTY_ID))
         .bind(pid(ids::RANK_FILTER_PROPERTY_ID))
         .bind(pid(ids::RANK_START_DATE_PROPERTY_ID))
         .bind(pid(ids::RANK_END_DATE_PROPERTY_ID))
+        .bind(pid(ids::RANK_START_DATETIME_PROPERTY_ID))
+        .bind(pid(ids::RANK_END_DATETIME_PROPERTY_ID))
+        .bind(pid(ids::RANK_SUBMISSION_FREQUENCY_PROPERTY_ID))
         .bind(space_id)
         .fetch_one(&self.pool)
         .await?;
+
+        // The datetime property (GEO-2253) wins per-bound; the legacy date
+        // property is the fallback — same precedence as `detect::window_bound`,
+        // so the live and KG-recovery paths never disagree on a block that
+        // authors both.
+        let start_date = resolve_window_bound(block_id, "start", start_datetime, legacy_start_date);
+        let end_date = resolve_window_bound(block_id, "end", end_datetime, legacy_end_date);
 
         // Aggregation restriction is a relation (as detect() collects it),
         // likewise scoped to the block's home space.
@@ -274,6 +322,20 @@ impl Storage {
         .fetch_optional(&self.pool)
         .await?;
 
+        // Rolling is a second `TYPES` relation on the block (GEO-2328) — same
+        // relation type as the `Ranking Block` typing above, different target
+        // — not a dedicated property. See RANK_ROLLING_TYPE_ID's doc comment.
+        let (is_rolling,): (bool,) = sqlx::query_as(
+            "SELECT EXISTS (SELECT 1 FROM relations \
+             WHERE from_entity_id = $1 AND type_id = $2 AND to_entity_id = $3 AND space_id = $4)",
+        )
+        .bind(block_id)
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANK_ROLLING_TYPE_ID))
+        .bind(space_id)
+        .fetch_one(&self.pool)
+        .await?;
+
         Ok(Some(RankingBlock {
             id: block_id,
             space_id,
@@ -282,7 +344,209 @@ impl Storage {
             start_date,
             end_date,
             restriction_id: restriction.map(|(r,)| r),
+            ranking_type: is_rolling.then(|| pid(ids::RANK_ROLLING_TYPE_ID)),
+            submission_frequency: submission_frequency.and_then(|v| i32::try_from(v).ok()),
         }))
+    }
+
+    /// Entities typed `Ranking Block` in the indexed public graph that never
+    /// made it into `ranks.ranking_blocks`.
+    ///
+    /// `get_block_config_from_kg` (issue #738/#739) only ever runs when a rank
+    /// happens to link to the block *after* the block's own typing/config is
+    /// indexed; if no rank has linked to it since, or the link raced ahead of
+    /// kg-indexer committing the type relation, the block is stuck here
+    /// forever with nothing to retry it. Used by the one-off backfill binary
+    /// (`bin/backfill_blocks.rs`) and can also back a periodic reconciliation
+    /// sweep.
+    pub async fn find_unregistered_ranking_blocks(&self) -> Result<Vec<Uuid>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT DISTINCT r.from_entity_id FROM relations r \
+             WHERE r.type_id = $1 AND r.to_entity_id = $2 \
+               AND r.from_entity_id NOT IN (SELECT id FROM ranks.ranking_blocks)",
+        )
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANKING_BLOCK_TYPE_ID))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Every already-registered Rolling block (GEO-2328) — `ranking_type` is
+    /// `NOT NULL` — for the periodic sweep (`bin/rolling_sweep.rs`) to
+    /// recompute. A Rolling block's aggregate can go stale purely from
+    /// elapsed time (a submission ageing past `submission_frequency`), with
+    /// no edit to react to, so unlike everything else in this indexer it
+    /// needs a time-based trigger rather than an event-based one.
+    pub async fn find_rolling_ranking_blocks(&self) -> Result<Vec<Uuid>, IndexerError> {
+        let rows: Vec<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM ranks.ranking_blocks WHERE ranking_type IS NOT NULL")
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Already-registered blocks (`ranks.ranking_blocks` row exists) whose
+    /// `ranking_type` is still `NULL` even though the graph now tags them
+    /// Rolling — the same split-edit gap as `find_unregistered_ranking_blocks`,
+    /// one step later: `detect()` only sets `ranking_type` from a
+    /// `CreateEntity`'s own ops, so a block created as static and tagged
+    /// Rolling by a *later*, separate edit never gets its row updated (issue
+    /// found investigating GEO-2328/PR#821 — a real block on a live space sat
+    /// stuck this way until backfilled by hand). Used by `bin/backfill_blocks.rs`
+    /// alongside `find_unregistered_ranking_blocks`; the recovery step is
+    /// identical (`get_block_config_from_kg` + `upsert_ranking_block`), just
+    /// starting from a row that already exists instead of one that doesn't.
+    pub async fn find_stale_ranking_type_blocks(&self) -> Result<Vec<Uuid>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT rb.id FROM ranks.ranking_blocks rb \
+             WHERE rb.ranking_type IS NULL \
+               AND EXISTS ( \
+                 SELECT 1 FROM relations r \
+                 WHERE r.from_entity_id = rb.id AND r.type_id = $1 AND r.to_entity_id = $2 \
+               )",
+        )
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANK_ROLLING_TYPE_ID))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Entities typed `Rank` in the indexed public graph that never made it
+    /// into `ranks.rankings` — the identical split-edit gap as
+    /// `find_unregistered_ranking_blocks`, but for Rank submissions.
+    ///
+    /// Unlike blocks, nothing in the live consumer ever retries this (no
+    /// `get_block_config_from_kg`-style reactive trigger exists for ranks),
+    /// so recovery here is driven entirely by the periodic sweep — see
+    /// `get_rank_config_from_kg`.
+    pub async fn find_unregistered_ranks(&self) -> Result<Vec<Uuid>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT DISTINCT r.from_entity_id FROM relations r \
+             WHERE r.type_id = $1 AND r.to_entity_id = $2 \
+               AND r.from_entity_id NOT IN (SELECT id FROM ranks.rankings)",
+        )
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANK_TYPE_ID))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Reconstruct a Rank submission's config from the indexed public graph.
+    ///
+    /// Mirrors `get_block_config_from_kg` (issue #738/#739) for the identical
+    /// gap on Rank entities: `detect()` only registers a rank when its
+    /// `TYPES -> Rank` relation and its `rank_type` property arrive in the
+    /// *same* edit. There is deliberately no reactive live-path trigger for
+    /// this (unlike blocks, which recover the moment a rank links to one) —
+    /// recovery is periodic-sweep-only, so this also resolves `block_id`
+    /// directly from the `RANK_BLOCK` relation here rather than depending on
+    /// `set_ranking_block`'s live path, which is a bare `UPDATE` that
+    /// silently touches zero rows against a not-yet-registered rank.
+    ///
+    /// `submitted_at`/`updated_at_block` come from `public.entities`
+    /// (`updated_at`/`updated_at_block`, not `created_at`, so dedup ordering
+    /// reflects the *latest* on-chain change) rather than a live edit's
+    /// metadata, since a recovery run has no current edit to take them from.
+    /// `update_index` has no public-schema equivalent; recovered ranks get
+    /// `0`, which only risks a wrong dedup tie-break against another
+    /// submission landing in the exact same chain block (narrow, accepted).
+    /// `author_address` is `None`, matching what the live path always
+    /// produces today (unimplemented there too — not a recovery gap).
+    /// Returns `None` if the entity is not (yet) typed as a Rank.
+    pub async fn get_rank_config_from_kg(
+        &self,
+        rank_id: Uuid,
+    ) -> Result<Option<Ranking>, IndexerError> {
+        use sdk::core::ids;
+        let pid = |s: &str| Uuid::parse_str(s).expect("valid system ID constant");
+
+        let typed: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT space_id FROM relations \
+             WHERE from_entity_id = $1 AND type_id = $2 AND to_entity_id = $3 \
+             LIMIT 1",
+        )
+        .bind(rank_id)
+        .bind(pid(ids::TYPE_RELATION_TYPE_ID))
+        .bind(pid(ids::RANK_TYPE_ID))
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some((space_id,)) = typed else {
+            return Ok(None);
+        };
+
+        let rank_type: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT text FROM values \
+             WHERE entity_id = $1 AND space_id = $2 AND property_id = $3 LIMIT 1",
+        )
+        .bind(rank_id)
+        .bind(space_id)
+        .bind(pid(ids::RANK_TYPE_PROPERTY_ID))
+        .fetch_optional(&self.pool)
+        .await?;
+        let rank_type = rank_type.and_then(|(t,)| t);
+
+        let block_id: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT to_entity_id FROM relations \
+             WHERE from_entity_id = $1 AND type_id = $2 LIMIT 1",
+        )
+        .bind(rank_id)
+        .bind(pid(ids::RANK_BLOCK_RELATION_TYPE_ID))
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let entity: Option<(String, String)> =
+            sqlx::query_as("SELECT updated_at, updated_at_block FROM entities WHERE id = $1")
+                .bind(rank_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        let (submitted_at, updated_at_block) = match entity {
+            Some((updated_at, updated_at_block)) => (
+                updated_at
+                    .parse::<i64>()
+                    .ok()
+                    .and_then(|ts| DateTime::<Utc>::from_timestamp(ts, 0)),
+                updated_at_block.parse::<i64>().unwrap_or(0),
+            ),
+            None => (None, 0),
+        };
+
+        Ok(Some(Ranking {
+            id: rank_id,
+            block_id: block_id.map(|(b,)| b),
+            space_id,
+            author_address: None,
+            rank_type,
+            submitted_at,
+            updated_at_block,
+            update_index: 0,
+        }))
+    }
+
+    /// The chain height/timestamp hermes has indexed up to, for stamping
+    /// entities the backfill binary mints (it runs off-band, with no edit of
+    /// its own to take `BlockMeta` from). Falls back to `(0, 0)` if the cursor
+    /// row is absent (e.g. a fresh/local database) — the projection is stamped
+    /// but otherwise unaffected, since dedup/ordering key off `rankings`'
+    /// own `updated_at_block`, not this value.
+    pub async fn current_chain_meta(&self) -> Result<BlockMeta, IndexerError> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT block_number FROM meta WHERE id = 'hermes_pipeline'")
+                .fetch_optional(&self.pool)
+                .await?;
+        let number = row.and_then(|(s,)| s.parse::<i64>().ok()).unwrap_or(0);
+        Ok(BlockMeta {
+            number,
+            timestamp: Utc::now().timestamp(),
+        })
     }
 
     /// Load all submissions currently linked to a block (pre-dedup).
@@ -305,14 +569,17 @@ impl Storage {
         sqlx::query(
             r#"
             INSERT INTO ranks.ranking_blocks
-                (id, space_id, name, filter, start_date, end_date, restriction_id, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+                (id, space_id, name, filter, start_date, end_date, restriction_id,
+                 ranking_type, submission_frequency, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
             ON CONFLICT (id, space_id) DO UPDATE SET
                 name = EXCLUDED.name,
                 filter = EXCLUDED.filter,
                 start_date = EXCLUDED.start_date,
                 end_date = EXCLUDED.end_date,
                 restriction_id = EXCLUDED.restriction_id,
+                ranking_type = EXCLUDED.ranking_type,
+                submission_frequency = EXCLUDED.submission_frequency,
                 updated_at = now()
             "#,
         )
@@ -323,6 +590,8 @@ impl Storage {
         .bind(b.start_date)
         .bind(b.end_date)
         .bind(b.restriction_id)
+        .bind(b.ranking_type)
+        .bind(b.submission_frequency)
         .execute(&self.pool)
         .await?;
         Ok(())

--- a/ranking-indexer/tests/e2e.rs
+++ b/ranking-indexer/tests/e2e.rs
@@ -7,6 +7,7 @@
 //! connection string. Skips (passes) if unset, so it never runs on a generic
 //! CI `DATABASE_URL` that lacks the `ranks` schema.
 
+use chrono::{DateTime, TimeZone, Utc};
 use grc_20::model::builder::EditBuilder;
 use hermes_schema::pb::membership::{HermesRoleGranted, HermesRoleRevoked, MembershipRole};
 use sdk::core::ids::*;
@@ -15,7 +16,8 @@ use uuid::Uuid;
 
 use ranking_indexer::detect::detect;
 use ranking_indexer::membership::{apply_membership_event, MembershipEvent};
-use ranking_indexer::recompute::apply_detected_edit;
+use ranking_indexer::models::BlockMeta;
+use ranking_indexer::recompute::{apply_detected_edit, recompute_block};
 use ranking_indexer::storage::Storage;
 
 fn gid(n: u128) -> [u8; 16] {
@@ -461,6 +463,360 @@ async fn cross_edit_block_is_recovered_from_kg_and_scored() {
         "both ranked entities scored once the block is recovered"
     );
 }
+
+/// Regression (GEO-2253): `get_block_config_from_kg` must resolve the same
+/// datetime-over-legacy-date precedence as `detect::window_bound`, or the
+/// live path and the KG-recovery path disagree on an unregistered block's
+/// window. Start authors both properties (datetime should win); end authors
+/// only the legacy property (must still fall back correctly).
+#[tokio::test]
+async fn cross_edit_block_recovers_datetime_bounds_preferring_new_property_over_legacy() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    const SPACE: u128 = 0xE2E5_0000_3001;
+    const MEMBER: u128 = 0xE2E5_0000_3011;
+    const BLOCK: u128 = 0xE2E5_0000_3021;
+    const TYPE_REL: u128 = 0xE2E5_0000_3022;
+    const START_LEGACY_VAL: u128 = 0xE2E5_0000_3023;
+    const START_DATETIME_VAL: u128 = 0xE2E5_0000_3024;
+    const END_LEGACY_VAL: u128 = 0xE2E5_0000_3025;
+    const ENT_A: u128 = 0xE2E5_0000_3031;
+    const RANK: u128 = 0xE2E5_0000_3041;
+
+    let su = |s: &str| Uuid::parse_str(s).unwrap();
+    let legacy_start = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+    let new_start = Utc.with_ymd_and_hms(2026, 2, 2, 9, 30, 0).unwrap();
+    let legacy_end = Utc.with_ymd_and_hms(2026, 3, 3, 0, 0, 0).unwrap();
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+    ] {
+        sqlx::query(sql).bind(u(SPACE)).execute(pool).await.unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.members WHERE space_id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed prerequisites --------------------------------------------------
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e3')")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)")
+        .bind(u(MEMBER))
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // Seed the KG as kg-indexer would: the block's `TYPES -> Ranking Block`
+    // relation, plus start authored on BOTH the legacy and datetime property
+    // (datetime should win), and end authored on only the legacy property
+    // (must fall back). Never registered in `ranks`.
+    sqlx::query(
+        "INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(u(TYPE_REL))
+    .bind(u(TYPE_REL))
+    .bind(su(TYPE_RELATION_TYPE_ID))
+    .bind(u(BLOCK))
+    .bind(su(RANKING_BLOCK_TYPE_ID))
+    .bind(u(SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, datetime_utc) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(START_LEGACY_VAL).to_string())
+    .bind(u(BLOCK))
+    .bind(u(SPACE))
+    .bind(su(RANK_START_DATE_PROPERTY_ID))
+    .bind(legacy_start)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, datetime_utc) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(START_DATETIME_VAL).to_string())
+    .bind(u(BLOCK))
+    .bind(u(SPACE))
+    .bind(su(RANK_START_DATETIME_PROPERTY_ID))
+    .bind(new_start)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, datetime_utc) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(END_LEGACY_VAL).to_string())
+    .bind(u(BLOCK))
+    .bind(u(SPACE))
+    .bind(su(RANK_END_DATE_PROPERTY_ID))
+    .bind(legacy_end)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Precondition: the block is NOT registered in the ranks schema.
+    assert!(
+        storage.get_ranking_block(u(BLOCK)).await.unwrap().is_none(),
+        "precondition: block must be unregistered before the rank arrives"
+    );
+
+    // --- a member submits a rank linked to the (unregistered) block --------
+    let rank_edit = EditBuilder::new(gid(RANK ^ 0xED17))
+        .create_relation(|r| {
+            r.id(gid(0x310))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(sid(RANK_TYPE_ID))
+        })
+        .create_entity(gid(RANK), |e| {
+            e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+        })
+        .create_relation(|r| {
+            r.id(gid(0x311))
+                .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(BLOCK))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x312))
+                .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(ENT_A))
+                .to_space(gid(SPACE))
+                .position("a0")
+        })
+        .build();
+    apply_detected_edit(&detect(&rank_edit, u(MEMBER), 2, 0), u(MEMBER), &storage)
+        .await
+        .unwrap();
+
+    // --- the recovered block prefers the datetime bound over the legacy one,
+    //     and falls back to legacy where the datetime bound is absent --------
+    let (start_date, end_date): (Option<chrono::DateTime<Utc>>, Option<chrono::DateTime<Utc>>) =
+        sqlx::query_as("SELECT start_date, end_date FROM ranks.ranking_blocks WHERE id = $1")
+            .bind(u(BLOCK))
+            .fetch_one(pool)
+            .await
+            .unwrap();
+
+    assert_eq!(
+        start_date,
+        Some(new_start),
+        "start: the datetime property must win over the legacy one authored on the same block"
+    );
+    assert_eq!(
+        end_date,
+        Some(legacy_end),
+        "end: must fall back to the legacy property when no datetime property is authored"
+    );
+}
+
+/// GEO-2328: a Rolling block's submission stays eligible only for
+/// `submission_frequency` hours after `submitted_at` — unlike a static
+/// block's fixed `[start, end]` window, it ages out purely from elapsed time,
+/// with no new edit required. Recomputes the same block twice with different
+/// injected `now` values (no real sleep) to simulate what the future sweep
+/// binary will do periodically.
+#[tokio::test]
+async fn rolling_block_drops_a_submission_once_it_ages_past_its_frequency() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    const SPACE: u128 = 0xE2E5_0000_4001;
+    const MEMBER: u128 = 0xE2E5_0000_4011;
+    const BLOCK: u128 = 0xE2E5_0000_4021;
+    const ENT_A: u128 = 0xE2E5_0000_4031;
+    const RANK: u128 = 0xE2E5_0000_4041;
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+    ] {
+        sqlx::query(sql).bind(u(SPACE)).execute(pool).await.unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.members WHERE space_id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id = $1")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed prerequisites --------------------------------------------------
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xe2e4')")
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO ranks.members (member_space_id, space_id) VALUES ($1, $2)")
+        .bind(u(MEMBER))
+        .bind(u(SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- edit 1: a Rolling block with a 1-hour submission_frequency ---------
+    // Rolling is a second `TYPES` relation (GEO-2328) alongside the standard
+    // `Ranking Block` typing, not a dedicated property.
+    let block_edit = EditBuilder::new(gid(1))
+        .create_relation(|r| {
+            r.id(gid(0x400))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(BLOCK))
+                .to(sid(RANKING_BLOCK_TYPE_ID))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x401))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(BLOCK))
+                .to(sid(RANK_ROLLING_TYPE_ID))
+        })
+        .create_entity(gid(BLOCK), |e| {
+            e.text(sid(NAME_PROPERTY_ID), "Rolling Block", None)
+                .integer(sid(RANK_SUBMISSION_FREQUENCY_PROPERTY_ID), 1, None)
+        })
+        .build();
+    apply_detected_edit(&detect(&block_edit, u(SPACE), 1, 0), u(SPACE), &storage)
+        .await
+        .unwrap();
+
+    // --- a member submits a rank at submitted_at = epoch 0 -------------------
+    let rank_edit = EditBuilder::new(gid(RANK ^ 0xED17))
+        .create_relation(|r| {
+            r.id(gid(0x410))
+                .relation_type(sid(TYPE_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(sid(RANK_TYPE_ID))
+        })
+        .create_entity(gid(RANK), |e| {
+            e.text(sid(RANK_TYPE_PROPERTY_ID), "ORDINAL", None)
+        })
+        .create_relation(|r| {
+            r.id(gid(0x411))
+                .relation_type(sid(RANK_BLOCK_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(BLOCK))
+        })
+        .create_relation(|r| {
+            r.id(gid(0x412))
+                .relation_type(sid(RANK_VOTES_RELATION_TYPE_ID))
+                .from(gid(RANK))
+                .to(gid(ENT_A))
+                .to_space(gid(SPACE))
+                .position("a0")
+        })
+        .build();
+    apply_detected_edit(
+        &detect(&rank_edit, u(MEMBER), 2, 0), // block_timestamp 0 -> submitted_at = epoch 0
+        u(MEMBER),
+        &storage,
+    )
+    .await
+    .unwrap();
+
+    let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0).unwrap();
+    let scored_count = || async {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT count(*) FROM ranks.ranking_scores WHERE block_id = $1 AND entity_id = $2",
+        )
+        .bind(u(BLOCK))
+        .bind(u(ENT_A))
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    };
+
+    // --- recompute at now = 30 min: still within the 1-hour frequency -------
+    recompute_block(u(BLOCK), BlockMeta::default(), t(30 * 60), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        scored_count().await,
+        1,
+        "a submission still within its submission_frequency must be scored"
+    );
+
+    // --- recompute at now = 2h: aged past the frequency, no new edit --------
+    recompute_block(u(BLOCK), BlockMeta::default(), t(2 * 3600), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        scored_count().await,
+        0,
+        "a submission past its submission_frequency must be dropped purely from \
+         elapsed time, with no new edit required"
+    );
+}
+
 /// Regression: a projection row written before this PR has `from_space_id IS
 /// NULL` but keeps the deterministic v5 relation id (the PK). The step-2 DELETE
 /// in `replace_rank_position_projection` must clear it on the next recompute;
@@ -949,12 +1305,12 @@ async fn recompute_is_idempotent_when_a_prior_value_row_is_orphaned() {
     let pool = storage.pool();
 
     // Distinct scenario ids so this can share a DB with the other e2e tests.
-    const SPACE: u128 = 0xE2E5_0000_3001;
-    const MEMBER: u128 = 0xE2E5_0000_3011;
-    const BLK: u128 = 0xE2E5_0000_3021;
+    const SPACE: u128 = 0xE2E5_0000_4001;
+    const MEMBER: u128 = 0xE2E5_0000_4011;
+    const BLK: u128 = 0xE2E5_0000_4021;
     const ENT_A: u128 = 0xE2E5_0000_3031;
     const ENT_B: u128 = 0xE2E5_0000_3032;
-    const RNK: u128 = 0xE2E5_0000_3041;
+    const RNK: u128 = 0xE2E5_0000_4041;
 
     // --- clean prior runs (idempotent) -------------------------------------
     for sql in [
@@ -1124,4 +1480,203 @@ async fn recompute_is_idempotent_when_a_prior_value_row_is_orphaned() {
     );
     let v1: i64 = rows[1].get("value");
     assert_eq!(v1, 50, "second entity converges to 50");
+}
+
+/// Companion to `cross_edit_block_is_recovered_from_kg_and_scored`, for the
+/// identical split-edit gap on Rank entities — except there's no reactive
+/// live-path trigger for ranks (unlike blocks), so recovery is
+/// periodic-sweep-only: `find_unregistered_ranks` + `get_rank_config_from_kg`
+/// + a manual `upsert_ranking` + `recompute_block`, exactly what
+/// `bin/backfill_blocks.rs` runs on a schedule.
+#[tokio::test]
+async fn cross_edit_rank_is_recovered_from_kg_and_scored() {
+    let Ok(url) = std::env::var("RANKING_INDEXER_E2E_DATABASE_URL") else {
+        eprintln!("skipping e2e: RANKING_INDEXER_E2E_DATABASE_URL not set");
+        return;
+    };
+    let storage = Storage::new(&url).await.expect("connect");
+    let pool = storage.pool();
+
+    const BLOCK_SPACE: u128 = 0xE2E5_0000_4001;
+    const MEMBER_SPACE: u128 = 0xE2E5_0000_4011; // the rank's own (personal) space
+    const BLOCK: u128 = 0xE2E5_0000_4021;
+    const RANK: u128 = 0xE2E5_0000_4041;
+    const TYPE_REL: u128 = 0xE2E5_0000_4042;
+    const BLOCK_REL: u128 = 0xE2E5_0000_4043;
+    const RANK_TYPE_VAL: u128 = 0xE2E5_0000_4044;
+    const ENT_A: u128 = 0xE2E5_0000_4051;
+    const ENT_B: u128 = 0xE2E5_0000_4052;
+
+    let su = |s: &str| Uuid::parse_str(s).unwrap();
+
+    // --- clean prior runs (idempotent) -------------------------------------
+    for sql in [
+        "DELETE FROM relations WHERE space_id = $1",
+        "DELETE FROM values WHERE space_id = $1",
+        "DELETE FROM entities WHERE id = $2",
+    ] {
+        sqlx::query(sql)
+            .bind(u(MEMBER_SPACE))
+            .bind(u(RANK))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query("DELETE FROM ranks.ranking_items WHERE ranking_id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_scores WHERE block_id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM ranks.ranking_blocks WHERE id = $1")
+        .bind(u(BLOCK))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM spaces WHERE id IN ($1, $2)")
+        .bind(u(BLOCK_SPACE))
+        .bind(u(MEMBER_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // --- seed prerequisites: a Personal block (no membership check needed,
+    // "All of Geo" admits any submitter) already registered in `ranks`. ----
+    sqlx::query("INSERT INTO spaces (id, type, address) VALUES ($1, 'Personal', '0xe2e3')")
+        .bind(u(BLOCK_SPACE))
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ranks.ranking_blocks (id, space_id, name, updated_at) \
+         VALUES ($1, $2, 'Recovered Rank Target', now())",
+    )
+    .bind(u(BLOCK))
+    .bind(u(BLOCK_SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // --- seed the KG as kg-indexer would: the rank's `TYPES -> Rank`
+    // relation, its rank_type value, its `RANK_BLOCK` link, and its entity
+    // row — WITHOUT registering it in `ranks.rankings` — i.e. the exact
+    // state where detect() never saw the type and the entity in one edit. --
+    sqlx::query(
+        "INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block) \
+         VALUES ($1, '1700000000', '42', '1700000100', '43')",
+    )
+    .bind(u(RANK))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+         VALUES ($1, $1, $2, $3, $4, $5)",
+    )
+    .bind(u(TYPE_REL))
+    .bind(su(TYPE_RELATION_TYPE_ID))
+    .bind(u(RANK))
+    .bind(su(RANK_TYPE_ID))
+    .bind(u(MEMBER_SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO values (id, entity_id, space_id, property_id, text) VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(u(RANK_TYPE_VAL).to_string())
+    .bind(u(RANK))
+    .bind(u(MEMBER_SPACE))
+    .bind(su(RANK_TYPE_PROPERTY_ID))
+    .bind("ORDINAL")
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id) \
+         VALUES ($1, $1, $2, $3, $4, $5)",
+    )
+    .bind(u(BLOCK_REL))
+    .bind(su(RANK_BLOCK_RELATION_TYPE_ID))
+    .bind(u(RANK))
+    .bind(u(BLOCK))
+    .bind(u(MEMBER_SPACE))
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Votes landed via the live path at the time (RANK_VOTES relations are
+    // collected regardless of whether their `from` entity is classified),
+    // so they're already sitting in `ranking_items` — orphaned, since
+    // `ranks.rankings` has no row for RANK to attach them to yet.
+    for (entity, position) in [(ENT_A, "a0"), (ENT_B, "a1")] {
+        sqlx::query(
+            "INSERT INTO ranks.ranking_items (ranking_id, entity_id, space_id, position) \
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(u(RANK))
+        .bind(u(entity))
+        .bind(u(MEMBER_SPACE))
+        .bind(position)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    // --- precondition: the rank is NOT registered in the ranks schema ------
+    let registered: i64 = sqlx::query_scalar("SELECT count(*) FROM ranks.rankings WHERE id = $1")
+        .bind(u(RANK))
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        registered, 0,
+        "precondition: rank must be unregistered before recovery"
+    );
+
+    // --- the sweep's recovery path: find it, reconstruct it, score it ------
+    let candidates = storage.find_unregistered_ranks().await.unwrap();
+    assert!(
+        candidates.contains(&u(RANK)),
+        "find_unregistered_ranks must surface the orphaned rank"
+    );
+
+    let recovered = storage
+        .get_rank_config_from_kg(u(RANK))
+        .await
+        .unwrap()
+        .expect("rank must be reconstructable from the KG");
+    assert_eq!(recovered.rank_type.as_deref(), Some("ORDINAL"));
+    assert_eq!(
+        recovered.block_id,
+        Some(u(BLOCK)),
+        "block_id must be resolved directly from the RANK_BLOCK relation, \
+         not from ranks.rankings (set_ranking_block silently no-ops against \
+         an unregistered rank)"
+    );
+
+    storage.upsert_ranking(&recovered).await.unwrap();
+    recompute_block(u(BLOCK), BlockMeta::default(), Utc::now(), &storage)
+        .await
+        .unwrap();
+
+    let scores: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM ranks.ranking_scores WHERE block_id = $1")
+            .bind(u(BLOCK))
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        scores, 2,
+        "both previously-orphaned items scored once the rank is recovered"
+    );
 }

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -61,9 +61,28 @@ pub const RANKING_BLOCK_TYPE_ID: &str = "150db6de-fe23-44f0-805a-fa57502e2c32";
 pub const RANK_BLOCK_RELATION_TYPE_ID: &str = "09c219c1-03d1-4d2a-a5c7-8edbf2d0182a";
 pub const RANK_START_DATE_PROPERTY_ID: &str = "eed03a04-0acd-4a9e-81e0-8272ed70a817";
 pub const RANK_END_DATE_PROPERTY_ID: &str = "b08b8f63-dc1e-4156-8b08-19946f2b011c";
+// Datetime successors to the start/end date properties (GEO-2253). Minted
+// on-chain 2026-07-09; not yet in geo-sdk. When a block authors both, the
+// datetime property wins per-bound and the legacy date one is ignored.
+pub const RANK_START_DATETIME_PROPERTY_ID: &str = "2d696bf0-510f-403e-985b-8cd1e73feb9b";
+pub const RANK_END_DATETIME_PROPERTY_ID: &str = "c3445f6b-e2c0-4f25-b73a-5eb876c4f50c";
 pub const RANK_AGGREGATION_RESTRICTION_PROPERTY_ID: &str = "1e4caa2d-e331-4efa-8ac2-4e8d9d3e9fe9";
 pub const RANK_RESTRICTION_MEMBERS_AND_EDITORS_ID: &str = "10a7b103-90f9-4a72-8087-935052ffaa69";
 pub const RANK_FILTER_PROPERTY_ID: &str = "14a46854-bfd1-4b18-8215-2785c2dab9f3";
+// Rolling rankings (GEO-2328). `Submission frequency` is an integer number of
+// hours (confirmed by product 2026-07-13): a submission stays eligible for
+// `submission_frequency` hours after `submitted_at`, then requires
+// resubmission.
+//
+// The block-level Rolling/static classifier is NOT a dedicated property (the
+// ID originally given for one in the spec doc turned out to be a copy-paste
+// duplicate of RANK_TYPE_PROPERTY_ID above — flagged and confirmed with
+// Preston 2026-07-17). Instead a Rolling block gets a second `TYPES` relation
+// (the same TYPE_RELATION_TYPE_ID used for RANKING_BLOCK_TYPE_ID etc.)
+// pointing at RANK_ROLLING_TYPE_ID, mirroring how block-typing already works.
+// No separate "ranking type property" ID exists or is needed.
+pub const RANK_SUBMISSION_FREQUENCY_PROPERTY_ID: &str = "c0ab9953-8eeb-4d7c-8ccb-1dd585ae4711";
+pub const RANK_ROLLING_TYPE_ID: &str = "d00ddc89-b23c-4a20-a63f-ebf545ddc139";
 // The 8th ranking-block property in the canonical ontology: a Relation -> a
 // "Data source" entity describing how the block sources its candidate set
 // (query vs collection). V1 aggregation works off the submitted Rank entities


### PR DESCRIPTION
`ranking-indexer` had diverged: seven commits shipped on `main` and none of
them reached `staging`, so the v2 stack was running the pre-#808 indexer.
This brings the whole directory to parity with `main` and wires the two
CronJobs into the v2 cluster, which never had them.

What comes across:

- #808  datetime ranking-block bounds (GEO-2253): `Start/End datetime`
        properties take precedence over the legacy date ones, on both the
        live `detect` path and the KG-recovery path.
- #809  `backfill_blocks` — self-heals blocks the one-shot live recovery
        (#738/#739) missed because kg-indexer had not yet indexed the
        block's config when a rank linked to it.
- #810  the hourly backfill CronJob, plus its binary in the image.
- #811  the same sweep also recovers orphaned Rank submissions.
- #821  rolling rankings backend (GEO-2328): `ranking_type` /
        `submission_frequency`, `rolling_admits`, and the `rolling_sweep`
        binary that gives Rolling blocks their time-based recompute trigger.
- #826  `rolling_sweep` in the runtime image.
- #827  backfill stale `ranking_type` on already-registered blocks.

Ported as a whole-directory sync rather than seven cherry-picks: the
`staging..main` diff for `ranking-indexer/` is exactly the union of those
commits, so the result is identical and there are no partial-conflict
resolutions to audit. `k8s/v2/ranking-indexer.yaml` is staging-only and is
preserved.

Two things could not be copied verbatim:

- The drizzle migration is REGENERATED, not copied. On `main` the two
  ALTER TABLEs are `0068` on top of `0067_support_entities_without_value`;
  on `staging` `0067` is `governance_v2`. The SQL is byte-identical, but
  the snapshot has to be generated against staging's baseline. (Note for
  whoever ports #789 next: `0068` is now taken, that one becomes `0069`.)
- The v2 CronJobs are new files. `k8s/v2/` had only the Deployment, so the
  backfill and rolling sweep would never have run on the testnet cluster.
  Modeled on the staging pair with v2 conventions applied (namespace
  `gaia`, `regcred` pull secret, non-root pod securityContext). Both need
  only `DATABASE_URL` — no Kafka. They ship with the Deployment in
  `deploy-v2.yml` since all three run the same image.

On whether rolling rankings should be live on v2 at all: until product
creates a Rolling block, `ranking_type` is NULL everywhere, every block
takes the static path, and the sweep finds nothing and exits. Shipping the
backend ahead of the product decision costs nothing and avoids leaving
staging on a fork of the indexer. The sweep cadence stays a plain CronJob
schedule edit, to be retuned once real `submission_frequency` values exist.

Verified: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`,
`cargo build --release --bins` (all three binaries), 34 unit tests, and
all 8 e2e tests — including
`rolling_block_drops_a_submission_once_it_ages_past_its_frequency` —
against a scratch Postgres migrated from staging's drizzle chain through
the new `0068`. `api` typechecks and passes `biome format`.