### PR TITLE
perf(proposal-executor): ask the DAO before paying to find out

### DIFF
--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -190,6 +190,26 @@ export const TESTNET_SAFE_ADDRESSES = {
 // ---------------------------------------------------------------------------
 
 /** keccak256('GOVERNANCE.PROPOSAL_EXECUTED') — action hash for enter() */
+/**
+ * DAOSpace ABI — the single view we need to avoid wasting sponsored simulations.
+ *
+ * `canExecuteProposal` is the exact predicate `_executeProposal` checks before
+ * it reverts with `CanNotExecute()` (0xdf322356). Calling it first is a free
+ * `eth_call`; letting it fail instead costs a sponsored UserOperation
+ * simulation and produces a `proposal_reverted` log that reads like a fault.
+ *
+ * See geo-migration `contracts/src/contracts/DAOSpace.sol`.
+ */
+export const DaoSpaceAbi = [
+	{
+		inputs: [{internalType: "bytes16", name: "_proposalId", type: "bytes16"}],
+		name: "canExecuteProposal",
+		outputs: [{internalType: "bool", name: "_canExecuteProposal", type: "bool"}],
+		stateMutability: "view",
+		type: "function",
+	},
+] as const
+
 export const PROPOSAL_EXECUTED_ACTION = "0x62a60c0a9681612871e0dafa0f24bb0c83cbdde8be5a6299979c88d382369e96" as Hex
 
 /** keccak256('GOVERNANCE.PROPOSAL_VOTED') — action hash for casting a vote via enter() */

--- a/proposal-executor/src/execute.ts
+++ b/proposal-executor/src/execute.ts
@@ -31,6 +31,7 @@ import {
 import {entryPoint07Address} from "viem/account-abstraction"
 import {privateKeyToAccount} from "viem/accounts"
 import {
+	DaoSpaceAbi,
 	EMPTY_SIGNATURE,
 	getChain,
 	InfraError,
@@ -319,6 +320,18 @@ export function classifyAsRevert(error: unknown, errorName: string, message: str
  *
  * Retry and timeout are composed externally in index.ts.
  */
+/**
+ * Raised by the pre-flight check when the DAO reports the proposal cannot
+ * execute. A named class rather than a message match, so classification does
+ * not depend on error text we do not control.
+ */
+class NotExecutableError extends Error {
+	constructor() {
+		super("canExecuteProposal returned false — skipped before simulation")
+		this.name = "NotExecutableError"
+	}
+}
+
 export function executeProposal(
 	wallet: SmartWallet,
 	proposal: Proposal,
@@ -334,6 +347,40 @@ export function executeProposal(
 			try: async () => {
 				const daoSpaceId = uuidToBytes16(proposal.spaceId)
 				const proposalIdHex = uuidToBytes16(proposal.id)
+
+				// Ask the DAO whether this can execute before paying to find out.
+				//
+				// `_executeProposal` reverts with CanNotExecute() (0xdf322356) when
+				// `canExecuteProposal` is false. Reaching that revert costs a sponsored
+				// UserOperation simulation and logs `proposal_reverted`, which reads as
+				// a fault. Checking first is a plain eth_call and costs nothing.
+				//
+				// This is not a race guard — a proposal can still be executed by someone
+				// else between the check and the send, which the RevertError path below
+				// still handles. It exists because the migration left proposals in the
+				// database that were never created on chain 55516, so they can NEVER
+				// execute: `creator == bytes16(0)`. Without this, each one burns a
+				// sponsored simulation every run, forever. See gaia notes on
+				// v2-proposals-absent-on-chain.
+				const daoAddress = await wallet.publicClient.readContract({
+					address: spaceRegistryAddress,
+					abi: SpaceRegistryAbi,
+					functionName: "spaceIdToAddress",
+					args: [daoSpaceId],
+				})
+
+				const canExecute = await wallet.publicClient.readContract({
+					address: daoAddress,
+					abi: DaoSpaceAbi,
+					functionName: "canExecuteProposal",
+					args: [proposalIdHex],
+				})
+
+				if (!canExecute) {
+					// Deliberately a RevertError with expected: true — this is a skip, not
+					// a failure, and the caller already treats expected reverts as such.
+					throw new NotExecutableError()
+				}
 
 				const calldata = encodeFunctionData({
 					abi: SpaceRegistryAbi,
@@ -371,11 +418,12 @@ export function executeProposal(
 				// Capture error type for observability — helps tighten classification over time
 				const errorName = error instanceof Error ? error.name : typeof error
 
-				const isRevert = classifyAsRevert(error, errorName, message)
+				const isRevert = error instanceof NotExecutableError || classifyAsRevert(error, errorName, message)
 
 				if (isRevert) {
 					// Expected reverts: proposal already executed (race condition window)
 					const isExpected =
+						error instanceof NotExecutableError ||
 						message.includes("already executed") ||
 						message.includes("ProposalAlreadyExecuted") ||
 						message.includes("InvalidAction")


### PR DESCRIPTION
## Problem

Every run, the executor builds and submits a sponsored UserOperation for ~8 proposals that **can never execute**, and each reverts with `CanNotExecute()` (`0xdf322356`).

That is a sponsored simulation burned per proposal per run — every 5 minutes, indefinitely — plus a `proposal_reverted` log line per proposal that reads like a fault when it is a no-op. Current runs look like:

```
run_start           proposalsFound: 9, spaces: 4
proposal_reverted   x8
run_end             succeeded: 0, failed: 0, skipped: 8
```

## Why those proposals can never execute

They are a migration artifact. They exist in the v2 database but were never created on chain 55516 — reading the DAO directly shows `creator == bytes16(0)`, empty tally, no actions. Of 24,246 proposals in the v2 DB, only the few hundred created natively on 55516 exist on-chain.

They do not age out either: detection drops proposals older than `MAX_PROPOSAL_AGE` (7 days), but `proposals.created_at` carries **migration replay time** rather than original creation time, so all 3,252 unexecuted proposals look fresh and the clock restarts on every delta migration.

## Fix

`canExecuteProposal` is the exact predicate `_executeProposal` checks before reverting (geo-migration `contracts/src/contracts/DAOSpace.sol`). Call it first — it is a plain `eth_call` and costs nothing.

**This is not a race guard.** A proposal can still be executed by someone else between the check and the send, and the existing `RevertError` path still handles that. It exists for the permanently-impossible ones.

Skips raise a named `NotExecutableError`, classified as an *expected* revert, so they log as `proposal_skip_expected` rather than `proposal_reverted`. Classification is by class, not by matching error text we do not control.

## Test plan

- [x] `tsc --noEmit` clean — and verified the check actually fails on an injected error, rather than trusting a green exit code
- [x] `biome check` clean
- [x] `bun test` — 137 pass, 0 fail
- [ ] After deploy, confirm runs log `proposal_skip_expected` instead of `proposal_reverted` and that sponsored simulations drop

## Related, not fixed here

Repairing `proposals.created_at` from prod would let these age out on their own, which is the more complete fix. Separate change — this one stops the bleeding without touching data.