### PR TITLE
fix(search-indexer): halve the v2 memory request to 1Gi

### DIFF
--- a/search-indexer-deploy/k8s/v2/search-indexer.yaml
+++ b/search-indexer-deploy/k8s/v2/search-indexer.yaml
@@ -136,7 +136,13 @@ spec:
               protocol: TCP
           resources:
             requests:
-              memory: "2Gi"
+              # Steady state is ~840Mi; the 2Gi request reserved more than twice
+              # what it uses and made this the largest single consumer of
+              # schedulable memory on a 3-node pool, pushing total requests past
+              # single-node-failure tolerance (KubeMemoryOvercommit).
+              # The 4Gi limit is unchanged, so bulk-reindex bursts still have
+              # room — requests govern scheduling, limits govern runtime.
+              memory: "1Gi"
               cpu: "100m"
             limits:
               memory: "4Gi"


### PR DESCRIPTION
## Why

`search-indexer-0` reserved **2Gi** and uses **~840Mi** — 41% of its request, and the largest single consumer of schedulable memory on the 3-node v2 pool (more than eight API pods combined at 0.75Gi each). Its CPU request of 100m against ~6m actual is similarly generous but harmless.

That one pod pushed the cluster past single-node-failure tolerance:

```
total memory requests   15.60 Gi
pool                    23.30 Gi   (3 x s-4vcpu-8gb)
after losing one node   15.50 Gi available  ->  DOES NOT FIT
```

This surfaced immediately after standing up monitoring on the new cluster — `KubeMemoryOvercommit` and `KubeCPUOvercommit` were among the first alerts to fire, and both were correct.

**Autoscaling does not cover this.** The pool is `auto_scale: true, min 3, max 5`, but the cluster-autoscaler only scales up in response to *Pending* pods. It never pre-provisions failover headroom, so it would have sat at 3 nodes indefinitely and only reacted after a node loss had already caused evictions.

## After

```
total memory requests   14.58 Gi  ->  fits with 0.92 Gi spare
```

Cluster is back inside single-node-failure tolerance.

## What is deliberately unchanged

The **4Gi limit stays**. Requests govern scheduling; limits govern runtime. Search indexers can spike during bulk reindex, so the pod keeps its burst room — it just stops reserving that headroom against the scheduler at all times.

Only the `k8s/v2` manifest is touched. `staging` and `production` still target the old cluster with different node pools, so their sizing is left alone.

## Test plan

- [x] Applied live to `do-nyc2-geo-testnet-k8s` / `gaia`; StatefulSet rolled cleanly, pod `1/1 Running`
- [x] Recomputed cluster-wide requests post-change: 14.58 Gi, fits after a node loss
- [ ] Confirm `KubeMemoryOvercommit` clears on its next evaluation

Note `KubeCPUOvercommit` is a separate axis (8.8 of 12 cores requested) and is **not** addressed here. The API pods request 500m and use 79–234m, so there is comparable slack, but I would rather observe them under real load before trimming.