### PR TITLE
chore: apply cargo fmt to the five drifting files

### DIFF
--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -680,10 +680,10 @@ async fn async_main() -> anyhow::Result<()> {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(82655); // Space Registry deployment block
-    // `0` is the Substreams protocol's sentinel for "never stop". Passing
-    // `u64::MAX` instead makes the server plan a bounded job of ~18 quintillion
-    // blocks: it backprocesses forever, emitting progress but never a single
-    // `BlockScopedData`.
+                           // `0` is the Substreams protocol's sentinel for "never stop". Passing
+                           // `u64::MAX` instead makes the server plan a bounded job of ~18 quintillion
+                           // blocks: it backprocesses forever, emitting progress but never a single
+                           // `BlockScopedData`.
     let end_block: u64 = env::var("SUBSTREAMS_END_BLOCK")
         .ok()
         .and_then(|s| s.parse().ok())

--- a/hermes-pipeline/src/decode.rs
+++ b/hermes-pipeline/src/decode.rs
@@ -170,8 +170,8 @@ pub fn decode_edits_published_args(data: &[u8]) -> Result<PublishArgs, DecodeErr
     // Params encoding (two offsets + tails), matching the SDK's
     // `encodeAbiParameters([{bytes}, {bytes}], ...)`.
     type EditsArgsType = sol! { (bytes, bytes) };
-    let (content_uri, metadata) =
-        EditsArgsType::abi_decode_params(data).map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+    let (content_uri, metadata) = EditsArgsType::abi_decode_params(data)
+        .map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
 
     let content_uri_str = decode_utf8_bytes(content_uri.to_vec())?;
 
@@ -692,8 +692,8 @@ fn decode_proposal_created_inner_v2(data: &[u8]) -> Result<ProposalCreatedData, 
         ParamType::FixedBytes(16),
         ParamType::Uint(8),
         ParamType::Array(Box::new(ParamType::Tuple(vec![
-            ParamType::Address,         // toAddress (decoded-and-discarded)
-            ParamType::FixedBytes(16),  // toSpaceId (decoded-and-discarded)
+            ParamType::Address,        // toAddress (decoded-and-discarded)
+            ParamType::FixedBytes(16), // toSpaceId (decoded-and-discarded)
             ParamType::Uint(256),
             ParamType::Bytes,
         ]))),
@@ -1658,14 +1658,25 @@ mod real_data_verification {
         let data = hex::decode(hex).unwrap();
 
         let (result, _unwrap_level) = decode_proposal_created(&data).unwrap();
-        assert_eq!(hex::encode(&result.proposal_id), "be7748130da24c9d841e77ef9c780a18");
+        assert_eq!(
+            hex::encode(&result.proposal_id),
+            "be7748130da24c9d841e77ef9c780a18"
+        );
         assert_eq!(result.voting_mode, 1);
         assert_eq!(result.actions.len(), 1);
         assert_eq!(
             hex::encode(&result.actions[0].to_address),
             "533b21f8af11753c8d2dbed1fbe7c1dd4962bd0e"
         );
-        assert_eq!(result.actions[0].to_space_id, vec![0u8; 16], "legacy action synthesizes zero toSpaceId");
-        assert_eq!(&result.actions[0].data[0..4], &[0x6b, 0x47, 0xf6, 0x1a][..], "publish() selector");
+        assert_eq!(
+            result.actions[0].to_space_id,
+            vec![0u8; 16],
+            "legacy action synthesizes zero toSpaceId"
+        );
+        assert_eq!(
+            &result.actions[0].data[0..4],
+            &[0x6b, 0x47, 0xf6, 0x1a][..],
+            "publish() selector"
+        );
     }
 }

--- a/hermes-pipeline/src/pipelines/spaces.rs
+++ b/hermes-pipeline/src/pipelines/spaces.rs
@@ -46,7 +46,11 @@ pub fn transform(actions: &[Action], meta: &BlockMetadata) -> Result<TransformRe
             // new owner address left-aligned in `topic`.
             address_updates.push(HermesSpaceAddressUpdated {
                 space_id: action.to_id.clone(),
-                address: action.topic.get(0..20).map(|s| s.to_vec()).unwrap_or_default(),
+                address: action
+                    .topic
+                    .get(0..20)
+                    .map(|s| s.to_vec())
+                    .unwrap_or_default(),
                 meta: Some(meta.to_proto(index as u32)),
             });
             continue;

