### PR TITLE
fix(api): bring the v2 manifest up to parity with #841 and #863

### DIFF
--- a/api/k8s/v2/api.yaml
+++ b/api/k8s/v2/api.yaml
@@ -94,8 +94,12 @@ spec:
                   key: DATABASE_URL
             - name: PG_CONNECTION_TIMEOUT_MS
               value: "3000"
+            - name: PG_STATEMENT_TIMEOUT_MS
+              value: "30000"
+            - name: PG_QUERY_TIMEOUT_MS
+              value: "35000"
             - name: PG_POOL_PRESSURE_WAITING_THRESHOLD
-              value: "1"
+              value: "5"
             - name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD
               value: "90"
             - name: PG_POOL_PRESSURE_TIMEOUT_THRESHOLD


### PR DESCRIPTION
## Problem

**#841 and #863 never reached the cluster serving production traffic.**

Both edited only `api/k8s/production/api.yaml` and `api/k8s/staging/api.yaml`. The live cluster deploys from `api/k8s/v2/api.yaml` via `deploy-v2.yml`, which neither PR touched. For #863 that was my error — I checked that `k8s/production` and `k8s/staging` existed and never looked for `k8s/v2`.

Confirmed against the running deployment (`kubectl get deploy api -o jsonpath=...env[*].name`): `PG_STATEMENT_TIMEOUT_MS` and `PG_QUERY_TIMEOUT_MS` are absent, and `PG_POOL_PRESSURE_WAITING_THRESHOLD` is still `1`.

| | before | after | source |
|---|---|---|---|
| `PG_STATEMENT_TIMEOUT_MS` | absent | `30000` | #863 |
| `PG_QUERY_TIMEOUT_MS` | absent | `35000` | #863 |
| `PG_POOL_PRESSURE_WAITING_THRESHOLD` | `1` | `5` | #841 |

v2 now matches production exactly on all three.

## Impact

Timeouts were not actually broken — they fall back to the code defaults in `api/src/kg/postgraphile.ts`, which #863 set to 30s/35s, and that image is deployed. So this is declaration drift rather than a live defect.

The shedding threshold **was** wrong: v2 has been running at `1`, the aggressive value #841 softened precisely because it shed GraphQL traffic whenever a single client was waiting on the pool. Under the current load (~23 req/s, HPA pinned at max) that is the wrong setting to be on.

## Found while investigating a real alert

`ApiHpaMaxedOut` fired for the first time after monitoring went live on the new cluster, and it is correct — the API is genuinely saturated:

```
14:16:22  cpu 61%   sum 2457m
14:17:28  cpu 89%   sum 3505m   at 8/8 replicas, unable to scale further
```

~23 req/s of server-rendered frontend traffic, with ~2,200 "High GraphQL query cost" warnings per 5 minutes (median cost 210 vs a threshold of 200).

## Deliberately NOT in this PR: the response cache

The obvious lever is the Valkey response cache — deployed, healthy, credentialed, and **never used** (`keyspace_hits: 0`, `DBSIZE: 0`). `VALKEY_URL` is commented out.

It is off on purpose. #655 disabled it after a user-facing bug:

> Triggered by a 60-second-stuck 'Create Personal Space' modal — the 60s TTL on `Query.spaces` was caching the per-user address-filter lookup, serving stale empty results during post-write polling.

And the cause is structural, not a TTL that needs nudging — `useResponseCache` is configured with `session: () => null`, so there is no per-user isolation and a user-scoped query is cached globally for everyone.

Re-enabling it would need either a real `session` key or the user-scoped coordinates excluded from `ttlPerSchemaCoordinate`. That is a code change with its own correctness argument, and it does not belong in a manifest-parity fix.

## Test plan

- [x] Diffed all three manifests; v2 now matches production on the three values
- [ ] Deploy to v2 and confirm the three vars are present in the pod env
- [ ] Watch whether softening the shedding threshold `1 -> 5` reduces shed traffic under the current load

## Follow-ups, not addressed here

- The response cache needs a correctness fix before it can be turned on anywhere — it is currently disabled in **all three** environments, so nobody is getting it.
- `ApiHpaMaxedOut` will keep firing until either capacity increases or per-request cost drops. I would rather not raise `maxReplicas` or `min_nodes` until the cache question is settled, since scaling out spends cluster headroom to recompute results we could be caching.