### PR TITLE
feat(membership-acceptor): support chain 55516 via EIP-7702 Kernel, add v2 deployment (GEO-2478)

### DIFF
--- a/.github/workflows/build-v2-images.yml
+++ b/.github/workflows/build-v2-images.yml
@@ -32,6 +32,7 @@ on:
           - notification-indexer
           - delivery-worker
           - ranking-indexer
+          - membership-acceptor
 
 concurrency:
   group: build-v2-images-${{ inputs.service }}
@@ -64,7 +65,8 @@ jobs:
             {"image":"scoring-service","dockerfile":"scoring-service/cronjob/Dockerfile","context":"scoring-service/cronjob"},
             {"image":"notification-indexer","dockerfile":"notification-service/notification-indexer/Dockerfile","context":"."},
             {"image":"delivery-worker","dockerfile":"notification-service/delivery-worker/Dockerfile","context":"."},
-            {"image":"ranking-indexer","dockerfile":"ranking-indexer/Dockerfile","context":"."}
+            {"image":"ranking-indexer","dockerfile":"ranking-indexer/Dockerfile","context":"."},
+            {"image":"membership-acceptor","dockerfile":"membership-acceptor/Dockerfile","context":"membership-acceptor"}
           ]'
           if [ "$SERVICE" = "all" ]; then
             MATRIX="$(echo "$ALL" | jq -c '{include: .}')"

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -34,6 +34,7 @@ on:
           - notification-indexer
           - delivery-worker
           - ranking-indexer
+          - membership-acceptor
       tag:
         description: "Image tag to deploy (from the build workflow, e.g. short SHA). Ignored for valkey (pinned public image)."
         required: true
@@ -93,6 +94,7 @@ jobs:
             # The two CronJobs ship with the Deployment: both run the same image
             # and are only useful at the same version as the consumer.
             ranking-indexer)   manifests="ranking-indexer/k8s/v2/ranking-indexer.yaml ranking-indexer/k8s/v2/backfill-cronjob.yaml ranking-indexer/k8s/v2/rolling-sweep-cronjob.yaml"; rollout="deployment/ranking-indexer" ;;
+            membership-acceptor) manifests="membership-acceptor/deployment/v2/deployment.yaml"; rollout="deployment/membership-acceptor" ;;
             *) echo "unknown service"; exit 1 ;;
           esac
           echo "manifests=$manifests" >> "$GITHUB_OUTPUT"

--- a/membership-acceptor/bun.lock
+++ b/membership-acceptor/bun.lock
@@ -6,6 +6,7 @@
       "name": "membership-acceptor",
       "dependencies": {
         "@sentry/node": "^10.36.0",
+        "@zerodev/sdk": "^5.5.10",
         "permissionless": "^0.3.2",
         "viem": "^2.43.5",
       },
