### PR TITLE
feat(scripts): declarative provisioning + drift check for v2 secrets

### DIFF
--- a/scripts/provision-v2-secrets.sh
+++ b/scripts/provision-v2-secrets.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+#
+# Provision and verify the v2 cluster's Kubernetes secrets from
+# scripts/v2-secrets.spec.yaml.
+#
+#   ./scripts/provision-v2-secrets.sh              # verify (default, read-only)
+#   ./scripts/provision-v2-secrets.sh --apply      # create/merge missing keys
+#   ./scripts/provision-v2-secrets.sh --diff       # show what --apply would change
+#
+# Never prints secret values. Hostname-bearing values are shown with
+# credentials stripped, because the whole point is catching a wrong hostname.
+#
+# Why this exists: every v2 secret incident has been a value copied verbatim
+# from the old cluster that needed re-pointing and did not get it — a Valkey URL
+# aimed at a namespace that does not exist here, Sentry absent entirely, an
+# atlas release tag naming a different service. All were invisible because the
+# affected feature was off or unmonitored. `--verify` makes that class loud, and
+# is safe to run from CI or a cron.
+set -euo pipefail
+
+SPEC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/v2-secrets.spec.yaml"
+MODE="verify"
+case "${1:-}" in
+	--apply) MODE="apply" ;;
+	--diff) MODE="diff" ;;
+	--verify | "") MODE="verify" ;;
+	-h | --help)
+		sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		echo "unknown argument: $1 (try --help)" >&2
+		exit 2
+		;;
+esac
+
+command -v kubectl >/dev/null || { echo "kubectl not found" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 not found" >&2; exit 1; }
+
+MODE="$MODE" SPEC="$SPEC" python3 - <<'PYTHON'
+import base64, json, os, subprocess, sys
+
+MODE = os.environ["MODE"]
+SPEC = os.environ["SPEC"]
+
+# The spec uses a small, fixed subset of YAML; parse it rather than requiring
+# PyYAML to be installed on whatever machine is running a rebuild.
+def load_spec(path):
+    import re
+    text = open(path).read()
+    # Strip comments and blank lines, then hand-parse the known shape.
+    out, cur_list, cur_item, section = {}, None, None, None
+    stack = []
+    for raw in text.splitlines():
+        line = raw.split("#")[0].rstrip() if not raw.strip().startswith("#") else ""
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        s = line.strip()
+        if indent == 0 and s.endswith(":"):
+            section = s[:-1]
+            out[section] = {} if section in ("target", "source") else []
+            continue
+        if section in ("target", "source"):
+            k, _, v = s.partition(":")
+            out[section][k.strip()] = v.strip()
+            continue
+        if s.startswith("- "):
+            cur_item = {}
+            out[section].append(cur_item)
+            s = s[2:]
+        if not s or cur_item is None:
+            continue
+        k, _, v = s.partition(":")
+        k, v = k.strip(), v.strip()
+        if v.startswith("[") and v.endswith("]"):
+            cur_item[k] = [x.strip() for x in v[1:-1].split(",") if x.strip()]
+        elif v in ("", ">-", "|"):
+            cur_item[k] = cur_item.get(k, "")
+            cur_item.setdefault("_pending", k)
+        elif v in ("true", "false"):
+            cur_item[k] = v == "true"
+        else:
+            if cur_item.get("_pending") == k:
+                cur_item.pop("_pending", None)
+            cur_item[k] = v
+        if k == "overrides":
+            cur_item[k] = {}
+            cur_item["_in_overrides"] = True
+    return out
+
+# The hand-parser above cannot handle nested `overrides:` maps or folded
+# scalars, so re-read those with a targeted pass.
+def load_overrides(path):
+    result, name, in_ov = {}, None, False
+    for raw in open(path).read().splitlines():
+        line = raw.split("#")[0].rstrip() if not raw.strip().startswith("#") else ""
+        if not line.strip():
+            continue
+        s = line.strip()
+        if s.startswith("- name:"):
+            name, in_ov = s.split(":", 1)[1].strip(), False
+            result.setdefault(name, {})
+        elif s == "overrides:":
+            in_ov = True
+        elif in_ov and s.endswith(":"):
+            in_ov = False
+        elif in_ov and ":" in s and name:
+            k, _, v = s.partition(":")
+            result[name][k.strip()] = v.strip()
+    return result
+
+spec = load_spec(SPEC)
+overrides_by_name = load_overrides(SPEC)
+TGT_CTX = spec["target"]["context"]
+TGT_NS = spec["target"]["namespace"]
+SRC_CTX = spec["source"]["context"]
+
+def kget(ctx, ns, name):
+    r = subprocess.run(
+        ["kubectl", "--context", ctx, "-n", ns, "get", "secret", name, "-o", "json"],
+        capture_output=True, text=True)
+    return json.loads(r.stdout).get("data", {}) if r.returncode == 0 else None
+
+def redact(value):
+    """Keep hosts visible, strip credentials — a wrong host is the bug we hunt."""
+    import re
+    return re.sub(r"(//)[^:/@]*:[^@]*@", r"\1***:***@", value)
+
+problems, changes = [], []
+
+# ---------------------------------------------------------------------------
+# 1. Secrets provisioned from the old cluster
+# ---------------------------------------------------------------------------
+print(f"target {TGT_CTX}/{TGT_NS}   source {SRC_CTX}\n")
+for item in spec.get("secrets", []):
+    name = item["name"]
+    src_ns, _, src_name = item["from"].partition("/")
+    copy_keys = item.get("copy_keys", [])
+    ovr = overrides_by_name.get(name, {})
+    merge = item.get("merge", False)
+
+    src = kget(SRC_CTX, src_ns, src_name)
+    dst = kget(TGT_CTX, TGT_NS, name)
+
+    want = {}
+    for k in copy_keys:
+        if src is None:
+            continue
+        if k in src:
+            want[k] = src[k]
+    for k, v in ovr.items():
+        want[k] = base64.b64encode(v.encode()).decode()
+
+    if dst is None and not merge:
+        problems.append(f"{name}: secret does not exist on the target")
+        changes.append((name, "create", sorted(want)))
+        print(f"  MISSING  {name}  (would create with {len(want)} keys)")
+        continue
+    if dst is None and merge:
+        problems.append(f"{name}: expected to exist for merge, but is absent")
+        print(f"  MISSING  {name}  (merge target absent — create it first)")
+        continue
+
+    missing = [k for k in want if k not in dst]
+    wrong = [k for k, v in ovr.items()
+             if k in dst and base64.b64decode(dst[k]).decode(errors="replace") != v]
+    if missing or wrong:
+        for k in missing:
+            problems.append(f"{name}/{k}: missing")
+        for k in wrong:
+            actual = base64.b64decode(dst[k]).decode(errors="replace")
+            problems.append(f"{name}/{k}: is '{actual}', spec requires '{ovr[k]}'")
+        changes.append((name, "merge", sorted(set(missing) | set(wrong))))
+        print(f"  DRIFT    {name}  missing={missing} wrong={wrong}")
+    else:
+        print(f"  ok       {name}")
+
+# ---------------------------------------------------------------------------
+# 2. Invariants — v2-specific values that must never be old-cluster copies
+# ---------------------------------------------------------------------------
+print("\ninvariants:")
+for inv in spec.get("invariants", []):
+    name, key, needle = inv["secret"], inv["key"], inv["must_contain"]
+    dst = kget(TGT_CTX, TGT_NS, name)
+    if dst is None or key not in dst:
+        problems.append(f"{name}/{key}: absent, cannot check invariant")
+        print(f"  ABSENT   {name}/{key}")
+        continue
+    val = base64.b64decode(dst[key]).decode(errors="replace")
+    if needle in val:
+        print(f"  ok       {name}/{key} contains {needle}")
+    else:
+        problems.append(f"{name}/{key}: expected to contain '{needle}', got '{redact(val)}'")
+        print(f"  WRONG    {name}/{key} = {redact(val)}")
+        print(f"           expected to contain: {needle}")
+
+# ---------------------------------------------------------------------------
+# 3. Manually provisioned secrets — presence only, never contents
+# ---------------------------------------------------------------------------
+print("\nmanual (not provisioned by this script):")
+for m in spec.get("manual", []):
+    ns = m.get("namespace", TGT_NS)
+    dst = kget(TGT_CTX, ns, m["name"])
+    if dst is None:
+        problems.append(f"{ns}/{m['name']}: absent (manual provisioning required)")
+        print(f"  ABSENT   {ns}/{m['name']}")
+    else:
+        missing = [k for k in m.get("keys", []) if k not in dst]
+        if missing:
+            problems.append(f"{ns}/{m['name']}: missing keys {missing}")
+            print(f"  PARTIAL  {ns}/{m['name']}  missing={missing}")
+        else:
+            print(f"  ok       {ns}/{m['name']}")
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+if MODE == "apply" and changes:
+    print("\napplying:")
+    for name, action, keys in changes:
+        item = next(i for i in spec["secrets"] if i["name"] == name)
+        src_ns, _, src_name = item["from"].partition("/")
+        src = kget(SRC_CTX, src_ns, src_name) or {}
+        ovr = overrides_by_name.get(name, {})
+        data = {k: src[k] for k in item.get("copy_keys", []) if k in src}
+        for k, v in ovr.items():
+            data[k] = base64.b64encode(v.encode()).decode()
+        if action == "create":
+            body = {"apiVersion": "v1", "kind": "Secret", "type": "Opaque",
+                    "metadata": {"name": name, "namespace": TGT_NS}, "data": data}
+            r = subprocess.run(["kubectl", "--context", TGT_CTX, "apply", "-f", "-"],
+                               input=json.dumps(body), capture_output=True, text=True)
+        else:
+            # Merge only the drifted keys. Never replace: these secrets also hold
+            # v2-specific values (Kafka, substreams, IPFS) that the source would
+            # overwrite with old-cluster ones.
+            patch = [{"op": "add", "path": f"/data/{k}", "value": data[k]}
+                     for k in keys if k in data]
+            r = subprocess.run(["kubectl", "--context", TGT_CTX, "-n", TGT_NS, "patch",
+                                "secret", name, "--type=json", "-p", json.dumps(patch)],
+                               capture_output=True, text=True)
+        print(f"  {action:6} {name}: {'ok' if r.returncode == 0 else r.stderr.strip()[:90]}")
+    print("\nWorkloads must be restarted to pick up changed secrets:")
+    print("  kubectl --context %s -n %s rollout restart deploy --all" % (TGT_CTX, TGT_NS))
+
+# ---------------------------------------------------------------------------
+print()
+if problems:
+    print(f"{len(problems)} problem(s):")
+    for p in problems:
+        print(f"  - {p}")
+    if MODE == "verify":
+        print("\nRun with --apply to fix what this script provisions.")
+        print("Anything under `manual` has to be created by hand — see the spec.")
+    sys.exit(1)
+print("All secrets match the spec.")
+PYTHON

--- a/scripts/v2-secrets.spec.yaml
+++ b/scripts/v2-secrets.spec.yaml
@@ -1,0 +1,160 @@
+# Declarative spec for the v2 cluster's Kubernetes secrets.
+#
+# Consumed by scripts/provision-v2-secrets.sh. Contains NO secret values — only
+# where each value comes from, and which values must be rewritten for v2.
+#
+# The point of this file is the `overrides` blocks. Every v2 incident so far
+# involving secrets has been a value copied verbatim from the old cluster that
+# needed re-pointing and did not get it:
+#
+#   VALKEY_URL              pointed at api-cache.api-staging (NXDOMAIN here)
+#   SENTRY_*                absent entirely — no error reporting after cutover
+#   SENTRY_RELEASE (atlas)  said hermes-ipfs-cache@1.0.0
+#
+# Each was invisible because the affected feature was off or unmonitored.
+# `--verify` exists to make that class of drift loud.
+#
+# ---------------------------------------------------------------------------
+# copy_keys   keys taken verbatim from the source secret
+# overrides   keys forced to a v2-specific value, ALWAYS applied after copying
+# merge       true  -> add keys to an existing secret, never replace it
+#             false -> create the secret from these keys alone
+# ---------------------------------------------------------------------------
+#
+# `merge: true` is load-bearing. The old cluster's hermes/kg secrets also hold
+# KAFKA_BROKER, SUBSTREAMS_ENDPOINT and IPFS_GATEWAY_URL. Replacing rather than
+# merging would repoint v2's indexers at the old Kafka and chain 19411.
+
+target:
+  context: do-nyc2-geo-testnet-k8s
+  namespace: gaia
+
+source:
+  # Where copied credentials come from today. The old cluster is being retired;
+  # when it goes, replace this with a secrets manager and keep the spec as-is.
+  context: do-nyc2-k8s-geo-testnet
+
+secrets:
+  - name: api-sentry
+    from: api/api-sentry
+    merge: false
+    copy_keys: [SENTRY_DSN, SENTRY_DEBUG, SENTRY_RELEASE, SENTRY_TRACES_SAMPLE_RATE]
+    overrides:
+      SENTRY_ENVIRONMENT: production-v2
+
+  - name: atlas-otel
+    from: knowledge/atlas-otel
+    merge: false
+    # OTEL_* deliberately not copied: the v2 atlas deployment references only
+    # SENTRY_*, and the OTEL endpoint is old-cluster infrastructure.
+    copy_keys: [SENTRY_DSN, SENTRY_DEBUG, SENTRY_SEND_DEFAULT_PII, SENTRY_TRACES_SAMPLE_RATE]
+    overrides:
+      SENTRY_ENVIRONMENT: production-v2
+      # The old cluster has this as hermes-ipfs-cache@1.0.0 — wrong there, and
+      # not worth reproducing here.
+      SENTRY_RELEASE: atlas@1.0.0
+
+  - name: topology-indexer-secrets
+    from: scoring/topology-indexer-secrets
+    merge: false
+    copy_keys: [SENTRY_DSN]
+    overrides:
+      SENTRY_ENVIRONMENT: production-v2
+
+  - name: vote-indexer-secrets
+    from: scoring/vote-indexer-secrets
+    merge: false
+    copy_keys: [SENTRY_DSN, SENTRY_RELEASE, SENTRY_SEND_DEFAULT_PII, SENTRY_TRACES_SAMPLE_RATE]
+    overrides:
+      SENTRY_ENVIRONMENT: production-v2
+
+  - name: scoring-cronjob-secrets
+    from: scoring/scoring-cronjob-secrets
+    merge: false
+    copy_keys: [SENTRY_DSN, SENTRY_RELEASE, SENTRY_SEND_DEFAULT_PII, SENTRY_TRACES_SAMPLE_RATE]
+    overrides:
+      SENTRY_ENVIRONMENT: production-v2
+
+  - name: hermes-pipeline-secrets
+    from: knowledge/hermes-pipeline-secrets
+    merge: true
+    copy_keys: [SENTRY_DSN, SENTRY_DEBUG, SENTRY_RELEASE, SENTRY_SEND_DEFAULT_PII, SENTRY_TRACES_SAMPLE_RATE]
+    overrides:
+      SENTRY_ENVIRONMENT: production-v2
+
+  - name: hermes-ipfs-cache-secrets
+    from: knowledge/hermes-ipfs-cache-secrets
+    merge: true
+    copy_keys: [SENTRY_DSN, SENTRY_DEBUG, SENTRY_RELEASE, SENTRY_SEND_DEFAULT_PII, SENTRY_TRACES_SAMPLE_RATE]
+    overrides:
+      SENTRY_ENVIRONMENT: production-v2
+
+  - name: kg-indexer-secrets
+    from: knowledge/kg-indexer-secrets
+    merge: true
+    copy_keys: [SENTRY_DSN, SENTRY_DEBUG, SENTRY_RELEASE, SENTRY_SEND_DEFAULT_PII, SENTRY_TRACES_SAMPLE_RATE]
+    overrides:
+      SENTRY_ENVIRONMENT: production-v2
+
+# Values that must be v2-specific regardless of where the secret came from.
+# `--verify` fails if the live cluster disagrees. This is the tripwire for the
+# whole class of copy-from-old-cluster mistakes.
+invariants:
+  - secret: api-cache-secrets
+    key: VALKEY_URL
+    must_contain: api-cache.gaia.svc.cluster.local
+    note: >-
+      Was api-cache.api-staging.svc.cluster.local, a namespace that does not
+      exist on this cluster. Failed open to the database, so it was silent.
+
+  - secret: api-secrets
+    key: DATABASE_URL
+    must_contain: db-pgsql-gaia-testnet
+    note: v2 has its own Postgres; the old cluster's is db-postgresql-nyc2-02334.
+
+  - secret: kafka-credentials
+    key: KAFKA_BROKER
+    must_contain: geo-testnet-kafka
+    note: v2 has its own Kafka; the old cluster's is db-kafka-nyc2-08394.
+
+  - secret: hermes-ipfs-cache-secrets
+    key: SUBSTREAMS_ENDPOINT
+    must_contain: geotestnet.substreams.pinax.network
+    note: >-
+      geotestnet is chain 55516. geotest is the old chain 19411 — pointing here
+      at geotest silently indexes the wrong chain.
+
+  - secret: proposal-executor-credentials
+    key: ZERODEV_SPONSORSHIP_RPC_URL
+    must_contain: /chain/55516
+    note: Sponsorship endpoint is chain-scoped.
+
+# Secrets that are NOT provisioned from the old cluster. Listed so a rebuild
+# does not silently omit them.
+manual:
+  - name: alertmanager-slack-webhook
+    namespace: monitoring
+    keys: [url, url-staging]
+    note: Alertmanager cannot send to Slack without this; copied from monitoring/alertmanager-slack-webhook.
+
+  - name: kube-prometheus-stack-grafana
+    namespace: monitoring
+    keys: [admin-user, admin-password]
+    note: values.yaml sets admin.existingSecret — Grafana CrashLoops with CreateContainerConfigError if absent.
+
+  - name: chain-tip-exporter-secrets
+    namespace: monitoring
+    keys: [RPC_URL]
+    note: Derive from gaia/proposal-executor-credentials RPC_URL (chain 55516).
+
+  - name: space-registry-admin-credentials
+    namespace: gaia
+    keys: [ADMIN_ADDRESS, ADMIN_PRIVATE_KEY]
+    note: Generated for v2; has no old-cluster equivalent. Not recoverable by copying.
+
+  - name: proposal-executor-credentials
+    namespace: gaia
+    keys: [EXECUTOR_PRIVATE_KEY, MEMBERSHIP_BOT_PRIVATE_KEY]
+    note: >-
+      v2-specific on-chain identities registered against the 55516 SpaceRegistry.
+      Copying the old cluster's keys would point at unregistered accounts.


### PR DESCRIPTION
## Why

Every v2 secret problem so far has been the same mistake: a value copied verbatim from the old cluster that needed re-pointing and did not get it.

| what | was | consequence |
|---|---|---|
| `VALKEY_URL` | `api-cache.api-staging…` | NXDOMAIN here; failed open to the DB, so silent |
| `SENTRY_*` (8 secrets) | absent | **no error reporting at all** after cutover |
| `SENTRY_RELEASE` (atlas) | `hermes-ipfs-cache@1.0.0` | atlas reporting under another service's tag |
| `gaia_namespace` | `knowledge` | chain-tip-exporter would not join to hermes metrics |
| ServiceMonitor scopes | `knowledge` / `api-staging` | nothing scraped |

Each was invisible because the affected feature was switched off or unmonitored. **None of it is in git**, so a cluster rebuild would reproduce all of it.

## What this adds

`scripts/v2-secrets.spec.yaml` — where each value comes from, and which values must be v2-specific. No secret values.

`scripts/provision-v2-secrets.sh`:

```
./scripts/provision-v2-secrets.sh            # verify (read-only, default)
./scripts/provision-v2-secrets.sh --apply    # create/merge missing keys
```

Verify exits non-zero on drift, so it is safe to wire into CI or a cron.

## Two properties worth preserving in review

**`merge: true` on the hermes/kg secrets.** Those also hold `KAFKA_BROKER`, `SUBSTREAMS_ENDPOINT` and `IPFS_GATEWAY_URL`. Replacing rather than merging would repoint v2's indexers at the **old Kafka and chain 19411**. The script only ever patches the drifted keys.

**`invariants:`** assert the v2-specific values directly — Valkey host, v2 Postgres, v2 Kafka, `geotestnet` (55516) not `geotest` (19411), `/chain/55516`. This is the tripwire for the whole class, independent of where a secret came from.

## Verified, not assumed

```
$ ./scripts/provision-v2-secrets.sh
  ok  api-sentry / atlas-otel / topology / vote / scoring / hermes x2 / kg-indexer
  ok  all 5 invariants
  ok  all 5 manual secrets present
  All secrets match the spec.                                    exit 0
```

A green check on a tripwire that has never fired proves nothing, so I tested both failure paths against the live cluster and restored afterwards:

- Reintroduced the original `api-staging` Valkey URL → `WRONG api-cache-secrets/VALKEY_URL … expected to contain api-cache.gaia.svc.cluster.local`, exit 1
- Deleted `api-sentry` → `MISSING api-sentry (would create with 5 keys)`, exit 1

Both restored; final verify passes. `shellcheck` clean.

## Deliberately out of scope

- **`manual:`** lists what cannot be provisioned by copying — the executor and space-registry keys are v2-specific on-chain identities (copying the old cluster's would point at unregistered accounts), and the Slack/Grafana secrets are hand-created. Listed so a rebuild does not silently omit them.
- **`AXIOM_*`** on the three hermes/kg services is still absent, pending a decision on whether that account is in use.
- The `source:` context is the old cluster, which is being retired. When it goes, that field becomes a secrets manager and the rest of the spec is unchanged.