### PR TITLE
feat(monitoring): add the new-cluster monitoring manifests

### DIFF
--- a/monitoring/k8s/v2/README.md
+++ b/monitoring/k8s/v2/README.md
@@ -1,0 +1,79 @@
+# Monitoring — new testnet cluster (`do-nyc2-geo-testnet-k8s`)
+
+The v2 stack runs in a single `gaia` namespace on a cluster that serves traffic
+through a **Cilium Gateway**, not ingress-nginx. The manifests in the parent
+directory assume the old cluster's namespace layout (`knowledge`, `api`,
+`api-staging`) and its nginx ingress, so the files here replace the ones that
+do not carry over.
+
+## Deploy
+
+The chart render and the cluster-agnostic rules come from the parent directory:
+
+```bash
+CTX=do-nyc2-geo-testnet-k8s
+
+kubectl --context $CTX apply -f monitoring/k8s/namespace.yaml
+kubectl --context $CTX apply -f monitoring/k8s/prometheus-stack.yaml --server-side   # run twice; CRDs first
+kubectl --context $CTX apply -f monitoring/k8s/hermes-lag-alerts.yaml                # cluster-agnostic
+```
+
+Two secrets must exist in `monitoring` before Alertmanager and Grafana start.
+Both are copied from the old cluster; neither is in git:
+
+```bash
+# Slack webhooks (keys: url, url-staging) — Alertmanager mounts this via
+# alertmanagerSpec.secrets, and fails to send without it.
+kubectl --context $CTX -n monitoring create secret generic alertmanager-slack-webhook ...
+
+# Grafana admin (keys: admin-user, admin-password) — values.yaml sets
+# admin.existingSecret, so Grafana CrashLoops with CreateContainerConfigError
+# if this is absent.
+kubectl --context $CTX -n monitoring create secret generic kube-prometheus-stack-grafana ...
+
+# Registry pull secret, for chain-tip-exporter.
+kubectl --context $CTX -n gaia get secret regcred -o yaml \
+  | sed 's/namespace: gaia/namespace: monitoring/' | kubectl --context $CTX apply -f -
+
+# RPC endpoint for chain-tip-exporter, reusing the executor's chain-55516 URL.
+kubectl --context $CTX -n monitoring create secret generic chain-tip-exporter-secrets \
+  --from-literal=RPC_URL="$(kubectl --context $CTX -n gaia get secret \
+      proposal-executor-credentials -o jsonpath='{.data.RPC_URL}' | base64 -d)"
+```
+
+Then this directory:
+
+```bash
+kubectl --context $CTX apply -f monitoring/k8s/v2/
+```
+
+## What is here and why
+
+| file | why it differs from the parent copy |
+|---|---|
+| `hermes-metrics-servicemonitor.yaml` | scrapes `gaia` instead of `knowledge` / `knowledge-staging` |
+| `api-capacity-alerts.yaml` | targets `gaia`; drops the `api-staging` duplicate; latency/5xx alerts rebased onto the Gateway |
+| `gateway-metrics.yaml` | scrapes Cilium's Envoy and provides the `api:gateway_*` recording rules that replace the nginx-derived `api:ingress_*` pair |
+| `chain-tip-exporter.yaml` | this cluster had no exporter at all, so `HermesBehindChainTip` could never fire |
+
+## Deliberately not ported
+
+- **`ingress-nginx-metrics.yaml`, `api-ingress-rules.yaml`, `api-ingress-dashboard.yaml`** —
+  there is no ingress-nginx here. `gateway-metrics.yaml` supplies the equivalent
+  signals from Envoy.
+- **`prometheus-adapter-*.yaml`** — the API's HPA runs on cpu/memory via
+  metrics-server. Nothing on this cluster consumes external metrics.
+- **`kafka-exporter.yaml`, `opensearch-exporter.yaml`** and their lag alerts —
+  these need this cluster's Kafka and OpenSearch credentials wiring first. Until
+  they land, `KafkaConsumerLagHigh` / `KafkaConsumerStuck` are **not** watching
+  the v2 pipeline.
+- **Dashboards** (`*-dashboard.yaml`) — the `gaia-v2-*` ones point at the old
+  cluster's `gaia-v2` namespace and need the same re-pointing treatment.
+
+## Alert routing
+
+`values.yaml` routes `namespace =~ ".*-staging"` to `#infra-alerts-staging` and
+everything else to `#alerts`. This cluster's namespace is `gaia`, which matches
+neither staging pattern, so **v2 alerts go to `#alerts`** — correct now that v2
+serves production, but note the old cluster's Alertmanager is still running and
+also posting there.

