### PR TITLE
fix: read version-scoped proposal columns from their new home

### DIFF
--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -244,12 +244,18 @@ export function batchGetProposalsWithPublishActions(
 				SELECT
 					p.id as proposal_id,
 					p.space_id,
-					p.start_time,
-					p.end_time,
+					pv.start_time,
+					pv.end_time,
 					p.executed_at,
 					pa.content_uri
 				FROM proposals p
-				LEFT JOIN proposal_actions pa ON pa.proposal_id = p.id AND pa.action_type = 'Publish'
+				LEFT JOIN proposal_actions pa
+					ON pa.proposal_id = p.id
+					AND pa.proposal_version = p.current_version
+					AND pa.action_type = 'Publish'
+				INNER JOIN proposal_versions pv
+					ON pv.proposal_id = p.id
+					AND pv.proposal_version = p.current_version
 				WHERE p.id = ANY(${idsArray}::uuid[])
 			`)
 

--- a/kg-indexer/tests/e2e.rs
+++ b/kg-indexer/tests/e2e.rs
@@ -335,7 +335,11 @@ async fn test_proposal_1_details() {
 
     // Verify proposal exists in SPACE_A with Fast voting mode
     let proposal: Option<(Uuid, String)> =
-        sqlx::query_as("SELECT space_id, voting_mode::text FROM proposals WHERE id = $1")
+        sqlx::query_as(
+            // voting_mode is version-scoped since governance-v2; proposals_current
+            // is the view that re-exposes the current version's columns flat.
+            "SELECT space_id, voting_mode::text FROM proposals_current WHERE id = $1",
+        )
             .bind(proposal_id)
             .fetch_optional(&pool)
             .await
@@ -358,7 +362,11 @@ async fn test_proposal_2_details() {
 
     // Verify proposal exists in SPACE_A with Slow voting mode
     let proposal: Option<(Uuid, String)> =
-        sqlx::query_as("SELECT space_id, voting_mode::text FROM proposals WHERE id = $1")
+        sqlx::query_as(
+            // voting_mode is version-scoped since governance-v2; proposals_current
+            // is the view that re-exposes the current version's columns flat.
+            "SELECT space_id, voting_mode::text FROM proposals_current WHERE id = $1",
+        )
             .bind(proposal_id)
             .fetch_optional(&pool)
             .await

--- a/kg-indexer/tests/e2e.rs
+++ b/kg-indexer/tests/e2e.rs
@@ -334,16 +334,15 @@ async fn test_proposal_1_details() {
     let space_a = uuid_from_bytes(expected::SPACE_A);
 
     // Verify proposal exists in SPACE_A with Fast voting mode
-    let proposal: Option<(Uuid, String)> =
-        sqlx::query_as(
-            // voting_mode is version-scoped since governance-v2; proposals_current
-            // is the view that re-exposes the current version's columns flat.
-            "SELECT space_id, voting_mode::text FROM proposals_current WHERE id = $1",
-        )
-            .bind(proposal_id)
-            .fetch_optional(&pool)
-            .await
-            .expect("Failed to query proposal");
+    let proposal: Option<(Uuid, String)> = sqlx::query_as(
+        // voting_mode is version-scoped since governance-v2; proposals_current
+        // is the view that re-exposes the current version's columns flat.
+        "SELECT space_id, voting_mode::text FROM proposals_current WHERE id = $1",
+    )
+    .bind(proposal_id)
+    .fetch_optional(&pool)
+    .await
+    .expect("Failed to query proposal");
 
     let (space_id, voting_mode) = proposal.expect("Proposal 1 should exist");
     assert_eq!(space_id, space_a, "Proposal 1 should be in SPACE_A");
@@ -361,16 +360,15 @@ async fn test_proposal_2_details() {
     let space_a = uuid_from_bytes(expected::SPACE_A);
 
     // Verify proposal exists in SPACE_A with Slow voting mode
-    let proposal: Option<(Uuid, String)> =
-        sqlx::query_as(
-            // voting_mode is version-scoped since governance-v2; proposals_current
-            // is the view that re-exposes the current version's columns flat.
-            "SELECT space_id, voting_mode::text FROM proposals_current WHERE id = $1",
-        )
-            .bind(proposal_id)
-            .fetch_optional(&pool)
-            .await
-            .expect("Failed to query proposal");
+    let proposal: Option<(Uuid, String)> = sqlx::query_as(
+        // voting_mode is version-scoped since governance-v2; proposals_current
+        // is the view that re-exposes the current version's columns flat.
+        "SELECT space_id, voting_mode::text FROM proposals_current WHERE id = $1",
+    )
+    .bind(proposal_id)
+    .fetch_optional(&pool)
+    .await
+    .expect("Failed to query proposal");
 
     let (space_id, voting_mode) = proposal.expect("Proposal 2 should exist");
     assert_eq!(space_id, space_a, "Proposal 2 should be in SPACE_A");


### PR DESCRIPTION
Fixes two of the three failures that CI surfaced on `staging` once #873 pointed it there.

Migration `0067_governance_v2` moved `start_time`, `end_time`, `voting_mode`, `name` and the threshold columns off `proposals` onto `proposal_versions`. Two readers were never updated. Both were invisible because nothing ran tests on staging.

## 1. api — grouped proposal diff returned 500

`batchGetProposalsWithPublishActions` selected `p.start_time` / `p.end_time`:

```
GET /v2/versioned/proposal-groups/diff
  → QueryError → column p.start_time does not exist → HTTP 500
```

**I didn't have to invent the fix.** The singular `getProposalWithPublishAction`, twenty lines above in the same file, was already migrated correctly — it `INNER JOIN`s `proposal_versions` and selects `pv.start_time`. This makes the batch path match the singular path exactly.

That also fixes **a second bug in the same query**: its `proposal_actions` join lacked `AND pa.proposal_version = p.current_version`, so it could match a Publish action from *any* version of the proposal — wrong `content_uri`, or duplicate rows. The singular query already had that condition.

## 2. kg-indexer — a real schema fix, but it does NOT turn the suite green

`SELECT space_id, voting_mode FROM proposals` → SQLSTATE 42703. Switched to the **`proposals_current` view**, which `0067` created for exactly this purpose: it joins `proposals` to its current `proposal_versions` row and re-exposes the columns in the old flat shape.

⚠️ **Correcting my own earlier claim on this PR:** fixing the query removed the 42703, but KG Indexer E2E is *still red*, for a deeper and unrelated reason that the schema error was masking:

```
Batch failed: insert or update on table "proposal_votes"
violates foreign key constraint "proposal_votes_version_fk"

counts_by_event_type   = { PROPOSAL_VOTED: 37, PROPOSAL_EXECUTED: 15, ... }
expected_counts_by_type = { PROPOSAL_CREATED: 0, PROPOSAL_UPDATED: 0, ... }
```

The fixture emits 37 `PROPOSAL_VOTED` and 15 `PROPOSAL_EXECUTED` events for proposals it **never creates**. The vote inserts fail the FK to `proposal_versions`, the batch is transactional, so nothing commits — the database ends up empty and all 14 tests fail with *"Space … should exist but was not found"* in 0.03s.

That's a fixture/producer problem, not a query problem, and it needs whoever owns the governance-v2 event flow. The change here is still correct and still needed — without it, the suite would hit 42703 again the moment the fixture is fixed.

## Verification

Against a database migrated through 0071:

- `proposal-diff-edit-flow.test.ts` → **31/31** (was 1 failing)
- full `src/versioned` suite → **283/283**
- fixed kg-indexer query `PREPARE`s successfully; the old form still errors with `column "voting_mode" does not exist` — both directions checked, so the fix is demonstrably the cause
- `tsc`, biome, and `cargo build -p kg-indexer --tests` all clean

## Scope

This is the whole family I could find. I swept every `FROM proposals` / `JOIN proposals` in the repo; the remaining hits all read columns that genuinely stayed on `proposals` (`id`, `space_id`, `current_version`, `executed_at`) and are fine.

One known relative still outstanding and **not** fixed here: `notification-indexer` queries `proposals.end_time` / `name`, which kills expired-proposal notifications. It's the same root cause but a different service with its own tests, so it deserves its own PR rather than being smuggled into this one.

## Not fixed: the third red

`Notification Service E2E Tests` also fails on staging, but for an unrelated reason — `ERROR: Timeout. Received 93/105`. That's a timing/flake issue, not schema skew, and needs separate diagnosis.

## Error handling note

`QueryError` maps to a deliberate opaque 500 (`"An unexpected error occurred"`), which is right for a public API — but it meant a schema bug surfaced with no diagnosable signal, and I had to instrument the router locally to find the cause. Worth considering server-side logging of `QueryError.operation`, but that's a separate concern and I've left it alone.

