### PR TITLE
fix(notifications): give the e2e harness the governance-v2 schema

### DIFF
--- a/notification-service/e2e-tests/setup.sql
+++ b/notification-service/e2e-tests/setup.sql
@@ -2,24 +2,54 @@
 -- Only includes tables needed by the notification-indexer and delivery-worker.
 
 -- Required by notification-indexer for rejection polling (expired proposals).
--- Simplified version of the full proposals table — no FK to spaces.
+-- Simplified version of the real tables — no FK to spaces.
+--
+-- Mirrors the governance-v2 split (migration 0067): `proposals` is an identity
+-- table and all mutable, version-scoped state lives in `proposal_versions`,
+-- with the `proposals_current` view joining each proposal to its current
+-- version. The harness previously carried the pre-v2 flat shape, so
+-- `find_expired_proposals` — which correctly reads `proposals_current` — failed
+-- every poll with `relation "proposals_current" does not exist`, and the
+-- proposal_rejected notifications it drives never fired.
 CREATE TABLE IF NOT EXISTS proposals (
     id uuid PRIMARY KEY,
     space_id uuid NOT NULL,
     proposed_by uuid NOT NULL,
+    created_at text NOT NULL DEFAULT '0',
+    created_at_block text NOT NULL DEFAULT '0',
+    current_version integer NOT NULL DEFAULT 1,
+    executed_at bigint
+);
+
+CREATE TABLE IF NOT EXISTS proposal_versions (
+    proposal_id uuid NOT NULL,
+    proposal_version integer NOT NULL,
     voting_mode text NOT NULL DEFAULT 'Slow',
     start_time bigint NOT NULL,
     end_time bigint NOT NULL,
     quorum bigint NOT NULL DEFAULT 0,
     threshold bigint NOT NULL DEFAULT 0,
-    executed_at bigint,
-    created_at text NOT NULL DEFAULT '0',
-    created_at_block text NOT NULL DEFAULT '0',
     name text,
     yes_count bigint NOT NULL DEFAULT 0,
     no_count bigint NOT NULL DEFAULT 0,
-    abstain_count bigint NOT NULL DEFAULT 0
+    abstain_count bigint NOT NULL DEFAULT 0,
+    PRIMARY KEY (proposal_id, proposal_version)
 );
