### PR TITLE
feat(ranking-indexer): add --recompute-all to backfill_blocks

### DIFF
--- a/ranking-indexer/src/bin/backfill_blocks.rs
+++ b/ranking-indexer/src/bin/backfill_blocks.rs
@@ -50,6 +50,17 @@ async fn main() -> Result<(), IndexerError> {
         .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
     let dry_run = env::var("DRY_RUN").is_ok_and(|v| v == "true" || v == "1");
 
+    // Opt-in full recompute of EVERY registered block. Deliberately not part of
+    // the normal run: the hourly CronJob is a cheap self-heal that touches only
+    // what is broken, and silently turning it into a full recompute would make
+    // an unbounded amount of work happen on a schedule nobody chose.
+    //
+    // This exists for the case the reactive triggers cannot see — an aggregate's
+    // INPUTS being corrected underneath it from outside the indexer, with no
+    // edit to react to. See `Storage::find_all_ranking_blocks`.
+    let recompute_all = env::args().any(|a| a == "--recompute-all")
+        || env::var("RECOMPUTE_ALL").is_ok_and(|v| v == "true" || v == "1");
+
     let storage = Storage::new(&database_url).await?;
 
     let block_candidates = storage.find_unregistered_ranking_blocks().await?;
@@ -63,6 +74,17 @@ async fn main() -> Result<(), IndexerError> {
         "found unregistered/stale blocks and unregistered ranks"
     );
 
+    let all_blocks = if recompute_all {
+        let all = storage.find_all_ranking_blocks().await?;
+        info!(
+            blocks = all.len(),
+            "--recompute-all: will recompute EVERY registered block"
+        );
+        all
+    } else {
+        Vec::new()
+    };
+
     if dry_run {
         for id in &block_candidates {
             info!(block_id = %id, "would recover block");
@@ -73,10 +95,17 @@ async fn main() -> Result<(), IndexerError> {
         for id in &rank_candidates {
             info!(rank_id = %id, "would recover rank");
         }
+        for id in &all_blocks {
+            info!(block_id = %id, "would recompute (--recompute-all)");
+        }
         return Ok(());
     }
 
-    if block_candidates.is_empty() && stale_blocks.is_empty() && rank_candidates.is_empty() {
+    if block_candidates.is_empty()
+        && stale_blocks.is_empty()
+        && rank_candidates.is_empty()
+        && all_blocks.is_empty()
+    {
         return Ok(());
     }
 
@@ -89,6 +118,9 @@ async fn main() -> Result<(), IndexerError> {
     let mut recovered_ranks = 0;
     let mut still_unregistered_ranks = 0;
     let mut failed = 0;
+    // Blocks recomputed by the recovery/resync passes below, so the optional
+    // full recompute at the end does not redo them.
+    let mut handled_blocks: HashSet<uuid::Uuid> = HashSet::new();
 
     // Blocks first: a recovered rank's block_id is guaranteed to already be
     // registered by the time we get to it below, since this scan already
@@ -112,6 +144,7 @@ async fn main() -> Result<(), IndexerError> {
                 }
                 info!(block_id = %block_id, "recovered + recomputed block");
                 recovered_blocks += 1;
+                handled_blocks.insert(block_id);
             }
             Ok(None) => {
                 // Typed in `relations` a moment ago, not typed now — a
@@ -145,6 +178,7 @@ async fn main() -> Result<(), IndexerError> {
                 }
                 info!(block_id = %block_id, "resynced stale ranking_type + recomputed block");
                 resynced_stale_blocks += 1;
+                handled_blocks.insert(block_id);
             }
             Ok(None) => {
                 // No longer typed as a Ranking Block at all — leave its
@@ -189,6 +223,7 @@ async fn main() -> Result<(), IndexerError> {
     // Recompute every block a recovered rank links to — its aggregate needs
     // to include the rank that just appeared.
     for block_id in affected_blocks {
+        handled_blocks.insert(block_id);
         if let Err(e) = recompute_block(block_id, meta, now, &storage).await {
             error!(
                 block_id = %block_id,
@@ -199,12 +234,37 @@ async fn main() -> Result<(), IndexerError> {
         }
     }
 
+    // Full recompute last, so anything recovered above is included rather than
+    // recomputed twice. Blocks already handled above are skipped for the same
+    // reason — recompute_block is idempotent, but doing it twice doubles the
+    // cost of the expensive mode for no benefit.
+    let mut recomputed_all = 0;
+    for block_id in &all_blocks {
+        if handled_blocks.contains(block_id) {
+            continue;
+        }
+        if let Err(e) = recompute_block(*block_id, meta, now, &storage).await {
+            error!(block_id = %block_id, error = %e, "recompute failed (--recompute-all)");
+            failed += 1;
+        } else {
+            recomputed_all += 1;
+        }
+    }
+    if recompute_all {
+        info!(
+            recomputed = recomputed_all,
+            skipped_already_done = all_blocks.len() - recomputed_all,
+            "full recompute complete"
+        );
+    }
+
     info!(
         recovered_blocks,
         still_unregistered_blocks,
         resynced_stale_blocks,
         recovered_ranks,
         still_unregistered_ranks,
+        recomputed_all,
         failed,
         "backfill complete"
     );

--- a/ranking-indexer/src/storage.rs
+++ b/ranking-indexer/src/storage.rs
@@ -388,6 +388,29 @@ impl Storage {
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
+    /// EVERY registered block, for a deliberate full recompute
+    /// (`bin/backfill_blocks.rs --recompute-all`).
+    ///
+    /// Every other trigger in this indexer is reactive — an edit, a membership
+    /// event, a rank appearing, time elapsing for a Rolling block. None of them
+    /// fire when the *inputs* an aggregate was derived from are corrected
+    /// underneath it by something outside the indexer.
+    ///
+    /// That gap is not hypothetical: on 2026-07-31 every migrated
+    /// `ranks.rankings.submitted_at` was repaired (the chain migration had
+    /// stamped 349 submissions with migration wall-clock time instead of their
+    /// real dates, collapsing 348 distinct timestamps into 101). Eligibility is
+    /// decided by `submitted_at` against a block's date window, so the stored
+    /// aggregates were computed from wrong inputs — and nothing recomputed them,
+    /// because no edit had happened. `backfill_blocks` reported
+    /// `blocks=0 stale_blocks=0`: correct for what it looks at, useless here.
+    pub async fn find_all_ranking_blocks(&self) -> Result<Vec<Uuid>, IndexerError> {
+        let rows: Vec<(Uuid,)> = sqlx::query_as("SELECT id FROM ranks.ranking_blocks ORDER BY id")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     /// Already-registered blocks (`ranks.ranking_blocks` row exists) whose
     /// `ranking_type` is still `NULL` even though the graph now tags them
     /// Rolling — the same split-edit gap as `find_unregistered_ranking_blocks`,


### PR DESCRIPTION
Every recompute trigger in this indexer is reactive: an edit arrives, a
membership event fires, a rank appears, or time passes for a Rolling block.
None of them fire when the INPUTS an aggregate was derived from are
corrected underneath it by something outside the indexer.

That gap is not hypothetical. On 2026-07-31 every migrated
`ranks.rankings.submitted_at` was repaired — the chain migration had
stamped 349 submissions with migration wall-clock time instead of their
real dates, collapsing 348 distinct timestamps into 101 (GEO-2476).
Eligibility is decided by `submitted_at` against a block's date window, so
the stored aggregates had been computed from wrong inputs. Nothing
recomputed them, because no edit had happened: `backfill_blocks` reported
`blocks=0 stale_blocks=0` and `rolling_sweep` found 0 Rolling blocks. Both
correct for what they look at, and both useless here — there was no way to
say "the data changed, redo the arithmetic".

`--recompute-all` (or `RECOMPUTE_ALL=1`) recomputes every registered block.

Deliberately opt-in and NOT part of the normal run. The hourly CronJob is a
cheap self-heal that touches only what is broken; silently turning it into a
full recompute would put an unbounded amount of work on a schedule nobody
chose. It runs last and skips blocks the recovery/resync passes already
recomputed — `recompute_block` is idempotent, but doing it twice doubles the
cost of the expensive mode for nothing.

`DRY_RUN=true` lists what would be recomputed, and the counts appear in both
the dedicated `full recompute complete` line and the `backfill complete`
summary, so an operator can see the size before and after committing to it.

Verified against a real migrated schema: with no flag a registered block is
left alone (no recompute lines at all); with the flag,
`recomputed=1 skipped_already_done=0 failed=0`. fmt, clippy -D warnings and
34 unit tests clean.