### PR TITLE
fix(api): never cache empty GraphQL results

### DIFF
--- a/api/src/kg/__tests__/responseCacheEmptyResults.test.ts
+++ b/api/src/kg/__tests__/responseCacheEmptyResults.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from "vitest"
+import {hasCacheableData} from "../responseCachePolicy"
+
+// =============================================================================
+// hasCacheableData — gates what the response cache is allowed to store.
+//
+// The rule it enforces: a result that says "nothing here" must never be
+// cached, because writes land out of band (chain -> indexer -> Postgres) and
+// nothing will invalidate it before its TTL expires. See #655.
+// =============================================================================
+
+describe("hasCacheableData — empty results are not cacheable", () => {
+	it("rejects a null or missing payload", () => {
+		expect(hasCacheableData(null)).toBe(false)
+		expect(hasCacheableData(undefined)).toBe(false)
+	})
+
+	it("rejects an empty list — the #655 case", () => {
+		// A client polling for a space it just created, before the indexer
+		// caught up. Caching this is what stuck the modal for 60s.
+		expect(hasCacheableData({spaces: []})).toBe(false)
+	})
+
+	it("rejects a null single-entity lookup", () => {
+		expect(hasCacheableData({entity: null})).toBe(false)
+	})
+
+	it("rejects an empty Relay connection", () => {
+		expect(hasCacheableData({spacesConnection: {nodes: [], totalCount: 0}})).toBe(false)
+		expect(hasCacheableData({spacesConnection: {edges: [], totalCount: 0}})).toBe(false)
+	})
+
+	it("rejects a payload with no root fields at all", () => {
+		expect(hasCacheableData({})).toBe(false)
+	})
+})
+
+describe("hasCacheableData — real results stay cacheable", () => {
+	it("accepts a populated list", () => {
+		expect(hasCacheableData({spaces: [{id: "a"}]})).toBe(true)
+	})
+
+	it("accepts a populated connection", () => {
+		expect(hasCacheableData({spacesConnection: {nodes: [{id: "a"}], totalCount: 1}})).toBe(true)
+	})
+
+	it("accepts a single entity that exists", () => {
+		expect(hasCacheableData({entity: {id: "a", name: "Thing"}})).toBe(true)
+	})
+
+	it("accepts a partially populated payload", () => {
+		// One empty root field must not disqualify a response that carries data
+		// elsewhere — otherwise the large, stable queries stop being cached.
+		expect(hasCacheableData({spaces: [], entities: [{id: "a"}]})).toBe(true)
+	})
+
+	it("treats a zero totalCount as empty but a positive one as data", () => {
+		expect(hasCacheableData({c: {totalCount: 0}})).toBe(false)
+		expect(hasCacheableData({c: {totalCount: 3}})).toBe(true)
+	})
+
+	it("accepts scalar root fields", () => {
+		expect(hasCacheableData({__typename: "Query"})).toBe(true)
+		// `false` and `0` are legitimate answers, not absence.
+		expect(hasCacheableData({flag: false})).toBe(true)
+		expect(hasCacheableData({count: 0})).toBe(true)
+	})
+
+	it("looks through nesting rather than trusting the wrapper", () => {
+		expect(hasCacheableData({a: {b: {c: []}}})).toBe(false)
+		expect(hasCacheableData({a: {b: {c: [1]}}})).toBe(true)
+	})
+})

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -23,6 +23,7 @@ import {shouldUnmaskError} from "./errorMasking"
 import HideProceduresPlugin from "./hideProceduresPlugin"
 import {useGraphQLInstrumentation} from "./instrumentationPlugin"
 import PaginationCapPlugin, {NoFirstAndLastRule} from "./paginationCapPlugin"
+import {hasCacheableData} from "./responseCachePolicy"
 import {useSearchInvocationLogger} from "./searchInvocationLogger"
 import {createShedEpisodeTracker} from "./shedEpisodeTracker"
 import UndashedUuidPlugin from "./uuidScalarPlugin"
@@ -393,6 +394,7 @@ const DEFAULT_TTL_MS = 10_000
 // Longer TTL for expensive, rarely-changing queries identified in production logs.
 // These queries are identical across all users and produce large responses (2-15 MB).
 const LONG_TTL_MS = 60_000
