### PR TITLE
fix(mock): encode governance-v2 proposal payloads in the mock event stream

### DIFF
--- a/hermes-pipeline/src/pipelines/governance.rs
+++ b/hermes-pipeline/src/pipelines/governance.rs
@@ -1867,4 +1867,69 @@ mod tests {
             panic!("Expected Publish action");
         }
     }
+
+    // ========================================================================
+    // Mock-stream contract
+    //
+    // The mock event generator encodes payloads that this module decodes. When
+    // the two drift, nothing fails loudly: a settings payload that won't decode
+    // leaves the settings map empty, the squash below discards every paired
+    // PROPOSAL_CREATED, and the stream silently contains zero proposals. The
+    // kg-indexer E2E then fails far downstream with a foreign-key violation on
+    // proposal_votes and 14 assertions reporting "space not found".
+    //
+    // These tests pin the mock stream against the real decoders so that drift
+    // fails here, in a unit test, with a message that names the cause.
+    // ========================================================================
+
+    #[test]
+    fn mock_stream_yields_decodable_proposals() {
+        let actions = hermes_relay::source::mock_events::test_topology::generate();
+        let result = transform(&actions, &test_meta(), &HashMap::new()).unwrap();
+
+        assert!(
+            !result.proposals_created.is_empty(),
+            "mock stream produced zero PROPOSAL_CREATED events. The most likely \
+             cause is that mock_events' PROPOSAL_SETTINGS_SELECTED payload no \
+             longer matches decode_proposal_settings_used, so the squash \
+             discarded every proposal."
+        );
+    }
+
+    #[test]
+    fn mock_stream_settings_decode_into_created_proposals() {
+        let actions = hermes_relay::source::mock_events::test_topology::generate();
+        let result = transform(&actions, &test_meta(), &HashMap::new()).unwrap();
+
+        for p in &result.proposals_created {
+            let settings = p.settings.as_ref().expect(
+                "a squashed PROPOSAL_CREATED must carry settings; if this is None the \
+                 squash emitted an unpaired event",
+            );
+            // start/end come straight from the mock's voting window, so a field
+            // ordering regression in the ABI shows up as zeroes here.
+            assert!(
+                settings.last_date > settings.start_date,
+                "decoded voting window is not ordered (start={}, end={}) — likely an \
+                 ABI field-order mismatch between mock_events and decode.rs",
+                settings.start_date,
+                settings.last_date
+            );
+        }
+    }
+
+    #[test]
+    fn mock_stream_votes_are_version_scoped() {
+        let actions = hermes_relay::source::mock_events::test_topology::generate();
+        let result = transform(&actions, &test_meta(), &HashMap::new()).unwrap();
+
+        assert!(
+            !result.proposals_voted.is_empty(),
+            "mock stream produced zero PROPOSAL_VOTED events — the vote payload \
+             likely lost its proposal_version field and now fails to decode"
+        );
+        // The decoder reads proposal_version off the wire but HermesProposalVoted
+        // does not carry it, so there is nothing further to assert here — a
+        // non-empty result already proves the three-field payload decoded.
+    }
 }

--- a/hermes-relay/src/source/mock_events.rs
+++ b/hermes-relay/src/source/mock_events.rs
@@ -534,13 +534,22 @@ fn encode_proposal_data(
 }
 
 // Type alias for encoding vote data: (bytes16, uint8)
-type VoteDataType = sol! { (bytes16, uint8) };
+// PROPOSAL_VOTED (V2): abi.encode(bytes16 proposalId, uint8 proposalVersion, uint8 voteOption).
+// Governance-v2 made votes version-scoped; the pre-v2 two-field payload decodes
+// as a buffer overrun.
+type VoteDataType = sol! { (bytes16, uint8, uint8) };
 