--- a/monitoring/k8s/v2/api-capacity-alerts.yaml
+++ b/monitoring/k8s/v2/api-capacity-alerts.yaml
@@ -1,0 +1,71 @@
+# API capacity alerts for the gaia namespace.
+#
+# The old cluster's copy defines three alerts twice (once for `api`, once for
+# `api-staging`). The new cluster runs a single `gaia` namespace, so the
+# staging duplicate is dropped.
+#
+# The two latency/error alerts were originally backed by
+# nginx_ingress_controller_* metrics. This cluster serves through a Cilium
+# Gateway, so they are now backed by the api:gateway_* recording rules in
+# gateway-metrics.yaml, which derive from Cilium's Envoy.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: api-capacity-observability
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: api.capacity
+      rules:
+        - alert: ApiReadinessDegraded
+          expr: |
+            (
+              sum(kube_pod_status_ready{namespace="gaia", condition="true", pod=~"api-.*"})
+              /
+              clamp_min(sum(kube_pod_status_phase{namespace="gaia", phase="Running", pod=~"api-.*"}), 1)
+            ) < 0.75
+          for: 5m
+          labels:
+            severity: warning
+            service: api
+          annotations:
+            summary: API readiness ratio is degraded
+            description: Fewer than 75% of running API pods are ready for 5 minutes.
+
+        # Restores the old cluster's pairing: saturation alone is normal and
+        # self-correcting, saturation WITH a latency tail is not. Firing on the
+        # replica count by itself produced false alarms on a healthy API.
+        #
+        # Threshold raised from the old cluster's 2s to 5s: p99 here measures
+        # only the Envoy -> pod leg but currently sits at ~4.4s against a p50 of
+        # 0.03s and p90 of 0.31s. That tail is a real problem worth fixing, but
+        # it is the steady state today, so alerting at 2s would page constantly.
+        # Lower this to 2s once the tail is addressed.
+        - alert: ApiHpaMaxedWithHighP99
+          expr: |
+            kube_horizontalpodautoscaler_status_current_replicas{namespace="gaia", horizontalpodautoscaler="api"}
+            >=
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace="gaia", horizontalpodautoscaler="api"}
+            and api:gateway_p99_latency_seconds:5m > 5
+          for: 10m
+          labels:
+            severity: critical
+            service: api
+          annotations:
+            summary: API HPA is maxed while p99 latency is high
+            description: >-
+              API is at max replicas with sustained p99 latency above 5s. Unlike
+              a bare max-replicas condition this means requests are actually
+              suffering, not merely that the autoscaler has hit its ceiling.
+
+        - alert: Api5xxRateHigh
+          expr: api:gateway_5xx_ratio:rate5m > 0.02
+          for: 10m
+          labels:
+            severity: warning
+            service: api
+          annotations:
+            summary: API 5xx rate above 2%
+            description: More than 2% of gateway responses for the API have been 5xx for 10 minutes.

--- a/monitoring/k8s/v2/chain-tip-exporter.yaml
+++ b/monitoring/k8s/v2/chain-tip-exporter.yaml
@@ -1,0 +1,95 @@
+# chain-tip-exporter for the new cluster (chain 55516).
+#
+# Publishes `chain_tip_block_number`, which HermesBehindChainTip subtracts
+# `hermes_latest_processed_block` from. Without this deployment that alert can
+# never fire — which is why the 2026-07-31 indexing stall went unnoticed for
+# 3.5 hours.
+#
+# The `gaia_namespace` label is what joins this to the hermes metrics: the
+# ServiceMonitor lifts it via `targetLabels`, and the alert does
+# `label_replace(..., "namespace", "$1", "gaia_namespace", "(.*)")`. On the old
+# cluster it was `knowledge`; here the stack lives in `gaia`.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chain-tip-exporter
+  namespace: monitoring
+  labels:
+    app: chain-tip-exporter
+    environment: production
+    gaia_namespace: gaia
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chain-tip-exporter
+      environment: production
+  template:
+    metadata:
+      labels:
+        app: chain-tip-exporter
+        environment: production
+        gaia_namespace: gaia
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      containers:
+        - name: chain-tip-exporter
+          image: registry.digitalocean.com/geo/chain-tip-exporter:latest
+          imagePullPolicy: Always
+          ports:
+            - name: metrics
+              containerPort: 9464
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: RPC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chain-tip-exporter-secrets
+                  key: RPC_URL
+            - name: POLL_INTERVAL_SECS
+              value: "30"
+            # Chain 55516 only produces blocks on demand — multi-hour gaps with
+            # no transactions are normal, so the old cluster's 300s staleness
+            # warning would be permanent noise here.
+            - name: LATEST_BLOCK_BEHIND_THRESHOLD_SECS
+              value: "86400"
+            - name: SENTRY_ENVIRONMENT
+              value: "production"
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chain-tip-exporter
+  namespace: monitoring
+  labels:
+    app: chain-tip-exporter
+    environment: production
+    gaia_namespace: gaia
+spec:
+  type: ClusterIP
+  selector:
+    app: chain-tip-exporter
+    environment: production
+  ports:
+    - name: metrics
+      port: 9464
+      targetPort: metrics
+      protocol: TCP