@@ -89,6 +90,8 @@
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
+    "@zerodev/sdk": ["@zerodev/sdk@5.5.10", "", { "dependencies": { "semver": "^7.6.0" }, "peerDependencies": { "viem": "^2.28.0" } }, "sha512-WVyj2XR9F6zK2GdXrvappx7yo6zoJ46cWe42dOIArp3xDjFBninjA4O1O94MwohB0G+yFqtXNsEU+WxdE67SgQ=="],
+
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
@@ -130,6 +133,8 @@
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "semifies": ["semifies@1.0.0", "", {}, "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/membership-acceptor/deployment/v2/deployment.yaml
+++ b/membership-acceptor/deployment/v2/deployment.yaml
@@ -1,0 +1,158 @@
+# membership-acceptor — gaia v2 stack (chain 55516, namespace `gaia`).
+#
+# GEO-2478: this service existed only on prod (ns `knowledge`, chain 19411) and
+# was never brought to the v2 cluster, so automatic member acceptance simply did
+# not run there. Modeled on deployment/production/deployment.yaml with the v2
+# conventions applied: namespace `gaia`, `regcred` pull secret (prod uses `geo`),
+# and chain-55516 config.
+#
+# Sponsorship differs from prod: 55516 has no Safe infrastructure, so the
+# acceptor uses an EIP-7702 Kernel account via ZeroDev instead of Safe+Pimlico
+# (see src/wallet.ts). Under EIP-7702 the acting address IS the acceptor's EOA,
+# not a Safe proxy — that EOA must own ACCEPTOR_SPACE_ID and hold editor rights
+# in the auto-accept spaces, which is NOT the same identity as on prod.
+#
+# Requires a `membership-acceptor-credentials` secret in `gaia` holding
+# ACCEPTOR_PRIVATE_KEY, GEO_WEBHOOK_SECRET, RPC_URL, ZERODEV_SPONSORSHIP_RPC_URL
+# and (optionally) SENTRY_DSN. PIMLICO_API_KEY is deliberately absent — this
+# chain never calls Pimlico.
+#
+# It also needs a row in `app_webhooks` pointing at this Service, or nothing will
+# ever invoke it; the notification system is what drives the bot.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: membership-acceptor
+  namespace: gaia
+  labels:
+    app: membership-acceptor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: membership-acceptor
+  template:
+    metadata:
+      labels:
+        app: membership-acceptor
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+      imagePullSecrets:
+        - name: regcred
+      containers:
+        - name: membership-acceptor
+          image: registry.digitalocean.com/geo/membership-acceptor:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            # Shared secret — MUST equal this service's app_webhooks.secret row
+            - name: GEO_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: GEO_WEBHOOK_SECRET
+            # Voting identity (sensitive)
+            - name: ACCEPTOR_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: ACCEPTOR_PRIVATE_KEY
+            - name: RPC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: RPC_URL
+            # ZeroDev bundler + paymaster (replaces PIMLICO_API_KEY on this chain)
+            - name: ZERODEV_SPONSORSHIP_RPC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: ZERODEV_SPONSORSHIP_RPC_URL
+            # Non-sensitive config
+            #
+            # !!! BLOCKED — READ BEFORE ENABLING ANY AUTO-ACCEPT SPACE !!!
+            # This space id is correct and exists on 55516, but the space is
+            # registered to 0xE23D205e0850c73319627512C5a25275A02a9caa — the
+            # acceptor's *Safe* address from prod. Under EIP-7702 on this chain
+            # the acceptor acts as its EOA (0xcCc140d7715bA5C7544205e9588541c796bD6372),
+            # and SpaceRegistry.enter() requires msg.sender to be the space's
+            # account, so every vote would revert. 55516 has no Safe infra, so
+            # that Safe address can never be controlled there.
+            #
+            # The space must be re-keyed on-chain to the acceptor's EOA first —
+            # the same operation that repaired 672 personal spaces after the
+            # migration. This space is one of 103 that repair missed.
+            #
+            # Until then MEMBERSHIP_AUTOACCEPT_SPACE_IDS below is intentionally
+            # empty: the service starts and serves /health, but votes on nothing.
+            - name: ACCEPTOR_SPACE_ID
+              value: "0x24208422558b4ac801e24a71a889dfad"
+            # Self-owned SpaceRegistry deployed 2026-07-29 on chain 55516
+            - name: SPACE_REGISTRY_ADDRESS
+              value: "0xCF13491802747e759e1BB8E364bc43045398d1DD"
+            - name: CHAIN_ID
+              value: "55516"
+            # In-cluster: avoids an external hop and does not depend on public DNS
+            - name: GRAPHQL_ENDPOINT
+              value: "http://api.gaia.svc.cluster.local:3000/graphql"
+            # DAO spaces this acceptor auto-accepts, as 0x-prefixed bytes16 hex
+            # (dashed UUIDs also accepted). EMPTY = accept none, which is the safe
+            # default: the service runs and answers health checks but votes on
+            # nothing until the v2 space ids are filled in.
+            - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
+              value: ""
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              value: "testnet"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: membership-acceptor
+  namespace: gaia
+spec:
+  selector:
+    app: membership-acceptor
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/membership-acceptor/package.json
+++ b/membership-acceptor/package.json
@@ -13,6 +13,7 @@
 	},
 	"dependencies": {
 		"@sentry/node": "^10.36.0",
+		"@zerodev/sdk": "^5.5.10",
 		"permissionless": "^0.3.2",
 		"viem": "^2.43.5"
 	},

