### PR TITLE
ci: run tests and checks on the staging branch

### DIFF
--- a/.github/workflows/api-cache-integration-tests.yml
+++ b/.github/workflows/api-cache-integration-tests.yml
@@ -2,7 +2,7 @@ name: API Cache Integration Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'api/src/kg/valkeyCache.ts'
       - 'api/src/kg/postgraphile.ts'
@@ -12,7 +12,7 @@ on:
       - 'api/package.json'
       - '.github/workflows/api-cache-integration-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'api/src/kg/valkeyCache.ts'
       - 'api/src/kg/postgraphile.ts'

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -2,11 +2,11 @@ name: API Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'api/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'api/**'
 

--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -2,13 +2,13 @@ name: API Integration Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'api/**'
       - 'api/drizzle/**'
       - '.github/workflows/api-integration-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'api/**'
       - 'api/drizzle/**'

--- a/.github/workflows/api-unit-tests.yml
+++ b/.github/workflows/api-unit-tests.yml
@@ -2,12 +2,12 @@ name: API Unit Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'api/**'
       - 'api/drizzle/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'api/**'
       - 'api/drizzle/**'

--- a/.github/workflows/atlas-check.yml
+++ b/.github/workflows/atlas-check.yml
@@ -2,7 +2,7 @@ name: Atlas Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'atlas/**'
       - 'hermes-instrumentation/**'
@@ -10,7 +10,7 @@ on:
       - 'hermes-substream/**'
       - 'stream/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'atlas/**'
       - 'hermes-instrumentation/**'

--- a/.github/workflows/atlas-e2e-tests.yml
+++ b/.github/workflows/atlas-e2e-tests.yml
@@ -2,7 +2,7 @@ name: Atlas E2E Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'atlas/**'
       - 'hermes-relay/**'
@@ -10,7 +10,7 @@ on:
       - 'stream/**'
       - '.github/workflows/atlas-e2e-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'atlas/**'
       - 'hermes-relay/**'

--- a/.github/workflows/atlas-unit-tests.yml
+++ b/.github/workflows/atlas-unit-tests.yml
@@ -2,14 +2,14 @@ name: Atlas Unit Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'atlas/**'
       - 'hermes-relay/**'
       - 'hermes-substream/**'
       - 'stream/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'atlas/**'
       - 'hermes-relay/**'

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -7,14 +7,14 @@ name: Cargo Deny (supply-chain)
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - '**/Cargo.toml'
       - 'Cargo.lock'
       - 'deny.toml'
       - '.github/workflows/cargo-deny.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - '**/Cargo.toml'
       - 'Cargo.lock'

