### PR TITLE
feat(api): bound concurrent expensive work and add a cost ceiling

### DIFF
--- a/api/src/kg/__tests__/admissionControl.test.ts
+++ b/api/src/kg/__tests__/admissionControl.test.ts
@@ -1,0 +1,141 @@
+import {afterEach, describe, expect, it} from "vitest"
+import {
+	ADMISSION_COST_FLOOR,
+	getInFlightExpensiveCount,
+	MAX_CONCURRENT_EXPENSIVE,
+	resetAdmissionControl,
+	useAdmissionControl,
+} from "../admissionControl"
+import {GRAPHQL_QUERY_COST_CONTEXT_KEY} from "../costLoggerPlugin"
+
+type ExecuteHook = (args: {args: unknown}) => {onExecuteDone?: () => void} | undefined
+type ResponseHook = (args: {request: Request}) => void
+
+function hook() {
+	return (useAdmissionControl() as unknown as {onExecute: ExecuteHook}).onExecute
+}
+
+function plugin() {
+	return useAdmissionControl() as unknown as {onExecute: ExecuteHook; onResponse: ResponseHook}
+}
+
+/** A request context carrying the cost the cost plugin would have stashed. */
+function ctx(cost: number | undefined, request?: Request) {
+	const base = cost === undefined ? {} : {[GRAPHQL_QUERY_COST_CONTEXT_KEY]: cost}
+	return request ? {...base, request} : base
+}
+
+function execute(onExecute: ExecuteHook, cost: number | undefined, operationName = "op") {
+	return onExecute({args: {contextValue: ctx(cost), operationName}})
+}
+
+afterEach(() => {
+	resetAdmissionControl()
+})
+
+describe("useAdmissionControl", () => {
+	it("does not count operations below the cost floor", () => {
+		const onExecute = hook()
+		for (let i = 0; i < MAX_CONCURRENT_EXPENSIVE * 3; i++) {
+			expect(() => execute(onExecute, ADMISSION_COST_FLOOR - 1)).not.toThrow()
+		}
+		expect(getInFlightExpensiveCount()).toBe(0)
+	})
+
+	it("lets cheap traffic through while the expensive limit is saturated", () => {
+		const onExecute = hook()
+		for (let i = 0; i < MAX_CONCURRENT_EXPENSIVE; i++) execute(onExecute, ADMISSION_COST_FLOOR)
+		expect(getInFlightExpensiveCount()).toBe(MAX_CONCURRENT_EXPENSIVE)
+
+		// The whole point of the cost gate: a burst of light lookups must not be
+		// refused because heavy feed queries are in flight.
+		expect(() => execute(onExecute, 10)).not.toThrow()
+		expect(() => execute(onExecute, ADMISSION_COST_FLOOR)).toThrow(/at capacity/)
+	})
+
+	it("rejects with 503 and Retry-After once the limit is reached", () => {
+		const onExecute = hook()
+		for (let i = 0; i < MAX_CONCURRENT_EXPENSIVE; i++) execute(onExecute, 250)
+
+		try {
+			execute(onExecute, 250)
+			throw new Error("expected a rejection")
+		} catch (error) {
+			const ext = (error as {extensions?: Record<string, unknown>}).extensions
+			expect(ext?.code).toBe("SERVICE_UNAVAILABLE")
+			expect(ext?.http).toEqual({status: 503, headers: {"Retry-After": "1"}})
+		}
+	})
+
+	it("frees a slot when the operation finishes", () => {
+		const onExecute = hook()
+		const handles = []
+		for (let i = 0; i < MAX_CONCURRENT_EXPENSIVE; i++) handles.push(execute(onExecute, 250))
+		expect(() => execute(onExecute, 250)).toThrow()
+
+		handles[0]?.onExecuteDone?.()
+		expect(getInFlightExpensiveCount()).toBe(MAX_CONCURRENT_EXPENSIVE - 1)
+		expect(() => execute(onExecute, 250)).not.toThrow()
+	})
+
+	it("treats a missing cost as cheap rather than guessing", () => {
+		// Introspection, or a cost walk that threw. Refusing on unknown cost
+		// would turn a cost-plugin bug into an outage.
+		const onExecute = hook()
+		for (let i = 0; i < MAX_CONCURRENT_EXPENSIVE * 2; i++) {
+			expect(() => execute(onExecute, undefined)).not.toThrow()
+		}
+		expect(getInFlightExpensiveCount()).toBe(0)
+	})
+
+	it("self-heals if a release is missed, instead of wedging the pod shut", () => {
+		const onExecute = hook()
+		// Fill every slot and deliberately never call onExecuteDone — the leak
+		// that would otherwise reject all expensive traffic until a restart.
+		for (let i = 0; i < MAX_CONCURRENT_EXPENSIVE; i++) execute(onExecute, 250)
+		expect(() => execute(onExecute, 250)).toThrow()
+
+		// Entries older than MAX_AGE_MS are pruned on the next check.
+		const wellPastMaxAge = Date.now() + 120_000
+		expect(getInFlightExpensiveCount(wellPastMaxAge)).toBe(0)
+		expect(() => execute(onExecute, 250)).not.toThrow()
+	})
+
+	it("releases the slot via onResponse when onExecuteDone never fires", () => {
+		// The real leak path, and the reason onExecuteDone alone is not enough.
+		// envelop runs handleMaybePromise(beforeHooks, thenExecuteAndAfterHooks)
+		// with no error handler, so when a LATER plugin's onExecute throws —
+		// usePgClient shedding, or a failed pool.connect(), both of which happen
+		// exactly during an incident — the after-hooks are skipped entirely.
+		// Without the backstop the pod would progressively wedge shut under the
+		// conditions the limiter exists to survive.
+		const p = plugin()
+		const requests: Request[] = []
+
+		for (let i = 0; i < MAX_CONCURRENT_EXPENSIVE; i++) {
+			const req = new Request(`https://example.test/graphql?i=${i}`)
+			requests.push(req)
+			// Deliberately discard the returned hooks: simulate onExecuteDone
+			// never being invoked.
+			p.onExecute({args: {contextValue: ctx(250, req), operationName: "op"}})
+		}
+
+		expect(getInFlightExpensiveCount()).toBe(MAX_CONCURRENT_EXPENSIVE)
+		expect(() =>
+			p.onExecute({args: {contextValue: ctx(250, new Request("https://example.test/x")), operationName: "op"}}),
+		).toThrow(/at capacity/)
+
+		for (const req of requests) p.onResponse({request: req})
+
+		expect(getInFlightExpensiveCount()).toBe(0)
+		expect(() =>
+			p.onExecute({args: {contextValue: ctx(250, new Request("https://example.test/y")), operationName: "op"}}),
+		).not.toThrow()
+	})
+
+	it("onResponse is harmless for a request that never took a slot", () => {
+		const p = plugin()
+		expect(() => p.onResponse({request: new Request("https://example.test/none")})).not.toThrow()
+		expect(getInFlightExpensiveCount()).toBe(0)
+	})
+})

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -492,18 +492,44 @@ describe("query cost histogram", () => {
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 2$/m)
 	})
 