+
+-- Column list mirrors the production view in 0067_governance_v2 for the columns
+-- this harness exercises. `executed_at` stays on `proposals` and is carried
+-- through, which is what lets find_expired_proposals filter on it.
+CREATE OR REPLACE VIEW proposals_current AS
+SELECT
+    p.id, p.space_id, p.proposed_by, p.created_at, p.created_at_block,
+    p.current_version, p.executed_at,
+    pv.proposal_version, pv.voting_mode, pv.start_time, pv.end_time,
+    pv.quorum, pv.threshold, pv.name,
+    pv.yes_count, pv.no_count, pv.abstain_count
+FROM proposals p
+INNER JOIN proposal_versions pv
+    ON pv.proposal_id = p.id
+   AND pv.proposal_version = p.current_version;
 
 -- Required by notification-indexer for per-editor fan-out.
 -- Simplified version of the full editors table — no FK to spaces.

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -248,6 +248,44 @@ fn verify_hmac(secret: &str, body: &[u8], signature_header: &str) -> bool {
 // Database seeding
 // ---------------------------------------------------------------------------
 
+/// Insert a proposal across the governance-v2 two-table split.
+///
+/// `proposals` holds identity, `proposal_versions` holds the version-scoped
+/// mutable state, and the `proposals_current` view joins them — which is what
+/// the notification-indexer actually reads. Writing only `proposals` (the
+/// pre-v2 flat shape) leaves the view empty, and `find_expired_proposals`
+/// silently returns nothing.
+async fn insert_proposal(
+    pool: &sqlx::PgPool,
+    id: Uuid,
+    space_id: Uuid,
+    proposed_by: Uuid,
+    start_time: i64,
+    end_time: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO proposals (id, space_id, proposed_by, created_at, created_at_block, current_version) \
+         VALUES ($1, $2, $3, '0', '0', 1) ON CONFLICT DO NOTHING",
+    )
+    .bind(id)
+    .bind(space_id)
+    .bind(proposed_by)
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO proposal_versions (proposal_id, proposal_version, start_time, end_time) \
+         VALUES ($1, 1, $2, $3) ON CONFLICT DO NOTHING",
+    )
+    .bind(id)
+    .bind(start_time)
+    .bind(end_time)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 async fn seed_database(
     pool: &PgPool,
     webhook_port: u16,
@@ -299,16 +337,14 @@ async fn seed_database(
         .as_secs() as i64;
     let proposer = Uuid::from_bytes(PROPOSER_ID_BYTES);
 
-    sqlx::query(
-        "INSERT INTO proposals (id, space_id, proposed_by, start_time, end_time, created_at, created_at_block) \
-         VALUES ($1, $2, $3, $4, $5, '0', '0') ON CONFLICT DO NOTHING",
+    insert_proposal(
+        pool,
+        Uuid::from_bytes(PROP_3E_REJECTED_BYTES),
+        space_3e,
+        proposer,
+        now - 7200,
+        now - 3600,
     )
-    .bind(Uuid::from_bytes(PROP_3E_REJECTED_BYTES))
-    .bind(space_3e)
-    .bind(proposer)
-    .bind(now - 7200)
-    .bind(now - 3600)
-    .execute(pool)
     .await?;
 
     // Proposals for the VOTED and EXECUTED events so the indexer can resolve the
@@ -316,16 +352,14 @@ async fn seed_database(
     // on / approved" to them. end_time is in the FUTURE so the rejection poller
     // does NOT also reject these (it only rejects end_time < now).
     for prop in [PROP_3E_VOTED_BYTES, PROP_3E_EXECUTED_BYTES] {
-        sqlx::query(
-            "INSERT INTO proposals (id, space_id, proposed_by, start_time, end_time, created_at, created_at_block) \
-             VALUES ($1, $2, $3, $4, $5, '0', '0') ON CONFLICT DO NOTHING",
+        insert_proposal(
+            pool,
+            Uuid::from_bytes(prop),
+            space_3e,
+            proposer,
+            now - 3600,
+            now + 3600,
         )
-        .bind(Uuid::from_bytes(prop))
-        .bind(space_3e)
-        .bind(proposer)
-        .bind(now - 3600)
-        .bind(now + 3600)
-        .execute(pool)
         .await?;
     }
 
@@ -447,16 +481,14 @@ async fn seed_database(
 
     // Phase 2a: a proposal in its own space for the comment test. end_time in the
     // future so the rejection poller ignores it. The recipient is the proposer.
-    sqlx::query(
-        "INSERT INTO proposals (id, space_id, proposed_by, start_time, end_time, created_at, created_at_block) \
-         VALUES ($1, $2, $3, $4, $5, '0', '0') ON CONFLICT DO NOTHING",
+    insert_proposal(
+        pool,
+        Uuid::from_bytes(COMMENT_PROPOSAL_BYTES),
+        Uuid::from_bytes(COMMENT_SPACE_BYTES),
+        Uuid::from_bytes(COMMENT_PROPOSER_BYTES),
+        now - 3600,
+        now + 3600,
     )
-    .bind(Uuid::from_bytes(COMMENT_PROPOSAL_BYTES))
-    .bind(Uuid::from_bytes(COMMENT_SPACE_BYTES))
-    .bind(Uuid::from_bytes(COMMENT_PROPOSER_BYTES))
-    .bind(now - 3600)
-    .bind(now + 3600)
-    .execute(pool)
     .await?;
 
     // The allowed commenter is a *member* (not editor) of the proposal's space,

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -840,10 +840,16 @@ impl Storage {
         .flatten()
     }
 
-    /// Look up the human-readable name for a proposal from the proposals table.
+    /// Look up the human-readable name for a proposal.
+    ///
+    /// Reads `proposals_current`, not `proposals`: `name` is version-scoped
+    /// under governance-v2 (see `find_expired_proposals`). The old text errored
+    /// with `column "name" does not exist`, and because this swallows errors
+    /// with `.ok()` the failure was invisible — names just silently stopped
+    /// appearing in notification payloads.
     pub async fn lookup_proposal_name(&self, proposal_id: Uuid) -> Option<String> {
         sqlx::query_scalar::<_, String>(
-            "SELECT name FROM proposals WHERE id = $1 AND name IS NOT NULL",
+            "SELECT name FROM proposals_current WHERE id = $1 AND name IS NOT NULL",
         )
         .bind(proposal_id)
         .fetch_optional(&self.pool)
@@ -853,9 +859,13 @@ impl Storage {
     }
 
     /// Look up current vote tallies for a proposal.
+    ///
+    /// Reads `proposals_current` for the same reason as `lookup_proposal_name`:
+    /// the tallies are version-scoped under governance-v2, and this call also
+    /// swallows errors, so the old query degraded to "no tallies" in silence.
     pub async fn lookup_vote_tallies(&self, proposal_id: Uuid) -> Option<(i64, i64, i64)> {
         sqlx::query_as::<_, (i64, i64, i64)>(
-            "SELECT yes_count, no_count, abstain_count FROM proposals WHERE id = $1",
+            "SELECT yes_count, no_count, abstain_count FROM proposals_current WHERE id = $1",
         )
         .bind(proposal_id)
         .fetch_optional(&self.pool)


### PR DESCRIPTION
Fixes the `Notification Service E2E` failure on staging — one of the two reds currently on every PR.

## Diagnosis

The suite failed with `Timeout. Received 93/105`. Twelve short, which is exactly the `proposal_rejected` group (3 editors + proposer × 3 webhooks). The indexer's own logs in the failing run say why:

```
ERROR notification_indexer: Failed to query expired proposals
  error=relation "proposals_current" does not exist
```

**The production code was right and the test harness was wrong** — the opposite of what I expected. `find_expired_proposals` correctly reads `proposals_current`, and carries a comment explaining this precise hazard. But `e2e-tests/setup.sql` still builds the *pre*-governance-v2 flat `proposals` table: no `proposal_versions`, no view. So the rejection poller errored on every tick and those 12 notifications never fired.

## The fix

Splits the harness schema to mirror migration `0067`: identity `proposals`, version-scoped `proposal_versions`, and the `proposals_current` view. The three seed sites now go through one `insert_proposal` helper that writes both tables.

## Two production bugs the harness was concealing

Because the harness's flat table still had the columns, these looked fine in tests while being broken in production:

| Query | Column | Effect |
|---|---|---|
| `lookup_proposal_name` | `name` | proposal names missing from payloads |
| `lookup_vote_tallies` | `yes_count`/`no_count`/`abstain_count` | vote tallies missing from payloads |

Both moved to `proposal_versions`. Both callers end in `.ok().flatten()`, so the query error was swallowed and they degraded to `None` **in complete silence** — no error, no log, no failing test. That's why this sat unnoticed.

This is the same family as #876, and it's the last of it I can find: every remaining `FROM proposals` in the indexer reads `proposed_by`, `space_id` or `created_at_block`, which genuinely stayed.

## Verification

Applied the updated `setup.sql` to a live Postgres, seeded a proposal the way the helper does, and ran all three previously-broken queries:

- `find_expired_proposals` → **returns the expired row it was missing**
- `lookup_proposal_name` → resolves
- `lookup_vote_tallies` → resolves

Plus `cargo clippy -p notification-indexer -- -D warnings`, `cargo fmt --all --check`, and build — all clean.

## Caveat

I couldn't run the full E2E locally — it needs the Kafka + Postgres compose stack and a 105-call webhook flow. The diagnosis is grounded (the error is explicit in the logs, and 12 missing calls matches the `proposal_rejected` group exactly), but **CI on this PR is the real test**. If it still comes up short, the remaining gap is something other than the view.