--- a/.github/workflows/chain-tip-exporter-check.yml
+++ b/.github/workflows/chain-tip-exporter-check.yml
@@ -2,12 +2,12 @@ name: Chain Tip Exporter Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'chain-tip-exporter/**'
       - 'hermes-instrumentation/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'chain-tip-exporter/**'
       - 'hermes-instrumentation/**'

--- a/.github/workflows/delivery-worker-tests.yml
+++ b/.github/workflows/delivery-worker-tests.yml
@@ -3,12 +3,12 @@ name: Delivery Worker Unit Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, dev, feat/notification-service]  # TODO: remove feat branch before merge
+    branches: [main, dev, staging, feat/notification-service]  # TODO: remove feat branch before merge
     paths:
       - 'notification-service/delivery-worker/**'
       - '.github/workflows/delivery-worker-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'notification-service/delivery-worker/**'
       - '.github/workflows/delivery-worker-tests.yml'

--- a/.github/workflows/hermes-ipfs-cache-check.yml
+++ b/.github/workflows/hermes-ipfs-cache-check.yml
@@ -2,7 +2,7 @@ name: Hermes IPFS Cache Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'hermes-ipfs-cache/**'
       - 'hermes-relay/**'
@@ -11,7 +11,7 @@ on:
       - 'ipfs/**'
       - 'stream/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'hermes-ipfs-cache/**'
       - 'hermes-relay/**'

--- a/.github/workflows/hermes-pipeline-check.yml
+++ b/.github/workflows/hermes-pipeline-check.yml
@@ -2,7 +2,7 @@ name: Hermes Pipeline Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'hermes-pipeline/**'
       - 'hermes-instrumentation/**'
@@ -13,7 +13,7 @@ on:
       - 'stream/**'
       - 'wire/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'hermes-pipeline/**'
       - 'hermes-instrumentation/**'

--- a/.github/workflows/hermes-relay-check.yml
+++ b/.github/workflows/hermes-relay-check.yml
@@ -2,13 +2,13 @@ name: Hermes Relay Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'hermes-relay/**'
       - 'hermes-substream/**'
       - 'stream/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'hermes-relay/**'
       - 'hermes-substream/**'

--- a/.github/workflows/ipfs-check.yml
+++ b/.github/workflows/ipfs-check.yml
@@ -2,11 +2,11 @@ name: IPFS Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'ipfs/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'ipfs/**'
 

--- a/.github/workflows/kg-indexer-check.yml
+++ b/.github/workflows/kg-indexer-check.yml
@@ -2,14 +2,14 @@ name: KG Indexer Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'kg-indexer/**'
       - 'hermes-schema/**'
       - 'wire/**'
       - 'indexer_utils/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'kg-indexer/**'
       - 'hermes-schema/**'

--- a/.github/workflows/kg-indexer-e2e-tests.yml
+++ b/.github/workflows/kg-indexer-e2e-tests.yml
@@ -2,7 +2,7 @@ name: KG Indexer E2E Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'kg-indexer/**'
       - 'hermes-pipeline/**'
@@ -12,7 +12,7 @@ on:
       - 'wire/**'
       - 'api/drizzle/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'kg-indexer/**'
       - 'hermes-pipeline/**'

--- a/.github/workflows/kg-indexer-unit-tests.yml
+++ b/.github/workflows/kg-indexer-unit-tests.yml
@@ -2,14 +2,14 @@ name: KG Indexer Unit Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'kg-indexer/**'
       - 'hermes-schema/**'
       - 'wire/**'
       - 'indexer_utils/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'kg-indexer/**'
       - 'hermes-schema/**'

--- a/.github/workflows/membership-acceptor-check.yml
+++ b/.github/workflows/membership-acceptor-check.yml
@@ -2,7 +2,7 @@ name: Membership Acceptor Check
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'membership-acceptor/**'
       - '.github/workflows/membership-acceptor-check.yml'

--- a/.github/workflows/membership-acceptor-tests.yml
+++ b/.github/workflows/membership-acceptor-tests.yml
@@ -2,7 +2,7 @@ name: Membership Acceptor Tests
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'membership-acceptor/**'
       - '.github/workflows/membership-acceptor-tests.yml'

--- a/.github/workflows/notification-indexer-tests.yml
+++ b/.github/workflows/notification-indexer-tests.yml
@@ -3,14 +3,14 @@ name: Notification Indexer Unit Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, dev, feat/notification-service]  # TODO: remove feat branch before merge
+    branches: [main, dev, staging, feat/notification-service]  # TODO: remove feat branch before merge
     paths:
       - 'notification-service/notification-indexer/**'
       - 'hermes-schema/**'
       - 'hermes-kafka/**'
       - '.github/workflows/notification-indexer-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'notification-service/notification-indexer/**'
       - 'hermes-schema/**'

--- a/.github/workflows/notification-service-e2e-tests.yml
+++ b/.github/workflows/notification-service-e2e-tests.yml
@@ -3,14 +3,14 @@ name: Notification Service E2E Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, dev, feat/notification-service]  # TODO: remove feat branch before merge
+    branches: [main, dev, staging, feat/notification-service]  # TODO: remove feat branch before merge
     paths:
       - 'notification-service/**'
       - 'hermes-schema/**'
       - 'hermes-kafka/**'
       - '.github/workflows/notification-service-e2e-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'notification-service/**'
       - 'hermes-schema/**'

--- a/.github/workflows/proposal-executor-check.yml
+++ b/.github/workflows/proposal-executor-check.yml
@@ -2,7 +2,7 @@ name: Proposal Executor Check
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'proposal-executor/**'
       - '.github/workflows/proposal-executor-check.yml'

--- a/.github/workflows/proposal-executor-tests.yml
+++ b/.github/workflows/proposal-executor-tests.yml
@@ -2,7 +2,7 @@ name: Proposal Executor Tests
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'proposal-executor/**'
       - '.github/workflows/proposal-executor-tests.yml'

--- a/.github/workflows/ranking-indexer-check.yml
+++ b/.github/workflows/ranking-indexer-check.yml
@@ -2,7 +2,7 @@ name: Ranking Indexer Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'ranking-indexer/**'
       - 'hermes-schema/**'
@@ -11,7 +11,7 @@ on:
       - 'indexer_utils/**'
       - 'sdk/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'ranking-indexer/**'
       - 'hermes-schema/**'

--- a/.github/workflows/scoring-cronjob-tests.yml
+++ b/.github/workflows/scoring-cronjob-tests.yml
@@ -2,7 +2,7 @@ name: Scoring Cronjob Tests
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'scoring-service/cronjob/**'
       - '.github/workflows/scoring-cronjob-tests.yml'

--- a/.github/workflows/scoring-topology-indexer-tests.yml
+++ b/.github/workflows/scoring-topology-indexer-tests.yml
@@ -2,14 +2,14 @@ name: Scoring Topology Indexer Unit Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'scoring-service/topology-indexer/**'
       - 'hermes-schema/**'
       - 'wire/**'
       - '.github/workflows/scoring-topology-indexer-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'scoring-service/topology-indexer/**'
       - 'hermes-schema/**'

--- a/.github/workflows/scoring-vote-indexer-tests.yml
+++ b/.github/workflows/scoring-vote-indexer-tests.yml
@@ -2,14 +2,14 @@ name: Vote Indexer Unit Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'scoring-service/vote-indexer/**'
       - 'hermes-schema/**'
       - 'wire/**'
       - '.github/workflows/scoring-vote-indexer-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'scoring-service/vote-indexer/**'
       - 'hermes-schema/**'

--- a/.github/workflows/search-indexer-docker-build.yml
+++ b/.github/workflows/search-indexer-docker-build.yml
@@ -2,7 +2,7 @@ name: Search Indexer Docker Build
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'search-indexer/**'
       - 'search-indexer-shared/**'
@@ -16,7 +16,7 @@ on:
       - 'sdk/**'
       - '.github/workflows/search-indexer-docker-build.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'search-indexer/**'
       - 'search-indexer-shared/**'

--- a/.github/workflows/search-indexer-e2e-tests.yml
+++ b/.github/workflows/search-indexer-e2e-tests.yml
@@ -2,7 +2,7 @@ name: Search Indexer E2E Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'search-indexer/**'
       - 'search-indexer-repository/**'
@@ -13,7 +13,7 @@ on:
       - 'search-indexer/tests/load-test/**'
       - '.github/workflows/search-indexer-e2e-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'search-indexer/**'
       - 'search-indexer-repository/**'

--- a/.github/workflows/search-indexer-unit-tests.yml
+++ b/.github/workflows/search-indexer-unit-tests.yml
@@ -2,7 +2,7 @@ name: Search Indexer Unit Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'search-indexer/**'
       - 'search-indexer-repository/**'
@@ -11,7 +11,7 @@ on:
       - 'wire/**'
       - '.github/workflows/search-indexer-unit-tests.yml'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'search-indexer/**'
       - 'search-indexer-repository/**'

--- a/.github/workflows/stream-check.yml
+++ b/.github/workflows/stream-check.yml
@@ -2,11 +2,11 @@ name: Stream Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'stream/**'
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, staging]
     paths:
       - 'stream/**'
 


### PR DESCRIPTION
`staging` is the integration branch in practice — every one of the last 15 merged PRs targeted it — but **no workflow referenced it**. So PRs into staging ran zero checks, and roughly 62 commits have merged without an automated test run.

This adds `staging` to the `push` and `pull_request` branch filters of the 31 test/check workflows.

## Scope

The only lines changed are branch filters:

```diff
-    branches: [main, dev]
+    branches: [main, dev, staging]
```

57 such lines across 31 files. Nothing else in any workflow is touched.

**Deliberately excluded:**

| Excluded | Why |
|---|---|
| every `*-deploy*.yml` | so this cannot change where anything deploys |
| `dev-sync-check.yml` | specifically about `dev` |
| `search-admin-build.yml` | publishes images, and has no `pull_request` trigger, so it adds nothing to PR CI |

## Verification

- No deploy workflow modified, and no file outside `.github/workflows/` touched — asserted, not eyeballed.
- All 66 workflows still parse as valid YAML.
- Programmatic re-read of the parsed `on:` blocks confirms `staging` present on `pull_request` for all 31 and on `push` for the 26 that have a push trigger (five are PR-only by design). No deploy workflow gained `staging`.
- 17 of the 31 include `.github/workflows` in their `paths`, so **this PR triggers them itself** — the checks appearing below are the proof the change works. The other 14 are path-filtered to their own service and won't run here.

## One thing to know: cargo-deny

`cargo-deny` is included for parity with main/dev, and it has been failing on its daily schedule for some time. It will now show **red on staging PRs too**.

That is pre-existing and unrelated to whatever a given PR changes. `staging` has no branch protection, so it doesn't block merges. But a check that's permanently red trains people to ignore CI, which defeats the point of this PR — it should be fixed or explicitly ignored as a follow-up rather than left as standing noise.

## Follow-ups this doesn't do

- Reconciling `main` and `staging` (their drizzle chains have forked — `0067`/`0068` mean different migrations on each branch).
- Deciding whether `dev` and the 14 `*-deploy-staging.yml` workflows should still exist; `dev` currently has zero unique commits and is 10 behind main.
- Disabling the 16 production deploy workflows before the legacy cluster is shut down — they all break when it goes away.