--- a/hermes-substream/src/helpers.rs
+++ b/hermes-substream/src/helpers.rs
@@ -179,7 +179,9 @@ fn decode_proposal_actions_inner(data: &[u8]) -> Option<Vec<Vec<u8>>> {
     // data. Fall back to whichever decode succeeded at all, preferring v2.
     decode_proposal_tokens(data, 4)
         .and_then(|tokens| extract_action_field(&tokens, 3))
-        .or_else(|| decode_proposal_tokens(data, 3).and_then(|tokens| extract_action_field(&tokens, 2)))
+        .or_else(|| {
+            decode_proposal_tokens(data, 3).and_then(|tokens| extract_action_field(&tokens, 2))
+        })
 }
 
 /// Decode `(bytes16 proposalId, uint8 votingMode, Action[])` where each
@@ -457,7 +459,10 @@ mod tests {
         let ping = encode_edit_ping(&crate::ACTION_EDITS_PUBLISHED, uri);
         let proposal = encode_proposal_with_action(ping);
 
-        assert_eq!(extract_proposal_publish_uris(&proposal), vec![uri.to_string()]);
+        assert_eq!(
+            extract_proposal_publish_uris(&proposal),
+            vec![uri.to_string()]
+        );
     }
 
     #[test]
@@ -474,7 +479,10 @@ mod tests {
         ]));
         let proposal = encode_proposal_with_action_legacy(calldata);
 
-        assert_eq!(extract_proposal_publish_uris(&proposal), vec![uri.to_string()]);
+        assert_eq!(
+            extract_proposal_publish_uris(&proposal),
+            vec![uri.to_string()]
+        );
     }
 
     #[test]

--- a/kg-indexer/tests/governance_storage_integration.rs
+++ b/kg-indexer/tests/governance_storage_integration.rs
@@ -934,7 +934,18 @@ async fn test_process_tally_queue_backfills_executed_at_for_passed_fast_path() {
         "executed_at must be backfilled to the latest vote's timestamp once the effective threshold is cleared"
     );
 
-    cleanup_proposal(&pool, proposal_id, &[space_id, proposer_id, voter_ids[0], voter_ids[1], voter_ids[2]]).await;
+    cleanup_proposal(
+        &pool,
+        proposal_id,
+        &[
+            space_id,
+            proposer_id,
+            voter_ids[0],
+            voter_ids[1],
+            voter_ids[2],
+        ],
+    )
+    .await;
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
`cargo fmt --all --check` fails on five files that predate this change. It was invisible until #873 pointed CI at staging; now it fails the **Build & Lint** step of Atlas Check, Hermes Pipeline Check and KG Indexer Check on **every Rust PR**, which buries real signal under a permanent red.

Pure rustfmt output — no logic touched.

| File | |
|---|---|
| `atlas/src/main.rs` | comment indentation |
| `hermes-pipeline/src/decode.rs` | reflow |
| `hermes-pipeline/src/pipelines/spaces.rs` | method-chain wrapping |
| `hermes-substream/src/helpers.rs` | reflow |
| `kg-indexer/tests/governance_storage_integration.rs` | long-line wrapping |

## Verification

- `cargo fmt --all -- --check` → clean (exit 0)
- `cargo build --workspace --all-targets` → 0 errors
- These files are untouched by any open PR of mine; I confirmed the drift exists on pristine `origin/staging` by running `rustfmt --check` against the branch's own copies, so this isn't cleaning up after myself.

## Why separately from the other CI failures

`cargo-deny` is also red, but for an unrelated and more serious reason — three live RUSTSEC advisories (`anyhow` unsound downcast, `crossbeam-epoch` invalid pointer deref, and `ruint` incorrect overflow flags in Uint shift ops). That needs a dependency bump and a judgement call, not a formatter, so it doesn't belong in the same PR as whitespace.
