### PR TITLE
fix(notification-indexer): read expired proposals from proposals_current, bound the first run

### DIFF
--- a/notification-service/deployment/v2/notification-indexer.yaml
+++ b/notification-service/deployment/v2/notification-indexer.yaml
@@ -76,6 +76,16 @@ spec:
               value: "notification-indexer-knowledge-edits-testnet-v1"
             - name: REJECTION_POLL_INTERVAL_SECS
               value: "60"
+            # Rejection notifications were dead on this cluster for its whole
+            # life (the query read `proposals.end_time`, which governance-v2
+            # moved to `proposal_versions`), so switching them on finds every
+            # proposal the chain migration replayed: 3,241 expired-unnotified
+            # proposals dating back to 1970 when measured on 2026-07-30. This
+            # bounds the first run to the preceding 10 hours — 10 real
+            # proposals — and is then persisted, so this value has no further
+            # effect on a database that already has a floor.
+            - name: REJECTION_BACKFILL_HOURS
+              value: "10"
             # Logging
             - name: RUST_LOG
               value: "info,notification_indexer=debug"

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -108,6 +108,31 @@ async fn async_main() -> Result<(), IndexerError> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(60);
 
+    // How far back the rejection poller looks the FIRST time it runs against a
+    // given database. Only proposals that ended after `now - this` are ever
+    // notified. Applied once and persisted (see `Storage::rejection_floor`), so
+    // changing it later has no effect on a database that already has a floor.
+    //
+    // This exists because the query below was broken on the v2 schema for its
+    // whole life, so switching it on finds every proposal the chain migration
+    // replayed. Measured on testnet 2026-07-30: 3,241 expired-unnotified
+    // proposals dating back to 1970, of which 10 were from the preceding 10h.
+    // Negative values would push the floor into the future and silence the
+    // poller entirely, so reject them rather than defaulting.
+    let rejection_backfill_hours: i64 = match env::var("REJECTION_BACKFILL_HOURS") {
+        Ok(v) => match v.parse::<i64>() {
+            Ok(h) if h >= 0 => h,
+            _ => {
+                error!(
+                    value = %v,
+                    "REJECTION_BACKFILL_HOURS must be a non-negative integer; refusing to start"
+                );
+                std::process::exit(1);
+            }
+        },
+        Err(_) => 10,
+    };
+
     // Retention: delete notification_outbox / notification_deliveries rows older
     // than this many days. Unset = default 30; 0 disables the cleanup task.
     // Validate rather than silently default — a malformed value could mask a
@@ -286,6 +311,30 @@ async fn async_main() -> Result<(), IndexerError> {
             rejection_poll_interval_secs,
         ));
 