--- a/monitoring/k8s/v2/gateway-metrics.yaml
+++ b/monitoring/k8s/v2/gateway-metrics.yaml
@@ -1,0 +1,93 @@
+# Scrape Cilium's Envoy, which backs the Gateway API on this cluster.
+#
+# Replaces the ingress-nginx metrics the old cluster used. Every cilium agent
+# exposes ~2,600 envoy_* series on the `envoy-metrics` port; the Gateway's
+# request counters and latency histograms live there.
+#
+# Traffic for a given backend appears on whichever nodes' Envoy handled it —
+# currently 3 of 4 — so every rule below must aggregate across pods before
+# computing a ratio or quantile.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cilium-envoy-metrics
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  podMetricsEndpoints:
+    - port: envoy-metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+# Recording rules replacing the nginx-derived api:ingress_* pair.
+#
+# The Envoy cluster name is assigned by Cilium as
+#   <gateway-namespace>/cilium-gateway-<gateway>/<backend-ns>_<svc>_<port>
+# and for the API that is:
+#   geo-chat/cilium-gateway-geo-chat-api/gaia_api_3000
+# Note the `geo-chat` prefix: gaia's HTTPRoute attaches cross-namespace to the
+# shared Gateway that lives in the geo-chat namespace, so nothing here is
+# labelled `gaia`. The match keys on the `gaia_api_3000` suffix instead, which
+# will need updating if the service or its port is ever renamed.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gateway-api-recording-rules
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: gateway.api.recording
+      interval: 30s
+      rules:
+        # p99 of Envoy -> API-pod latency, in SECONDS.
+        #
+        # envoy_cluster_upstream_rq_time is denominated in MILLISECONDS — its
+        # buckets run to 3,600,000 — so the /1000 is required. Without it this
+        # records ~4760 and any threshold expressed in seconds fires forever.
+        #
+        # NOT identical to the old nginx metric: that measured the full
+        # client-facing request including proxy queueing, this measures the
+        # upstream leg only, so it reads slightly lower. Envoy does not expose
+        # a downstream latency histogram here (only rq_timeout counters), so
+        # this is the closest available equivalent.
+        #
+        # Bucket boundaries are coarse near the tail (…1000, 2500, 5000, 10000…),
+        # so a p99 in that range is interpolated. Treat it as an order of
+        # magnitude, not a precise figure.
+        - record: api:gateway_p99_latency_seconds:5m
+          expr: |
+            histogram_quantile(0.99,
+              sum by (le) (
+                rate(envoy_cluster_upstream_rq_time_bucket{
+                  envoy_cluster_name=~".*gaia_api_3000"
+                }[5m])
+              )
+            ) / 1000
+
+        # 5xx as a share of all responses.
+        #
+        # Uses envoy_cluster_upstream_rq_xx only. Envoy also publishes
+        # envoy_cluster_external_upstream_rq_xx with identical values for this
+        # cluster; including both would double-count.
+        - record: api:gateway_5xx_ratio:rate5m
+          expr: |
+            sum(rate(envoy_cluster_upstream_rq_xx{
+              envoy_cluster_name=~".*gaia_api_3000", envoy_response_code_class="5"
+            }[5m]))
+            /
+            clamp_min(
+              sum(rate(envoy_cluster_upstream_rq_xx{
+                envoy_cluster_name=~".*gaia_api_3000"
+              }[5m])),
+              0.001
+            )

