### PR TITLE
fix(api): stop the liveness probe killing busy-but-alive pods on v2

### DIFF
--- a/api/k8s/v2/api.yaml
+++ b/api/k8s/v2/api.yaml
@@ -178,14 +178,28 @@ spec:
               cpu: "500m"
             limits:
               memory: "2Gi"
+          # Liveness answers "is this process wedged?", not "is it busy?".
+          # At timeoutSeconds 3 / failureThreshold 3 it answered the second
+          # question: ~30s of event-loop stall killed a pod sitting at
+          # 400-534Mi of the 2Gi limit. That is actively harmful under load —
+          # the kill drops the pod's in-flight requests (straight 5xx), sheds
+          # its share of traffic onto the surviving pods, and brings it back
+          # with a cold JIT, so one burst of expensive queries cascaded into
+          # five dead pods in 30 seconds on 2026-08-06.
+          #
+          # 10s x 6 means ~60s of *consecutive* unresponsiveness before a
+          # restart, which still catches a genuinely wedged process while
+          # leaving a merely saturated one alone. Readiness below is
+          # deliberately left tighter: a slow pod should leave the
+          # load-balancer rotation and recover, not be destroyed.
           livenessProbe:
             httpGet:
               path: /health/liveness
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSeconds: 3
-            failureThreshold: 3
+            timeoutSeconds: 10
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /health/readiness


### PR DESCRIPTION
Brings `api/k8s/v2/api.yaml` in line with a change already applied live on the v2 cluster by `kubectl patch` during tonight's incident. **Until this merges, the manifest and the cluster disagree and the next deploy silently reverts the fix.**

```diff
 livenessProbe:
-  timeoutSeconds: 3
-  failureThreshold: 3
+  timeoutSeconds: 10
+  failureThreshold: 6
```

## The problem

At `3s x 3`, ~30 seconds of event-loop stall was enough to SIGKILL a pod sitting at **400–534 Mi of its 2 Gi limit**. That is a liveness probe answering *"is it busy?"* rather than *"is it wedged?"*.

Killing a saturated pod makes saturation worse. It drops that pod's in-flight requests as 5xx, sheds its share of traffic onto pods that are already struggling, and returns it with a cold JIT. On 2026-08-06 one burst of expensive queries from a single client took out **five of eight pods within 30 seconds** this way.

## Evidence

Restart reasons on v2 before the change, across 9 pods:

| reason | pods |
|---|---|
| `Error` (liveness kill) | **6** |
| `OOMKilled` | 3 |

Both surface as exit 137, which is how this went misdiagnosed as purely an OOM problem for most of the evening. The majority of restarts were liveness kills.

After widening the probe on the cluster, **every subsequent restart was `OOMKilled` and none were `Error`** — the liveness class disappeared. The probe still logs failures, but now with `read: connection reset by peer`, i.e. it is observing a pod that died of OOM rather than causing the death.

## Why these values

`10s x 6` = ~60 s of *consecutive* unresponsiveness before a restart. Still recycles a genuinely wedged process, but leaves a merely saturated one alone.

Readiness is deliberately **not** touched (`5s`, threshold 3). That is the right lever for "too busy": a slow pod drops out of the load-balancer rotation and recovers, shedding load gracefully instead of being destroyed.

## Scope

**v2 only**, per request. `api/k8s/production/api.yaml` and `api/k8s/staging/api.yaml` carry identical probe settings and the same latent issue, but neither is showing the failure — production has run 9 days with 0–1 restarts on the same 2 Gi limit. Worth a follow-up, not this PR.

## What this does not fix

The stalls themselves. `costLoggerPlugin` logs `High GraphQL query cost` at `cost: 207` against `threshold: 200` and serves the query anyway; bursts of those are what stall the event loop. The real fixes are enforcing that limit and adding a per-response node budget to `paginationCapPlugin` — `first` is capped per *argument* (max 1000, default 100) while nested lists multiply, so `entities { valuesList(first: 1000) relationsList(first: 1000) }` is legal and enormous.

This PR only stops us amplifying the problem.

## Verification

- `yaml.safe_load_all` parses; probe values confirmed as `timeoutSeconds: 10`, `failureThreshold: 6`
- `kubectl apply --dry-run=server` against the live v2 cluster: `deployment.apps/api configured`
- Manifest-only change; no image rebuild required

CI will not report — GitHub Actions is still in `major_outage`.

Related: #879 (do not merge — the cache-cap approach in it was harmful and is documented there).