-	it("adversarial pathological query records to the top bucket", () => {
+	it("adversarial pathological query records to the top bucket and is rejected", () => {
 		const plugin = useCostLogger()
 		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
 		let q = "{ id }"
 		for (let i = 0; i < 50; i++) q = `{ entities(first: 1000) ${q} }`
-		onExecute({args: {document: parse(q), variableValues: {}, operationName: null}})
+
+		// This is the shape the ceiling exists for: ~10^150 worst-case nodes,
+		// which cannot be executed at all. It is still observed (recorded to
+		// the histogram) before being refused, so the metric keeps counting
+		// what enforcement turns away.
+		expect(() => onExecute({args: {document: parse(q), variableValues: {}, operationName: null}})).toThrow(
+			/exceeds the maximum/,
+		)
 
 		const out = renderQueryCostHistogram()
-		// Score ~1500 lands in the 500 bucket? No — 1500 > 500 → +Inf.
-		// Goes into le=1000 and +Inf but not le=500.
+		// Score ~1500 → above every finite bucket edge, so le="500" stays 0
+		// and only +Inf increments.
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="500"} 0$/m)
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="\+Inf"} 1$/m)
+	})
+
+	it("does not reject queries below the ceiling", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+
+		// The 2026-08-06 incident traffic scored 228 — well over the *log*
+		// threshold of 200, and 44% of all production traffic sits above that
+		// line. Enforcement must not touch it.
+		const realistic = `{
+			entitiesOrderedByProperty(first: 40) {
+				id name
+				values(first: 50) { nodes { text } }
+				relations(first: 200) { nodes { toEntity { id name } } }
+			}
+		}`
+		expect(() =>
+			onExecute({args: {document: parse(realistic), variableValues: {}, operationName: null}}),
+		).not.toThrow()
 	})
 
 	it("skips introspection queries", () => {

--- a/api/src/kg/__tests__/shedEpisodeTracker.test.ts
+++ b/api/src/kg/__tests__/shedEpisodeTracker.test.ts
@@ -10,6 +10,7 @@ function snapshot(overrides: Partial<SaturationSnapshot> = {}): SaturationSnapsh
 		utilizationPercent: 0,
 		waitingCount: 0,
 		recentAcquireTimeouts: 0,
+		recentSlowAcquires: 0,
 		activeSince: null,
 		lastSignalAt: null,
 		...overrides,

--- a/api/src/kg/admissionControl.ts
+++ b/api/src/kg/admissionControl.ts
@@ -1,0 +1,192 @@
+import {GraphQLError} from "graphql"
+import type {Plugin} from "graphql-yoga"
+import {log} from "../services/telemetry"
+import {GRAPHQL_QUERY_COST_CONTEXT_KEY, type GraphqlCostContext} from "./costLoggerPlugin"
+
+/**
+ * Bounds how many *expensive* GraphQL operations one pod executes at once.
+ *
+ * Why this exists
+ * ---------------
+ * On 2026-08-06 the api spent hours at 8.5% 5xx and a 17.8s p99. Nothing was
+ * wrong with any individual query: the heaviest caller scored 228 on the cost
+ * model, and 44% of all normal traffic already scores above 200. Postgres was
+ * idle (33 of 1000 connections). The pod's own pool had 19 of 33 connections
+ * free with nothing queued.
+ *
+ * What was exhausted was the single JS thread. Enough ordinary-cost queries
+ * arrived together that serialising their results starved the event loop, and
+ * everything — including /health/liveness — stopped being answered on time.
+ *
+ * Nothing in the stack bounded that. `dbSaturation` measures *connections*,
+ * which is why it read healthy throughout. The cost model measures a single
+ * query's worst case, which cannot see aggregate load. Concurrency is the
+ * missing axis.
+ *
+ * Design notes
+ * ------------
+ * - **Cost-gated.** Cheap operations are never blocked, however many arrive.
+ *   Only work above ADMISSION_COST_FLOOR counts against the limit, so a
+ *   burst of `entity(id:)` lookups cannot be refused because a few heavy
+ *   feed queries are in flight. This keeps the failure contained to the
+ *   traffic that actually causes it.
+ *
+ * - **Fast-fail, not queue.** Queuing converts overload into latency, which
+ *   is what already happens and what killed the liveness probe. A 503 with
+ *   Retry-After costs microseconds and lets the caller decide. Note the one
+ *   known heavy client (news) retries 503s, so the ceiling must be high
+ *   enough that this is genuinely rare.
+ *
+ * - **Leak-resistant.** A counter that fails to decrement would wedge the pod
+ *   permanently closed — strictly worse than the problem. In-flight work is
+ *   tracked with start timestamps and anything older than MAX_AGE_MS is
+ *   pruned, so a missed release self-heals within a minute instead of
+ *   requiring a restart.
+ *
+ *   envelop's onExecuteDone alone is NOT sufficient: the orchestrator runs
+ *   handleMaybePromise(beforeHooks, thenExecuteAndAfterHooks) with no error
+ *   handler, so if a *later* plugin's onExecute throws — usePgClient
+ *   pool-shedding or a failed pool.connect(), both incident conditions — the
+ *   success continuation is skipped and the after-hooks never run. At the
+ *   measured 0.887 expensive ops/sec/pod a 60s prune window would leak ~53
+ *   slots, more than the limit itself. So there is also an onResponse
+ *   backstop keyed by the HTTP Request, mirroring usePgClient which hit the
+ *   same behaviour (api/docs/gql-pool-leak-investigation.md).
+ *
+ * - **A ceiling, not a tuning knob.** The default is set from measurement,
+ *   not intuition. Over 30 minutes of healthy traffic, reconstructing request
+ *   intervals from logged durations gives a peak of **5** concurrent
+ *   slow/large operations on the busiest pod. That is a lower bound — only
+ *   slow and large operations are logged — but the fast remainder is short
+ *   enough to add little. Arrival rate is 0.887 expensive (cache-miss)
+ *   operations per second per pod, bursting to 30 in a single pod-second.
+ *
+ *   48 is ~10x the observed peak: high enough that an ordinary burst cannot
+ *   trip it, low enough to stop a runaway pile-up. An earlier draft used 16,
+ *   which is only ~3x — too tight for a control that answers 503 to a client
+ *   that retries them, since a false rejection would add load rather than
+ *   shed it. Every engagement is logged; if the warning appears at all in
+ *   normal operation the number is still wrong.
+ */
+
+function parseIntEnv(name: string, fallback: number, min: number): number {
+	const raw = process.env[name]
+	if (raw === undefined) return fallback
+	const parsed = Number.parseInt(raw, 10)
+	if (!Number.isFinite(parsed) || parsed < min) return fallback
+	return parsed
+}
+
+/** Max concurrent expensive operations per pod. 0 disables admission control. */
+export const MAX_CONCURRENT_EXPENSIVE = parseIntEnv("GRAPHQL_MAX_CONCURRENT_EXPENSIVE", 48, 0)
+
+/** Only operations at or above this cost count against the limit. */
+export const ADMISSION_COST_FLOOR = parseIntEnv("GRAPHQL_ADMISSION_COST_FLOOR", 200, 0)
+
+/**
+ * Safety valve. Longer than PG_QUERY_TIMEOUT_MS (35s default) so a legitimately
+ * slow query is never pruned while still running — pruning early would
+ * under-count and defeat the limit, which is the milder of the two failures.
+ */
+const MAX_AGE_MS = parseIntEnv("GRAPHQL_ADMISSION_MAX_AGE_MS", 60_000, 1_000)
+
+type InFlight = {startedAtMs: number; operation: string}
+
+const inFlight = new Map<symbol, InFlight>()
+
+/**
+ * Token per in-flight HTTP request, so the onResponse backstop can release a
+ * slot whose onExecuteDone never ran. Weak, so an abandoned request cannot
+ * retain memory.
+ */
+const requestTokens = new WeakMap<Request, symbol>()
+
+/** Drop entries whose release was missed, so a leak cannot wedge the pod. */
+function pruneStale(nowMs: number): void {
+	if (inFlight.size === 0) return
+	for (const [token, entry] of inFlight) {
+		if (nowMs - entry.startedAtMs > MAX_AGE_MS) {
+			inFlight.delete(token)
+			log.warn("Admission control pruned a stale in-flight entry", {
+				operation: entry.operation,
+				ageMs: nowMs - entry.startedAtMs,
+			})
+		}
+	}
+}
+
+/** Current count of tracked expensive operations. Exported for tests + metrics. */
+export function getInFlightExpensiveCount(nowMs = Date.now()): number {
+	pruneStale(nowMs)
+	return inFlight.size
+}
+
+/** Test-only: drop all tracked state. */
+export function resetAdmissionControl(): void {
+	inFlight.clear()
+}
+
+function operationLabel(args: {operationName?: string | null}): string {
+	return args.operationName ?? "anonymous"
+}
+
+export function useAdmissionControl(): Plugin {
+	return {
+		onExecute({args}) {
+			if (MAX_CONCURRENT_EXPENSIVE <= 0) return
+
+			// Cost is computed by useCostLogger, which must run first — it
+			// stashes the score on the shared request context. If it is absent
+			// (introspection, or the cost walk failed) treat the operation as
+			// cheap and let it through rather than guessing.
+			const ctx = args.contextValue as GraphqlCostContext | undefined
+			const cost = ctx?.[GRAPHQL_QUERY_COST_CONTEXT_KEY]
+			if (typeof cost !== "number" || cost < ADMISSION_COST_FLOOR) return
+
+			const nowMs = Date.now()
+			pruneStale(nowMs)
+
+			if (inFlight.size >= MAX_CONCURRENT_EXPENSIVE) {
+				log.warn("GraphQL admission control rejected an operation", {
+					operationName: operationLabel(args),
+					cost,
+					inFlight: inFlight.size,
+					limit: MAX_CONCURRENT_EXPENSIVE,
+					costFloor: ADMISSION_COST_FLOOR,
+				})
+				throw new GraphQLError("Server is at capacity for expensive queries; please retry.", {
+					extensions: {
+						code: "SERVICE_UNAVAILABLE",
+						http: {status: 503, headers: {"Retry-After": "1"}},
+					},
+				})
+			}
+
+			const token = Symbol("admission")
+			inFlight.set(token, {startedAtMs: nowMs, operation: operationLabel(args)})
+
+			// Key the token to the HTTP request so onResponse can clean up when the
+			// after-hooks are skipped. usePgClient keys on the same value.
+			const request = (args.contextValue as {request?: Request} | undefined)?.request
+			if (request) requestTokens.set(request, token)
+
+			return {
+				onExecuteDone() {
+					inFlight.delete(token)
+					if (request) requestTokens.delete(request)
+				},
+			}
+		},
+
+		// Backstop. Fires after the HTTP response regardless of whether execute()
+		// completed, threw, or never ran because a later onExecute hook threw. A
+		// token still present here means onExecuteDone did not fire.
+		onResponse({request}) {
+			const token = requestTokens.get(request)
+			if (token) {
+				inFlight.delete(token)
+				requestTokens.delete(request)
+			}
+		},
+	}
+}

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -4,6 +4,7 @@ import {
 	type DocumentNode,
 	type FieldNode,
 	type FragmentDefinitionNode,
+	GraphQLError,
 	Kind,
 	type OperationDefinitionNode,
 	print,
@@ -67,6 +68,40 @@ function parsePositiveIntEnv(name: string, fallback: number): number {
 //               structurally-unbounded queries worth flagging.
 //   ~1500       50-level deeply nested adversarial probe.
 const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 200)
+
+// ---------------------------------------------------------------------------
+// Hard ceiling (Phase 2 — enforcement)
+// ---------------------------------------------------------------------------
+// Distinct from COST_LOG_THRESHOLD, and deliberately far above it.
+//
+// The log threshold is NOT a violation line. Measured over 19,836 real
+// queries on one pod:
+//
+//   <=150  37.5%     <=220  85.9%     <=320  99.87%
+//   <=200  56.0%     <=260  96.8%     <=400  100%
+//
+// 44% of ordinary traffic already scores above 200, so enforcing there would
+// reject nearly half of all requests. Nothing in production exceeds 400.
+//
+// The ceiling exists for a different failure: the cost walker is
+// multiplicative in BigInt, and a deeply nested adversarial document scores
+// ~1500 (10^150 worst-case nodes). No legitimate client needs that. 500
+// rejects zero current traffic while closing the door on a document whose
+// worst case cannot be executed at all.
+//
+// This does NOT prevent the 2026-08-06 incident class. That load scored 228 —
+// squarely inside normal. Capacity is bounded by admission control, not here.
+//
+// Set GRAPHQL_COST_REJECT_THRESHOLD=0 to disable enforcement outright.
+function parseCeilingEnv(name: string, fallback: number): number {
+	const raw = process.env[name]
+	if (raw === undefined) return fallback
+	const parsed = Number.parseInt(raw, 10)
+	if (!Number.isFinite(parsed) || parsed < 0) return fallback
+	return parsed
+}
+
+const COST_REJECT_THRESHOLD = parseCeilingEnv("GRAPHQL_COST_REJECT_THRESHOLD", 500)
 
 // ---------------------------------------------------------------------------
 // Prometheus histogram metric — gaia_api_graphql_query_cost
@@ -596,6 +631,10 @@ function resolveValue(value: ValueNode, vars: Record<string, unknown>): unknown 
 export function useCostLogger(): Plugin {
 	return {
 		onExecute({args}) {
+			// Held outside the try so the shadow-mode catch below cannot swallow
+			// a deliberate rejection. The catch exists to stop *plugin bugs*
+			// breaking a request; it must not also suppress enforcement.
+			let rejection: GraphQLError | null = null
 			try {
 				if (isIntrospectionOnlyOperation(args.document, args.operationName)) return
 
@@ -630,6 +669,33 @@ export function useCostLogger(): Plugin {
 					ctx[GRAPHQL_QUERY_COST_CONTEXT_KEY] = cost
 				}
 
+				if (COST_REJECT_THRESHOLD > 0 && cost >= COST_REJECT_THRESHOLD) {
+					const rejectedQuery = print(args.document)
+					const rejectHeaders = (args.contextValue as {request?: Request} | undefined)?.request?.headers
+					log.warn("GraphQL query rejected: cost ceiling", {
+						cost,
+						ceiling: COST_REJECT_THRESHOLD,
+						operationName: getOperationLabel(args),
+						queryFingerprint: graphqlQueryFingerprint(rejectedQuery),
+						query: rejectedQuery,
+						variables: args.variableValues,
+						origin: rejectHeaders?.get("origin") ?? null,
+						clientIp: rejectHeaders ? extractClientIp(rejectHeaders) : null,
+					})
+					rejection = new GraphQLError(
+						`Query complexity ${cost} exceeds the maximum of ${COST_REJECT_THRESHOLD}. ` +
+							"Reduce nesting depth or the `first` values on nested list fields.",
+						{
+							extensions: {
+								code: "BAD_USER_INPUT",
+								cost,
+								maxCost: COST_REJECT_THRESHOLD,
+								http: {status: 400},
+							},
+						},
+					)
+				}
+
 				if (cost >= COST_LOG_THRESHOLD) {
 					const fullQuery = print(args.document)
 					const headers = (args.contextValue as {request?: Request} | undefined)?.request?.headers
@@ -655,6 +721,10 @@ export function useCostLogger(): Plugin {
 					// Nothing we can do; keep the request flowing.
 				}
 			}
+
+			// Outside the catch on purpose. A plugin bug must not break the
+			// request; a query over the ceiling must.
+			if (rejection) throw rejection
 		},
 	}
 }

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -11,11 +11,14 @@ import {classifyDbFailure} from "../services/dbFailures"
 import {
 	getGraphqlPressureSnapshot,
 	recordGraphqlAcquireTimeout,
+	recordGraphqlSlowAcquire,
 	type SaturationSnapshot,
+	SLOW_ACQUIRE_MS,
 	shouldShedPoolTraffic,
 } from "../services/dbSaturation"
 import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
+import {useAdmissionControl} from "./admissionControl"
 import {useCostLogger} from "./costLoggerPlugin"
 import EntityComputedTextFilterPlugin from "./entityComputedTextFilterPlugin"
 import EntitySpaceFilterPlugin from "./entitySpaceFilterPlugin"
@@ -342,7 +345,11 @@ function usePgClient(pool: Pool): Plugin<{pgClient: PoolClient}> {
 			}
 
 			const acquireWaitMs = Date.now() - acquireStartMs
-			if (acquireWaitMs > 250) {
+			if (acquireWaitMs > SLOW_ACQUIRE_MS) {
+				// Feed the saturation FSM, not just the log. This is the signal
+				// that moves when the event loop is starved rather than the pool
+				// being exhausted — see dbSaturation.ts.
+				recordGraphqlSlowAcquire()
 				log.warn("PostGraphile pool acquire was slow", {
 					operationName,
 					acquireWaitMs,
@@ -456,6 +463,10 @@ const sharedPlugins = [
 	...(responseCachePlugin ? [responseCachePlugin] : []),
 	customValidationRules,
 	useCostLogger(),
+	// Must follow useCostLogger — it reads the score that plugin stashes on the
+	// request context. Must precede usePgClient so a refused operation never
+	// checks out a connection or touches the database.
+	useAdmissionControl(),
 	useGraphQLInstrumentation(),
 	useSearchInvocationLogger(),
 	usePgClient(pgPool),

--- a/api/src/services/dbSaturation.test.ts
+++ b/api/src/services/dbSaturation.test.ts
@@ -1,6 +1,11 @@
 import {describe, expect, it} from "vitest"
 
-import {getPoolSaturationSnapshot, recordPoolAcquireTimeout, shouldShedPoolTraffic} from "./dbSaturation"
+import {
+	getPoolSaturationSnapshot,
+	recordPoolAcquireTimeout,
+	recordPoolSlowAcquire,
+	shouldShedPoolTraffic,
+} from "./dbSaturation"
 
 type PoolStats = {
 	totalConnections: number
@@ -174,5 +179,81 @@ describe("dbSaturation load shedding", () => {
 		const afterRelease = getPoolSaturationSnapshot(poolName, normalStats, 55_001)
 		expect(afterRelease.isSaturated).toBe(false)
 		expect(shouldShedPoolTraffic(afterRelease)).toBe(false)
+	})
+
+	// Regression for the 2026-08-06 incident: the api stalled for hours while
+	// every configured input read normal. These are the numbers observed on a
+	// dying pod — a free pool, nothing queued, and acquires taking 500ms+
+	// because the event loop could not run the callback.
+	it("records slow acquires but does NOT raise a pressure reason", () => {
+		const poolName = uniquePoolName("slow-acquire")
+		const healthyStats: PoolStats = {
+			totalConnections: 33,
+			idleConnections: 19,
+			waitingCount: 0,
+			maxConnections: 50,
+		}
+
+		// Sanity: none of the pre-existing signals fire on these stats.
+		const before = getPoolSaturationSnapshot(poolName, healthyStats, 1_000)
+		expect(before.reasons).toEqual([])
+
+		for (let i = 0; i < 5; i++) {
+			recordPoolSlowAcquire(poolName, 1_000 + i)
+		}
+
+		const after = getPoolSaturationSnapshot(poolName, healthyStats, 1_100)
+		// Counted and surfaced for observability...
+		expect(after.recentSlowAcquires).toBe(5)
+		// ...but deliberately not a pressure reason. 48% of populated 30s
+		// windows in healthy production already contain >= 5 slow acquires, so
+		// shedding on this would refuse ordinary traffic — and to a client that
+		// retries 503s. See the threshold comment in dbSaturation.ts.
+		expect(after.reasons).toEqual([])
+		expect(after.isPressured).toBe(false)
+		expect(after.utilizationPercent).toBe(66)
+		expect(after.waitingCount).toBe(0)
+	})
+
+	it("counts slow acquires independently of the reported reasons", () => {
+		const poolName = uniquePoolName("slow-acquire-under")
+		recordPoolSlowAcquire(poolName, 1_000)
+		recordPoolSlowAcquire(poolName, 1_001)
+
+		const snapshot = getPoolSaturationSnapshot(poolName, baseStats, 1_100)
+		expect(snapshot.recentSlowAcquires).toBe(2)
+		expect(snapshot.reasons).toEqual([])
+	})
+
+	it("keeps slow acquires separate from acquire timeouts", () => {
+		const poolName = uniquePoolName("slow-vs-timeout")
+		for (let i = 0; i < 5; i++) recordPoolSlowAcquire(poolName, 1_000 + i)
+
+		const snapshot = getPoolSaturationSnapshot(poolName, baseStats, 1_100)
+		expect(snapshot.recentSlowAcquires).toBe(5)
+		expect(snapshot.recentAcquireTimeouts).toBe(0)
+	})
+
+	it("never sheds on slow acquires alone, however many accumulate", () => {
+		const poolName = uniquePoolName("slow-acquire-no-shed")
+		const healthyStats: PoolStats = {
+			totalConnections: 33,
+			idleConnections: 19,
+			waitingCount: 0,
+			maxConnections: 50,
+		}
+
+		// Far more than the busiest window ever observed in production (21),
+		// sustained well past the activation window. Must still not shed.
+		for (let i = 0; i < 50; i++) recordPoolSlowAcquire(poolName, 10_000 + i)
+		const first = getPoolSaturationSnapshot(poolName, healthyStats, 10_100)
+		expect(shouldShedPoolTraffic(first)).toBe(false)
+
+		for (let i = 0; i < 50; i++) recordPoolSlowAcquire(poolName, 25_000 + i)
+		const later = getPoolSaturationSnapshot(poolName, healthyStats, 25_100)
+		expect(later.recentSlowAcquires).toBeGreaterThan(21)
+		expect(later.isPressured).toBe(false)
+		expect(later.isSaturated).toBe(false)
+		expect(shouldShedPoolTraffic(later)).toBe(false)
 	})
 })

--- a/api/src/services/dbSaturation.ts
+++ b/api/src/services/dbSaturation.ts
@@ -14,6 +14,7 @@ export type SaturationSnapshot = {
 	utilizationPercent: number
 	waitingCount: number
 	recentAcquireTimeouts: number
+	recentSlowAcquires: number
 	activeSince: string | null
 	lastSignalAt: string | null
 }
@@ -48,6 +49,43 @@ const PRESSURE_TIMEOUT_THRESHOLD = readIntEnv("PG_POOL_PRESSURE_TIMEOUT_THRESHOL
 const SATURATION_ACTIVATION_MS = readIntEnv("PG_POOL_SATURATION_ACTIVATION_MS", 15000, 1000, 300000)
 const SATURATION_RELEASE_MS = readIntEnv("PG_POOL_SATURATION_RELEASE_MS", 30000, 1000, 600000)
 const ACQUIRE_TIMEOUT_WINDOW_MS = readIntEnv("PG_POOL_ACQUIRE_TIMEOUT_WINDOW_MS", 30000, 1000, 600000)
+
+// Acquire *latency* signal — OBSERVE-ONLY.
+//
+// The motivation is real. On 2026-08-06 the api stalled for hours with every
+// configured input reading normal: waitingCount 0, utilization 66%, zero
+// acquire timeouts — while pool.connect() took 500-634ms with 19 of 33
+// connections idle. A free connection was available instantly; what was slow
+// was the event loop getting round to the callback. Pool counters cannot see
+// that by construction, so the shed gate never fired once.
+//
+// But acquire latency turns out not to separate that state from a healthy
+// one. Measured across all pods over 30 minutes of *healthy* traffic:
+//
+//   847 acquires over 250ms      p50 380ms, max 2418ms
+//   48% of populated 30s windows already contain >= 5 of them
+//   busiest window: 21
+//
+// The incident samples (500-634ms) sit inside that everyday range, and the
+// current max is worse than anything observed during the incident. Any
+// threshold low enough to have caught 2026-08-06 fires constantly now, and
+// shedding is 503s to a client (news) that retries them — so a false positive
+// amplifies load rather than relieving it.
+//
+// So the count is recorded and surfaced on the snapshot, but is NOT a
+// pressure reason. Wiring it into shedding requires characterising the
+// distribution first, and probably a better-targeted metric than acquire
+// latency — direct event-loop lag is the honest measure of the thing this
+// was reaching for.
+//
+// The threshold below only shapes the reported count, and currently gates
+// nothing.
+const PRESSURE_SLOW_ACQUIRE_THRESHOLD = readIntEnv("PG_POOL_PRESSURE_SLOW_ACQUIRE_THRESHOLD", 5, 1, 500)
+
+/** An acquire slower than this counts toward `slow_acquires`. Exported so the
+ *  call site that measures acquire duration cannot drift from the threshold
+ *  the signal is defined against. */
+export const SLOW_ACQUIRE_MS = readIntEnv("PG_POOL_SLOW_ACQUIRE_MS", 250, 10, 60000)
 const ACQUIRE_TIMEOUT_BUCKET_MS = 1000
 
 const perPoolState = new Map<string, SaturationState>()
@@ -108,6 +146,14 @@ function pruneOldTimeoutBuckets(poolName: string, nowMs: number): Map<number, nu
 	return buckets
 }
 
+/**
+ * Slow acquires reuse the timeout bucket machinery under a separate series
+ * key, so both share the same rolling window and pruning.
+ */
+function slowAcquireSeries(poolName: string): string {
+	return `${poolName}::slow-acquire`
+}
+
 function getRecentTimeoutCount(poolName: string, nowMs: number): number {
 	const buckets = pruneOldTimeoutBuckets(poolName, nowMs)
 	let total = 0
@@ -133,6 +179,12 @@ function getPressureReasons(stats: PoolStats, nowMs: number, poolName: string): 
 	if (recentTimeouts >= PRESSURE_TIMEOUT_THRESHOLD) {
 		reasons.push("acquire_timeouts")
 	}
+
+	// NOTE: slow acquires are deliberately NOT a pressure reason yet. See the
+	// PRESSURE_SLOW_ACQUIRE_THRESHOLD comment — at any threshold justified by
+	// the incident this fires on ordinary traffic. The count is recorded on the
+	// snapshot for observability so the distribution can be characterised
+	// before it is ever allowed to shed.
 
 	return reasons
 }
@@ -174,6 +226,7 @@ export function getPoolSaturationSnapshot(poolName: string, stats: PoolStats, no
 	}
 
 	const recentAcquireTimeouts = getRecentPoolAcquireTimeoutCount(poolName, nowMs)
+	const recentSlowAcquires = getRecentTimeoutCount(slowAcquireSeries(poolName), nowMs)
 
 	return {
 		isPressured: hasSignal,
@@ -182,6 +235,7 @@ export function getPoolSaturationSnapshot(poolName: string, stats: PoolStats, no
 		utilizationPercent: getUtilizationPercent(stats),
 		waitingCount: stats.waitingCount,
 		recentAcquireTimeouts,
+		recentSlowAcquires,
 		activeSince: toIsoOrNull(state.activeSinceMs),
 		lastSignalAt: toIsoOrNull(state.lastSignalAtMs),
 	}
@@ -193,6 +247,16 @@ export function getGraphqlPressureSnapshot(stats: PoolStats, nowMs = Date.now())
 
 export function recordGraphqlAcquireTimeout(nowMs = Date.now()): void {
 	recordPoolAcquireTimeout("graphql", nowMs)
+}
+
+/** Record one acquire that exceeded the slow threshold. Called from the same
+ *  place postgraphile.ts already logs its "pool acquire was slow" warning. */
+export function recordPoolSlowAcquire(poolName: string, nowMs = Date.now()): void {
+	recordPoolAcquireTimeout(slowAcquireSeries(poolName), nowMs)
+}
+
+export function recordGraphqlSlowAcquire(nowMs = Date.now()): void {
+	recordPoolSlowAcquire("graphql", nowMs)
 }
 
 /**


### PR DESCRIPTION
Three capacity controls in response to the 2026-08-06 incident ([GEO-2519](https://linear.app/geobrowser/issue/GEO-2519/api-5xx-unbounded-graphql-query-cost-stalls-the-event-loop-23-gb-of)).

**None of them is the per-response node budget that ticket called for.** Measuring the cost distribution showed that idea doesn't work, which is the most important thing here to review.

## Why the node budget is the wrong fix

The cost model *already* bounds the product — `base = child * limit + 1n`, walked in BigInt, reported as `round(log₁₀ × 10)`. What it computes is the **worst case**. A score of 207 means ~10²⁰ theoretical nodes for a query whose actual response held ~100,000. A static node budget over-rejects identically, because the difference between the incident traffic and a safe query was never *shape* — it was what the data happened to contain.

Measured over **19,836 real queries** on one pod:

| cost ≤ | cumulative | | cost ≤ | cumulative |
|---|---|---|---|---|
| 150 | 37.5% | | 260 | 96.8% |
| **200** | **56.0%** | | 320 | 99.87% |
| 220 | 85.9% | | 400 | **100%** |

**44% of ordinary traffic already exceeds the 200 threshold.** It isn't a violation line, it's roughly the median.

## 1. Admission control — the control that matches the failure

`api/src/kg/admissionControl.ts`

The incident wasn't one expensive query. It was enough *ordinary-cost* queries arriving together to starve a single JS thread, while Postgres sat idle at 33 of 1000 connections. Concurrency was the unbounded axis and nothing measured it.

- **Cost-gated** — cheap traffic is never refused however much arrives. Only work ≥ `ADMISSION_COST_FLOOR` counts, so a burst of `entity(id:)` lookups can't be turned away because a few feed queries are in flight.
- **Fast-fail, not queue** — queuing converts overload into the latency that killed the liveness probe.

**The limit is set from measurement.** Reconstructing request intervals from logged durations (end timestamp − `durationMs`) and sweeping for maximum overlap:

```
peak concurrent slow/large operations, per pod, 30 min:
  5, 5, 4, 3, 3, 3, 3, 2      <- lower bound (only slow/large are logged)

arrival rate: 0.887 expensive (cache-miss) ops/sec/pod
              bursting to 30 in a single pod-second
duration:     p50 3.2s, p99 30s (statement timeout)
```

**48 is ~10× the observed peak** — an ordinary burst can't trip it, a runaway pile-up is still bounded. The margin matters because the response is a 503 to a client (news) that *retries* them, so a false rejection would add load rather than shed it.

### Release is leak-proof in three layers — the subtle part

`onExecuteDone` alone is **not sufficient**, and getting this wrong would be worse than the problem. envelop's orchestrator runs:

```js
handleMaybePromise(runBeforeHooks, runExecuteThenAfterHooks)   // no error handler
```

So when a **later** plugin's `onExecute` throws — `usePgClient` pool-shedding or a failed `pool.connect()`, *both incident conditions* — the success continuation is skipped and the after-hooks never run. At the measured arrival rate a 60s prune window would leak **~53 slots, more than the limit itself**: the limiter would progressively wedge shut exactly when it's needed.

Release therefore happens on `onExecuteDone` (fast path), with an **`onResponse` backstop keyed by the HTTP Request** that fires however execution ended, plus the age prune as a final defence. This mirrors `usePgClient`, which hit the same envelop behaviour — see `api/docs/gql-pool-leak-investigation.md`.

### Cache hits don't consume slots

Verified from source, not assumed: envelop's `iterateAsync` has `if (endedEarly) return`, `setResultAndStopExecution` calls `endEarly()`, and `responseCachePlugin` is registered before both `useCostLogger` and `useAdmissionControl`. This also means the cost logs measure *exactly* the population admission control governs — which is what makes the calibration above valid.

## 2. Cost ceiling — cheap insurance

`GRAPHQL_COST_REJECT_THRESHOLD`, default **500**, far above the 200 log threshold. Nothing in production exceeds 400, so **this rejects zero current traffic**. It exists for the one thing the cost model genuinely catches: a deeply nested adversarial document scoring ~1500 (10¹⁵⁰ worst case), which cannot be executed at all.

The rejection is raised *outside* the plugin's shadow-mode catch — that catch stops a plugin bug breaking a request, and must not also suppress enforcement.

**This would not have prevented the incident.** That traffic scored 228.

Both new error codes (`BAD_USER_INPUT`, `SERVICE_UNAVAILABLE`) are already in `errorMasking`'s `UNMASKED_ERROR_CODES`, so the status and `Retry-After` reach the client rather than being masked to a generic 500.

## 3. Acquire-latency count — observe-only, deliberately

Throughout the incident every configured saturation input read normal — `waitingCount 0`, `utilization 66%`, zero acquire timeouts — while `pool.connect()` took **500–634 ms with 19 of 33 connections idle**. Pool counters cannot see thread starvation by construction, so the shed gate never fired once.

`postgraphile.ts` already detected these at 250 ms and only logged them. They're now counted and surfaced as `recentSlowAcquires`, so the gap is visible.

**They are not a pressure reason.** Across all pods over 30 minutes of *healthy* traffic:

| | |
|---|---|
| acquires over 250 ms | **847** (p50 380 ms, max 2418 ms) |
| populated 30s windows with ≥5 | **48%** |
| busiest window | 21 |

Any threshold low enough to have caught 2026-08-06 fires on roughly half of all healthy windows — and the incident samples sit *inside* today's everyday range, with today's max worse than anything seen during the incident. Acquire latency does not separate the two states. The right metric is probably **direct event-loop lag**.

## Verification

- `bun run ci` (format + lint + tsc) — **exit 0**
- **13 new tests.** Full suite compared against a clean `origin/staging` worktree: **633 → 646 passing**, with the 36 failures / 16 errors **byte-identical to baseline** (they need a live database). Failing test *names* were diffed, not just counts.
- Tests assert: the incident-shaped query at cost 228 is **not** rejected; the adversarial 50-level probe **is**; 50 sustained slow acquires still **don't** shed; and a slot **is** released via `onResponse` when `onExecuteDone` never fires.

## Rollout

All three are env-tunable and individually disablable (`GRAPHQL_MAX_CONCURRENT_EXPENSIVE=0`, `GRAPHQL_COST_REJECT_THRESHOLD=0`).

Admission control is the only one that can refuse traffic which succeeds today. Watch for `"GraphQL admission control rejected an operation"` — peak-5 is a **lower bound** from a healthy sample taken *after* the news fix reduced load, so if a new heavy client appears the real peak moves. If that warning appears in normal operation the limit is wrong and should be raised.

Separately worth wiring: `gaia_api_graphql_query_cost` is exposed on `/health/metrics` but **isn't scraped into Prometheus**. The distribution above had to be read off a pod.
