### PR TITLE
docs(scripts): record why AXIOM_* is absent, and its panic footgun

### DIFF
--- a/scripts/v2-secrets.spec.yaml
+++ b/scripts/v2-secrets.spec.yaml
@@ -158,3 +158,37 @@ manual:
     note: >-
       v2-specific on-chain identities registered against the 55516 SpaceRegistry.
       Copying the old cluster's keys would point at unregistered accounts.
+
+# ---------------------------------------------------------------------------
+# Deliberately absent
+# ---------------------------------------------------------------------------
+#
+# AXIOM_TOKEN / AXIOM_DATASET on hermes-pipeline-secrets,
+# hermes-ipfs-cache-secrets and kg-indexer-secrets.
+#
+# These are NOT an oversight. The old cluster has them; v2 does not, and the
+# three services run fine without them because the env refs are optional.
+#
+# ** If you add them, add BOTH keys in the same change. **
+#
+# `AxiomConfig::from_env()` (hermes-instrumentation/src/config.rs) panics when
+# AXIOM_TOKEN is set but AXIOM_DATASET is missing or empty — and vice versa for
+# an empty token. The panic happens during telemetry init, before the runtime
+# starts, so a half-provisioned pair crashloops hermes-pipeline,
+# hermes-ipfs-cache and kg-indexer at boot. That is the one change in this file
+# capable of taking the indexing stack down.
+#
+# Adding them is a real feature, not dead config: init.rs builds an OTLP
+# SpanExporter to https://api.axiom.co/v1/traces behind a BatchSpanProcessor,
+# so enabling it starts shipping distributed traces for real.
+#
+# Left off as of 2026-08-04 because nothing indicates the Axiom account is
+# still watched, and Sentry (errors) plus Prometheus (metrics and alerting)
+# already cover the gaps that actually hurt. Confirm ownership of the account
+# before enabling.
+#
+# To enable, add to the copy_keys of all three secrets together:
+#   copy_keys: [SENTRY_..., AXIOM_TOKEN, AXIOM_DATASET]
+# and consider whether AXIOM_DATASET should be overridden per environment — the
+# old cluster's value is the bare service name (`hermes-pipeline`), so v2 traces
+# would land in the same dataset as the old cluster's and be indistinguishable.


### PR DESCRIPTION
Comment-only change to `scripts/v2-secrets.spec.yaml`.

`AXIOM_TOKEN` / `AXIOM_DATASET` exist on the old cluster's hermes/kg secrets but not on v2. With nothing recorded, that reads as an oversight — and the obvious fix is the one dangerous change in this file.

## The footgun

`AxiomConfig::from_env()` (`hermes-instrumentation/src/config.rs`) panics when the pair is half-set:

```rust
let token = std::env::var("AXIOM_TOKEN").ok()?;
if token.is_empty() { panic!("AXIOM_TOKEN is set but empty …"); }
…
Some(_) => panic!("AXIOM_DATASET is set but empty …"),
None    => panic!("AXIOM_TOKEN is set but AXIOM_DATASET is not - both are required"),
```

This runs during telemetry init, before the runtime starts, so provisioning one key without the other **crashloops hermes-pipeline, hermes-ipfs-cache and kg-indexer at boot**. Nothing else in the spec can take indexing down.

## Also recorded

- **It is a live feature, not dead config.** `init.rs` builds an OTLP `SpanExporter` to `https://api.axiom.co/v1/traces` behind a `BatchSpanProcessor` — enabling it really does start shipping traces.
- **`AXIOM_DATASET` needs an override if enabled.** The old cluster's value is the bare service name (`hermes-pipeline`), so v2 traces would land in the same dataset as the old cluster's and be indistinguishable — the same trap `SENTRY_ENVIRONMENT` had.
- **Why it is off as of 2026-08-04**: nothing indicates the Axiom account is still watched, and Sentry plus Prometheus now cover the gaps that actually hurt. Ownership should be confirmed before enabling.

## Test plan

- [x] `./scripts/provision-v2-secrets.sh` still exits 0 — the spec uses a hand-rolled parser, so added comments were worth re-checking rather than assuming
- [x] Both claims verified against the source rather than from memory