--- a/membership-acceptor/src/config.ts
+++ b/membership-acceptor/src/config.ts
@@ -26,10 +26,15 @@ export interface AppConfig {
 	spaceRegistryAddress: `0x${string}`
 	/** Chain RPC endpoint (may contain an API key). */
 	rpcUrl: string
-	/** Pimlico bundler/paymaster API key (gas sponsorship). */
+	/** Pimlico bundler/paymaster API key (gas sponsorship). Empty on 55516, which uses ZeroDev. */
 	pimlicoApiKey: string
-	/** 80451 (mainnet) or 19411 (testnet). */
+	/** 80451 (mainnet), 19411 (testnet) or 55516 (testnet v2). */
 	chainId: SupportedChainId
+	/**
+	 * ZeroDev bundler+paymaster endpoint (embeds a project id) — required only on
+	 * 55516, which has no Safe infra and uses an EIP-7702 Kernel account instead.
+	 */
+	zerodevSponsorshipRpcUrl?: string
 	/** Geo GraphQL endpoint — used by policies (e.g. the editor check). */
 	graphqlEndpoint: string
 
@@ -97,14 +102,23 @@ export function parseConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
 	}
 
 	const rpcUrl = required(env, "RPC_URL")
-	const pimlicoApiKey = required(env, "PIMLICO_API_KEY")
 	const graphqlEndpoint = required(env, "GRAPHQL_ENDPOINT")
 
 	const rawChainId = env.CHAIN_ID?.trim() || "80451"
 	const chainId = Number(rawChainId)
-	if (chainId !== 80451 && chainId !== 19411) {
-		throw new ConfigError(`Invalid CHAIN_ID: expected 80451 (mainnet) or 19411 (testnet), got "${rawChainId}"`)
+	if (chainId !== 80451 && chainId !== 19411 && chainId !== 55516) {
+		throw new ConfigError(
+			`Invalid CHAIN_ID: expected 80451 (mainnet), 19411 (testnet) or 55516 (testnet v2), got "${rawChainId}"`,
+		)
 	}
+
+	// The two gas-sponsorship stacks are mutually exclusive, so each key is
+	// required only on the chains that actually use it. Demanding PIMLICO_API_KEY
+	// on 55516 would force operators to invent a value for a service that chain
+	// never calls.
+	const isV2Chain = chainId === 55516
+	const pimlicoApiKey = isV2Chain ? (env.PIMLICO_API_KEY?.trim() ?? "") : required(env, "PIMLICO_API_KEY")
+	const zerodevSponsorshipRpcUrl = isV2Chain ? required(env, "ZERODEV_SPONSORSHIP_RPC_URL") : undefined
 
 	// Canonicalize every allowlist entry to 0x bytes16 and validate it, so a
 	// typo'd id fails fast at startup instead of silently never matching. Incoming
@@ -131,6 +145,7 @@ export function parseConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
 		rpcUrl,
 		pimlicoApiKey,
 		chainId: chainId as SupportedChainId,
+		zerodevSponsorshipRpcUrl,
 		graphqlEndpoint,
 		autoacceptSpaceIds,
 	}

--- a/membership-acceptor/src/contracts.ts
+++ b/membership-acceptor/src/contracts.ts
@@ -52,11 +52,27 @@ export const testnetChain: Chain = {
 	rpcUrls: {default: {http: ["https://rpc-geo-test-zc16z3tcvf.t.conduit.xyz"]}},
 }
 
-export type SupportedChainId = 80451 | 19411
+/**
+ * Chain 55516 — the v2 testnet rollup. Definition matches
+ * proposal-executor/src/contracts.ts:152 exactly; keep them in sync.
+ *
+ * Unlike 19411/80451 this chain has NO Safe infrastructure deployed. It ships
+ * ZeroDev's Kernel v0.3.3 + EntryPoint v0.7 by default, so the acceptor uses an
+ * EIP-7702 Kernel account here instead of Safe+Pimlico — see `createSmartWallet`.
+ */
+export const testnetV2Chain: Chain = {
+	id: 55516,
+	name: "Geo Testnet",
+	nativeCurrency: {name: "Ethereum", symbol: "ETH", decimals: 18},
+	rpcUrls: {default: {http: ["https://rpc-geo-testnet-irdc0cgb0w.t.conduit.xyz"]}},
+}
+
+export type SupportedChainId = 80451 | 19411 | 55516
 
 export function getChain(chainId: SupportedChainId): Chain {
 	if (chainId === 80451) return mainnetChain
 	if (chainId === 19411) return testnetChain
+	if (chainId === 55516) return testnetV2Chain
 	const _exhaustive: never = chainId
 	throw new Error(`Unsupported chain ID: ${_exhaustive}`)
 }

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -43,8 +43,15 @@ async function main() {
 			pimlicoApiKey: config.pimlicoApiKey,
 			rpcUrl: config.rpcUrl,
 			chainId: config.chainId,
+			zerodevSponsorshipRpcUrl: config.zerodevSponsorshipRpcUrl,
 		})
