### PR TITLE
fix(substreams): send stop_block_num=0 for continuous streams, not u64::MAX

### DIFF
--- a/atlas/README.md
+++ b/atlas/README.md
@@ -54,7 +54,7 @@ Access Kafka UI at http://localhost:8080 to view messages.
 | `SUBSTREAMS_ENDPOINT` | No | `https://geotest.substreams.pinax.network:443` | Live substreams endpoint |
 | `SUBSTREAMS_API_TOKEN` | No | - | Optional auth token for substreams endpoint |
 | `SUBSTREAMS_START_BLOCK` | No | `82655` | Start block for live stream |
-| `SUBSTREAMS_END_BLOCK` | No | `u64::MAX` | End block for live stream |
+| `SUBSTREAMS_END_BLOCK` | No | `0` | End block for live stream (`0` = never stop) |
 | `ATLAS_CHECKPOINT_DATABASE_URL` | No | - | PostgreSQL URL for checkpoint persistence |
 | `ATLAS_INDEXER_ID` | Conditional | - | Required and non-empty when checkpoint persistence is enabled |
 | `ATLAS_RUNTIME_COMPATIBILITY_MARKER` | No | `atlas-v2` | Runtime marker used for checkpoint compatibility validation |

--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -12,7 +12,8 @@
 //! - `USE_MOCK` - Use mock data source instead of live substream (default: false)
 //! - `SUBSTREAMS_ENDPOINT` - Substream endpoint URL (default: geotest.substreams.pinax.network:443)
 //! - `SUBSTREAMS_START_BLOCK` - Start block number (default: 82655, Space Registry deployment)
-//! - `SUBSTREAMS_END_BLOCK` - End block number (default: u64::MAX for continuous streaming)
+//! - `SUBSTREAMS_END_BLOCK` - End block number (default: 0, the Substreams
+//!   sentinel for "stream forever"). Do not set this to `u64::MAX`.
 //! - `SUBSTREAMS_API_TOKEN` - Optional API token for authenticated endpoints
 //!
 //! ### Graph Configuration
