### PR TITLE
fix(membership): treat v2's unsnapshotted voting window as open, not expired

### DIFF
--- a/membership-acceptor/src/detect.ts
+++ b/membership-acceptor/src/detect.ts
@@ -62,11 +62,18 @@ export function detectMembershipRequest(
 	const spaceId = typeof p.space_id === "string" ? p.space_id : null
 	if (!proposalId || !spaceId) return null
 
-	// Best-effort still-open check: if the payload advertises an end_date already
-	// in the past, the voting window is closed — skip. Authoritative check is M3.
+	// Best-effort still-open check: if the payload advertises a positive end_date
+	// already in the past, the voting window is closed — skip. Authoritative check is M3.
+	//
+	// A zero end_date is "not started", i.e. OPEN — it must not be read as a window that
+	// closed at the epoch. Governance v2 snapshots startDate/lastDate lazily, on the
+	// first cast vote, so a freshly created proposal — the only kind this service ever
+	// sees, since it reacts to proposal_created — always advertises 0. Comparing that
+	// against `now` skips literally every request. The same inverted assumption disabled
+	// proposal-executor's membership path on v2 entirely.
 	const settings = asRecord(p.settings)
 	const endDate = settings?.end_date
-	if (typeof endDate === "number" && endDate <= nowSeconds) return null
+	if (typeof endDate === "number" && endDate > 0 && endDate <= nowSeconds) return null
 
 	const requesterSpaceId = typeof action.target_address === "string" ? action.target_address : ""
 	return {proposalId, spaceId, requesterSpaceId}

--- a/membership-acceptor/tests/detect.test.ts
+++ b/membership-acceptor/tests/detect.test.ts
@@ -81,6 +81,15 @@ describe("detectMembershipRequest", () => {
 		expect(detectMembershipRequest(p, NOW)).not.toBeNull()
 	})
 
+	// Governance v2 snapshots the voting window on the first cast vote, so a
+	// just-created proposal always advertises end_date 0 — and proposal_created is the
+	// only event this service reacts to. Reading 0 as "closed at the epoch" would skip
+	// every single request, which is precisely how the same assumption disabled
+	// proposal-executor's membership path on v2.
+	test("detects when end_date is 0 — an unsnapshotted window is open, not long expired", () => {
+		expect(detectMembershipRequest(membershipPayload({settings: {end_date: 0}}), NOW)).not.toBeNull()
+	})
+
 	test("requesterSpaceId is empty when target_address is missing", () => {
 		const actions = [{type: "add_member"}]
 		expect(detectMembershipRequest(membershipPayload({actions}), NOW)?.requesterSpaceId).toBe("")

--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -88,12 +88,23 @@ export const DAOSpaceAbi = [
 			{internalType: "bool", name: "_executed", type: "bool"},
 			{internalType: "bytes16", name: "_creator", type: "bytes16"},
 			{
+				// v2 ProposalParameters — 8 fields. The v1 struct this used to declare
+				// (votingMode, supportThreshold, quorum, startDate, lastDate) is a
+				// *shorter* static tuple, so decoding a v2 return through it silently
+				// slid every later slot: startDate read flatSupportThreshold and lastDate
+				// read quorum. Verified against the deployed contracts — chain 19411
+				// really is the 5-field v1 struct, chain 55516 is this one — so this ABI
+				// is now correct only for v2, which is all that outlives the 19411
+				// cluster's retirement.
 				components: [
 					{internalType: "enum IDAOSpace.VotingMode", name: "votingMode", type: "uint8"},
-					{internalType: "uint256", name: "supportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "partialPercentageSupportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "universalPercentageSupportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "flatSupportThreshold", type: "uint256"},
 					{internalType: "uint256", name: "quorum", type: "uint256"},
 					{internalType: "uint256", name: "startDate", type: "uint256"},
 					{internalType: "uint256", name: "lastDate", type: "uint256"},
+					{internalType: "uint256", name: "executeBy", type: "uint256"},
 				],
 				internalType: "struct IDAOSpace.ProposalParameters",
 				name: "_parameters",

--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -227,12 +227,24 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
  * - Not yet executed (executed_at IS NULL)
  * - Created in the past (guards against corrupt future timestamps; no age cutoff
  *   — backlog is admitted, unlike the executor's MAX_PROPOSAL_AGE)
- * - Voting period has not ended (now <= end_time + CLOCK_SKEW_BUFFER) — the protocol
- *   rejects votes cast after the period closes, and an untouched Fast proposal whose
- *   period has ended is already classified REJECTED (threshold not reached). The same
- *   60s skew buffer the stage-2 eligibility check applies (isVotingOpen, membership.ts)
- *   is added here so detection never excludes a request that stage 2 would still vote
- *   on — `now` must therefore be the same chain-sourced timestamp stage 2 uses.
+ * - Voting period has not ended (end_time = 0, or now <= end_time + CLOCK_SKEW_BUFFER)
+ *   — the protocol rejects votes cast after the period closes, and an untouched Fast
+ *   proposal whose period has ended is already classified REJECTED (threshold not
+ *   reached). The same 60s skew buffer the stage-2 eligibility check applies
+ *   (isVotingOpen, membership.ts) is added here so detection never excludes a request
+ *   that stage 2 would still vote on — `now` must therefore be the same chain-sourced
+ *   timestamp stage 2 uses.
+ *
+ *   `end_time = 0` means the voting window has not been snapshotted yet, which is OPEN.
+ *   Governance v2 made the window lazy — DAOSpace leaves startDate/lastDate at zero
+ *   until the first vote is cast — so the indexer records 0 for every proposal nobody
+ *   has voted on. Without the zero branch this predicate degenerates to `now <= 60`,
+ *   false for all of recorded time, and it is mutually exclusive with the NOT EXISTS
+ *   vote check below: a proposal only earns a non-zero end_time once it has a vote,
+ *   which is exactly when this query stops considering it. No row could satisfy both,
+ *   so membership auto-accept admitted nobody on v2 from the contract migration until
+ *   this fix. Stage 2 re-reads the window from the chain, so a stale end_time here can
+ *   only cost a skipped vote, never a wrongly-cast one.
  * - Exactly one action, and it is an AddMember
  * - No indexed votes (NOT EXISTS in proposal_votes) — checks raw indexed votes,
  *   not the async-denormalized yes_count/no_count/abstain_count columns
@@ -265,7 +277,7 @@ WHERE p.space_id = ANY($1)
   AND p.voting_mode = 'Fast'
   AND p.executed_at IS NULL
   AND p.created_at::bigint <= $2::bigint
-  AND $2::bigint <= p.end_time + ${CLOCK_SKEW_BUFFER}
+  AND (p.end_time = 0 OR $2::bigint <= p.end_time + ${CLOCK_SKEW_BUFFER})
   AND a.action_type = 'AddMember'
   AND NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)
   AND (SELECT COUNT(*) FROM proposal_actions a2 WHERE a2.proposal_id = p.id) = 1

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -378,12 +378,16 @@ export function bytes16ToUuid(spaceId: Hex): string {
  * - `voting_window_closed` — stage 2: the voting period has ended, so the protocol
  *   would reject a late vote. An untouched-but-expired request is left alone — this is
  *   independent of the tally, which may well be zero.
+ * - `not_on_chain` — stage 2: the DAO has no such proposal (zero `_creator`), so a vote
+ *   could only ever revert. These are migration artifacts — present in the v2 database,
+ *   never created on chain — and they are permanent, not transient.
  */
 export type MembershipSkipReason =
 	| "indexed_vote"
 	| "already_executed"
 	| "onchain_tally_nonzero"
 	| "voting_window_closed"
+	| "not_on_chain"
 
 /**
  * The outcome of processing one membership request:
@@ -420,11 +424,15 @@ interface MembershipSummary {
  * Returns `null` when the request is still eligible (the bot should vote), otherwise
  * the specific reason it is ineligible. Stays in lock-step with isEligibleToVote — it
  * returns null in exactly the cases that function returns true, then names the cause:
- * executed first, then a non-zero tally, and finally a closed voting window (the
- * remaining cause for an untouched, unexecuted request).
+ * absent from the DAO first, then executed, then a non-zero tally, and finally a closed
+ * voting window (the remaining cause for an untouched, unexecuted request).
+ *
+ * `not_on_chain` is tested first because an absent proposal reads back as all zeros, so
+ * every later branch would also match it and report a misleading cause.
  */
 export function classifyMembershipSkip(tally: ProposalTally, nowSeconds: bigint): MembershipSkipReason | null {
 	if (isEligibleToVote(tally, nowSeconds)) return null
+	if (!tally.existsOnChain) return "not_on_chain"
 	if (tally.executed) return "already_executed"
 	if (tally.yes !== 0n || tally.no !== 0n || tally.abstain !== 0n) return "onchain_tally_nonzero"
 	return "voting_window_closed"

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -42,14 +42,33 @@ export interface ProposalTally {
 	yes: bigint
 	no: bigint
 	abstain: bigint
-	/** Unix seconds the voting window opens (ProposalParameters.startDate). */
+	/**
+	 * Unix seconds the voting window opens (ProposalParameters.startDate).
+	 * Zero until the first vote is cast — see {@link isVotingOpen}.
+	 */
 	startDate: bigint
 	/** Unix seconds the voting window closes (ProposalParameters.lastDate); later votes revert. */
 	lastDate: bigint
+	/**
+	 * Whether the DAO actually knows this proposal — i.e. `_creator` is not the zero
+	 * space id. An unknown proposal id does not revert; it returns an all-zero struct
+	 * that is otherwise identical to a real proposal awaiting its first vote, so this
+	 * is the only field that separates the two. See {@link isEligibleToVote}.
+	 */
+	existsOnChain: boolean
 }
 
 /** SpaceRegistry.spaceIdToAddress returns this for an unregistered space. */
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+/**
+ * Whether a bytes16 space id is the zero id, tolerating any hex casing and an
+ * absent `0x` prefix. `getLatestProposalInformation` returns a zero `_creator`
+ * for a proposal the DAO has never heard of.
+ */
+function isZeroSpaceId(spaceId: Hex): boolean {
+	return /^(0x)?0*$/i.test(spaceId)
+}
 
 /**
  * Seconds of slack added past the on-chain voting window's close when deciding
@@ -162,7 +181,7 @@ export function readProposalTally(
 		return Effect.tryPromise({
 			try: async () => {
 				const proposalIdHex = uuidToBytes16(proposalId)
-				const [executed, , parameters, tally] = await wallet.publicClient.readContract({
+				const [executed, creator, parameters, tally] = await wallet.publicClient.readContract({
 					address: daoSpaceAddress,
 					abi: DAOSpaceAbi,
 					functionName: "getLatestProposalInformation",
@@ -175,6 +194,7 @@ export function readProposalTally(
 					abstain: tally.abstain,
 					startDate: parameters.startDate,
 					lastDate: parameters.lastDate,
+					existsOnChain: !isZeroSpaceId(creator),
 				}
 			},
 			catch: (error) =>
@@ -204,14 +224,21 @@ export function readChainTimeSeconds(wallet: SmartWallet): Effect.Effect<bigint>
 }
 
 /**
- * A proposal's voting window is open iff now is at/after startDate and at/before
- * lastDate extended by the clock-skew buffer. The bound is inclusive on both ends,
- * matching the inclusive upper bound in the stage-1 detection SQL ($2 <= end_time +
- * skew) so the two stages agree at the skew boundary. The close is widened, not
- * narrowed:
+ * A proposal's voting window is open iff its timers have not been snapshotted yet,
+ * or now is at/after startDate and at/before lastDate extended by the clock-skew
+ * buffer. The bound is inclusive on both ends, matching the inclusive upper bound in
+ * the stage-1 detection SQL ($2 <= end_time + skew) so the two stages agree at the
+ * skew boundary. The close is widened, not narrowed:
  * during the final CLOCK_SKEW_BUFFER_SECONDS — and up to that long past lastDate —
  * the bot still votes, accepting a possible late revert over wrongly skipping a
  * still-open request. now should be a chain-sourced timestamp (readChainTimeSeconds).
+ *
+ * A zero `lastDate` means OPEN, not closed. Under governance v2 the voting window is
+ * lazy: DAOSpace leaves startDate/lastDate/executeBy at zero until the first vote is
+ * cast (`_startProposalVotingWindow`), and the contract itself uses `lastDate == 0`
+ * as that "not started" sentinel. Treating zero as a closed window is what made the
+ * whole auto-accept path dead on v2 — every untouched request, which is precisely the
+ * set the bot exists to vote on, has a zero window by definition.
  */
 export function isVotingOpen(
 	nowSeconds: bigint,
@@ -219,18 +246,30 @@ export function isVotingOpen(
 	lastDate: bigint,
 	skewSeconds: bigint = CLOCK_SKEW_BUFFER_SECONDS,
 ): boolean {
+	if (lastDate === 0n) return true
 	return startDate <= nowSeconds && nowSeconds <= lastDate + skewSeconds
 }
 
 /**
  * A request is eligible for an auto-accept YES vote iff:
+ * - the DAO actually has the proposal (see below),
  * - it has not executed,
  * - no vote of any kind is recorded on-chain — a non-zero tally covers both a human's
  *   vote (indexing lag) and the bot's own in-flight vote → SKIP (onchain_tally_nonzero),
  *   which is what makes the job idempotent across cycles, and
  * - its on-chain voting window is still open (now within [startDate, lastDate], with the
- *   clock-skew buffer applied to the close). The protocol rejects votes outside the
- *   window, so this is the authoritative stage-2 guard against voting on a closed request.
+ *   clock-skew buffer applied to the close, and a not-yet-snapshotted zero window
+ *   counting as open). The protocol rejects votes outside the window, so this is the
+ *   authoritative stage-2 guard against voting on a closed request.
+ *
+ * The `existsOnChain` term is load-bearing precisely *because* a zero window now counts
+ * as open. A proposal that lives in the database but was never created on chain — the
+ * migration artifacts described in the executor's canExecuteProposal pre-check — reads
+ * back as all zeros: not executed, empty tally, zero window. Every one of those would
+ * otherwise look permanently eligible, and the bot would burn a sponsored UserOperation
+ * on a guaranteed revert for each, every five minutes, forever. They never age out
+ * either: the membership query has no MAX_PROPOSAL_AGE cutoff. A zero `_creator` is the
+ * only thing that distinguishes them from a genuine untouched request.
  *
  * now should be a chain-sourced timestamp (readChainTimeSeconds).
  */
@@ -240,6 +279,7 @@ export function isEligibleToVote(
 	skewSeconds: bigint = CLOCK_SKEW_BUFFER_SECONDS,
 ): boolean {
 	return (
+		tally.existsOnChain &&
 		!tally.executed &&
 		tally.yes === 0n &&
 		tally.no === 0n &&

--- a/proposal-executor/tests/contracts.test.ts
+++ b/proposal-executor/tests/contracts.test.ts
@@ -67,50 +67,75 @@ describe("DAOSpaceAbi", () => {
 		expect(tally?.components?.every((c) => c.type === "uint256")).toBe(true)
 	})
 
-	test("ProposalParameters matches the deployed 5-field struct (votingMode, supportThreshold, quorum, startDate, lastDate)", () => {
+	test("ProposalParameters matches the deployed v2 8-field struct", () => {
 		const params = getInfo?.outputs?.[2]
 		expect(params?.type).toBe("tuple")
 		// Authoritative source: geo-contracts-foundry IDAOSpace.ProposalParameters.
-		// The struct has exactly 5 fields; an over- or under-count silently misaligns
+		// The v2 struct has exactly 8 fields; an over- or under-count silently misaligns
 		// the startDate/lastDate slot reads in readProposalTally (overflow / garbage),
 		// which is what the on-chain decode regression below guards against end-to-end.
+		// The 5-field v1 shape this used to declare belongs to chain 19411, which is
+		// being retired; on 55516 it made startDate read flatSupportThreshold.
 		expect(params?.components?.map((c) => c.name)).toEqual([
 			"votingMode",
-			"supportThreshold",
+			"partialPercentageSupportThreshold",
+			"universalPercentageSupportThreshold",
+			"flatSupportThreshold",
 			"quorum",
 			"startDate",
 			"lastDate",
+			"executeBy",
 		])
-		expect(params?.components?.map((c) => c.type)).toEqual(["uint8", "uint256", "uint256", "uint256", "uint256"])
+		expect(params?.components?.map((c) => c.type)).toEqual([
+			"uint8",
+			"uint256",
+			"uint256",
+			"uint256",
+			"uint256",
+			"uint256",
+			"uint256",
+			"uint256",
+		])
 	})
 
-	// Regression for the ABI struct-shape bug: decode REAL on-chain return bytes (captured
-	// from getLatestProposalInformation on the Geo testnet) through DAOSpaceAbi and assert the
-	// fields land correctly. The earlier 8-field ProposalParameters misaligned the parameters
-	// slots, so startDate/lastDate read garbage and viem threw a safe-integer overflow. A
-	// fixture-based decode — not a self-consistent round-trip — is the only thing that catches
-	// an ABI that doesn't match the deployed contract. Words: executed=false, creator (bytes16),
-	// params(votingMode=1, supportThreshold=0, quorum=1, startDate, lastDate), tally(0,0,0), 1 action.
-	test("decodes a real getLatestProposalInformation return with correct startDate/lastDate", () => {
+	// Regression for the ABI struct-shape bug: decode REAL on-chain return bytes through
+	// DAOSpaceAbi and assert the fields land correctly. A fixture-based decode — not a
+	// self-consistent round-trip — is the only thing that catches an ABI that doesn't
+	// match the deployed contract.
+	//
+	// Captured from chain 55516 (the v2 stack behind geobrowser.io) on 2026-08-11:
+	// DAOSpace 0xF3E30A62…111222, proposal c9b38b02…489101, a real member request that
+	// the bot had failed to auto-accept. The previous fixture came from chain 19411,
+	// whose v1 contract really does return the 5-field struct — which is exactly how an
+	// ABI wrong for v2 kept a green test suite. Decoding these v2 bytes through the
+	// 5-field shape slid every later slot and threw a safe-integer overflow.
+	//
+	// Note startDate/lastDate/executeBy are all 0 while the tally is empty: v2 snapshots
+	// the voting window on the first vote, so "untouched" and "zero window" coincide.
+	test("decodes a real v2 getLatestProposalInformation return with correct startDate/lastDate", () => {
 		const raw = ("0x" +
 			"0000000000000000000000000000000000000000000000000000000000000000" + // executed = false
-			"924ac01ba0a4355f16f40e0dfdc4823000000000000000000000000000000000" + // creator (bytes16)
+			"70a0a4ddda1057868ae4feebceaaacef00000000000000000000000000000000" + // creator (bytes16) — non-zero: the DAO knows this proposal
 			"0000000000000000000000000000000000000000000000000000000000000001" + // votingMode = Fast
-			"0000000000000000000000000000000000000000000000000000000000000000" + // supportThreshold
-			"0000000000000000000000000000000000000000000000000000000000000001" + // quorum
-			"000000000000000000000000000000000000000000000000000000006a2c457c" + // startDate = 1781286268
-			"000000000000000000000000000000000000000000000000000000006a2d96fc" + // lastDate  = 1781372668
+			"00000000000000000000000000000000000000000000000000000000004dd1e0" + // partialPercentageSupportThreshold = 5100000
+			"00000000000000000000000000000000000000000000000000000000004dd1e0" + // universalPercentageSupportThreshold = 5100000
+			"0000000000000000000000000000000000000000000000000000000000000001" + // flatSupportThreshold = 1
+			"0000000000000000000000000000000000000000000000000000000000000001" + // quorum = 1
+			"0000000000000000000000000000000000000000000000000000000000000000" + // startDate = 0 (window not snapshotted)
+			"0000000000000000000000000000000000000000000000000000000000000000" + // lastDate  = 0 (window not snapshotted)
+			"0000000000000000000000000000000000000000000000000000000000000000" + // executeBy = 0
 			"0000000000000000000000000000000000000000000000000000000000000000" + // tally.yes
 			"0000000000000000000000000000000000000000000000000000000000000000" + // tally.no
 			"0000000000000000000000000000000000000000000000000000000000000000" + // tally.abstain
-			"0000000000000000000000000000000000000000000000000000000000000160" + // actions offset
+			"00000000000000000000000000000000000000000000000000000000000001c0" + // actions offset
 			"0000000000000000000000000000000000000000000000000000000000000001" + // actions.length = 1
 			"0000000000000000000000000000000000000000000000000000000000000020" + // actions[0] offset
-			"0000000000000000000000007fadb2a38e44a34e6256273b149e6f436e911713" + // actions[0].to
+			"000000000000000000000000f3e30a621aaef2e924bbf777440999b973111222" + // actions[0].toAddress
+			"0000000000000000000000000000000000000000000000000000000000000000" + // actions[0].toSpaceId
 			"0000000000000000000000000000000000000000000000000000000000000000" + // actions[0].value
-			"0000000000000000000000000000000000000000000000000000000000000060" + // actions[0].data offset
+			"0000000000000000000000000000000000000000000000000000000000000080" + // actions[0].data offset
 			"0000000000000000000000000000000000000000000000000000000000000024" + // actions[0].data length = 36
-			"2afbe350924ac01ba0a4355f16f40e0dfdc48230000000000000000000000000" + // actions[0].data
+			"2afbe35070a0a4ddda1057868ae4feebceaaacef000000000000000000000000" + // actions[0].data — addMember(requester)
 			"0000000000000000000000000000000000000000000000000000000000000000") as `0x${string}` // data tail pad
 
 		const [executed, creator, parameters, tally] = decodeFunctionResult({
@@ -120,9 +145,11 @@ describe("DAOSpaceAbi", () => {
 		})
 
 		expect(executed).toBe(false)
-		expect(creator).toBe("0x924ac01ba0a4355f16f40e0dfdc48230")
-		expect(parameters.startDate).toBe(1781286268n)
-		expect(parameters.lastDate).toBe(1781372668n)
+		expect(creator).toBe("0x70a0a4ddda1057868ae4feebceaaacef")
+		expect(parameters.flatSupportThreshold).toBe(1n)
+		expect(parameters.quorum).toBe(1n)
+		expect(parameters.startDate).toBe(0n)
+		expect(parameters.lastDate).toBe(0n)
 		expect(tally.yes).toBe(0n)
 		expect(tally.no).toBe(0n)
 		expect(tally.abstain).toBe(0n)

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -234,6 +234,16 @@ describe("membership detection SQL", () => {
 		// on-chain eligibility check would still vote on.
 		expect(membershipSql).toContain("$2::bigint <= p.end_time + 60")
 	})
+
+	// The regression that made auto-accept admit nobody on v2. Governance v2 snapshots
+	// the voting window on the first vote, so every proposal without a vote has
+	// end_time = 0. Without the zero branch the predicate reads `now <= 60` — false for
+	// all of recorded time — and it is mutually exclusive with the NOT EXISTS vote check
+	// above: end_time only becomes non-zero once a vote exists, which is exactly when
+	// this query stops considering the row. No row could ever satisfy both.
+	test("treats end_time = 0 as a not-yet-started (open) window, not one closed at the epoch", () => {
+		expect(membershipSql).toContain("(p.end_time = 0 OR $2::bigint <= p.end_time + 60)")
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -381,9 +381,18 @@ const REQUEST_B: MembershipRequest = {
 	requesterId: "33333333-3333-3333-3333-333333333333",
 }
 
-/** A fully-eligible tally: not executed, zero votes, voting window wide open. */
+/** A fully-eligible tally: on chain, not executed, zero votes, voting window wide open. */
 function makeTally(overrides: Partial<ProposalTally> = {}): ProposalTally {
-	return {executed: false, yes: 0n, no: 0n, abstain: 0n, startDate: 0n, lastDate: 10_000_000_000n, ...overrides}
+	return {
+		executed: false,
+		yes: 0n,
+		no: 0n,
+		abstain: 0n,
+		startDate: 0n,
+		lastDate: 10_000_000_000n,
+		existsOnChain: true,
+		...overrides,
+	}
 }
 
 interface FakeWalletOpts {
@@ -417,7 +426,10 @@ function makeFakeWallet(opts: FakeWalletOpts = {}): FakeWallet {
 				if (functionName === "getLatestProposalInformation") {
 					return [
 						tally.executed,
-						`0x${"0".repeat(32)}`,
+						// The creator slot IS the existsOnChain signal — a zero bytes16 means
+						// the DAO never created this proposal, so it must track the fixture
+						// rather than being hardcoded zero (which would read as "absent").
+						tally.existsOnChain ? `0x${"1".repeat(32)}` : `0x${"0".repeat(32)}`,
 						{startDate: tally.startDate, lastDate: tally.lastDate},
 						{yes: tally.yes, no: tally.no, abstain: tally.abstain},
 						[],
@@ -489,6 +501,21 @@ describe("classifyMembershipSkip — stage-2 skip reasons", () => {
 		// now=1000, lastDate=100 (+60s skew) → window closed, yet the tally is zero:
 		// the cause is expiry, not a recorded vote.
 		expect(classifyMembershipSkip(makeTally({lastDate: 100n}), 1000n)).toBe("voting_window_closed")
+	})
+
+	// An absent proposal reads back all-zero, so it also satisfies "zero tally" and
+	// "not executed". It has to be named first or the reason reported would be a
+	// misleading transient one, hiding a permanently dead proposal behind a retryable label.
+	test("a proposal absent from the DAO is skipped as not_on_chain, not a transient reason", () => {
+		expect(classifyMembershipSkip(makeTally({existsOnChain: false}), 1000n)).toBe("not_on_chain")
+		// Even when another cause is also technically true, absence wins.
+		expect(classifyMembershipSkip(makeTally({existsOnChain: false, lastDate: 100n}), 1000n)).toBe("not_on_chain")
+	})
+
+	// Regression for the v2 lazy voting window: an untouched request has startDate and
+	// lastDate of 0, and must classify as eligible (null) rather than voting_window_closed.
+	test("an untouched request with a zero window is eligible, not voting_window_closed", () => {
+		expect(classifyMembershipSkip(makeTally({startDate: 0n, lastDate: 0n}), 1_800_000_000n)).toBeNull()
 	})
 })
 

--- a/proposal-executor/tests/membership.test.ts
+++ b/proposal-executor/tests/membership.test.ts
@@ -48,6 +48,15 @@ const START_DATE = NOW - 3_600n // opened an hour ago
 const LAST_DATE = NOW + 3_600n // closes in an hour
 /** A ProposalParameters tuple whose only fields the read uses are startDate/lastDate. */
 const OPEN_PARAMS = {startDate: START_DATE, lastDate: LAST_DATE}
+/**
+ * The v2 shape of a proposal nobody has voted on yet: the voting window is not
+ * snapshotted until the first vote, so both bounds are zero.
+ */
+const UNSTARTED_PARAMS = {startDate: 0n, lastDate: 0n}
+/** A creator space id the DAO actually recorded (any non-zero bytes16). */
+const REAL_CREATOR = "0x70a0a4ddda1057868ae4feebceaaacef"
+/** What getLatestProposalInformation returns for a proposal the DAO never created. */
+const ZERO_CREATOR = "0x00000000000000000000000000000000"
 
 /**
  * Minimal SmartWallet stub. sendTransaction / readContract / getBlock are injected
@@ -230,7 +239,7 @@ describe("readProposalTally", () => {
 				expect(args.args[0]).toBe(PROPOSAL_BYTES16)
 				return [
 					false, // executed
-					"0xcreator", // creator
+					REAL_CREATOR, // creator
 					OPEN_PARAMS, // parameters → startDate/lastDate
 					{yes: 3n, no: 1n, abstain: 2n}, // tally
 					[], // actions
@@ -246,7 +255,20 @@ describe("readProposalTally", () => {
 			abstain: 2n,
 			startDate: START_DATE,
 			lastDate: LAST_DATE,
+			existsOnChain: true,
 		})
+	})
+
+	// A proposal the DAO has never heard of does not revert — it returns an all-zero
+	// struct. `creator` is the only field that separates it from a genuine untouched
+	// request, so the read has to surface it or isEligibleToVote cannot tell them apart.
+	test("reports existsOnChain false when the DAO returns a zero creator", async () => {
+		const wallet = fakeWallet({
+			readContract: async () => [false, ZERO_CREATOR, UNSTARTED_PARAMS, {yes: 0n, no: 0n, abstain: 0n}, []],
+		})
+
+		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
+		expect(tally.existsOnChain).toBe(false)
 	})
 
 	test("surfaces a read failure as an InfraError carrying the proposalId", async () => {
@@ -274,10 +296,24 @@ describe("isEligibleToVote", () => {
 		abstain: 0n,
 		startDate: START_DATE,
 		lastDate: LAST_DATE,
+		existsOnChain: true,
 	}
 
 	test("eligible iff !executed && zero tally && voting window open", () => {
 		expect(isEligibleToVote(fresh, NOW)).toBe(true)
+	})
+
+	// The case the whole auto-accept path exists to handle, and the one v2 broke: a
+	// real request nobody has voted on has a zero window, and must still be voted on.
+	test("eligible when the voting window has not been snapshotted yet (v2 zero window)", () => {
+		expect(isEligibleToVote({...fresh, ...UNSTARTED_PARAMS}, NOW)).toBe(true)
+	})
+
+	// Counterpart guard: an all-zero read that is zero because the DAO has no such
+	// proposal must NOT be voted on, or the bot burns a sponsored revert every cycle
+	// forever. Identical to the case above in every field except existsOnChain.
+	test("ineligible when the proposal is absent from the DAO, despite looking untouched", () => {
+		expect(isEligibleToVote({...fresh, ...UNSTARTED_PARAMS, existsOnChain: false}, NOW)).toBe(false)
 	})
 
 	test("ineligible when already executed", () => {
@@ -317,6 +353,19 @@ describe("isVotingOpen", () => {
 	test("open at exactly startDate, closed just before it", () => {
 		expect(isVotingOpen(START_DATE, START_DATE, LAST_DATE)).toBe(true)
 		expect(isVotingOpen(START_DATE - 1n, START_DATE, LAST_DATE)).toBe(false)
+	})
+
+	// v2 snapshots startDate/lastDate on the first cast vote, so a zero lastDate is the
+	// contract's own "not started" sentinel — open, not closed at the epoch. Reading it
+	// as closed is what silently disabled auto-accept for every untouched request.
+	test("a zero window means not-yet-started, which is open", () => {
+		expect(isVotingOpen(NOW, 0n, 0n)).toBe(true)
+		// Open no matter how far the clock has advanced — there is no deadline yet.
+		expect(isVotingOpen(NOW + 10_000_000n, 0n, 0n)).toBe(true)
+	})
+
+	test("a real elapsed window is still closed (the zero case must not swallow it)", () => {
+		expect(isVotingOpen(LAST_DATE + 61n, START_DATE, LAST_DATE, 60n)).toBe(false)
 	})
 
 	test("the buffer extends the close, never shrinks it", () => {


### PR DESCRIPTION
Automatic member acceptance has admitted **nobody** on chain 55516 since the governance v2 contract migration. Every `proposal-executor` run logs `requestsFound: 0` while genuine requests sit `PROPOSED` forever.

Reported by Preston against [this request](https://www.geobrowser.io/space/c9f267dcb0d270718c2a3c45a64afd32/governance?proposalId=c9b38b02d169491bacf6bce132489101) — still open and untouched on chain as of writing.

> Note: on v2 this path lives in `proposal-executor`, **not** `membership-acceptor` — the latter is deployed only on the legacy 19411 stack despite being written as its successor.

## Root cause

Governance v2 made the voting window **lazy**. `DAOSpace` leaves `startDate`/`lastDate`/`executeBy` at zero until the first vote is cast (`_startProposalVotingWindow`), and uses `lastDate == 0` as its own "not started" sentinel:

> `@param startDate Timestamp when voting starts; zero until the first cast vote` — `IDAOSpace.sol:63`

Both stages still assumed v1 semantics, where the window was fixed at creation:

- **`MEMBERSHIP_DETECTION_SQL`** required `now <= end_time + 60`, which with `end_time = 0` degenerates to `now <= 60`. Worse, it is **mutually exclusive** with the query's own `NOT EXISTS(proposal_votes)` check: a proposal only earns a non-zero `end_time` once it has a vote, which is exactly when the query stops considering it. No row could ever satisfy both predicates.
- **`isVotingOpen(now, 0, 0)`** returned `false` for the same reason, so stage 2 would have rejected the request even had detection surfaced it.

Both now treat a zero window as open. Stage 2 re-reads the window from the chain, so a stale `end_time` can only ever cost a skipped vote, never a wrongly-cast one.

## Also fixed: the ABI was silently misdecoding

`DAOSpaceAbi` still declared the v1 5-field `ProposalParameters`. That is a *shorter static tuple*, so decoding a v2 return slid every later slot — `startDate` read `flatSupportThreshold`, `lastDate` read `quorum`.

Verified against both live deployments: 19411 genuinely is the 5-field struct, 55516 is the 8-field one. The ABI moves to v2 only, which is what outlives the 19411 cluster's retirement.

The regression fixture is re-captured from 55516. The previous one came from **19411** — which is precisely how an ABI wrong for v2 kept a green test suite.

## The companion guard this needed

Making a zero window count as open is not safe on its own. A proposal that exists in the database but was never created on chain — the migration artifacts ca55a3d added `canExecuteProposal` for — reads back **all zeros**: not executed, empty tally, zero window. Every one would look permanently eligible, and the bot would burn a sponsored UserOperation on a guaranteed revert every five minutes forever. They never age out either: the membership query has no `MAX_PROPOSAL_AGE` cutoff.

An unknown proposal id doesn't revert, so a zero `_creator` is the only thing separating those from a genuine untouched request. Eligibility now requires it, with a `not_on_chain` skip reason so telemetry names the permanent cause rather than a transient-looking one.

## `membership-acceptor`

Carried the same inverted assumption (`end_date <= now` skips a zero `end_date` — i.e. every `proposal_created` it will ever see). Fixed there too. No-op on 19411, where v1 sets the window at creation; means the service isn't born broken if it's ever promoted to v2.

## Verification

Against the live chain, using the patched modules rather than mocks:

```
REAL pending request (c9b38b02, space c9f267dc)
  → existsOnChain: true,  isEligibleToVote: true
ABSENT proposal (identical in every field but existsOnChain)
  → existsOnChain: false, isEligibleToVote: false
```

Bot permissions were never the problem — `hasRole(EDITOR, 0xf61e…29ba) = true`, and the allowlist already contains the space.

145 tests pass; typecheck and lint clean.

**Gap:** stage 1's SQL is covered by unit test and by confirming `end_time = 0` through the API, but the query was **not** run against the staging database (needs credentials from a k8s secret). The boolean logic is simple and the value is confirmed, but a `bun run start` against staging before deploy would close this.

## After merge

Needs a `proposal-executor` image build + deploy to the new cluster (ns `gaia`) to take effect. Preston's request should be admitted on the next 5-minute tick — it is still open and untouched, so nothing needs recreating.
