### PR TITLE
fix(proposal-executor): membership detection must read proposals_current (GEO-2478)

### DIFF
--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -245,12 +245,21 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
  * This filters voting_mode = 'Fast' while the executor's query filters 'Slow',
  * so the two paths never return the same proposal.
  *
+ * Reads `proposals_current`, NOT `proposals`. Under governance-v2 (migration
+ * `0067_governance_v2`) `proposals` became an identity table and the mutable
+ * per-version state — `voting_mode` and `end_time` among it — moved to
+ * `proposal_versions`; `proposals_current` is the view joining each proposal to
+ * its `current_version`. DETECTION_SQL above was updated for this and this query
+ * was not, so on a v2 database it failed with `column p.voting_mode does not
+ * exist` and the ENTIRE membership path errored out every run — silently, as far
+ * as anyone auto-accepting members could tell (GEO-2478).
+ *
  * ORDER BY created_at::bigint ASC for FIFO ordering (created_at is text Unix
  * seconds, so the ::bigint cast ensures numeric ordering).
  */
 export const MEMBERSHIP_DETECTION_SQL = `
 SELECT p.id, p.space_id AS "spaceId", a.target_id AS "requesterId"
-FROM proposals p
+FROM proposals_current p
 JOIN proposal_actions a ON a.proposal_id = p.id
 WHERE p.space_id = ANY($1)
   AND p.voting_mode = 'Fast'

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -97,6 +97,32 @@ describe("V2 detection SQL", () => {
 		expect(DETECTION_SQL).toMatch(/voting_mode\s*=\s*'Slow'/)
 	})
 
+	// GEO-2478: DETECTION_SQL was moved to proposals_current and this one was
+	// not, so on a v2 database the whole membership path died every run with
+	// `column p.voting_mode does not exist` and nobody was ever auto-accepted.
+	// The asymmetry is the bug — assert BOTH queries, not just the executor's.
+	test("MEMBERSHIP_DETECTION_SQL also reads proposals_current", () => {
+		expect(MEMBERSHIP_DETECTION_SQL).toMatch(/FROM\s+proposals_current/)
+		expect(MEMBERSHIP_DETECTION_SQL).not.toMatch(/FROM\s+proposals\s+p\b/)
+	})
+
+	test("both queries source every moved column from the current-version view", () => {
+		// voting_mode and end_time live on proposal_versions post-0067, so any
+		// read of them must come from the view. Catches a partial revert that
+		// swaps the FROM back but leaves the columns, or vice versa.
+		for (const sql of [DETECTION_SQL, MEMBERSHIP_DETECTION_SQL]) {
+			expect(sql).toMatch(/FROM\s+proposals_current/)
+			expect(sql).not.toMatch(/FROM\s+proposals\s/)
+		}
+	})
+
+	test("the two paths stay mutually exclusive on voting_mode", () => {
+		// If both ever selected the same mode the executor and the membership bot
+		// would race for the same proposal.
+		expect(DETECTION_SQL).toMatch(/voting_mode\s*=\s*'Slow'/)
+		expect(MEMBERSHIP_DETECTION_SQL).toMatch(/voting_mode\s*=\s*'Fast'/)
+	})
+
 	test("uses partial_percentage_support_threshold in the slow-late ratio", () => {
 		// V1 used a single `threshold` column; V2 slow-late must use `partial`.
 		expect(DETECTION_SQL).toContain("partial_percentage_support_threshold")


### PR DESCRIPTION
The membership path failed on every run against the v2 database:

    membership_path_failed: Membership detection query failed:
      column p.voting_mode does not exist

`MEMBERSHIP_DETECTION_SQL` selected `FROM proposals p` and filtered on
`p.voting_mode` / `p.end_time`. Governance-v2 (`0067_governance_v2`) made
`proposals` an identity table and moved the mutable per-version state —
`voting_mode` and `end_time` among it — into `proposal_versions`.

The telling detail is that `DETECTION_SQL`, ten lines above in the same
file, was already migrated to `proposals_current` and this query was not.
One of the pair was updated and the other was missed, and only the updated
one had a test asserting where it reads from. So the drift was invisible:
the executor path kept working, the membership path died every run, and
the only symptom was a log line nobody was watching.

This is the third distinct cause behind "member bot is not functioning",
after the empty MEMBERSHIP_AUTOACCEPT_SPACE_IDS allowlist and the
registry-registration issue.

Fix: read `proposals_current`, the view joining each proposal to its
`current_version`. `executed_at` and `created_at` stayed on `proposals` and
the view carries them through, so every column in the query resolves.
Verified by running the corrected SQL against the live v2 database with the
four allowlisted space ids — it executes and returns rows rather than
erroring.

Tests now assert BOTH queries, since the asymmetry was the bug:
- MEMBERSHIP_DETECTION_SQL reads proposals_current (mirrors the existing
  DETECTION_SQL assertion)
- neither query reads `FROM proposals`, catching a partial revert that
  swaps the FROM back but leaves the columns, or vice versa
- the two stay mutually exclusive on voting_mode ('Slow' vs 'Fast'), so the
  executor and the membership bot can never race for the same proposal

Verified: 137 tests, `tsc --noEmit`, biome lint.