+
 const responseCachePlugin = (() => {
 	const valkeyUrl = process.env.VALKEY_URL
 	if (!valkeyUrl) {
@@ -401,8 +403,22 @@ const responseCachePlugin = (() => {
 	}
 	log.info("Response cache enabled", {valkeyUrl: valkeyUrl.replace(/\/\/.*@/, "//<redacted>@")})
 	return useResponseCache({
+		// Deliberately null: the API has no authenticated session, and the cache
+		// key already includes the query document and its variables, so callers
+		// filtering by different addresses get different entries.
 		session: () => null,
 		ttl: DEFAULT_TTL_MS,
+		// Replaces the plugin default (`!result.errors?.length`), so the error
+		// check has to be repeated here. See hasCacheableData for why empty
+		// results must not be cached.
+		shouldCacheResult: ({result}) => {
+			if (result.errors?.length) return false
+			if (hasCacheableData(result.data)) return true
+			log.debug("Response cache skipped: empty result", {
+				reason: "empty_result_not_cacheable",
+			})
+			return false
+		},
 		ttlPerSchemaCoordinate: {
 			// All DAO spaces list — 12 MB, called on 5+ pages, near-static
 			"Query.spaces": LONG_TTL_MS,

--- a/api/src/kg/responseCachePolicy.ts
+++ b/api/src/kg/responseCachePolicy.ts
@@ -1,0 +1,47 @@
+/**
+ * What the GraphQL response cache is allowed to store.
+ *
+ * Lives in its own module so it can be unit tested: importing `postgraphile.ts`
+ * opens a Postgres pool and builds the PostGraphile schema at module load.
+ */
+
+/**
+ * True when a GraphQL result carries at least one root field with actual data.
+ *
+ * Used to keep "not there yet" responses out of the response cache. Writes in
+ * this system land out of band — on-chain, then indexer, then Postgres — so no
+ * GraphQL mutation ever runs and the cache's mutation-driven invalidation never
+ * fires. A cached empty result therefore survives its full TTL no matter what
+ * happens in the database.
+ *
+ * That is what broke in #655: a client polling `Query.spaces` for a freshly
+ * created space cached the pre-indexing empty response for 60s and kept being
+ * served it, leaving the "Create Personal Space" modal stuck for a full minute.
+ * The response cache was disabled outright rather than narrowed.
+ *
+ * Non-empty results stay cacheable — by then the write has landed, which is the
+ * expensive-and-stable case the cache exists for (the spaces and entity lists
+ * run 2-15 MB).
+ *
+ * Bounded on purpose: this fixes empty -> non-empty, not a populated list that
+ * is missing a newly added member. Closing that needs real invalidation driven
+ * by the indexer.
+ */
+export function hasCacheableData(data: unknown): boolean {
+	if (data === null || data === undefined) return false
+	if (typeof data !== "object") return true
+	if (Array.isArray(data)) return data.length > 0
+
+	const record = data as Record<string, unknown>
+
+	// Relay-style connection: trust the collection, not the wrapper object.
+	if (Array.isArray(record.nodes)) return record.nodes.length > 0
+	if (Array.isArray(record.edges)) return record.edges.length > 0
+	if (typeof record.totalCount === "number") return record.totalCount > 0
+
+	// Root payload (or a plain object): non-empty if any field carries data.
+	// `{entity: null}` and `{spaces: []}` are both misses; `{entity: {...}}` is a hit.
+	const values = Object.values(record)
+	if (values.length === 0) return false
+	return values.some((value) => hasCacheableData(value))
+}


### PR DESCRIPTION
## Why

The Valkey response cache has been disabled in **every** environment since #655 and has never served a request — `keyspace_hits: 0`, `DBSIZE: 0` on the v2 cluster today. It is deployed, healthy, credentialed, and idle.

#655 disabled it for a genuine reason:

> Triggered by a 60-second-stuck 'Create Personal Space' modal — the 60s TTL on `Query.spaces` was caching the per-user address-filter lookup, serving stale empty results during post-write polling.

**The root cause is that writes land out of band.** Data changes on-chain → indexer → Postgres. No GraphQL mutation ever runs, so the cache's mutation-driven invalidation never fires. A cached empty result then survives its entire TTL regardless of what the database does. Client polls, gets a cached "not found", and keeps getting it for 60s.

## The fix

Refuse to cache "nothing here". `shouldCacheResult` now rejects results whose root fields are all empty:

```
{spaces: []}                              -> not cached
{entity: null}                            -> not cached
{spacesConnection: {nodes: [], total: 0}} -> not cached
{}                                        -> not cached

{spaces: [{...}]}                         -> cached
{spaces: [], entities: [{...}]}           -> cached  (partial data is real data)
```

The polling sequence now self-corrects: the pre-indexing empty response is not stored, so the next poll re-queries and sees the space as soon as it lands.

This costs nothing on the queries the cache exists for. The 12 MB spaces list and the 2–15 MB entity lists are never empty, so they still cache at their 60s TTL.

Note this **replaces** the plugin's default `shouldCacheResult` (`!result.errors?.length`), so the error check is repeated explicitly rather than inherited.

## What I did NOT change, and why

`session: () => null` looks like a per-user isolation hole. **It isn't.** I checked how the plugin builds its key (`@graphql-yoga/plugin-response-cache/cjs/index.js:96-100`): it includes the document, `variableValues`, and `sessionId`. Callers filtering by different addresses already get different entries, and the API has no authenticated session to key on anyway. Adding a session key would fix nothing. Left as-is with a comment saying so, since it invites exactly this misreading.

## Scope

Bounded on purpose: this fixes **empty → non-empty**. It does not fix a populated list missing a newly added member — a cached non-empty list can still be up to 60s stale. Closing that needs real invalidation driven by the indexer, which already knows precisely when spaces and entities change. Worth doing if this proves insufficient; not worth doing first.

## Structure

`hasCacheableData` lives in a new `responseCachePolicy.ts` rather than in `postgraphile.ts`, because importing the latter opens a Postgres pool and builds the PostGraphile schema at module load — the first version of the test failed with `SASL: client password must be a string` before reaching an assertion.

## Test plan

- [x] 12 unit tests covering the #655 case, connections, partial payloads, and scalars (`false`/`0` are data, not absence)
- [x] `bun run check` (tsc) clean
- [x] `biome check` clean on all three files
- [ ] Enable `VALKEY_URL` on v2 and confirm `keyspace_hits` climbs while the create-space flow stays responsive

`VALKEY_URL` stays commented out everywhere — this only makes enabling it safe. I would suggest v2 first, since nothing has run this code path since #655.