### PR TITLE
fix(proposal-executor): enable membership auto-accept on v2, correct the registry address (GEO-2478)

### DIFF
--- a/membership-acceptor/deployment/v2/deployment.yaml
+++ b/membership-acceptor/deployment/v2/deployment.yaml
@@ -57,12 +57,14 @@ spec:
                 secretKeyRef:
                   name: membership-acceptor-credentials
                   key: GEO_WEBHOOK_SECRET
-            # Voting identity (sensitive)
+            # Voting identity (sensitive).
+            # Reads the SAME key proposal-executor's membership path uses rather
+            # than copying it into a second secret — one private key in one place.
             - name: ACCEPTOR_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: membership-acceptor-credentials
-                  key: ACCEPTOR_PRIVATE_KEY
+                  name: proposal-executor-credentials
+                  key: MEMBERSHIP_BOT_PRIVATE_KEY
             - name: RPC_URL
               valueFrom:
                 secretKeyRef:
@@ -76,23 +78,17 @@ spec:
                   key: ZERODEV_SPONSORSHIP_RPC_URL
             # Non-sensitive config
             #
-            # !!! BLOCKED — READ BEFORE ENABLING ANY AUTO-ACCEPT SPACE !!!
-            # This space id is correct and exists on 55516, but the space is
-            # registered to 0xE23D205e0850c73319627512C5a25275A02a9caa — the
-            # acceptor's *Safe* address from prod. Under EIP-7702 on this chain
-            # the acceptor acts as its EOA (0xcCc140d7715bA5C7544205e9588541c796bD6372),
-            # and SpaceRegistry.enter() requires msg.sender to be the space's
-            # account, so every vote would revert. 55516 has no Safe infra, so
-            # that Safe address can never be controlled there.
-            #
-            # The space must be re-keyed on-chain to the acceptor's EOA first —
-            # the same operation that repaired 672 personal spaces after the
-            # migration. This space is one of 103 that repair missed.
-            #
-            # Until then MEMBERSHIP_AUTOACCEPT_SPACE_IDS below is intentionally
-            # empty: the service starts and serves /health, but votes on nothing.
+            # Uses the v2 membership-bot identity, NOT prod's. v2 provisioned a
+            # dedicated bot space + key during bring-up:
+            #   space 0xf61e6ac5a54f47898ee23ae48a0729ba
+            #     -> registered to 0x14b3F486aD9a2f5E2a15B54bCa43684C17210e3A
+            #   proposal-executor-credentials/MEMBERSHIP_BOT_PRIVATE_KEY
+            #     -> derives to that same address (verified 2026-07-30)
+            # which is EOA-keyed and therefore works under EIP-7702. Prod's
+            # acceptor space is registered to a *Safe* address that cannot exist
+            # on 55516, so reusing prod's identity here would revert every vote.
             - name: ACCEPTOR_SPACE_ID
-              value: "0x24208422558b4ac801e24a71a889dfad"
+              value: "0xf61e6ac5a54f47898ee23ae48a0729ba"
             # Self-owned SpaceRegistry deployed 2026-07-29 on chain 55516
             - name: SPACE_REGISTRY_ADDRESS
               value: "0xCF13491802747e759e1BB8E364bc43045398d1DD"
@@ -101,10 +97,19 @@ spec:
             # In-cluster: avoids an external hop and does not depend on public DNS
             - name: GRAPHQL_ENDPOINT
               value: "http://api.gaia.svc.cluster.local:3000/graphql"
-            # DAO spaces this acceptor auto-accepts, as 0x-prefixed bytes16 hex
-            # (dashed UUIDs also accepted). EMPTY = accept none, which is the safe
-            # default: the service runs and answers health checks but votes on
-            # nothing until the v2 space ids are filled in.
+            # !!! MUST STAY EMPTY UNLESS proposal-executor's LIST IS EMPTIED !!!
+            #
+            # On v2 automatic member acceptance is ALREADY handled by
+            # proposal-executor's built-in membership path (src/membership.ts —
+            # stage-1 detect + stage-2 on-chain eligibility read + YES vote),
+            # driven by its own MEMBERSHIP_AUTOACCEPT_SPACE_IDS. That is the path
+            # GEO-2478 was actually about: the variable was simply never set
+            # there, so the allowlist was empty and nobody was admitted.
+            #
+            # This standalone webhook-driven service is the second implementation
+            # of the same behaviour (prod runs both). Listing a space in BOTH
+            # places means two independent bots vote on the same request. Pick
+            # one owner per space.
             - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
               value: ""
             - name: SENTRY_DSN

