### PR TITLE
fix(proposal-executor): scope the unexecutable backfill to what is actually broken

### DIFF
--- a/proposal-executor/src/backfill-unexecutable.ts
+++ b/proposal-executor/src/backfill-unexecutable.ts
@@ -34,18 +34,54 @@
 
 import Pg from "pg"
 import {createPublicClient, getAddress, type Hex, http} from "viem"
-import {DAOSpaceAbi, getChain, SpaceRegistryAbi, type SupportedChainId} from "./contracts.js"
+import {DAOSpaceAbi, getChain, RATIO_BASE, SpaceRegistryAbi, type SupportedChainId} from "./contracts.js"
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
-/** Candidates: unexecuted, not already flagged, and past their voting window. */
+/**
+ * Candidates: exactly the proposals the API currently reports as `EXECUTABLE`.
+ *
+ * This mirrors `sqlIsExecutable` in `api/src/proposals/queries.ts` branch for
+ * branch, because "the API says you can execute this" is the precise definition
+ * of the problem being fixed — a proposal advertised as executable that reverts
+ * forever. Keep the two in step; a fourth copy of the decision tree is the cost
+ * of scoping this correctly (see the note at the top of `detect.ts`).
+ *
+ * The looser "everything unexecuted whose voting window closed" scope this
+ * replaced matched 3265 rows against 51. The extra ~3200 are migrated proposals
+ * that already read REJECTED because they lost their vote, so flagging them
+ * changes nothing anyone sees, while stamping a "verified unexecutable" claim
+ * across most of the table and spending ~64x the eth_calls to do it. Worse, it
+ * quietly redefines the column from "was falsely advertised as executable" to
+ * "is a migrated proposal", which is not what any reader of it expects.
+ */
 const CANDIDATE_SQL = `
 SELECT pc.id, pc.space_id AS "spaceId", pc.name
 FROM proposals_current pc
 WHERE pc.executed_at IS NULL
   AND pc.unexecutable_at IS NULL
   AND pc.end_time > 0
-  AND $1::bigint > pc.end_time
+  AND (
+    (pc.voting_mode = 'Fast' AND pc.yes_count > (CASE WHEN pc.flat_support_threshold = 0 THEN 0 ELSE pc.flat_support_threshold - 1 END))
+    OR (
+      pc.voting_mode = 'Slow'
+      AND $1::bigint <= pc.end_time
+      AND COALESCE((SELECT sec.total_editors FROM space_editor_counts sec WHERE sec.space_id = pc.space_id), 0) > 0
+      AND pc.universal_percentage_support_threshold > 0
+      AND pc.yes_count::numeric >= CEIL(
+        (pc.universal_percentage_support_threshold::numeric
+          * COALESCE((SELECT sec.total_editors FROM space_editor_counts sec WHERE sec.space_id = pc.space_id), 0)::numeric)
+        / ${RATIO_BASE}::numeric
+      )
+    )
+    OR (
+      pc.voting_mode = 'Slow'
+      AND $1::bigint > pc.end_time
+      AND (pc.yes_count + pc.no_count + pc.abstain_count) >= pc.quorum
+      AND (${RATIO_BASE}::numeric - pc.partial_percentage_support_threshold::numeric) * pc.yes_count::numeric
+          > pc.partial_percentage_support_threshold::numeric * pc.no_count::numeric
+    )
+  )
   AND ($2::uuid IS NULL OR pc.space_id = $2::uuid)
 ORDER BY pc.space_id, pc.end_time
 LIMIT $3::int


### PR DESCRIPTION
Follow-up to #884, which is merged and deployed. Found while dry-running the backfill against production.

## Problem

The candidate query was "everything unexecuted whose voting window closed". Against production that matches **3265** proposals. The set that actually exhibits the bug — advertised as executable, reverts forever — is **51**.

The extra ~3200 are migrated proposals that already read `REJECTED` because they lost their vote. Flagging them:

- changes nothing anyone sees (they're already rejected),
- stamps a "verified unexecutable" claim across most of the table,
- spends ~64× the `eth_calls` to do it — the first dry run was still probing after 10 minutes,
- and quietly redefines the column from *"was falsely advertised as executable"* to *"is a migrated proposal"*, which is not what a later reader would assume it means.

## Change

Narrow `CANDIDATE_SQL` to mirror `sqlIsExecutable` branch for branch (Fast threshold, Slow-early, Slow-late), since "the API says you can execute this" is the precise definition of the problem being fixed.

## Verification

Against production (read-only):

| scope | rows |
|---|---|
| shipped in #884 | 3265 |
| this PR | **51** |

For space `41e85161` it returns exactly the five proposal ids the live API returns for `status=EXECUTABLE` — verified by id, not just count.

147 executor tests pass; `tsc` and biome clean.

## Reviewer note

This adds a **fourth** copy of the executable decision tree, which is a genuine maintenance cost. I judged correct scoping worth it over reusing the looser predicate, and flagged it in the query's comment next to the existing three-copy warning at the top of `detect.ts`. If you'd rather consolidate, the natural move is a shared SQL fragment — but that means the executor importing from `api/`, which no service does today.

No production data has been flagged yet — the backfill remains manual and dry-run by default.