### PR TITLE
fix(ranking): decay rolling ballots by recency instead of expiring them at one frequency

### DIFF
--- a/ranking-indexer/src/eligibility.rs
+++ b/ranking-indexer/src/eligibility.rs
@@ -67,10 +67,19 @@ pub fn window_admits(
 
 /// Does a Rolling-type block's submission remain eligible?
 ///
-/// Valid while `now - submitted_at < submission_frequency` (hours); once a
-/// submission ages past its frequency it requires resubmission. `now` is a
-/// parameter (never read via an inline `Utc::now()` call here) so callers —
-/// tests and the periodic sweep alike — control it deterministically.
+/// `submission_frequency` is a *half-life*, not a cliff: a ballot's contribution
+/// decays continuously (see `scoring::recency_weight`) and this check only drops
+/// it once decay has taken it below the resolution of the published projection,
+/// at `ROLLING_MAX_HALF_LIVES` half-lives.
+///
+/// It used to expire at exactly one `submission_frequency`, which made a block
+/// publish nothing whenever nobody had submitted inside the trailing window —
+/// the common case, since the window equalled the cadence users were told to
+/// resubmit on. That rendered a "Trending" table as empty rather than stale, and
+/// it also drove the client to blank the author's ballot on roll-off.
+///
+/// `now` is a parameter (never read via an inline `Utc::now()` call here) so
+/// callers — tests and the periodic sweep alike — control it deterministically.
 ///
 /// An absent frequency or unknown submission time can't be evaluated, so (like
 /// `window_admits`) we admit rather than silently drop.
@@ -82,7 +91,12 @@ pub fn rolling_admits(
     let (Some(submitted_at), Some(frequency_hours)) = (submitted_at, frequency_hours) else {
         return true;
     };
-    now - submitted_at < chrono::Duration::hours(frequency_hours.into())
+    if frequency_hours <= 0 {
+        return true;
+    }
+    let cutoff_hours = f64::from(frequency_hours) * crate::scoring::ROLLING_MAX_HALF_LIVES;
+    let age_hours = (now - submitted_at).num_milliseconds() as f64 / 3_600_000.0;
+    age_hours < cutoff_hours
 }
 
 /// Filter deduped submissions to those eligible for `block`.
@@ -209,19 +223,26 @@ mod tests {
     }
 
     #[test]
-    fn rolling_admits_window() {
+    fn rolling_admits_until_the_decay_cutoff_not_one_frequency() {
         let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0).unwrap();
         let hour = 3600;
-        // within: 1 hour old, 2-hour frequency
-        assert!(rolling_admits(Some(t(0)), Some(2), t(hour)));
-        // exactly-at-boundary: elapsed == frequency is expired, not admitted
-        assert!(!rolling_admits(Some(t(0)), Some(1), t(hour)));
-        // just past the boundary
-        assert!(!rolling_admits(Some(t(0)), Some(1), t(hour + 1)));
-        // just before the boundary
-        assert!(rolling_admits(Some(t(0)), Some(1), t(hour - 1)));
+        // A ballot one frequency old is NOT expired any more — it decays instead
+        // (scoring::recency_weight halves it), which is what stops a Rolling block
+        // publishing an empty table between submissions.
+        assert!(rolling_admits(Some(t(0)), Some(1), t(hour)));
+        assert!(rolling_admits(Some(t(0)), Some(1), t(hour + 1)));
+        // Still admitted just inside the cutoff (8 half-lives), dropped at/after it.
+        let cutoff = (crate::scoring::ROLLING_MAX_HALF_LIVES as i64) * hour;
+        assert!(rolling_admits(Some(t(0)), Some(1), t(cutoff - 1)));
+        assert!(!rolling_admits(Some(t(0)), Some(1), t(cutoff)));
+        assert!(!rolling_admits(Some(t(0)), Some(1), t(cutoff + hour)));
+        // The cutoff scales with the frequency: 24h frequency -> 8 days.
+        assert!(rolling_admits(Some(t(0)), Some(24), t(7 * 24 * hour)));
+        assert!(!rolling_admits(Some(t(0)), Some(24), t(8 * 24 * hour)));
         // absent frequency imposes no limit
         assert!(rolling_admits(Some(t(0)), None, t(hour * 1000)));
+        // a non-positive frequency can't define a cutoff
+        assert!(rolling_admits(Some(t(0)), Some(0), t(hour * 1000)));
         // unknown submission time can't be rejected
         assert!(rolling_admits(None, Some(1), t(hour * 1000)));
     }
@@ -230,17 +251,19 @@ mod tests {
     fn filter_eligible_uses_rolling_admits_for_rolling_blocks() {
         let t = |n: i64| DateTime::<Utc>::from_timestamp(n, 0).unwrap();
         let hour = 3600;
-        let b = rolling_block(Some(1)); // 1-hour frequency
+        let b = rolling_block(Some(1)); // 1-hour frequency -> 8-hour cutoff
         let mut members = HashSet::new();
         members.insert(Uuid::from_u128(1));
 
         let subs = vec![
-            submission(1, Some(t(0))),         // member, still within frequency -> keep
-            submission(1, Some(t(-2 * hour))), // member, expired -> drop
-            submission(2, Some(t(0))),         // non-member -> drop
+            submission(1, Some(t(0))),          // member, fresh -> keep
+            submission(1, Some(t(-2 * hour))),  // member, aged but inside cutoff -> keep (decays)
+            submission(1, Some(t(-20 * hour))), // member, past the cutoff -> drop
+            submission(2, Some(t(0))),          // non-member -> drop
         ];
         let kept = filter_eligible(&b, SpaceKind::Dao, &members, subs, t(hour / 2));
-        assert_eq!(kept.len(), 1);
-        assert_eq!(kept[0].submitted_at, Some(t(0)));
+        assert_eq!(kept.len(), 2);
+        assert!(kept.iter().all(|s| s.space_id == Uuid::from_u128(1)));
+        assert!(kept.iter().all(|s| s.submitted_at != Some(t(-20 * hour))));
     }
 }

--- a/ranking-indexer/src/recompute.rs
+++ b/ranking-indexer/src/recompute.rs
@@ -115,7 +115,17 @@ pub async fn recompute_block(
         .iter()
         .map(|r| (r, items_by_ranking.remove(&r.id).unwrap_or_default()))
         .collect();
-    let scores = scoring::aggregate(&ballots, scoring::NORM_LO, scoring::NORM_HI);
+    // Rolling blocks weight each ballot by recency, using the block's
+    // `submission_frequency` as the half-life; static blocks score every eligible
+    // ballot at full weight.
+    let decay = block
+        .ranking_type
+        .and(block.submission_frequency)
+        .map(|frequency_hours| scoring::RecencyDecay {
+            half_life_hours: f64::from(frequency_hours),
+            now,
+        });
+    let scores = scoring::aggregate(&ballots, scoring::NORM_LO, scoring::NORM_HI, decay);
     storage.replace_ranking_scores(block_id, &scores).await?;
 
     // 4. Publish: project RANK_POSITION relations (+ the integer rank-position

--- a/ranking-indexer/src/scoring.rs
+++ b/ranking-indexer/src/scoring.rs
@@ -16,6 +16,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::models::{Ranking, RankingItem};
@@ -24,6 +25,56 @@ use crate::models::{Ranking, RankingItem};
 pub const NORM_LO: f64 = 0.5;
 /// Default normalization ceiling: the top of a ballot.
 pub const NORM_HI: f64 = 1.0;
+
+/// How many half-lives a Rolling ballot keeps contributing before it is dropped
+/// outright (see `eligibility::rolling_admits`).
+///
+/// Decay alone never reaches zero, so without a cutoff every entity ever ranked
+/// would stay in the projection forever carrying a vanishing score, and the
+/// published table would grow without bound. At eight half-lives a ballot is
+/// down to 1/256 of its original weight — far below the resolution of the
+/// integer 0–100 projection — so dropping it there is invisible in the output
+/// while keeping the table bounded.
+pub const ROLLING_MAX_HALF_LIVES: f64 = 8.0;
+
+/// Recency decay for a Rolling block: ballots lose half their weight every
+/// `half_life_hours`.
+///
+/// This replaces the hard 24h cliff that `submission_frequency` used to impose.
+/// The cliff meant a block published *nothing* whenever no one had submitted
+/// inside the window — routinely, since the window equalled the resubmission
+/// cadence — so a "Trending" table read as empty rather than stale. Decaying
+/// instead keeps fresh ballots dominant without the table ever emptying.
+#[derive(Debug, Clone, Copy)]
+pub struct RecencyDecay {
+    /// Age at which a ballot's contribution halves — the block's
+    /// `submission_frequency`, reinterpreted as a half-life rather than a cliff.
+    pub half_life_hours: f64,
+    /// Instant ages are measured against. A parameter, never an inline
+    /// `Utc::now()`, so a sweep and a test can both pin it.
+    pub now: DateTime<Utc>,
+}
+
+/// A ballot's recency multiplier: `0.5 ^ (age / half_life)`, clamped to `[0, 1]`.
+///
+/// A ballot with no `submitted_at`, or a non-positive half-life, can't be aged
+/// and so decays not at all — consistent with `eligibility`, which admits rather
+/// than silently drops what it cannot evaluate. Ballots dated in the future
+/// (clock skew between the chain and this process) are treated as brand new
+/// rather than amplified beyond full weight.
+pub fn recency_weight(decay: RecencyDecay, submitted_at: Option<DateTime<Utc>>) -> f64 {
+    let Some(submitted_at) = submitted_at else {
+        return 1.0;
+    };
+    if !decay.half_life_hours.is_finite() || decay.half_life_hours <= 0.0 {
+        return 1.0;
+    }
+    let age_hours = (decay.now - submitted_at).num_milliseconds() as f64 / 3_600_000.0;
+    if age_hours <= 0.0 {
+        return 1.0;
+    }
+    0.5_f64.powf(age_hours / decay.half_life_hours)
+}
 
 /// A computed aggregate row (mirrors `ranks.ranking_scores`).
 #[derive(Debug, Clone, PartialEq)]
@@ -112,11 +163,24 @@ fn normalize_ordinal(items: &[RankingItem], lo: f64, hi: f64) -> Vec<((Uuid, Uui
 }
 
 /// Aggregate eligible ballots into the block's ordered result.
-pub fn aggregate(ballots: &[(&Ranking, Vec<RankingItem>)], lo: f64, hi: f64) -> Vec<ScoreRow> {
+///
+/// `decay` is `Some` only for Rolling blocks, where each ballot's contribution is
+/// scaled by its recency (see [`recency_weight`]). Static blocks pass `None` and
+/// are scored exactly as before — every eligible ballot at full weight.
+pub fn aggregate(
+    ballots: &[(&Ranking, Vec<RankingItem>)],
+    lo: f64,
+    hi: f64,
+    decay: Option<RecencyDecay>,
+) -> Vec<ScoreRow> {
     let mut totals: HashMap<(Uuid, Uuid), f64> = HashMap::new();
     for (ranking, items) in ballots {
+        let weight = match decay {
+            Some(decay) => recency_weight(decay, ranking.submitted_at),
+            None => 1.0,
+        };
         for (key, value) in normalize_ballot(ranking, items, lo, hi) {
-            *totals.entry(key).or_insert(0.0) += value;
+            *totals.entry(key).or_insert(0.0) += value * weight;
         }
     }
 
@@ -234,7 +298,7 @@ mod tests {
         let b3 = vec![item(200, Some("a0"), None), item(100, Some("a1"), None)]; // B=1.0, A=0.5
 
         let ballots = vec![(&r1, b1), (&r2, b2), (&r3, b3)];
-        let rows = aggregate(&ballots, NORM_LO, NORM_HI);
+        let rows = aggregate(&ballots, NORM_LO, NORM_HI, None);
 
         // A: 1.0 + 1.0 + 0.5 = 2.5 ; B: 0.5 + 0.5 + 1.0 = 2.0
         assert_eq!(rows.len(), 2);
@@ -266,7 +330,112 @@ mod tests {
                 weight: None,
             },
         ];
-        let rows = aggregate(&[(&r, items)], NORM_LO, NORM_HI);
+        let rows = aggregate(&[(&r, items)], NORM_LO, NORM_HI, None);
         assert_eq!(rows.len(), 2); // two perspectives -> two rows
+    }
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp(secs, 0).unwrap()
+    }
+
+    fn ranking_submitted(id: u128, rank_type: &str, submitted_at: DateTime<Utc>) -> Ranking {
+        Ranking {
+            submitted_at: Some(submitted_at),
+            ..ranking(id, rank_type)
+        }
+    }
+
+    #[test]
+    fn recency_weight_halves_every_half_life() {
+        let hour = 3600;
+        let decay = |now: i64| RecencyDecay {
+            half_life_hours: 24.0,
+            now: at(now),
+        };
+        let submitted = Some(at(0));
+        assert!((recency_weight(decay(0), submitted) - 1.0).abs() < 1e-12);
+        assert!((recency_weight(decay(24 * hour), submitted) - 0.5).abs() < 1e-12);
+        assert!((recency_weight(decay(48 * hour), submitted) - 0.25).abs() < 1e-12);
+        // Never reaches zero — that is what keeps the table from emptying.
+        assert!(recency_weight(decay(1000 * hour), submitted) > 0.0);
+    }
+
+    #[test]
+    fn recency_weight_admits_what_it_cannot_age() {
+        let hour = 3600;
+        let decay = RecencyDecay {
+            half_life_hours: 24.0,
+            now: at(100 * hour),
+        };
+        // Unknown submission time -> full weight, not silently zeroed.
+        assert_eq!(recency_weight(decay, None), 1.0);
+        // Non-positive half-life can't decay anything.
+        assert_eq!(
+            recency_weight(
+                RecencyDecay {
+                    half_life_hours: 0.0,
+                    ..decay
+                },
+                Some(at(0))
+            ),
+            1.0
+        );
+        // Future-dated (clock skew) is capped at full weight, never amplified.
+        assert_eq!(recency_weight(decay, Some(at(200 * hour))), 1.0);
+    }
+
+    #[test]
+    fn decay_lets_a_fresh_ballot_outrank_an_older_agreeing_majority() {
+        let hour = 3600;
+        // Two stale ballots rank A first; one fresh ballot ranks B first.
+        let stale_a = ranking_submitted(1, "ORDINAL", at(0));
+        let stale_b = ranking_submitted(2, "ORDINAL", at(0));
+        let fresh = ranking_submitted(3, "ORDINAL", at(96 * hour));
+        let a_first = || vec![item(100, Some("a0"), None), item(200, Some("a1"), None)];
+        let b_first = vec![item(200, Some("a0"), None), item(100, Some("a1"), None)];
+
+        let ballots = vec![
+            (&stale_a, a_first()),
+            (&stale_b, a_first()),
+            (&fresh, b_first),
+        ];
+
+        // Undecayed, the two agreeing ballots win: A = 2.5, B = 2.0.
+        let flat = aggregate(&ballots, NORM_LO, NORM_HI, None);
+        assert_eq!(flat[0].entity_id, Uuid::from_u128(100));
+
+        // With a 24h half-life the 4-day-old ballots are down to 1/16, so the
+        // fresh ballot's preference leads.
+        let decayed = aggregate(
+            &ballots,
+            NORM_LO,
+            NORM_HI,
+            Some(RecencyDecay {
+                half_life_hours: 24.0,
+                now: at(96 * hour),
+            }),
+        );
+        assert_eq!(decayed[0].entity_id, Uuid::from_u128(200));
+        assert_eq!(decayed[0].position, 1);
+        // Stale ballots still contribute — they are decayed, not discarded.
+        assert!(decayed[1].score > 0.0);
+    }
+
+    #[test]
+    fn decay_never_empties_a_block_that_has_ballots() {
+        let hour = 3600;
+        let old = ranking_submitted(1, "ORDINAL", at(0));
+        let ballots = vec![(&old, vec![item(100, Some("a0"), None)])];
+        let rows = aggregate(
+            &ballots,
+            NORM_LO,
+            NORM_HI,
+            Some(RecencyDecay {
+                half_life_hours: 24.0,
+                now: at(120 * hour), // 5 days old
+            }),
+        );
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].score > 0.0);
     }
 }