+        // Resolve the floor once, before the first tick. Seeded on first run to
+        // `now - REJECTION_BACKFILL_HOURS`; thereafter read from the database, so
+        // restarts and config changes cannot widen it retroactively.
+        let rejection_floor = match poller_storage
+            .rejection_floor(rejection_backfill_hours)
+            .await
+        {
+            Ok(floor) => {
+                info!(
+                    floor = floor,
+                    backfill_hours = rejection_backfill_hours,
+                    "Rejection floor resolved; proposals that ended before it are never notified"
+                );
+                floor
+            }
+            Err(e) => {
+                // Without a floor we would notify the entire historical backlog,
+                // which on a migrated chain is thousands of replayed proposals.
+                // Skipping a poll cycle is strictly better than that.
+                error!(error = %e, "Failed to resolve rejection floor; rejection poller disabled");
+                return;
+            }
+        };
+
         loop {
             tokio::select! {
                 _ = shutdown_rx2.recv() => {
@@ -297,7 +346,7 @@ async fn async_main() -> Result<(), IndexerError> {
 
                     // Process in batches to avoid unbounded memory usage
                     loop {
-                        match poller_storage.find_expired_proposals(BATCH_LIMIT).await {
+                        match poller_storage.find_expired_proposals(BATCH_LIMIT, rejection_floor).await {
                             Ok(expired) => {
                                 let batch_len = expired.len();
                                 if !expired.is_empty() {

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -14,6 +14,11 @@ use crate::error::StorageError;
 use crate::ids;
 use crate::models::{event_notification_types, NotificationEvent, KNOWN_NOTIFICATION_TYPES};
 
+/// `notification_poll_cursors` key holding the rejection-notification floor.
+/// See [`Storage::rejection_floor`] — this one is a fixed floor, not a
+/// high-water mark like `entity_votes_threshold`.
+pub const REJECTION_FLOOR_CURSOR: &str = "proposal_rejected_floor";
+
 /// How long the in-memory `app_webhooks` snapshot is reused before re-reading the
 /// table. The table is tiny (a handful of rows) and changes rarely, so we serve
 /// filtering from memory and refresh lazily — a filter change takes effect within
@@ -618,25 +623,47 @@ impl Storage {
     /// Find proposals that have expired (end_time < now) without being executed,
     /// and for which we haven't yet sent a rejection notification.
     ///
+    /// Reads from `proposals_current`, NOT `proposals`. Under the governance-v2
+    /// schema (migration `0067_governance_v2`) `proposals` is an identity table
+    /// and all mutable state — including `end_time` — lives in
+    /// `proposal_versions`; `proposals_current` is the view joining each
+    /// proposal to its `current_version`. `executed_at` stayed on `proposals`
+    /// and the view carries it through, so every column here resolves.
+    ///
+    /// NOTE: this makes the query v2-only. It must not be cherry-picked to a
+    /// branch without `0067_governance_v2` — there is no `proposals_current`
+    /// there and the query fails at runtime, which is exactly how this broke:
+    /// the old `FROM proposals` text is correct pre-v2 and silently started
+    /// erroring (`column p.end_time does not exist`) once the split landed.
+    ///
+    /// `min_end_time` is an absolute epoch-seconds floor: proposals that ended
+    /// before it are never notified. It exists because turning this query back
+    /// on against a migrated chain would otherwise fire a rejection for every
+    /// proposal replayed by the transplant — 3,241 of them when this was fixed,
+    /// spanning 1970 to 2026, versus 10 that were genuinely recent. See
+    /// `rejection_floor`.
+    ///
     /// Results are limited to `limit` rows to prevent unbounded memory usage.
     /// Callers should loop until a batch returns fewer than `limit` rows.
     #[instrument(
         name = "notification_indexer.storage.find_expired_proposals",
         skip(self),
-        fields(limit = limit)
+        fields(limit = limit, min_end_time = min_end_time)
     )]
     pub async fn find_expired_proposals(
         &self,
         limit: i64,
+        min_end_time: i64,
     ) -> Result<Vec<ExpiredProposal>, StorageError> {
         let rows = sqlx::query(
             r#"
             SELECT p.id, p.space_id, p.proposed_by, p.end_time
-            FROM proposals p
+            FROM proposals_current p
             LEFT JOIN notification_outbox o
               ON o.event_type = 'proposal_rejected'
              AND (o.payload->>'proposal_id')::uuid = p.id
             WHERE p.end_time < EXTRACT(EPOCH FROM now())
+              AND p.end_time >= $2
               AND p.executed_at IS NULL
               AND o.id IS NULL
             ORDER BY p.end_time ASC, p.id
@@ -644,6 +671,7 @@ impl Storage {
             "#,
         )
         .bind(limit)
+        .bind(min_end_time)
         .fetch_all(&self.pool)
         .await?;
 
@@ -959,6 +987,44 @@ impl Storage {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Read the rejection floor, seeding it on first run.
+    ///
+    /// Unlike the other entries in `notification_poll_cursors` this is a FIXED
+    /// floor, not an advancing high-water mark: it is written once and then only
+    /// ever read. Deduplication of already-sent rejections is handled by the
+    /// `notification_outbox` anti-join in `find_expired_proposals`, so this only
+    /// needs to answer "how far back do we look the very first time".
+    ///
+    /// It must be absolute and persisted rather than computed as
+    /// `now() - backfill` on each poll. A relative window would permanently skip
+    /// any proposal that expired while the service was down for longer than the
+    /// window — the anti-join would never see a notification for it, but the
+    /// window would have moved past it. Persisting the floor means catching up
+    /// after an outage still notifies everything after it.
+    ///
+    /// `backfill_hours` therefore only has an effect on a database that has
+    /// never run this poller. Changing it later is a no-op; to move an existing
+    /// floor, update the row.
+    #[instrument(name = "notification_indexer.storage.rejection_floor", skip(self))]
+    pub async fn rejection_floor(&self, backfill_hours: i64) -> Result<i64, StorageError> {
+        if let Some((ts, _)) = self.get_poll_cursor(REJECTION_FLOOR_CURSOR).await? {
+            return Ok(ts.timestamp());
+        }
+
+        // Epoch arithmetic rather than a chrono `Duration`, which collides with
+        // the `std::time::Duration` already imported in this module.
+        let floor_secs = Utc::now().timestamp() - backfill_hours * 3600;
+        let floor = DateTime::<Utc>::from_timestamp(floor_secs, 0).ok_or_else(|| {
+            StorageError::Database(sqlx::Error::Protocol(format!(
+                "rejection floor {floor_secs} is not a representable timestamp \
+                 (check REJECTION_BACKFILL_HOURS)"
+            )))
+        })?;
+        self.set_poll_cursor(REJECTION_FLOOR_CURSOR, floor, 0)
+            .await?;
+        Ok(floor.timestamp())
     }
 }
 

--- a/notification-service/notification-indexer/tests/expired_proposals.rs
+++ b/notification-service/notification-indexer/tests/expired_proposals.rs
@@ -1,0 +1,215 @@
+//! Integration test for `find_expired_proposals` and the rejection floor.
+//!
+//! Runs only when `NOTIF_TEST_DATABASE_URL` points at a throwaway Postgres
+//! (it DROPs/CREATEs the tables it needs).
+//!
+//! Two regressions are covered here.
+//!
+//! 1. The query used to read `FROM proposals`, taking `end_time` off it. The
+//!    governance-v2 split (`0067_governance_v2`) moved `end_time` to
+//!    `proposal_versions` and left `proposals` as an identity table, so the
+//!    query started failing with `column p.end_time does not exist` — every
+//!    minute, for the life of the v2 cluster, with rejection notifications
+//!    silently dead. The schema below mirrors v2: `end_time` exists ONLY on
+//!    `proposal_versions`, so a regression to `FROM proposals` fails here
+//!    rather than in production.
+//!
+//! 2. Simply fixing the query would have fired a rejection for every proposal
+//!    the chain migration replayed (3,241 on testnet, back to 1970). The floor
+//!    bounds that, and — because it is persisted rather than recomputed — an
+//!    outage longer than the backfill window must NOT cause proposals to be
+//!    skipped.
+
+use notification_indexer::storage::{Storage, REJECTION_FLOOR_CURSOR};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Mirrors the governance-v2 shape: `end_time` lives on `proposal_versions`,
+/// `executed_at` stays on `proposals`, and `proposals_current` joins each
+/// proposal to its current version.
+const SCHEMA: &str = r#"
+DROP VIEW IF EXISTS proposals_current;
+DROP TABLE IF EXISTS proposal_versions;
+DROP TABLE IF EXISTS proposals;
+DROP TABLE IF EXISTS notification_outbox;
+DROP TABLE IF EXISTS notification_poll_cursors;
+CREATE TABLE proposals (
+    id uuid PRIMARY KEY,
+    space_id uuid NOT NULL,
+    proposed_by uuid NOT NULL,
+    executed_at bigint,
+    current_version integer NOT NULL DEFAULT 1
+);
+CREATE TABLE proposal_versions (
+    proposal_id uuid NOT NULL REFERENCES proposals(id),
+    proposal_version integer NOT NULL,
+    end_time bigint NOT NULL,
+    name text,
+    PRIMARY KEY (proposal_id, proposal_version)
+);
+CREATE VIEW proposals_current AS
+    SELECT p.*, pv.proposal_version AS pv_version, pv.end_time, pv.name
+    FROM proposals p
+    JOIN proposal_versions pv
+      ON pv.proposal_id = p.id AND pv.proposal_version = p.current_version;
+CREATE TABLE notification_outbox (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    idempotency_key text NOT NULL UNIQUE,
+    event_type text NOT NULL,
+    payload jsonb NOT NULL DEFAULT '{}',
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE notification_poll_cursors (
+    name text PRIMARY KEY,
+    cursor_updated_at timestamptz NOT NULL,
+    cursor_id bigint NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+"#;
+
+/// Insert a proposal whose current version ended `hours_ago` hours ago.
+async fn seed_proposal(pool: &PgPool, name: &str, hours_ago: i64, executed: bool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO proposals (id, space_id, proposed_by, executed_at)
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(id)
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(if executed { Some(1_i64) } else { None })
+    .execute(pool)
+    .await
+    .expect("insert proposal");
+
+    sqlx::query(
+        "INSERT INTO proposal_versions (proposal_id, proposal_version, end_time, name)
+         VALUES ($1, 1, EXTRACT(EPOCH FROM now())::bigint - $2, $3)",
+    )
+    .bind(id)
+    .bind(hours_ago * 3600)
+    .bind(name)
+    .execute(pool)
+    .await
+    .expect("insert proposal_version");
+    id
+}
+
+async fn connect() -> Option<PgPool> {
+    let url = std::env::var("NOTIF_TEST_DATABASE_URL").ok()?;
+    let pool = PgPool::connect(&url).await.expect("connect");
+    for stmt in SCHEMA.split(';').filter(|s| !s.trim().is_empty()) {
+        sqlx::query(stmt).execute(&pool).await.expect("schema");
+    }
+    Some(pool)
+}
+
+#[tokio::test]
+async fn reads_end_time_from_the_current_version_not_the_proposals_table() {
+    let Some(pool) = connect().await else {
+        eprintln!("skipping: set NOTIF_TEST_DATABASE_URL to run");
+        return;
+    };
+    let storage = Storage::new(pool.clone());
+
+    let recent = seed_proposal(&pool, "recent", 2, false).await;
+    seed_proposal(&pool, "executed", 2, true).await;
+
+    // Floor of 10h: the 2h-old proposal is inside it.
+    let found = storage
+        .find_expired_proposals(100, floor_hours_ago(10))
+        .await
+        .expect("query must resolve against the v2 schema");
+
+    let ids: Vec<Uuid> = found.iter().map(|p| p.id).collect();
+    assert_eq!(ids, vec![recent], "only the unexecuted in-window proposal");
+}
+
+#[tokio::test]
+async fn floor_excludes_the_replayed_migration_backlog() {
+    let Some(pool) = connect().await else {
+        eprintln!("skipping: set NOTIF_TEST_DATABASE_URL to run");
+        return;
+    };
+    let storage = Storage::new(pool.clone());
+
+    let inside = seed_proposal(&pool, "in window", 3, false).await;
+    seed_proposal(&pool, "yesterday", 30, false).await;
+    seed_proposal(&pool, "ancient (migration replay)", 24 * 365 * 40, false).await;
+
+    let found = storage
+        .find_expired_proposals(100, floor_hours_ago(10))
+        .await
+        .expect("query");
+    assert_eq!(
+        found.iter().map(|p| p.id).collect::<Vec<_>>(),
+        vec![inside],
+        "everything older than the floor stays silent"
+    );
+
+    // A floor of 0 means "no floor" — the historical backlog is exactly what we
+    // are protecting against, so assert it WOULD come back without one.
+    let unbounded = storage.find_expired_proposals(100, 0).await.expect("query");
+    assert_eq!(
+        unbounded.len(),
+        3,
+        "without a floor the whole backlog fires"
+    );
+}
+
+#[tokio::test]
+async fn already_notified_proposals_are_not_repeated() {
+    let Some(pool) = connect().await else {
+        eprintln!("skipping: set NOTIF_TEST_DATABASE_URL to run");
+        return;
+    };
+    let storage = Storage::new(pool.clone());
+    let id = seed_proposal(&pool, "already sent", 1, false).await;
+
+    sqlx::query(
+        "INSERT INTO notification_outbox (idempotency_key, event_type, payload)
+         VALUES ('k1', 'proposal_rejected', jsonb_build_object('proposal_id', $1::text))",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .expect("seed outbox");
+
+    let found = storage
+        .find_expired_proposals(100, floor_hours_ago(10))
+        .await
+        .expect("query");
+    assert!(found.is_empty(), "the outbox anti-join dedupes");
+}
+
+#[tokio::test]
+async fn floor_is_seeded_once_and_then_stable() {
+    let Some(pool) = connect().await else {
+        eprintln!("skipping: set NOTIF_TEST_DATABASE_URL to run");
+        return;
+    };
+    let storage = Storage::new(pool.clone());
+
+    let first = storage.rejection_floor(10).await.expect("seed");
+    let persisted = storage
+        .get_poll_cursor(REJECTION_FLOOR_CURSOR)
+        .await
+        .expect("read")
+        .expect("floor row written on first call");
+    assert_eq!(persisted.0.timestamp(), first);
+
+    // The whole point of persisting: a later call with a DIFFERENT backfill
+    // must not move the floor. If this recomputed `now - backfill` each time, a
+    // restart after an outage longer than the window would silently skip every
+    // proposal that expired during it.
+    let second = storage.rejection_floor(999).await.expect("read back");
+    assert_eq!(first, second, "an existing floor is never widened or moved");
+}
+
+fn floor_hours_ago(hours: i64) -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_secs() as i64
+        - hours * 3600
+}


### PR DESCRIPTION
Rejection notifications have never worked on the v2 cluster. Every 60s:

    ERROR notification_indexer: Failed to query expired proposals
          error=... column p.end_time does not exist

`find_expired_proposals` selects `p.end_time FROM proposals p`. That is
correct pre-v2 and still correct on `main`, where `proposals` is a flat
table. The staging-only `0067_governance_v2` migration made `proposals` an
identity table and moved all mutable state — `end_time` included — into
`proposal_versions`, and this query was never updated. `storage.rs` is
byte-identical on `staging` and `main`, so this is NOT a missed
cherry-pick: the code stood still while the schema moved underneath it.

Fix: read from `proposals_current`, the view that joins each proposal to
its `current_version`. `executed_at` stayed on `proposals` and the view
carries it through, so every column the query needs resolves. No proposal
on testnet has a NULL `current_version`, so the view's inner join drops
nothing.

**This makes the query v2-only.** It must not be cherry-picked to a branch
without `0067_governance_v2` — there is no `proposals_current` there and it
would fail exactly the way this bug did. It is only safe travelling with
that migration.

Second, and the reason this is more than a one-line change: switching the
query back on would immediately fire a rejection for every proposal the
chain migration replayed. Measured on testnet before fixing:

    3,241 expired-unnotified proposals
      1970-01     38   (end_time = 0, migration artifacts)
      2026-02    981
      2026-05    925
      ...
      last 24h    16

So `find_expired_proposals` now takes an absolute epoch floor, seeded once
from `REJECTION_BACKFILL_HOURS` (default 10, set explicitly in the v2
manifest) and persisted in `notification_poll_cursors` as
`proposal_rejected_floor`. On testnet a 10h floor admits 10 proposals, all
genuinely from this afternoon.

The floor is deliberately absolute-and-persisted rather than a rolling
`now - backfill` computed per poll. A rolling window would permanently skip
any proposal that expired while the service was down longer than the
window: the outbox anti-join would never have recorded a notification for
it, but the window would have moved past it. Persisting means catching up
after an outage still notifies everything after the floor. It also means
changing the env var later is a no-op on a database that already has one —
to move an existing floor, update the row.

Unlike `entity_votes_threshold`, this cursor never advances; deduplication
is already handled by the `notification_outbox` anti-join. It only answers
"how far back do we look the very first time".

If the floor cannot be resolved the poller now declines to start rather
than running unbounded, since the failure mode of guessing is the storm.
A negative `REJECTION_BACKFILL_HOURS` would push the floor into the future
and silence the poller, so it is rejected at startup instead of defaulted.

Tests (`tests/expired_proposals.rs`, gated on `NOTIF_TEST_DATABASE_URL`)
build the v2 shape — `end_time` present ONLY on `proposal_versions` — so a
regression to `FROM proposals` fails there instead of in production. They
cover the current-version read, the floor excluding the replayed backlog
(and asserting the backlog *would* fire without one), the outbox anti-join,
and that an existing floor is never moved by a later call with a different
backfill.

Verified: 4/4 new tests, 84 unit + 2 existing integration tests, `cargo
fmt --check`, `cargo clippy --all-targets -D warnings`.