### PR TITLE
feat(api): enable the response cache on v2

### DIFF
--- a/api/k8s/v2/api.yaml
+++ b/api/k8s/v2/api.yaml
@@ -130,12 +130,18 @@ spec:
                   key: OPENSEARCH_URL
             - name: TOPOLOGY_SERVICE_URL
               value: "http://search-indexer:8080"
-            # Response cache disabled — uncomment to re-enable.
-            # - name: VALKEY_URL
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: api-cache-secrets
-            #       key: VALKEY_URL
+            # Response cache. Disabled in #655 after a stuck "Create Personal
+            # Space" modal: a client polling for its new space cached the
+            # pre-indexing empty result for 60s and kept being served it.
+            # Re-enabled here now that #867 refuses to cache empty results.
+            # Writes land out of band (chain -> indexer -> Postgres), so the
+            # cache's mutation-driven invalidation never fires — not caching
+            # "nothing here" is what makes read-after-write polling safe.
+            - name: VALKEY_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-cache-secrets
+                  key: VALKEY_URL
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What

Uncomments `VALKEY_URL` for the v2 cluster. Safe now that #867 refuses to cache empty results — the exact failure that caused #655 to disable it.

## Why now

The cache has **never served a request** in any environment:

```
keyspace_hits: 0   keyspace_misses: 0   DBSIZE: 0
api-cache: 6m CPU / 6Mi memory
```

Meanwhile the API's latency profile is:

```
p50  0.03 s
p90  0.31 s
p99  2.2 - 4.4 s
```

A small number of very expensive repeated queries — precisely the shape a response cache flattens. That tail is also why `ApiHpaMaxedWithHighP99` had to be set at 5s in #866 instead of the old cluster's 2s.

## A broken secret this surfaced

`VALKEY_URL` on v2 pointed at:

```
redis://***@api-cache.api-staging.svc.cluster.local:6379   ->  NXDOMAIN
```

`api-staging` is an **old-cluster namespace that does not exist here**. The secret was copied during the migration and never re-pointed; nobody noticed because the cache has never been enabled. The service actually lives at `api-cache.gaia.svc.cluster.local` (10.109.42.21).

Corrected in the cluster and verified with a round trip:

```
PING -> PONG    SET __smoke -> OK    GET -> ok    DEL -> 1
maxmemory 512Mi, policy allkeys-lru
```

Worth noting this would **not** have caused an outage — `createValkeyCache` uses `lazyConnect: true` with connection errors logged as warnings, so it fails open to the database. But enabling it would have appeared to do nothing while quietly filling the logs with `Valkey cache error`, and we would have gone looking in the wrong place.

The secret is cluster state, not in git, so that fix is not in this diff.

## Scope

**v2 only.** `staging` and `production` keep the cache off until this is proven here.

## Test plan

- [x] Valkey reachable, read/write verified over the corrected service name
- [x] Eviction configured (`allkeys-lru`, 512Mi) so it cannot grow unbounded
- [ ] Deploy, then confirm `keyspace_hits` climbs from zero
- [ ] **Someone runs the Create Personal Space flow in the UI** — this is the regression #655 hit, and it cannot be checked from a terminal
- [ ] Watch p99 and HPA replicas for a few minutes afterwards

Reverting is one line plus a rollout if anything looks wrong.