@@ -679,10 +680,14 @@ async fn async_main() -> anyhow::Result<()> {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(82655); // Space Registry deployment block
+    // `0` is the Substreams protocol's sentinel for "never stop". Passing
+    // `u64::MAX` instead makes the server plan a bounded job of ~18 quintillion
+    // blocks: it backprocesses forever, emitting progress but never a single
+    // `BlockScopedData`.
     let end_block: u64 = env::var("SUBSTREAMS_END_BLOCK")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(u64::MAX);
+        .unwrap_or(0);
 
     // Root space configuration
     let root_space_id = parse_root_space_id()?;

--- a/hermes-ipfs-cache/README.md
+++ b/hermes-ipfs-cache/README.md
@@ -42,7 +42,7 @@ Environment variables:
 | `SUBSTREAMS_ENDPOINT` | Live mode | Substreams endpoint URL (e.g., `geotest.substreams.pinax.network:443`) |
 | `SUBSTREAMS_API_TOKEN` | Live mode | API token for substreams authentication |
 | `SUBSTREAMS_START_BLOCK` | No | Block to start from (default: `82655`; set to `0` for a fresh/local chain) |
-| `SUBSTREAMS_END_BLOCK` | No | Block to end at (default: u64::MAX = stream forever) |
+| `SUBSTREAMS_END_BLOCK` | No | Block to end at (default: `0` = stream forever) |
 
 ## Database Schema
 

--- a/hermes-ipfs-cache/src/main.rs
+++ b/hermes-ipfs-cache/src/main.rs
@@ -16,7 +16,8 @@
 //! Optional:
 //! - `SUBSTREAMS_START_BLOCK` - First block to consume on cold start (default: 138000).
 //!   Ignored when a persisted cursor exists in the `meta` table.
-//! - `SUBSTREAMS_END_BLOCK` - Last block to consume (default: u64::MAX for continuous)
+//! - `SUBSTREAMS_END_BLOCK` - Last block to consume (default: 0, the Substreams
+//!   sentinel for "stream forever"). Do not set this to `u64::MAX`.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -190,10 +191,14 @@ async fn async_main() -> anyhow::Result<()> {
             .and_then(|s| s.parse().ok())
             .unwrap_or(138000);
 
+        // `0` is the Substreams protocol's sentinel for "never stop". Passing
+        // `u64::MAX` instead makes the server plan a bounded job of ~18
+        // quintillion blocks: it backprocesses forever, emitting progress but
+        // never a single `BlockScopedData`.
         let end_block: u64 = env::var("SUBSTREAMS_END_BLOCK")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(u64::MAX);
+            .unwrap_or(0);
 
         info!(
             endpoint = %endpoint,

--- a/hermes-pipeline/README.md
+++ b/hermes-pipeline/README.md
@@ -88,7 +88,7 @@ This transformer is part of the Hermes architecture (see `docs/architecture.md`)
 | `SUBSTREAMS_ENDPOINT` | Substreams gRPC endpoint URL | `geotest.substreams.pinax.network:443` |
 | `SUBSTREAMS_API_TOKEN` | Auth token for substreams | - |
 | `SUBSTREAMS_START_BLOCK` | Block number to start from. Set to `0` for a fresh/local Anvil chain; set to the contract deploy block for other chains. | `82655` |
-| `SUBSTREAMS_END_BLOCK` | Block number to stop at | `u64::MAX` (continuous) |
+| `SUBSTREAMS_END_BLOCK` | Block number to stop at | `0` (continuous) |
 
 ### Kafka Environment Variables
 

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -30,7 +30,8 @@
 //! - `SUBSTREAMS_API_TOKEN` - API token for substreams authentication
 //! - `SUBSTREAMS_START_BLOCK` - First block to consume on cold start (default: 138000).
 //!   Ignored when a persisted cursor exists in the `meta` table.
-//! - `SUBSTREAMS_END_BLOCK` - Last block to consume (default: u64::MAX for continuous)
+//! - `SUBSTREAMS_END_BLOCK` - Last block to consume (default: 0, the Substreams
+//!   sentinel for "stream forever"). Do not set this to `u64::MAX`.
 //! - `KAFKA_BROKER` - Kafka broker address (default: localhost:9092)
 //! - `KAFKA_USERNAME` - SASL username for managed Kafka (optional)
 //! - `KAFKA_PASSWORD` - SASL password for managed Kafka (optional)
@@ -1089,10 +1090,14 @@ async fn async_main() -> anyhow::Result<()> {
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(138000);
+        // `0` is the Substreams protocol's sentinel for "never stop". Passing
+        // `u64::MAX` instead makes the server plan a bounded job of ~18
+        // quintillion blocks: it backprocesses forever, emitting progress but
+        // never a single `BlockScopedData`.
         let end_block: u64 = env::var("SUBSTREAMS_END_BLOCK")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(u64::MAX);
+            .unwrap_or(0);
 
         info!(
             endpoint = %endpoint,


### PR DESCRIPTION
## What

All three live Substreams consumers — `hermes-pipeline`, `hermes-ipfs-cache`, `atlas` — default `SUBSTREAMS_END_BLOCK` to `u64::MAX`. The Substreams protocol sentinel for "never stop" is **`0`**; `u64::MAX` is read as a bounded range.

```rust
-    .unwrap_or(u64::MAX);
+    .unwrap_or(0);
```

## Why

With `stop_block_num = u64::MAX` the server plans a job of ~18 quintillion blocks. Sending our exact request shape through the CLI makes it say so out loud:

```
FailedPrecondition: request needs to process a total of
18446744073709531041 blocks
```

The stream connects, authenticates, opens a session, emits `Progress` messages whose block counts climb past the chain head — and never delivers a single `BlockScopedData`. Externally this is indistinguishable from a broken provider: `grpc.health.v1.Health/Check` returns `SERVING`, `EndpointInfo/Info` is valid, the session has a trace ID, and the cursor never moves.

## Impact observed

This stalled **all v2 indexing (chain 55516) for ~3.5 hours** on 2026-07-31, cursor pinned at block 20573 while the chain head sat at 20581. Three restarts reproduced it exactly: connect, ~15s of progress, then silence at 1m CPU.

Setting `SUBSTREAMS_END_BLOCK=0` on the two v2 deployments cleared it immediately:

```
19:32:27Z  env applied, rollout complete
19:32:29Z  hermes_ipfs_cache=20580  hermes_pipeline=20575
19:32:37Z  cursor=20581   "Cursor persist"   ← caught up to head
```

Ten seconds, after 3.5 hours stuck.

## Latent, not a regression

`stream/` is byte-identical between the running prod image (`1f60e60e`, 2026-06-22) and the v2 image (`ca066053`, 2026-07-30) — `git diff --stat <prod> <v2> -- stream/` is empty. Prod has run the same `u64::MAX` for months without symptoms.

Working theory: prod's Substreams account has warm module stores across its range, so the oversized plan resolves from cache; the v2 account is cold and actually attempts it. If that's right, **prod carries the same latent stall** and would hit it on a cache eviction or a fresh account. That's the main argument for shipping this to `main` as well, not just `staging`.

## Also

Corrected the three READMEs and three module headers, which all documented `u64::MAX` as the intended value for continuous streaming — that's how the bug survived this long.

## Test plan

- [x] `cargo check -p hermes-pipeline -p hermes-ipfs-cache -p atlas` passes
- [x] Verified live on the v2 cluster via the equivalent env override (`SUBSTREAMS_END_BLOCK=0`) — cursor advanced 20573 → 20581 and has stayed at head
- [ ] After merge, drop the temporary `SUBSTREAMS_END_BLOCK=0` env var from the two v2 deployments so they use the corrected default