### PR TITLE
fix(membership): encode the v2 three-field vote payload

### DIFF
--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -135,6 +135,16 @@ export const DAOSpaceAbi = [
 		stateMutability: "view",
 		type: "function",
 	},
+	{
+		// Needed because a v2 vote payload carries the proposal version, and
+		// getLatestProposalInformation does not return it. Zero means the DAO has no
+		// such proposal — versions start at 1 on creation.
+		inputs: [{internalType: "bytes16", name: "_proposalId", type: "bytes16"}],
+		name: "latestProposalVersion",
+		outputs: [{internalType: "uint8", name: "_version", type: "uint8"}],
+		stateMutability: "view",
+		type: "function",
+	},
 ] as const
 
 // ---------------------------------------------------------------------------

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -466,8 +466,9 @@ function castVoteWithRetry(
 	request: MembershipRequest,
 	botSpaceId: Hex,
 	spaceRegistryAddress: Address,
+	proposalVersion: number,
 ): Effect.Effect<string, InfraError | RevertError> {
-	return castMembershipVote(wallet, request, botSpaceId, spaceRegistryAddress).pipe(
+	return castMembershipVote(wallet, request, botSpaceId, spaceRegistryAddress, proposalVersion).pipe(
 		Effect.timeoutFail({
 			duration: Duration.seconds(30),
 			onTimeout: () =>
@@ -550,7 +551,9 @@ export function processMembershipRequest(
 				)
 			}
 
-			return castVoteWithRetry(wallet, request, botSpaceId, spaceRegistryAddress).pipe(
+			// tally.version, not a hardcoded 1: an escalated proposal is on a later
+			// version, and _canVote rejects a vote aimed at a stale one.
+			return castVoteWithRetry(wallet, request, botSpaceId, spaceRegistryAddress, tally.version).pipe(
 				Effect.tap((txHash) =>
 					Effect.logInfo("membership_vote_cast").pipe(
 						Effect.annotateLogs({

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -56,6 +56,13 @@ export interface ProposalTally {
 	 * is the only field that separates the two. See {@link isEligibleToVote}.
 	 */
 	existsOnChain: boolean
+	/**
+	 * The proposal's current version (1 on creation; bumped when a fast-path proposal
+	 * escalates). A v2 vote payload must carry it — see {@link encodeVoteData} — and
+	 * voting on a stale version would be rejected by `_canVote`, so it is read at the
+	 * same moment as the tally rather than assumed to be 1.
+	 */
+	version: number
 }
 
 /** SpaceRegistry.spaceIdToAddress returns this for an unregistered space. */
@@ -94,16 +101,27 @@ function sanitizeError(error: unknown): string {
 // ---------------------------------------------------------------------------
 
 /**
- * ABI-encode the PROPOSAL_VOTED data payload: abi.encode(bytes16 proposalId, uint8 voteOption).
+ * ABI-encode the PROPOSAL_VOTED data payload:
+ * `abi.encode(bytes16 proposalId, uint8 proposalVersion, VoteOption vote)`.
  * A YES vote passes VOTE_YES (1) — see the IDAOSpace.VoteOption enum (None=0, Yes=1, No=2, Abstain=3).
+ *
+ * All THREE fields are required. v2 added the proposal version, and `_voteProposal`
+ * decodes the payload as `(bytes16, uint8, VoteOption)` — 96 bytes. Encoding only
+ * `(proposalId, vote)` produces 64 bytes, and `abi.decode` of three static words from
+ * a 64-byte buffer reverts with EMPTY data. That surfaces far from its cause: the
+ * bundler reports `UserOperation reverted during simulation with reason: 0x`, with no
+ * selector to decode and no hint that the payload is simply too short. The revert
+ * happens in `DAOSpace.fetch` before `_canVote` is ever reached, so it is invisible to
+ * every permission and eligibility check — the vote just never lands.
  */
-export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
+export function encodeVoteData(proposalIdHex: Hex, proposalVersion: number, voteOption: number): Hex {
 	return encodeAbiParameters(
 		[
 			{name: "proposalId", type: "bytes16"},
+			{name: "proposalVersion", type: "uint8"},
 			{name: "voteOption", type: "uint8"},
 		],
-		[proposalIdHex, voteOption],
+		[proposalIdHex, proposalVersion, voteOption],
 	)
 }
 
@@ -181,12 +199,22 @@ export function readProposalTally(
 		return Effect.tryPromise({
 			try: async () => {
 				const proposalIdHex = uuidToBytes16(proposalId)
-				const [executed, creator, parameters, tally] = await wallet.publicClient.readContract({
-					address: daoSpaceAddress,
-					abi: DAOSpaceAbi,
-					functionName: "getLatestProposalInformation",
-					args: [proposalIdHex],
-				})
+				// Both reads describe the same proposal at the same block height, so they
+				// are issued together rather than sequenced.
+				const [[executed, creator, parameters, tally], version] = await Promise.all([
+					wallet.publicClient.readContract({
+						address: daoSpaceAddress,
+						abi: DAOSpaceAbi,
+						functionName: "getLatestProposalInformation",
+						args: [proposalIdHex],
+					}),
+					wallet.publicClient.readContract({
+						address: daoSpaceAddress,
+						abi: DAOSpaceAbi,
+						functionName: "latestProposalVersion",
+						args: [proposalIdHex],
+					}),
+				])
 				return {
 					executed,
 					yes: tally.yes,
@@ -195,6 +223,7 @@ export function readProposalTally(
 					startDate: parameters.startDate,
 					lastDate: parameters.lastDate,
 					existsOnChain: !isZeroSpaceId(creator),
+					version,
 				}
 			},
 			catch: (error) =>
@@ -323,7 +352,7 @@ function classifyVoteError(error: unknown, proposalId: string, durationMs: numbe
  * PROPOSAL_VOTED action and the (proposalId, Yes) vote data:
  *
  *   enter(botSpaceId, daoSpaceId, PROPOSAL_VOTED, bytes32(proposalId),
- *         abi.encode(bytes16 proposalId, uint8 1), "0x")
+ *         abi.encode(bytes16 proposalId, uint8 proposalVersion, uint8 1), "0x")
  *
  * Returns the transaction hash on success. Errors are classified as RevertError /
  * InfraError; retry and timeout are composed externally in index.ts.
@@ -333,6 +362,7 @@ export function castMembershipVote(
 	request: MembershipRequest,
 	botSpaceId: Hex,
 	spaceRegistryAddress: Address,
+	proposalVersion: number,
 ): Effect.Effect<string, RevertError | InfraError> {
 	// Effect.suspend captures `start` fresh on each retry attempt so durationMs reflects
 	// only the current attempt's wall time (matches executeProposal).
@@ -352,7 +382,8 @@ export function castMembershipVote(
 						daoSpaceId, // bytes16: DAO space being joined
 						PROPOSAL_VOTED_ACTION, // bytes32: action hash
 						padBytes16ToBytes32(proposalIdHex), // bytes32: topic = bytes32(proposalId), left-aligned
-						encodeVoteData(proposalIdHex, VOTE_YES), // bytes: abi.encode(bytes16 proposalId, uint8 1)
+						// bytes: abi.encode(bytes16 proposalId, uint8 proposalVersion, uint8 1)
+						encodeVoteData(proposalIdHex, proposalVersion, VOTE_YES),
 						EMPTY_SIGNATURE, // bytes: "0x" (ignored when msg.sender == _fromSpace)
 					],
 				})

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -7,8 +7,8 @@
 
 import {describe, expect, test} from "bun:test"
 import {Cause, ConfigProvider, Effect, Exit, Option, Redacted} from "effect"
-import type {Address, Hex} from "viem"
-import {InfraError, RevertError} from "../src/contracts.js"
+import {type Address, decodeAbiParameters, decodeFunctionData, type Hex} from "viem"
+import {InfraError, RevertError, SpaceRegistryAbi} from "../src/contracts.js"
 import {findMembershipRequests, type MembershipRequest} from "../src/detect.js"
 import {type SmartWallet, uuidToBytes16} from "../src/execute.js"
 import {
@@ -391,6 +391,7 @@ function makeTally(overrides: Partial<ProposalTally> = {}): ProposalTally {
 		startDate: 0n,
 		lastDate: 10_000_000_000n,
 		existsOnChain: true,
+		version: 1,
 		...overrides,
 	}
 }
@@ -404,7 +405,7 @@ interface FakeWalletOpts {
 
 interface FakeWallet {
 	wallet: SmartWallet
-	calls: {readContract: string[]; sendTransaction: number}
+	calls: {readContract: string[]; sendTransaction: number; lastCalldata: string | undefined}
 }
 
 /**
@@ -414,7 +415,7 @@ interface FakeWallet {
  */
 function makeFakeWallet(opts: FakeWalletOpts = {}): FakeWallet {
 	const tally = opts.tally ?? makeTally()
-	const calls = {readContract: [] as string[], sendTransaction: 0}
+	const calls = {readContract: [] as string[], sendTransaction: 0, lastCalldata: undefined as string | undefined}
 	const wallet = {
 		chain: {id: 80451},
 		accountAddress: "0x0000000000000000000000000000000000000001",
@@ -423,6 +424,8 @@ function makeFakeWallet(opts: FakeWalletOpts = {}): FakeWallet {
 			readContract: async ({functionName}: any) => {
 				calls.readContract.push(functionName)
 				if (functionName === "spaceIdToAddress") return opts.daoAddress ?? DAO_ADDRESS
+				// Read alongside the tally so the vote payload can name the version.
+				if (functionName === "latestProposalVersion") return tally.version
 				if (functionName === "getLatestProposalInformation") {
 					return [
 						tally.executed,
@@ -441,8 +444,10 @@ function makeFakeWallet(opts: FakeWalletOpts = {}): FakeWallet {
 		},
 		smartAccountClient: {
 			account: {address: "0x0000000000000000000000000000000000000002"},
-			sendTransaction: async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: minimal stub
+			sendTransaction: async (args: any) => {
 				calls.sendTransaction += 1
+				calls.lastCalldata = args?.data
 				if (opts.sendTransaction) return opts.sendTransaction(calls.sendTransaction)
 				return "0xtxhash"
 			},
@@ -527,6 +532,27 @@ describe("processMembershipRequest", () => {
 		)
 		expect(outcome.status).toBe("voted")
 		expect(calls.sendTransaction).toBe(1)
+	})
+
+	// Guards the threading, which a hardcoded `1` would satisfy type-wise while
+	// silently voting on the wrong version of any escalated proposal (_canVote
+	// rejects that, so the vote would revert). The vote payload's second word is the
+	// version; assert it tracks the tally rather than a constant.
+	test("the vote payload carries the tally's version, not a hardcoded 1", async () => {
+		const {wallet, calls} = makeFakeWallet({tally: makeTally({version: 4})})
+		const outcome = await Effect.runPromise(
+			processMembershipRequest(wallet, REQUEST_A, DAO_ADDRESS, BOT_SPACE, REGISTRY_ADDRESS, 1000n),
+		)
+		expect(outcome.status).toBe("voted")
+		if (!calls.lastCalldata) throw new Error("no calldata captured")
+
+		const decoded = decodeFunctionData({abi: SpaceRegistryAbi, data: calls.lastCalldata as Hex})
+		expect(decoded.functionName).toBe("enter")
+		const voteData = (decoded.args as readonly Hex[])[4]
+		if (!voteData) throw new Error("enter() had no _data argument")
+		const [, version, vote] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}, {type: "uint8"}], voteData)
+		expect(version).toBe(4)
+		expect(vote).toBe(1) // VOTE_YES
 	})
 
 	test("a touched request is skipped without voting", async () => {

--- a/proposal-executor/tests/membership.test.ts
+++ b/proposal-executor/tests/membership.test.ts
@@ -86,31 +86,45 @@ function fakeWallet(overrides: {
 // ---------------------------------------------------------------------------
 
 describe("encodeVoteData", () => {
-	test("encodes abi.encode(bytes16 proposalId, uint8 voteOption)", () => {
-		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
-		const [proposalId, voteOption] = decodeAbiParameters(
+	const PROPOSAL_VERSION = 1
+
+	test("encodes abi.encode(bytes16 proposalId, uint8 proposalVersion, VoteOption vote)", () => {
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, PROPOSAL_VERSION, VOTE_YES)
+		const [proposalId, proposalVersion, voteOption] = decodeAbiParameters(
 			[
 				{name: "proposalId", type: "bytes16"},
+				{name: "proposalVersion", type: "uint8"},
 				{name: "voteOption", type: "uint8"},
 			],
 			data,
 		)
 		// bytes16 is left-aligned in its 32-byte word; viem returns it padded to bytes32.
 		expect((proposalId as string).slice(0, 34)).toBe(PROPOSAL_BYTES16)
+		expect(proposalVersion).toBe(PROPOSAL_VERSION)
 		expect(voteOption).toBe(VOTE_YES)
 	})
 
 	test("uses VOTE_YES === 1 for a YES vote", () => {
 		// Guards the documented enum discrepancy: a YES vote must encode uint8 1, not 2.
 		expect(VOTE_YES).toBe(1)
-		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
-		const [, voteOption] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}], data)
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, PROPOSAL_VERSION, VOTE_YES)
+		const [, , voteOption] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}, {type: "uint8"}], data)
 		expect(voteOption).toBe(1)
 	})
 
-	test("two words: bytes16 proposalId then uint8 voteOption (0x + 128 hex chars)", () => {
-		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
-		expect(data.length).toBe(2 + 128)
+	test("carries the version verbatim, so an escalated proposal votes on its own version", () => {
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, 3, VOTE_YES)
+		const [, proposalVersion] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}, {type: "uint8"}], data)
+		expect(proposalVersion).toBe(3)
+	})
+
+	// The payload length IS the bug this guards. DAOSpace decodes three static words
+	// (96 bytes); a two-word (64-byte) payload makes abi.decode revert with empty data,
+	// which the bundler reports only as "reverted during simulation with reason: 0x".
+	test("three words — 96 bytes (0x + 192 hex chars), not two", () => {
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, PROPOSAL_VERSION, VOTE_YES)
+		expect((data.length - 2) / 2).toBe(96)
+		expect(data.length).toBe(2 + 192)
 	})
 })
 
@@ -128,7 +142,7 @@ describe("castMembershipVote calldata", () => {
 			},
 		})
 
-		const hash = await Effect.runPromise(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY))
+		const hash = await Effect.runPromise(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY, 1))
 		expect(hash).toBe("0xtxhash")
 		if (!captured) throw new Error("sendTransaction was never called")
 		expect(captured.to).toBe(REGISTRY)
@@ -151,9 +165,13 @@ describe("castMembershipVote calldata", () => {
 		expect(topic.toLowerCase()).toBe(`${PROPOSAL_BYTES16}${"0".repeat(32)}`)
 		expect(signature).toBe("0x")
 
-		// Vote data decodes to (proposalId, Yes=1).
-		const [encodedId, encodedVote] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}], voteData)
+		// Vote data decodes to (proposalId, version=1, Yes=1) — three words, per v2.
+		const [encodedId, encodedVersion, encodedVote] = decodeAbiParameters(
+			[{type: "bytes16"}, {type: "uint8"}, {type: "uint8"}],
+			voteData,
+		)
 		expect((encodedId as string).slice(0, 34)).toBe(PROPOSAL_BYTES16)
+		expect(encodedVersion).toBe(1)
 		expect(encodedVote).toBe(1)
 	})
 })
@@ -173,7 +191,7 @@ describe("castMembershipVote error classification", () => {
 		})
 
 		const failure = await Effect.runPromise(
-			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY, 1)),
 		)
 		expect(failure._tag).toBe("RevertError")
 		expect((failure as {proposalId: string}).proposalId).toBe(REQUEST.id)
@@ -191,7 +209,7 @@ describe("castMembershipVote error classification", () => {
 		})
 
 		const failure = await Effect.runPromise(
-			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY, 1)),
 		)
 		expect(failure._tag).toBe("RevertError")
 		expect((failure as {expected: boolean}).expected).toBe(true)
@@ -205,7 +223,7 @@ describe("castMembershipVote error classification", () => {
 		})
 
 		const failure = await Effect.runPromise(
-			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY, 1)),
 		)
 		expect(failure._tag).toBe("InfraError")
 		expect((failure as {proposalId?: string}).proposalId).toBe(REQUEST.id)