--- a/monitoring/k8s/v2/hermes-metrics-servicemonitor.yaml
+++ b/monitoring/k8s/v2/hermes-metrics-servicemonitor.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hermes-metrics
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - monitoring
+      - gaia
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - hermes-pipeline
+          - hermes-ipfs-cache
+          - chain-tip-exporter
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 5s
+  targetLabels:
+    - gaia_namespace


### PR DESCRIPTION
## Why

The cluster now serving production had **no monitoring whatsoever** — no Prometheus, no Alertmanager, not even the prometheus-operator CRDs.

`HermesBehindChainTip` fires after 5 minutes and has been committed to this repo for months. It was deployed only to the old cluster. That is why the 2026-07-31 indexing stall sat unnoticed for **3.5 hours** and was found by asking rather than being paged.

## Structure

The parent directory's manifests assume the old cluster's namespaces (`knowledge`, `api`, `api-staging`) and ingress-nginx. This adds `monitoring/k8s/v2/` for the files that do not carry over, mirroring the existing `api/k8s/{production,staging,v2}` convention.

| file | why it differs |
|---|---|
| `hermes-metrics-servicemonitor.yaml` | scrapes `gaia`, not `knowledge` / `knowledge-staging` |
| `api-capacity-alerts.yaml` | targets `gaia`; drops the `api-staging` duplicate; latency/5xx rebased onto the Gateway |
| `gateway-metrics.yaml` | scrapes Cilium's Envoy; supplies the `api:gateway_*` rules replacing the nginx-derived `api:ingress_*` pair |
| `chain-tip-exporter.yaml` | this cluster had none, so `HermesBehindChainTip` could never fire |

`hermes-lag-alerts.yaml` and `prometheus-stack.yaml` are cluster-agnostic and applied from the parent directory unchanged.

## Replacing the nginx metrics

Cilium's Gateway is Envoy-backed, and each agent already exposes ~2,600 `envoy_*` series on port 9964 — nothing needed installing. The API has its own Envoy cluster:

```
envoy_cluster_name="geo-chat/cilium-gateway-geo-chat-api/gaia_api_3000"
```

which gives the same per-backend isolation the nginx rules had. Note the `geo-chat` prefix — gaia's HTTPRoute attaches cross-namespace to the shared Gateway, so nothing is labelled `gaia` and the match keys on the `gaia_api_3000` suffix.

**Hubble does not work for this**, despite `httpV2` being enabled. The only HTTP series it emits is `hubble_metrics_http_handler_*` — Hubble measuring its own metrics endpoint. Real L7 metrics require a `CiliumNetworkPolicy` with L7 rules to force traffic through the proxy, adding a datapath hop on every request for data Envoy already has.

## A trap worth recording

`envoy_cluster_upstream_rq_time` is denominated in **milliseconds** — its buckets run to 3,600,000. My first version of the p99 rule recorded **4760** against an alert threshold of `2`. It would have fired permanently and been tuned out within a day. The `/1000` is load-bearing and commented as such.

## Threshold change worth a second opinion

`ApiHpaMaxedWithHighP99` uses **5s**, not the old cluster's 2s. Measured distribution:

```
p50  0.03 s
p90  0.31 s
p99  2.2 – 4.4 s
```

That tail is a real problem, but it is the steady state today, so 2s would page constantly. The rule carries a comment to lower it to 2s once the tail is addressed. Happy to set 2s now if you would rather it page.

Also note the p99 measures the Envoy→pod leg only; the nginx metric was client-facing and included proxy queueing, so this reads slightly lower. Envoy exposes no downstream latency histogram here, only `rq_timeout` counters.

## Verified live

```
3 Envoy targets up
api:gateway_p99_latency_seconds:5m = 2.23 s     health ok
api:gateway_5xx_ratio:rate5m       = 0.0002     health ok
ApiReadinessDegraded / ApiHpaMaxedWithHighP99 / Api5xxRateHigh   inactive, healthy
```

Slack delivery confirmed end to end via a test alert (`alertmanager_notifications_total{integration="slack"}` incrementing, zero failures).

## Gaps this does not close

- **Kafka and OpenSearch exporters are not ported** — they need this cluster's credentials. Until then `KafkaConsumerLagHigh` / `KafkaConsumerStuck` are **not** watching the v2 pipeline.
- **Dashboards not ported** — the `gaia-v2-*` ones still point at the old cluster's namespace.
- Two secrets (`alertmanager-slack-webhook`, `kube-prometheus-stack-grafana`) are copied from the old cluster and are not in git; the README documents both, including that Grafana CrashLoops without the second.