### PR DESCRIPTION
## Problem

Arturas published a 5-claim ranking into AI space and reported it never appeared in the global rankings, with the front-page table empty. The ranking indexed correctly — this is the aggregation dropping it.

A Rolling block treated `submission_frequency` as a hard expiry: a ballot stopped counting once it aged past **one** frequency (24h on every rolling block in production). Because that window equals the cadence authors are told to resubmit on, a block routinely has nothing eligible and publishes an empty projection — so a "Trending" table reads as empty rather than stale.

AI-space "Trending claims" (`d132a147-2f33-4ec9-a1e6-d94c8d7070b5`) had **26 submissions accumulated over three weeks and published a single row**. Reconstructing its eligible set hour by hour, it hit literally zero twice in the preceding four days:

| time | eligible ballots |
|---|---|
| 08-08 12:00 | 4 |
| **08-08 21:00** | **0** |
| 08-09 00:00–21:00 | 1 |
| **08-10 00:00–09:00** | **0** |

This is systemic: all 20 rolling blocks collapse the same way.

## Change

Reinterpret `submission_frequency` as a **half-life** rather than a cliff.

- `scoring.rs` gains `RecencyDecay` and `recency_weight` — `0.5 ^ (age / half_life)`, applied per ballot in `aggregate`. Fresh ballots dominate, but the table never empties.
- `eligibility::rolling_admits` now drops a ballot at `ROLLING_MAX_HALF_LIVES` (8) half-lives instead of 1×, where it is down to 1/256 of full weight — below the resolution of the published integer 0–100 projection. Without widening this, decay could never take effect, since ballots were already gone at 1×. Some cutoff is still needed, or every entity ever ranked would linger forever at a vanishing score.
- `recompute.rs` builds the decay from `ranking_type` + `submission_frequency`.

**Static blocks are unaffected** — `aggregate` takes the decay as an `Option` and scores every eligible ballot at full weight when it is `None`.

## Verification

- 38 lib tests pass; clippy and `cargo fmt` clean.
- The two eligibility tests that encoded the old cliff are **rewritten, not adjusted** — the semantics deliberately changed.
- Simulated against production data, AI-space "Trending claims" goes from **1 row to 19**, with the fresh consensus claim still ranked first and older ballots contributing at reduced weight.

## Reviewer notes

- **The decay shape is the reviewable decision.** Exponential decay with `submission_frequency` as the half-life and an 8-half-life cutoff are both judgement calls, documented at the constants. This changes every published rolling ranking number, so it wants a staging soak.
- **This does not repair existing data.** It interacts with a client-side bug where roll-off blanked the author's ballot, so authors rebuilt from scratch and published single-entry ballots that `dedup_latest` then made permanent. Fixed separately in geobrowser/geogenesis#2122; the already-truncated ballots need one manual resubmission each.
- Two rolling blocks stay empty either way — their only submission predates any cutoff.
