### PR TITLE
fix(api): set statement_timeout from the app, raise the client fuse above it

### DIFF
--- a/api/docs/database-configuration.md
+++ b/api/docs/database-configuration.md
@@ -20,7 +20,7 @@ API Replicas (3x)              PgBouncer                 PostgreSQL
 | Setting | Value | Purpose |
 |---------|-------|---------|
 | `max_connections` | 100 | Maximum concurrent connections |
-| `statement_timeout` | 10s | Kill queries running longer than 10s |
+| `statement_timeout` | 30s | Kill queries running longer than 30s. Set per connection by the API (`PG_STATEMENT_TIMEOUT_MS`), not from the server config — the managed databases ship `0` (v2) and `1min` (production). |
 | `idle_in_transaction_session_timeout` | 30s | Kill connections stuck in a transaction without committing |
 
 ### Applying PostgreSQL Settings
@@ -128,11 +128,23 @@ Saturation env values are validated at startup. Invalid values fail fast instead
 
 Keep timeout budgets ordered so overload fails predictably:
 
-1. Pool acquire/connect timeout (shortest)
+1. Pool acquire/connect timeout (shortest) — `PG_CONNECTION_TIMEOUT_MS`
 2. Request/application deadline
-3. `statement_timeout` (longest)
+3. `statement_timeout` — `PG_STATEMENT_TIMEOUT_MS`, applied per connection by the API
+4. node-postgres `query_timeout` (longest) — `PG_QUERY_TIMEOUT_MS`
 
 Avoid setting all layers to the same value (for example all 10s), which makes root cause ambiguous.
+
+`query_timeout` must stay **above** `statement_timeout`. It is a client-side
+backstop: Postgres should cancel the query first and free the server, and
+`query_timeout` only reclaims the Node side if that fails. Inverting the two
+destroys connections for queries the server is still happily running, and the
+failure surfaces as an opaque `INTERNAL_SERVER_ERROR` with no server-side trace.
+
+Do not infer `statement_timeout` from the database's own configuration. The
+managed instances do not match this table on their own — v2 ships `0`
+(unlimited) and production ships `1min` — which is why the API sets it
+explicitly per connection.
 
 ### Readiness and Saturation Routing
 

--- a/api/k8s/production/api.yaml
+++ b/api/k8s/production/api.yaml
@@ -94,8 +94,10 @@ spec:
                   key: DATABASE_URL
             - name: PG_CONNECTION_TIMEOUT_MS
               value: "3000"
+            - name: PG_STATEMENT_TIMEOUT_MS
+              value: "30000"
             - name: PG_QUERY_TIMEOUT_MS
-              value: "12000"
+              value: "35000"
             - name: PG_POOL_PRESSURE_WAITING_THRESHOLD
               value: "5"
             - name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD

--- a/api/k8s/staging/api.yaml
+++ b/api/k8s/staging/api.yaml
@@ -96,8 +96,10 @@ spec:
                   key: DATABASE_URL
             - name: PG_CONNECTION_TIMEOUT_MS
               value: "3000"
+            - name: PG_STATEMENT_TIMEOUT_MS
+              value: "30000"
             - name: PG_QUERY_TIMEOUT_MS
-              value: "12000"
+              value: "35000"
             - name: PG_POOL_PRESSURE_WAITING_THRESHOLD
               value: "5"
             - name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -58,10 +58,13 @@ const pgPool = new Pool({
 	connectionTimeoutMillis: parseInt(process.env.PG_CONNECTION_TIMEOUT_MS || "3000", 10),
 	// Close idle connections after 30 seconds to free up PgBouncer slots
 	idleTimeoutMillis: parseInt(process.env.PG_IDLE_TIMEOUT_MS || "30000", 10),
-	// Deterministic client-side fuse: destroys a stuck query's connection just above
-	// Postgres' statement_timeout (10s, api/docs/database-configuration.md), so a client
-	// that doesn't get freed server-side is still reclaimed on the Node side.
-	query_timeout: parseInt(process.env.PG_QUERY_TIMEOUT_MS || "12000", 10),
+	// Client-side fuse, deliberately ABOVE the statement_timeout applied on connect
+	// below. Postgres must cancel the query first so the server-side backend is
+	// freed; this only reclaims the Node side if that fails. If this is ever the
+	// tighter of the two it destroys connections for queries the server is still
+	// running, and the failure surfaces as an opaque INTERNAL_SERVER_ERROR with no
+	// server-side trace. See api/docs/database-configuration.md.
+	query_timeout: parseInt(process.env.PG_QUERY_TIMEOUT_MS || "35000", 10),
 	// Allow process to exit cleanly when pool is idle (for graceful shutdown)
 	allowExitOnIdle: true,
 })