-/// ABI-encode proposal vote data: (bytes16 proposalId, uint8 voteOption)
+/// Version every mock proposal is created at. Proposals are created once and
+/// never updated in this stream, so their current_version is always 1.
+const MOCK_PROPOSAL_VERSION: u8 = 1;
+
+/// ABI-encode proposal vote data:
+/// (bytes16 proposalId, uint8 proposalVersion, uint8 voteOption)
 fn encode_vote_data(proposal_id: ProposalId, vote_option: VoteOption) -> Vec<u8> {
     use alloy::primitives::FixedBytes;
     VoteDataType::abi_encode(&(
         FixedBytes::<16>::from_slice(&proposal_id),
+        MOCK_PROPOSAL_VERSION,
         vote_option as u8,
     ))
 }
@@ -598,13 +607,23 @@ pub fn proposal_created(
 /// This event is emitted after PROPOSAL_CREATED to convey the proposal settings.
 /// The pipeline squashes PROPOSAL_CREATED + PROPOSAL_SETTINGS_SELECTED into a single event.
 ///
+/// ⚠️ The payload is the governance-v2 `ProposalParameters` struct, in the
+/// field order the pipeline's `decode_proposal_settings_used` expects:
+/// `(votingMode, partialPct, universalPct, flat, quorum, startDate, lastDate,
+/// executeBy)`. The pre-v2 shape was five fields in a different order; it
+/// decodes as an error, which makes the governance pipeline discard the paired
+/// PROPOSAL_CREATED entirely (see the squash in `pipelines/governance.rs`) —
+/// so a mismatch here silently produces a stream with zero proposals.
+///
 /// - `space_id`: The space with the proposal
 /// - `proposal_id`: The proposal ID (16 bytes)
 /// - `voting_mode`: Voting mode (Slow=0, Fast=1)
 /// - `start_date`: Block timestamp when voting starts
 /// - `end_date`: Block timestamp when voting ends
 /// - `quorum`: Minimum total votes for slow path
-/// - `support_threshold`: Support threshold (flat for fast, percentage for slow)
+/// - `support_threshold`: Support threshold, applied to the field matching
+///   `voting_mode` — flat for Fast, universal-percentage for Slow
+#[allow(clippy::too_many_arguments)]
 pub fn proposal_settings_selected(
     space_id: SpaceId,
     proposal_id: ProposalId,
@@ -614,16 +633,31 @@ pub fn proposal_settings_selected(
     quorum: u64,
     support_threshold: u64,
 ) -> Action {
-    // Encode settings as: (uint256 startDate, uint256 lastDate, uint8 votingMode, uint256 quorum, uint256 supportThreshold)
     use alloy::sol_types::SolType;
 
-    type SettingsType = sol! { (uint256, uint256, uint8, uint256, uint256) };
+    // Governance-v2 split the single support threshold into three. Route the
+    // caller's value to the one the voting mode actually uses and leave the
+    // others zero, so the mock exercises the same field the contract would.
+    let (partial_pct, universal_pct, flat) = match voting_mode {
+        VotingMode::Fast => (0u64, 0u64, support_threshold),
+        VotingMode::Slow => (0u64, support_threshold, 0u64),
+    };
+
+    // executeBy has no pre-v2 equivalent. Set it a week past the voting window
+    // so the execution deadline is never the reason a mock proposal fails.
+    let execute_by = end_date + 7 * 24 * 60 * 60;
+
+    type SettingsType =
+        sol! { (uint8, uint256, uint256, uint256, uint256, uint256, uint256, uint256) };
     let data = SettingsType::abi_encode(&(
+        voting_mode as u8,
+        U256::from(partial_pct),
+        U256::from(universal_pct),
+        U256::from(flat),
+        U256::from(quorum),
         U256::from(start_date),
         U256::from(end_date),
-        voting_mode as u8,
-        U256::from(quorum),
-        U256::from(support_threshold),
+        U256::from(execute_by),
     ));
 
     // Pad proposal_id to 32 bytes for topic field
@@ -2142,9 +2176,10 @@ mod tests {
         // Topic is proposal_id padded to 32 bytes
         assert_eq!(action.topic.len(), 32);
         assert_eq!(&action.topic[..16], &proposal_id);
-        // Data should contain encoded (bytes16 proposalId, uint8 voteOption)
-        // ABI-encoded: 32 bytes for bytes16 (padded) + 32 bytes for uint8 (padded)
-        assert_eq!(action.data.len(), 64);
+        // Data is the governance-v2 payload:
+        // (bytes16 proposalId, uint8 proposalVersion, uint8 voteOption)
+        // ABI-encoded, each field padded to 32 bytes.
+        assert_eq!(action.data.len(), 96);
     }
 
     #[test]


### PR DESCRIPTION
Fixes the last red on staging — `KG Indexer E2E`, where all 14 tests fail in 0.03s reporting *"Space … should exist but was not found"*.

## That error is four steps from the cause

```
mock_events encodes the pre-v2 PROPOSAL_SETTINGS_SELECTED payload
  → decode_proposal_settings_used fails (160 bytes supplied, 256 expected)
  → the governance squash discards every paired PROPOSAL_CREATED
  → PROPOSAL_CREATED: 0, so 37 votes have no parent row
  → proposal_votes_version_fk violation
  → the batch is transactional → nothing commits → empty database
  → all 14 assertions fail, looking like an infrastructure problem
```

The squash is explicit about it (`pipelines/governance.rs`): a `PROPOSAL_CREATED` with no matching `PROPOSAL_SETTINGS_SELECTED` is discarded with a warning. One undecodable payload therefore erases every proposal in the stream.

## Two stale payloads

| Event | Was | Now |
|---|---|---|
| `PROPOSAL_SETTINGS_SELECTED` | `(startDate, lastDate, votingMode, quorum, supportThreshold)` — 5 fields | `(votingMode, partialPct, universalPct, flat, quorum, startDate, lastDate, executeBy)` — 8 fields |
| `PROPOSAL_VOTED` | `(bytes16 proposalId, uint8 voteOption)` | `(bytes16 proposalId, uint8 proposalVersion, uint8 voteOption)` |

**Neither is a design question.** The decoders match the real `proposal_versions` columns and production indexes proposals fine on v2 — the mock was simply never updated when governance-v2 landed. Same shape as #876 and #877: production right, harness stale.

Two judgement calls, both documented in the code:

- **The support threshold split into three.** The mock routes the caller's single value to the field its `voting_mode` actually uses — flat for Fast, universal-percentage for Slow — and leaves the others zero, so it exercises the same field the contract would.
- **`executeBy` has no pre-v2 equivalent.** Set a week past the voting window, so the execution deadline is never the reason a mock proposal fails.

## The guard that should have existed

Nothing checked that the mock encoder and the decoder agree, which is exactly why this drifted silently for so long. Three new tests in the governance pipeline run the **real mock stream through the real decoders**:

- `mock_stream_yields_decodable_proposals`
- `mock_stream_settings_decode_into_created_proposals` — asserts the decoded voting window is ordered, so an ABI field-order regression surfaces as an assertion rather than as zeroes
- `mock_stream_votes_are_version_scoped`

**Mutation-tested:** reverting the settings encoding to v1 makes the first fail with a message naming the cause —

> mock stream produced zero PROPOSAL_CREATED events. The most likely cause is that mock_events' PROPOSAL_SETTINGS_SELECTED payload no longer matches decode_proposal_settings_used, so the squash discarded every proposal.

That's the message I'd have wanted three hours ago instead of "space not found".

## Verification

- `cargo test -p hermes-relay -p hermes-pipeline` → **170 passed, 0 failed**
- `cargo clippy -p hermes-relay -p hermes-pipeline -- -D warnings` → clean
- `cargo fmt --all --check` → clean

Also updates `test_proposal_voted_format`, which asserted the 64-byte v1 payload length.

## Caveat

I verified the pipeline half — the mock stream now decodes into proposals. I could **not** run the full kg-indexer E2E locally; it needs the Kafka + Postgres stack and a live indexer. The FK violation should follow from proposals existing, but **CI on this PR is the real test.** If it still fails, the remaining gap is downstream of event decoding.