-		log.info("acceptor wallet ready", {safe_address: wallet.safeAddress, chain_id: config.chainId})
+		// On 55516 this address is the EOA itself (EIP-7702), not a Safe proxy — it
+		// is what must own ACCEPTOR_SPACE_ID, so log it either way.
+		log.info("acceptor wallet ready", {
+			account_address: wallet.safeAddress,
+			chain_id: config.chainId,
+			sponsorship: config.chainId === 55516 ? "zerodev-kernel-7702" : "safe-pimlico",
+		})
 		const graphql = createGraphQLClient({endpoint: config.graphqlEndpoint})
 		// The editor check is the reference policy; space-defined policies compose here.
 		const policy = composePolicies(editorPolicy)

--- a/membership-acceptor/src/wallet.ts
+++ b/membership-acceptor/src/wallet.ts
@@ -1,12 +1,32 @@
 /**
- * Smart-wallet setup — a gas-sponsored Safe smart account (Pimlico paymaster).
+ * Smart-wallet setup — a gas-sponsored smart account.
  *
  * The acceptor votes via SpaceRegistry.enter() with `_fromSpaceId` = its own
  * personal space; the protocol requires msg.sender to be that space's account, so
- * the signer must be the Safe smart account that owns the acceptor's personal
- * space. Ported from proposal-executor/src/execute.ts (de-Effect-ified).
+ * the signer must be the smart account that owns the acceptor's personal space.
+ * Ported from proposal-executor/src/execute.ts (de-Effect-ified).
+ *
+ * Two paths, by chain:
+ *   19411 / 80451 — Safe smart account + Pimlico paymaster (original).
+ *   55516         — EIP-7702 Kernel account + ZeroDev paymaster. That chain has
+ *                   no Safe infra at all, but ships Kernel v0.3.3 + EntryPoint
+ *                   v0.7 by default. Mirrors proposal-executor's
+ *                   `createSmartWallet` (execute.ts:141) so the two stay
+ *                   comparable.
+ *
+ * IMPORTANT identity difference: under EIP-7702 the account address IS the raw
+ * EOA derived from `privateKey`, whereas the Safe path derives a separate proxy
+ * address. So on 55516 the acceptor acts as its EOA, and that EOA — not a Safe —
+ * must own ACCEPTOR_SPACE_ID and hold editor rights in the auto-accept spaces.
  */
 
+import {
+	createKernelAccount,
+	createKernelAccountClient,
+	createZeroDevPaymasterClient,
+	getUserOperationGasPrice,
+} from "@zerodev/sdk"
+import {getEntryPoint, KERNEL_V3_3} from "@zerodev/sdk/constants"
 import {createSmartAccountClient, type SmartAccountClient} from "permissionless"
 import {toSafeSmartAccount} from "permissionless/accounts"
 import {createPimlicoClient} from "permissionless/clients/pimlico"
@@ -19,23 +39,68 @@ import {getChain, type SupportedChainId, TESTNET_SAFE_ADDRESSES} from "./contrac
 export interface SmartWallet {
 	readonly smartAccountClient: SmartAccountClient
 	readonly chain: Chain
+	/** The account the acceptor votes as: a Safe proxy on 19411/80451, the EOA itself on 55516. */
 	readonly safeAddress: Address
 }
 
 export interface WalletConfig {
 	privateKey: `0x${string}`
+	/** Pimlico bundler/paymaster key. Unused (and meaningless) on 55516. */
 	pimlicoApiKey: string
 	rpcUrl: string
 	chainId: SupportedChainId
+	/** ZeroDev bundler+paymaster endpoint. Required when chainId is 55516, ignored otherwise. */
+	zerodevSponsorshipRpcUrl?: string
 }
 