@@ -219,7 +237,7 @@ describe("castMembershipVote error classification", () => {
 		})
 
 		const failure = await Effect.runPromise(
-			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY, 1)),
 		)
 		expect((failure as {message: string}).message).toContain("apikey=<redacted>")
 		expect((failure as {message: string}).message).not.toContain("secret123")
@@ -234,9 +252,10 @@ describe("readProposalTally", () => {
 	test("decodes the (executed, creator, parameters, Tally, actions) tuple into the tally", async () => {
 		const wallet = fakeWallet({
 			readContract: async (args) => {
-				expect(args.functionName).toBe("getLatestProposalInformation")
-				// proposalId passed as bytes16
+				// proposalId passed as bytes16 by both reads
 				expect(args.args[0]).toBe(PROPOSAL_BYTES16)
+				if (args.functionName === "latestProposalVersion") return 2
+				expect(args.functionName).toBe("getLatestProposalInformation")
 				return [
 					false, // executed
 					REAL_CREATOR, // creator
@@ -256,6 +275,9 @@ describe("readProposalTally", () => {
 			startDate: START_DATE,
 			lastDate: LAST_DATE,
 			existsOnChain: true,
+			// Read from the chain, not assumed to be 1 — an escalated proposal is on a
+			// later version and the vote payload must name the one it is voting on.
+			version: 2,
 		})
 	})
 
@@ -264,7 +286,10 @@ describe("readProposalTally", () => {
 	// request, so the read has to surface it or isEligibleToVote cannot tell them apart.
 	test("reports existsOnChain false when the DAO returns a zero creator", async () => {
 		const wallet = fakeWallet({
-			readContract: async () => [false, ZERO_CREATOR, UNSTARTED_PARAMS, {yes: 0n, no: 0n, abstain: 0n}, []],
+			readContract: async (args) =>
+				args.functionName === "latestProposalVersion"
+					? 0
+					: [false, ZERO_CREATOR, UNSTARTED_PARAMS, {yes: 0n, no: 0n, abstain: 0n}, []],
 		})
 
 		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
@@ -297,6 +322,7 @@ describe("isEligibleToVote", () => {
 		startDate: START_DATE,
 		lastDate: LAST_DATE,
 		existsOnChain: true,
+		version: 1,
 	}
 
 	test("eligible iff !executed && zero tally && voting window open", () => {


### PR DESCRIPTION
Follow-up to #883. That PR fixed detection — the bot now **finds** the pending request (`requestsFound: 1`, up from a permanent `0`) — and immediately exposed the next failure: it cannot actually vote.

Every attempt dies in sponsorship simulation with:

```
UserOperation reverted during simulation with reason: 0x
```

An empty revert. No selector, nothing to decode.

## Cause

v2's `DAOSpace._voteProposal` decodes the payload as **three** values:

```solidity
(bytes16 _proposalId, uint8 _proposalVersion, VoteOption _voteOption) =
  abi.decode(_data, (bytes16, uint8, VoteOption));
```

`encodeVoteData` emitted only `(proposalId, vote)` — **64 bytes where 96 are required**. `abi.decode` of three static words from a 64-byte buffer reverts with empty data.

Two things made this expensive to find:

1. It reverts inside `DAOSpace.fetch`, which `SpaceRegistry.enter` calls *before* `write`. So it fails **before `_canVote` is ever reached** — invisible to every permission and eligibility check.
2. An empty revert is indistinguishable at the bundler from any other simulation failure.

I verified roles, allowlist, space registration and 7702 delegation were all correct while this was the actual cause:

```
hasRole(EDITOR, botSpace)            = true
hasRole(FAST_PATH_RESTRICTED, ...)   = false
spaceIdToAddress(botSpace)           = bot EOA  ✓ (bidirectional)
bot EOA code                         = 0xef0100… (7702 delegation present)
activeSpaceIds(bot) / (dao)          = true / true
```

## Fix

Encode all three fields, and read the version from the DAO rather than hardcoding `1` — a fast-path proposal that escalates moves to a later version, and `_canVote` rejects a vote naming a stale one. `latestProposalVersion` is added to `DAOSpaceAbi` and read alongside the tally (same block, issued together).

## Verification

Simulating `enter()` against the live DAO as the bot:

| Payload | Result |
|---|---|
| 2-field (64 bytes) — current | ❌ reverted |
| 3-field (96 bytes) — this PR | ✅ **succeeds** |

147 tests pass; typecheck and lint clean. New tests cover the payload width (96 not 64), version pass-through, and that the orchestration threads `tally.version` rather than a constant — the last one would otherwise typecheck fine while being wrong.

## Note

This is the **third** v1→v2 drift in this one code path, after the lazy voting window and the `ProposalParameters` struct. All three survived because the test fixtures were captured from v1 — a green suite against the wrong chain's shapes. Worth considering a fixture captured from 55516 as a standing guard, or dropping the forked ABI in favour of a generated one, once the 19411 cluster is retired.
