### PR TITLE
DO NOT MERGE - cache cap was harmful (p99 6.9s->52.4s); see comments

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -28,4 +28,9 @@ USER geo
 
 EXPOSE 3000
 
-CMD ["bun", "run", "main.ts"]
+# --smol makes JSC collect far more eagerly instead of growing the heap
+# opportunistically. Bun does not reliably size its heap against the cgroup
+# limit, so in a 2Gi container (limits.memory in api/k8s/*/api.yaml) it can
+# walk past the limit and be OOMKilled before GC gets serious. Costs some
+# throughput; cheaper than a restart loop.
+CMD ["bun", "--smol", "run", "main.ts"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -28,9 +28,4 @@ USER geo
 
 EXPOSE 3000
 
-# --smol makes JSC collect far more eagerly instead of growing the heap
-# opportunistically. Bun does not reliably size its heap against the cgroup
-# limit, so in a 2Gi container (limits.memory in api/k8s/*/api.yaml) it can
-# walk past the limit and be OOMKilled before GC gets serious. Costs some
-# throughput; cheaper than a restart loop.
-CMD ["bun", "--smol", "run", "main.ts"]
+CMD ["bun", "run", "main.ts"]

--- a/api/src/kg/valkeyCache.ts
+++ b/api/src/kg/valkeyCache.ts
@@ -16,36 +16,55 @@ export type Cache = {
 }
 
 /**
- * Skip caching responses larger than this threshold. Serializing a large
- * response already allocates a second full copy of the data (JSON.stringify),
- * and handing that string to ioredis allocates a third in its send buffer.
- * For 30+ MB responses, this is the exact allocation spike that OOM'd pods
- * before the pagination cap landed. Skipping the SET entirely avoids the
- * ioredis buffer and the network send — the stringify still happens, but
- * the peak is bounded by one copy instead of three.
+ * Skip caching responses larger than this threshold.
  *
- * 15 MB is chosen to cover the full range of expected cacheable responses:
- *   - the 12 MB Query.spaces response (near-static, high-value to cache)
- *   - 2–15 MB Query.entities* / entitiesOrderedByProperty responses
- *   - common 2–5 MB entity-list shapes
+ * The previous value was 15 MB, sized so that the biggest responses — the
+ * ~12 MB `Query.spaces` list and the 2–15 MB `Query.entities*` lists — stayed
+ * cacheable, on the reasoning that they are expensive and near-static so
+ * caching them is where the win is. Two things were wrong with that.
  *
- * Per-request memory impact stays bounded:
- *   - Single SET peak = JS string (15 MB) + ioredis send buffer (15 MB) ≈
- *     30 MB per concurrent write — 0.7% of the 4 Gi pod limit
- *   - 8-pod cache stampede peaks at ~240 MB aggregate; each pod stays
- *     under 30 MB incremental during the stampede
- *   - SET over in-cluster networking is typically <200 ms; the 3 s
- *     commandTimeout gives ~1.5× headroom for bad network days
+ * First, the arithmetic assumed a 4 Gi pod limit ("30 MB per concurrent
+ * write — 0.7%"). `api/k8s/v2/api.yaml` and `api/k8s/production/api.yaml`
+ * both set `limits.memory: 2Gi`. The headroom was half what the sizing
+ * claimed.
  *
- * GET path on a cache hit parses the full JSON to rebuild the JS object
- * tree — ~100–250 ms CPU and up to ~90 MB transient memory per pod on
- * the biggest entries. For expensive queries this is still a net win over
- * hitting the DB; for cheap queries it can approach DB cost.
+ * Second, and the reason this is being lowered: the write path is the cheap
+ * half. On a hit the GET path parses the full JSON back into a JS object
+ * tree, which for the biggest entries costs ~100–250 ms CPU and up to ~90 MB
+ * transient per pod. Valkey is shared across all API pods, so one writer
+ * produces N readers, and `ttlPerSchemaCoordinate` in postgraphile.ts gives
+ * these exact queries the *longest* TTL (60 s) — the combination maximises
+ * hits per large entry, which is precisely the expensive direction.
  *
- * Responses over 15 MB fall through to the DB on every request rather
- * than cache, bounding the worst-case memory allocation path.
+ * Measured on the v2 cluster 2026-08-06, with the API OOMKilling on a ~2 h
+ * cycle (9 pods, 10–21 restarts each) against a production cluster on the
+ * same 2Gi limit that had run 9 days clean with the cache disabled:
+ *
+ *   DBSIZE 91, used_memory 15.08 MB, distributed as
+ *     8.39 MB   1 key
+ *     5.24 MB   1 key
+ *     1.05 MB   3 keys
+ *     ≤918 KB   86 keys (most ~17 KB)
+ *
+ * Two entries held 13.6 of 15.08 MB and both sailed under the 15 MB cap. A
+ * 1 MB cap keeps 89 of the 91 keys — ~2% of entries, ~90% of bytes — so the
+ * hit rate, which follows repeated small queries rather than one-off large
+ * ones, is largely preserved while the two amplifying entries stop being
+ * written and, more importantly, stop being re-parsed on every hit.
+ *
+ * This bounds the damage; it does not fix the cause. The responses are large
+ * because paginationCapPlugin.ts caps `first` *per argument* (max 1000,
+ * default 100) while nested lists multiply — `entities { valuesList(first:
+ * 1000) relationsList(first: 1000) }` is legal at every argument and still
+ * hundreds of thousands of rows. A per-response node budget is the real fix.
+ *
+ * Note the check below still runs *after* JSON.stringify, so lowering this
+ * avoids the ioredis send buffer, the network send, and every subsequent GET
+ * parse — but not the serialization itself. Skipping that too means bounding
+ * on row count in `shouldCacheResult` (postgraphile.ts), before the response
+ * is ever serialized.
  */
-export const MAX_CACHEABLE_BYTES = 15_000_000
+export const MAX_CACHEABLE_BYTES = 1_000_000
 
 /**
  * Decide whether to skip caching a serialized response based on its


### PR DESCRIPTION
## Problem

The v2 API has been OOMKilling on roughly a 2h cycle since 08-04 — 9 pods, 10–21 restarts each, exit 137. This is what's firing `Api5xxRateHighWARNING`.

Production runs the same image on the **same `limits.memory: 2Gi`** and has been clean for 9 days. The only config difference is the response cache:

| | production | v2 |
|---|---|---|
| `VALKEY_URL` | commented out (`api/k8s/production/api.yaml:134`) | set (`api/k8s/v2/api.yaml:140`) |
| `requests` / `limits` | 768Mi / 2Gi | 768Mi / 2Gi (identical) |

#868 enabled the cache on v2 only, on 08-04.

## Measurement

Per-key `MEMORY USAGE` on the v2 Valkey instance, 2026-08-06:

```
DBSIZE 91, used_memory 15.08 MB
  8.39 MB   1 key
  5.24 MB   1 key
  1.05 MB   3 keys
  <=918 KB  86 keys (most ~17 KB)
```

Two entries hold **13.6 of the 15.08 MB**, and both pass the 15 MB cap comfortably. Re-checked ~90s later, both had `ttl=-2` — they expire and get rewritten constantly.

Valkey is shared across all pods, so each large entry is written once and `JSON.parse`d back into a full object tree on **every hit across 9 readers** — up to ~90 MB transient per pod, per the estimate already in `valkeyCache.ts:40-43`. `ttlPerSchemaCoordinate` (`postgraphile.ts:427`) gives these same queries the *longest* TTL (60s), maximising hits per large entry.

The 15 MB cap was also sized against a 4 Gi pod limit — `"30 MB per concurrent write — 0.7% of the 4 Gi pod limit"`. Both manifests say 2Gi.

## Changes

1. **`MAX_CACHEABLE_BYTES` 15 MB → 1 MB.** Keeps 89 of 91 keys — ~2% of entries, ~90% of bytes. Hit rate comes from repeated small queries, not one-off large ones, so it should be largely preserved. The cache stays on.
2. **`bun --smol`.** JSC grows its heap opportunistically and doesn't reliably size against the cgroup limit, so it can walk past 2Gi before collecting. Independent of the cache theory, cheap to revert.

## What this is not

Neither change is the cause, and I want to be clear about that. Responses are large because `paginationCapPlugin.ts:32-33` caps `first` **per argument** (max 1000, default 100) while nested lists multiply — `entities { valuesList(first: 1000) relationsList(first: 1000) }` is legal at every argument and still hundreds of thousands of rows. A per-response node budget is the real fix and is not in this PR.

Also not here, deliberately: bounding on row count in `shouldCacheResult` before serialization. The check lowered here still runs *after* `JSON.stringify`, so this avoids the ioredis buffer, the network send, and every subsequent GET parse — but not the serialization itself.

## Uncertainty

I can't measure how many of the 1.27M recorded hits land on the two large keys; per-key hit counts aren't exposed without keyspace notifications. If they're disproportionately hot, this costs more hit rate than the key count suggests. It's a one-line revert, so measuring by shipping is cheaper than instrumenting for it.

## Verification

- `bun run ci` (format + lint + tsc) exits 0
- 26 tests pass across `valkeyCache.test.ts` and `responseCacheEmptyResults.test.ts`; they reference `MAX_CACHEABLE_BYTES` symbolically so the boundary cases still hold
- `--smol` flag placement verified against bun 1.3.14

Base is `staging`, which is where v2 deploys from — live image is `0d3e0986`, matching `origin/staging` HEAD.