-/** Create a gas-sponsored Safe smart account. Called once at startup. */
+/** Create a gas-sponsored smart account. Called once at startup. */
 export async function createSmartWallet(config: WalletConfig): Promise<SmartWallet> {
 	const chain = getChain(config.chainId)
-	const bundlerUrl = `https://api.pimlico.io/v2/${config.chainId}/rpc?apikey=${config.pimlicoApiKey}`
 
 	const publicClient = createPublicClient({chain, transport: http(config.rpcUrl)})
 	const owner = privateKeyToAccount(config.privateKey)
+
+	if (config.chainId === 55516) {
+		if (!config.zerodevSponsorshipRpcUrl) {
+			throw new Error("ZERODEV_SPONSORSHIP_RPC_URL is required when CHAIN_ID is 55516")
+		}
+
+		const entryPoint = getEntryPoint("0.7")
+		const kernelAccount = await createKernelAccount(publicClient, {
+			eip7702Account: owner,
+			entryPoint,
+			kernelVersion: KERNEL_V3_3,
+		})
+
+		const bundlerTransport = http(config.zerodevSponsorshipRpcUrl)
+		const paymasterClient = createZeroDevPaymasterClient({chain, transport: bundlerTransport})
+
+		const smartAccountClient = createKernelAccountClient({
+			account: kernelAccount,
+			chain,
+			client: publicClient,
+			bundlerTransport,
+			paymaster: {
+				getPaymasterStubData: (userOperation) =>
+					paymasterClient.sponsorUserOperation({userOperation, shouldConsume: false}),
+				getPaymasterData: (userOperation) => paymasterClient.sponsorUserOperation({userOperation}),
+			},
+			userOperation: {
+				estimateFeesPerGas: async ({bundlerClient}) => getUserOperationGasPrice(bundlerClient),
+			},
+		})
+
+		return {
+			// KernelAccountClient and permissionless's SmartAccountClient both expose
+			// the `.account` / `.sendTransaction(...)` shape the vote path uses — the
+			// only shape SmartWallet depends on here.
+			smartAccountClient: smartAccountClient as unknown as SmartAccountClient,
+			chain,
+			safeAddress: kernelAccount.address,
+		}
+	}
+
+	const bundlerUrl = `https://api.pimlico.io/v2/${config.chainId}/rpc?apikey=${config.pimlicoApiKey}`
 
 	const safeAccount = await toSafeSmartAccount({
 		client: publicClient,

--- a/membership-acceptor/tests/config.test.ts
+++ b/membership-acceptor/tests/config.test.ts
@@ -90,6 +90,48 @@ describe("parseConfig", () => {
 		expect(() => parseConfig({...validEnv(), CHAIN_ID: "1"})).toThrow(ConfigError)
 	})
 
+	// GEO-2478: 55516 was rejected outright, so the acceptor could not run on the
+	// v2 testnet at all — it would have thrown at startup even once deployed.
+	describe("chain 55516 (testnet v2)", () => {
+		const v2Env = (): NodeJS.ProcessEnv => ({
+			...validEnv(),
+			CHAIN_ID: "55516",
+			ZERODEV_SPONSORSHIP_RPC_URL: "https://rpc.zerodev.app/api/v3/proj/chain/55516",
+		})
+
+		test("is accepted", () => {
+			const c = parseConfig(v2Env())
+			expect(c.chainId).toBe(55516)
+			expect(c.zerodevSponsorshipRpcUrl).toBe("https://rpc.zerodev.app/api/v3/proj/chain/55516")
+		})
+
+		test("requires ZERODEV_SPONSORSHIP_RPC_URL — there is no Safe/Pimlico fallback there", () => {
+			const env = v2Env()
+			delete env.ZERODEV_SPONSORSHIP_RPC_URL
+			expect(() => parseConfig(env)).toThrow(ConfigError)
+		})
+
+		test("does NOT require PIMLICO_API_KEY — that chain never calls Pimlico", () => {
+			const env = v2Env()
+			delete env.PIMLICO_API_KEY
+			const c = parseConfig(env)
+			expect(c.chainId).toBe(55516)
+			expect(c.pimlicoApiKey).toBe("")
+		})
+	})
+
+	test("PIMLICO_API_KEY is still required on the Safe chains", () => {
+		const env = validEnv()
+		delete env.PIMLICO_API_KEY
+		env.CHAIN_ID = "19411"
+		expect(() => parseConfig(env)).toThrow(ConfigError)
+	})
+
+	test("ZERODEV_SPONSORSHIP_RPC_URL is ignored on the Safe chains", () => {
+		const c = parseConfig({...validEnv(), CHAIN_ID: "19411", ZERODEV_SPONSORSHIP_RPC_URL: "https://ignored"})
+		expect(c.zerodevSponsorshipRpcUrl).toBeUndefined()
+	})
+
 	test("throws on an out-of-range PORT", () => {
 		expect(() => parseConfig({...validEnv(), PORT: "70000"})).toThrow(ConfigError)
 	})

--- a/membership-acceptor/tests/contracts.test.ts
+++ b/membership-acceptor/tests/contracts.test.ts
@@ -66,6 +66,16 @@ describe("getChain", () => {
 	test("maps the supported chain ids", () => {
 		expect(getChain(80451).id).toBe(80451)
 		expect(getChain(19411).id).toBe(19411)
+		expect(getChain(55516).id).toBe(55516)
+	})
+
+	// Must stay identical to proposal-executor/src/contracts.ts:152 — the two
+	// services vote against the same registry on the same chain, so a drifted RPC
+	// or chain id would be a subtle split-brain rather than a loud failure.
+	test("55516 matches proposal-executor's definition", () => {
+		const c = getChain(55516)
+		expect(c.rpcUrls.default.http[0]).toBe("https://rpc-geo-testnet-irdc0cgb0w.t.conduit.xyz")
+		expect(c.nativeCurrency.decimals).toBe(18)
 	})
 })
 


### PR DESCRIPTION
Automatic member acceptance does not run on the v2 cluster. It is not
malfunctioning — it was never brought over, and could not have run if it
had been:

- No `membership-acceptor` workload exists in namespace `gaia`; prod has
  had one running in `knowledge` for 31 days.
- Zero references in `build-v2-images.yml` and `deploy-v2.yml`, and no
  v2 manifest anywhere in the repo — on any branch. The directory is
  byte-identical between `staging` and `main`, so nothing was lost in a
  merge; it simply was never started.
- `config.ts` hard-rejected the chain: `chainId !== 80451 && chainId !==
  19411` threw at startup, so even a correct deployment would have
  crash-looped.

This change covers the first three:

- `contracts.ts`: add chain 55516, definition copied verbatim from
  proposal-executor/src/contracts.ts:152 (a test asserts they match — the
  two services vote against the same registry on the same chain, so a
  drifted RPC would be split-brain rather than a loud failure).
- `wallet.ts`: on 55516 build an EIP-7702 Kernel account with a ZeroDev
  paymaster instead of Safe+Pimlico. That chain has no Safe infra but
  ships Kernel v0.3.3 + EntryPoint v0.7. Mirrors proposal-executor's
  `createSmartWallet` (execute.ts:141). 19411/80451 keep the Safe path
  untouched.
- `config.ts`: accept 55516; require ZERODEV_SPONSORSHIP_RPC_URL there and
  stop requiring PIMLICO_API_KEY, which that chain never calls. The two
  sponsorship stacks are mutually exclusive, so demanding both would force
  operators to invent a value for an unused service.
- `deployment/v2/deployment.yaml` + both workflow wirings.

NOT YET WORKING — one blocker remains, deliberately left visible rather
than papered over. The acceptor's personal space
`24208422-558b-4ac8-01e2-4a71a889dfad` is registered to
`0xE23D205e0850c73319627512C5a25275A02a9caa` on both prod and v2. Derived
inside the running prod pod, that address is the acceptor's *Safe*;
its EOA is `0xcCc140d7715bA5C7544205e9588541c796bD6372`. Under EIP-7702 it
acts as the EOA, and `SpaceRegistry.enter()` requires msg.sender to be the
space's account — so every vote would revert, and 55516 has no Safe infra
for that address to ever exist on.

The space must be re-keyed on-chain to the EOA first. It is not a one-off:
comparing all 805 v2 personal spaces against prod, 672 were rewritten to
owner EOAs by the post-migration repair and 116 were not; `eth_getCode` on
the prod chain shows **103 of those 116 are Safe contracts**, unusable on
55516. The acceptor is one of them.

So `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` ships EMPTY: the service starts and
serves /health but votes on nothing. Enabling a space before the re-key
would produce nothing but reverts.

Also still required before it functions: a
`membership-acceptor-credentials` secret in `gaia`, and an `app_webhooks`
row pointing at the Service — prod has exactly one such row, and v2's
table is empty, which is separately why v2 has zero notification
deliveries.

Verified: 97 tests (6 new, covering 55516 acceptance, the
ZERODEV_SPONSORSHIP_RPC_URL requirement, PIMLICO_API_KEY no longer being
required there but still required on the Safe chains, and chain-definition
parity with proposal-executor), `tsc --noEmit`, and biome lint.