--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -82,8 +82,21 @@ spec:
                   value: "0xc6fdd7ccff1b4f5ba5f81dae4e1eb99b"
                 - name: MEMBERSHIP_BOT_SPACE_ID
                   value: "0xf61e6ac5a54f47898ee23ae48a0729ba"
+                # GEO-2478: automatic member acceptance did nothing on this
+                # cluster because this variable was never set — an empty
+                # allowlist means "accept none", so the bot detected requests
+                # and admitted no one. These are the same four spaces prod
+                # auto-accepts; all four exist on 55516 under the same ids
+                # (verified 2026-07-30), since the migration preserved space ids.
+                - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
+                  value: "0xc9f267dcb0d270718c2a3c45a64afd32,0x84a679ce188f061ac9a92380bac2bab5,0x0477636ace64280fc43a9f440a502291,0x29a5122f65295cea9f421ec7a73ac825"
+                # Self-owned SpaceRegistry deployed 2026-07-29. The live CronJob
+                # was already patched to this address; this manifest still said
+                # 0x364231615dcEA33D13C823b13B449DD9F55381E7, so redeploying from
+                # the repo would have silently reverted the executor to the old
+                # registry. Fixed 2026-07-30 to match the cluster.
                 - name: SPACE_REGISTRY_ADDRESS
-                  value: "0x364231615dcEA33D13C823b13B449DD9F55381E7"
+                  value: "0xCF13491802747e759e1BB8E364bc43045398d1DD"
                 - name: RPC_URL
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Automatic member acceptance does nothing on the v2 cluster because
`MEMBERSHIP_AUTOACCEPT_SPACE_IDS` was never set there. An empty allowlist
means "accept none", so the bot detects membership requests and admits
nobody — silently, with no error. Prod sets four spaces; v2 set none.

This is the actual cause of GEO-2478, and it is not what it looked like.
The obvious reading was "the standalone `membership-acceptor` service is
missing from v2" — true, but a red herring. On v2 the behaviour is already
implemented inside proposal-executor (`src/membership.ts`: stage-1 detect,
stage-2 on-chain eligibility read, YES vote by a dedicated bot wallet),
wired into the run loop and configured with MEMBERSHIP_BOT_SPACE_ID +
MEMBERSHIP_BOT_PRIVATE_KEY. Only the allowlist was missing.

Deploying the standalone service instead would have been worse than doing
nothing: two independent bots voting on the same requests.

The four space ids are prod's, unchanged — all four exist on 55516 under
the same ids (verified), since the migration preserved space ids.

Also fixes repo-vs-cluster drift found while checking this. The live
CronJob has SPACE_REGISTRY_ADDRESS=0xcf13491802747e759e1bb8e364bc43045398d1dd
(the self-owned registry deployed 2026-07-29) but this manifest still
carried 0x364231615dcEA33D13C823b13B449DD9F55381E7. Redeploying the
executor from the repo would have silently pointed it back at the old
registry. A full env diff of repo vs cluster shows this was the ONLY
drifted value.

membership-acceptor's v2 manifest is corrected but deliberately still
inert:
- ACCEPTOR_SPACE_ID now uses v2's own bot space
  (0xf61e6ac5a54f47898ee23ae48a0729ba -> 0x14b3F486aD9a2f5E2a15B54bCa43684C17210e3A)
  instead of prod's, whose space is registered to a Safe address that
  cannot exist on 55516 and would revert every vote.
- ACCEPTOR_PRIVATE_KEY reads proposal-executor-credentials'
  MEMBERSHIP_BOT_PRIVATE_KEY (verified to derive to exactly that address)
  rather than copying a private key into a second secret.
- MEMBERSHIP_AUTOACCEPT_SPACE_IDS stays EMPTY, with a comment explaining
  that listing a space both here and in proposal-executor means two bots
  vote on the same request.

Both manifests parse as valid YAML.