@@ -149,6 +152,26 @@ function toUserInputGraphQLError(error: GraphQLError, pgError: {message: string}
 		},
 	})
 }
+
+// Apply the server-side query budget ourselves rather than trusting the database's
+// configured statement_timeout. api/docs/database-configuration.md documented 10s,
+// but the managed instances actually ship `0` (unlimited) on the v2 cluster and
+// `1min` on production — so a client-side fuse tuned "just above 10s" was in fact
+// the only, and tighter, limit. Setting it here makes the layering true everywhere.
+//
+// Fires once per new physical connection, not per request. This must be a plain
+// SET rather than a startup `options` parameter: DigitalOcean's PgBouncer rejects
+// `options: -c statement_timeout=...` at connect time with
+// `FATAL: unsupported startup parameter in options`.
+const PG_STATEMENT_TIMEOUT_MS = parseInt(process.env.PG_STATEMENT_TIMEOUT_MS || "30000", 10)
+pgPool.on("connect", (client) => {
+	client.query(`SET statement_timeout = ${PG_STATEMENT_TIMEOUT_MS}`).catch((err) => {
+		log.error("Failed to apply statement_timeout to new pool connection", {
+			error: String(err),
+			statementTimeoutMs: PG_STATEMENT_TIMEOUT_MS,
+		})
+	})
+})
 
 // Without this handler, background connection errors (PgBouncer closing idle connections,
 // network blips) become unhandled events. The pool doesn't remove the dead connection,


### PR DESCRIPTION
## Problem

#841 added a client-side `query_timeout: 12000` on the pg pool, commented as sitting *"just above Postgres' `statement_timeout` (10s, api/docs/database-configuration.md)"*.

That value exists nowhere:

| | `statement_timeout` |
|---|---|
| `api/docs/database-configuration.md` | 10s |
| v2 cluster (`gaia`) | **`0`** — unlimited |
| production (`knowledge`) | **`1min`** |

So the fuse was never a backstop. It was the **primary and tighter** limit in both environments:

- **v2** — the only limit that exists.
- **production** — silently lowered the effective ceiling from 60s to 12s. Any query in that window now fails where it previously succeeded. Nothing in the PR description would lead you to expect that.

It also fails in the least diagnosable way possible. node-postgres destroys the connection client-side; Postgres never cancelled anything, so there is no server-side trace, no slow-query log, nothing in `pg_stat_activity`. The client just gets `INTERNAL_SERVER_ERROR`.

That is exactly how the `typeIds` + `backlinks` report presented (#862): a genuinely slow query, but a diagnosis that pointed nowhere.

## Change

Set `statement_timeout` explicitly on every new pool connection, and move `query_timeout` above it:

```
PG_STATEMENT_TIMEOUT_MS  30000   (new, applied by the app)
PG_QUERY_TIMEOUT_MS      35000   (was 12000)
```

Now the documented hierarchy actually holds, regardless of how any given database happens to be configured.

## Why a `SET` and not a startup parameter

The obvious implementation — `options: '-c statement_timeout=...'` on the Pool — **does not work here**. DigitalOcean's PgBouncer rejects it at connect time:

```
FATAL: unsupported startup parameter in options: statement_timeout
```

I tried that first; it would have failed every API pod on boot. Using the pool's `connect` event instead costs one round-trip per *physical connection*, not per request. Verified against the live pooled endpoint that a session-level `SET` persists across subsequent statements on a checked-out connection.

## Docs

`api/docs/database-configuration.md` claimed a `statement_timeout` neither database has. Updated, and the Timeout Hierarchy section now lists `query_timeout` as a fourth layer with an explicit note that it must stay above `statement_timeout` and why.

## Test plan

- [x] `bun run check` (tsc) clean
- [x] `biome check src/kg/postgraphile.ts` clean
- [x] Confirmed `options:` is rejected by the pooler, and that a plain `SET` persists through it
- [ ] After deploy, confirm `SHOW statement_timeout` reports 30s on an API connection

## Note on ordering

#862 makes the reported query fast (15,133ms → 183ms), so it no longer approaches either limit. This PR is independent — it fixes the timeout layering itself, which would otherwise keep converting slow queries into untraceable 500s.