### PR TITLE
fix(atlas): restart on a stalled substream, and make the stall alertable

### DIFF
--- a/atlas/src/lib.rs
+++ b/atlas/src/lib.rs
@@ -10,6 +10,7 @@ pub mod events;
 pub mod graph;
 pub mod kafka;
 pub mod persistence;
+pub mod stall;
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -42,6 +42,7 @@ use atlas::persistence::{
     CheckpointConfig, CheckpointManager, PersistedEmissionBaseline, PersistedGraphState,
     RestoredCheckpoint,
 };
+use atlas::stall::{self, StreamProgress};
 use hermes_instrumentation::{debug, info, info_span, warn, Instrument};
 use hermes_relay::{Actions, HermesModule, Sink, StreamSource};
 use prost::Message;
@@ -73,6 +74,9 @@ struct AtlasSink {
     emitter: CanonicalGraphEmitter,
     /// Checkpoint manager for restore/persist/fail-open handling
     checkpoint_manager: CheckpointManager,
+    /// Last block the substream delivered, watched by the stall detector.
+    /// Lock-free so the block handler pays almost nothing to update it.
+    progress: StreamProgress,
 }
 
 impl AtlasSink {
@@ -146,6 +150,7 @@ impl AtlasSink {
             }),
             emitter,
             checkpoint_manager,
+            progress: StreamProgress::new(),
         };
 
         // Force-write on startup: if there's no baseline on disk yet but we
@@ -346,6 +351,28 @@ impl Sink for AtlasSink {
             .and_then(|c| c.timestamp.as_ref())
             .map(|t| t.seconds as u64)
             .unwrap_or(0);
+
+        // Mark liveness before any work: the watchdog cares that blocks are
+        // *arriving*, not that they contain events or change the graph. Quiet
+        // blocks are normal; silence is the failure.
+        self.progress.record_block(
+            block_number,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        );
+
+        // Same gauge the hermes services publish, so the existing
+        // HermesBehindChainTip alert covers atlas too rather than needing a
+        // parallel rule. This is the outside-the-process check: it still fires if
+        // the stall detector itself fails to notice.
+        hermes_instrumentation::metrics::set_latest_processed_block(block_number);
+        if block_timestamp > 0 {
+            hermes_instrumentation::metrics::set_latest_processed_block_timestamp(
+                block_timestamp as i64,
+            );
+        }
 
         let meta = BlockMetadata {
             block_number,
@@ -697,6 +724,12 @@ async fn async_main() -> anyhow::Result<()> {
     // persistence is enabled) before we connect to Kafka.
     let _checkpoint_preflight = CheckpointConfig::from_env(root_space_id, 1)?;
 
+    // Serves /metrics so Prometheus can see how far behind the chain tip we are.
+    // Without this atlas was invisible to monitoring: it wedged for two days and
+    // no alert could have fired, because nothing published its block height.
+    let metrics_port: Option<u16> = env::var("METRICS_PORT").ok().and_then(|s| s.parse().ok());
+    hermes_instrumentation::metrics::install("atlas", metrics_port)?;
+
     info!("Atlas Topology Processor starting");
     info!(
         kafka_broker = %broker,
@@ -729,6 +762,14 @@ async fn async_main() -> anyhow::Result<()> {
         );
         StreamSource::live(endpoint, HermesModule::Actions, start_block, end_block)
     };
+
+    // Armed before the stream starts so a substream that never delivers its
+    // first block is caught too, not just one that dies mid-flight.
+    match stall::timeout_from_env() {
+        Some(timeout) if !use_mock => stall::spawn(sink.progress.clone(), timeout),
+        Some(_) => info!("Mock source in use; substream stall detection not armed"),
+        None => {}
+    }
 
     sink.run(source).await?;
 

--- a/atlas/src/stall.rs
+++ b/atlas/src/stall.rs
@@ -1,0 +1,279 @@
+//! Substream stall detection.
+//!
+//! The substream can die without the process noticing. Observed 2026-08-10:
+//! Pinax dropped the HTTP/2 body (`h2 protocol error: error reading a body from
+//! connection`), the client logged `Blockstreams disconnected` then
+//! `Blockstreams connected`, and no `BlockScopedData` ever arrived again. The
+//! process stayed healthy — 0 restarts over 8 days — so nothing restarted it,
+//! and the canonical graph sat frozen at block 27694 for two days while the
+//! chain advanced to 29448. Personal spaces silently stopped becoming canonical.
+//!
+//! A plain restart was the entire remedy: atlas resumes from its persisted
+//! cursor and recomputes canonical state from full graph state, so re-processing
+//! is idempotent. Recovery took ~20 seconds. This module makes that automatic —
+//! on a stall it exits non-zero and lets the orchestrator restart the process.
+//!
+//! ## Why this keys on block advance
+//!
+//! **Not** on checkpoint writes or canonical changes. Those are legitimately
+//! sparse — real checkpoints landed hours apart (25278 → 25652 → 25791 → …)
+//! because atlas only persists when the graph actually changes. A detector
+//! watching for state changes would fire constantly on a healthy but quiet
+//! stream.
+//!
+//! Block arrival is the honest signal: chain 55516 produces blocks every couple
+//! of seconds, so a healthy stream is never idle for long. It also stays quiet
+//! during a legitimate long catch-up — replaying 1,750 blocks still advances
+//! blocks the whole way — which is the trap that made a latency-based liveness
+//! probe kill busy-but-alive api pods (#880).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use hermes_instrumentation::{error, info, warn};
+
+/// How long the stream may deliver nothing before it is treated as wedged.
+///
+/// Generous on purpose: a healthy stream sees blocks every few seconds, so this
+/// is ~two orders of magnitude above normal, and it must never fire on a slow
+/// block or a brief reconnect.
+pub const DEFAULT_STALL_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// How often the watchdog re-checks. Bounds how long a real stall persists
+/// beyond the timeout.
+const CHECK_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Shared record of the last block the stream delivered.
+///
+/// Cheap enough to touch on every block: two atomics, no lock, so the hot path
+/// is unaffected.
+#[derive(Debug, Clone, Default)]
+pub struct StreamProgress {
+    inner: Arc<ProgressInner>,
+}
+
+#[derive(Debug, Default)]
+struct ProgressInner {
+    /// Highest block seen. `0` means "nothing yet".
+    last_block: AtomicU64,
+    /// Monotonic-ish marker for when that block arrived, in seconds since the
+    /// watchdog's epoch. Written by the stream, read by the watchdog.
+    last_advance_secs: AtomicU64,
+}
+
+impl StreamProgress {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that a block arrived. Called from the block handler.
+    pub fn record_block(&self, block_number: u64, now_secs: u64) {
+        self.inner.last_block.store(block_number, Ordering::Relaxed);
+        self.inner
+            .last_advance_secs
+            .store(now_secs, Ordering::Relaxed);
+    }
+
+    pub fn last_block(&self) -> u64 {
+        self.inner.last_block.load(Ordering::Relaxed)
+    }
+
+    pub fn last_advance_secs(&self) -> u64 {
+        self.inner.last_advance_secs.load(Ordering::Relaxed)
+    }
+}
+
+/// What the watchdog decided on one tick. Separated from the exiting so the
+/// decision is unit-testable without killing the test process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StallVerdict {
+    /// Blocks are arriving, or not enough time has passed to judge.
+    Healthy,
+    /// Nothing has arrived for longer than the timeout — restart.
+    Stalled { idle_secs: u64, last_block: u64 },
+}
+
+/// Decide whether the stream is wedged.
+///
+/// `started_secs` is when the watchdog began, used as the baseline before the
+/// first block arrives — otherwise a slow startup (restore, Kafka connect, the
+/// initial substream handshake) would look like an instant stall.
+pub fn classify(
+    progress: &StreamProgress,
+    started_secs: u64,
+    now_secs: u64,
+    timeout: Duration,
+) -> StallVerdict {
+    let last_advance = progress.last_advance_secs();
+    // No block yet: judge against startup, so a stream that never delivers its
+    // first block is still caught rather than waiting forever.
+    let reference = if last_advance == 0 {
+        started_secs
+    } else {
+        last_advance
+    };
+
+    let idle_secs = now_secs.saturating_sub(reference);
+    if idle_secs >= timeout.as_secs() {
+        StallVerdict::Stalled {
+            idle_secs,
+            last_block: progress.last_block(),
+        }
+    } else {
+        StallVerdict::Healthy
+    }
+}
+
+/// Read the stall timeout from `ATLAS_STALL_TIMEOUT_SECS`.
+///
+/// `0` disables detection — an escape hatch for local runs against a mock or a
+/// deliberately paused stream, where no blocks arriving is expected.
+pub fn timeout_from_env() -> Option<Duration> {
+    match std::env::var("ATLAS_STALL_TIMEOUT_SECS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(0) => {
+                warn!("ATLAS_STALL_TIMEOUT_SECS=0 — substream stall detection disabled");
+                None
+            }
+            Ok(secs) => Some(Duration::from_secs(secs)),
+            Err(err) => {
+                warn!(
+                    value = %raw,
+                    error = %err,
+                    default_secs = DEFAULT_STALL_TIMEOUT.as_secs(),
+                    "Invalid ATLAS_STALL_TIMEOUT_SECS; using default"
+                );
+                Some(DEFAULT_STALL_TIMEOUT)
+            }
+        },
+        Err(_) => Some(DEFAULT_STALL_TIMEOUT),
+    }
+}
+
+/// Spawn the watchdog. Exits the process on a stall so the orchestrator restarts
+/// it; safe because atlas resumes from its persisted cursor.
+pub fn spawn(progress: StreamProgress, timeout: Duration) {
+    let started = unix_secs();
+    info!(
+        stall_timeout_secs = timeout.as_secs(),
+        check_interval_secs = CHECK_INTERVAL.as_secs(),
+        "Substream stall detector armed"
+    );
+
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(CHECK_INTERVAL);
+        loop {
+            ticker.tick().await;
+            match classify(&progress, started, unix_secs(), timeout) {
+                StallVerdict::Healthy => {}
+                StallVerdict::Stalled {
+                    idle_secs,
+                    last_block,
+                } => {
+                    // Exit rather than trying to rebuild the stream in place: a
+                    // restart is the remedy already known to work, and it also
+                    // clears any other state the dropped connection left behind.
+                    error!(
+                        idle_secs,
+                        last_block,
+                        stall_timeout_secs = timeout.as_secs(),
+                        "Substream delivered no blocks past the stall timeout; exiting so the \
+                         orchestrator restarts us. Atlas resumes from its persisted cursor."
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
+    });
+}
+
+fn unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TIMEOUT: Duration = Duration::from_secs(600);
+
+    #[test]
+    fn healthy_while_blocks_keep_arriving() {
+        let p = StreamProgress::new();
+        p.record_block(29_250, 1_000);
+        // 5 minutes idle, under the 10-minute timeout.
+        assert_eq!(classify(&p, 0, 1_300, TIMEOUT), StallVerdict::Healthy);
+    }
+
+    #[test]
+    fn stalls_once_the_timeout_elapses_with_no_new_block() {
+        let p = StreamProgress::new();
+        p.record_block(29_250, 1_000);
+        assert_eq!(
+            classify(&p, 0, 1_600, TIMEOUT),
+            StallVerdict::Stalled {
+                idle_secs: 600,
+                last_block: 29_250
+            }
+        );
+    }
+
+    #[test]
+    fn a_slow_catch_up_is_not_a_stall() {
+        // Replaying ~1,750 blocks takes a while but blocks keep advancing, which
+        // is exactly the case a latency-based probe gets wrong (#880).
+        let p = StreamProgress::new();
+        let mut now = 1_000;
+        for block in 27_694..27_894 {
+            p.record_block(block, now);
+            now += 5; // 5s per block: slow, but progressing
+            assert_eq!(classify(&p, 0, now, TIMEOUT), StallVerdict::Healthy);
+        }
+    }
+
+    #[test]
+    fn startup_is_measured_from_launch_not_from_zero() {
+        // No block yet. Without the startup baseline, `last_advance == 0` would
+        // make every fresh process look instantly stalled.
+        let p = StreamProgress::new();
+        assert_eq!(classify(&p, 1_000, 1_100, TIMEOUT), StallVerdict::Healthy);
+    }
+
+    #[test]
+    fn a_stream_that_never_delivers_a_first_block_still_trips() {
+        let p = StreamProgress::new();
+        assert_eq!(
+            classify(&p, 1_000, 1_600, TIMEOUT),
+            StallVerdict::Stalled {
+                idle_secs: 600,
+                last_block: 0
+            }
+        );
+    }
+
+    #[test]
+    fn recording_a_block_clears_a_pending_stall() {
+        let p = StreamProgress::new();
+        p.record_block(1, 1_000);
+        assert!(matches!(
+            classify(&p, 0, 1_700, TIMEOUT),
+            StallVerdict::Stalled { .. }
+        ));
+        // A reconnect that starts delivering again must un-stall it.
+        p.record_block(2, 1_700);
+        assert_eq!(classify(&p, 0, 1_700, TIMEOUT), StallVerdict::Healthy);
+    }
+
+    #[test]
+    fn progress_tracks_the_latest_block_and_time() {
+        let p = StreamProgress::new();
+        p.record_block(10, 500);
+        p.record_block(11, 505);
+        assert_eq!(p.last_block(), 11);
+        assert_eq!(p.last_advance_secs(), 505);
+    }
+}

--- a/hermes/k8s/v2/atlas.yaml
+++ b/hermes/k8s/v2/atlas.yaml
@@ -22,7 +22,21 @@ spec:
         - name: atlas
           image: registry.digitalocean.com/geo/atlas:latest
           imagePullPolicy: Always
+          ports:
+            - name: metrics
+              containerPort: 9464
+              protocol: TCP
           env:
+            # Publishes hermes_latest_processed_block{,_timestamp} so monitoring can
+            # see how far behind the chain atlas is. Without this atlas was invisible:
+            # it wedged for two days on a dropped Pinax stream and no alert could fire.
+            - name: METRICS_PORT
+              value: "9464"
+            # Exit if the substream delivers no blocks for this long, so the pod
+            # restarts and resumes from its persisted cursor. A restart was the
+            # entire remedy the one time this happened.
+            - name: ATLAS_STALL_TIMEOUT_SECS
+              value: "600"
             - name: KAFKA_BROKER
               valueFrom:
                 secretKeyRef:
@@ -138,3 +152,23 @@ spec:
             limits:
               memory: "1Gi"
               cpu: "1000m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: atlas
+  namespace: gaia
+  labels:
+    app: atlas
+    # Lifted into the metrics by the ServiceMonitor's `targetLabels`, which is what
+    # joins them to chain_tip_block_number in the lag alerts.
+    gaia_namespace: gaia
+spec:
+  type: ClusterIP
+  selector:
+    app: atlas
+  ports:
+    - name: metrics
+      port: 9464
+      targetPort: metrics
+      protocol: TCP

--- a/monitoring/k8s/hermes-lag-alerts.yaml
+++ b/monitoring/k8s/hermes-lag-alerts.yaml
@@ -9,6 +9,10 @@ spec:
   groups:
     - name: hermes.lag
       rules:
+        # atlas is excluded from this rule and covered by atlas-lag-alerts.yaml
+        # instead. It publishes the same gauge, but replays ~1,750 blocks after a
+        # restart, so a 5-block/5-minute threshold would page on every legitimate
+        # catch-up.
         - alert: HermesBehindChainTip
           expr: |
             (
@@ -18,7 +22,7 @@ spec:
               )
               -
               on(namespace) group_right
-              max by (namespace, service) (hermes_latest_processed_block)
+              max by (namespace, service) (hermes_latest_processed_block{service!="atlas"})
             ) > 5
           for: 5m
           labels:

--- a/monitoring/k8s/v2/atlas-lag-alerts.yaml
+++ b/monitoring/k8s/v2/atlas-lag-alerts.yaml
@@ -1,0 +1,114 @@
+# Atlas canonical-graph staleness alerts.
+#
+# Why these exist: on 2026-08-10 atlas's Pinax substream died in a way the client
+# never treated as fatal — it logged `h2 protocol error: error reading a body from
+# connection`, then `Blockstreams disconnected` / `Blockstreams connected`, and no
+# block ever arrived again. The process stayed healthy (0 restarts in 8 days), so
+# nothing restarted it, and the canonical graph sat frozen at block 27694 for two
+# days while the chain reached 29448. Personal spaces silently stopped becoming
+# canonical, and search quietly stopped returning people. Nothing alerted, because
+# atlas published no metrics at all.
+#
+# atlas now (a) exits on a stalled stream so the pod restarts and resumes from its
+# persisted cursor, and (b) publishes the shared hermes_latest_processed_block{,
+# _timestamp} gauges. These rules are the outside-the-process check: they still
+# fire if the in-process detector fails to notice.
+#
+# atlas is deliberately excluded from HermesBehindChainTip in
+# ../hermes-lag-alerts.yaml. It publishes the same gauge, but replays ~1,750
+# blocks after a restart, so that rule's 5-block/5-minute threshold would page on
+# every legitimate catch-up.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: atlas-lag-observability
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: atlas.lag
+      rules:
+        # PRIMARY: the exact signature of the outage. "atlas has not observed a
+        # block whose clock is recent", which is true whether the stream died, the
+        # endpoint went away, or the process wedged.
+        #
+        # Uses the block's own timestamp rather than a chain-tip subtraction, so it
+        # does not depend on chain-tip-exporter being healthy — the failure mode
+        # where both the indexer and its reference metric are down is exactly when
+        # an alert matters most.
+        - alert: AtlasStreamStalled
+          expr: |
+            (time() - max(hermes_latest_processed_block_timestamp{service="atlas"})) > 900
+          for: 5m
+          labels:
+            severity: critical
+            service: atlas
+          annotations:
+            summary: Atlas has not processed a recent block
+            description: >-
+              Atlas has processed no block newer than 15 minutes for over 5 minutes.
+              The canonical graph is frozen, so spaces will not become canonical and
+              search will not return newly-verified people. Atlas should self-restart
+              via its stall detector; if this stays firing, the detector did not trip
+              and the pod needs restarting manually (it resumes from its cursor).
+
+        # Catches the case where atlas is running and consuming but cannot keep up,
+        # which the timestamp rule alone would miss while it slowly advances.
+        # Threshold is deliberately loose: a post-restart replay of ~1,750 blocks is
+        # normal and clears on its own well inside 30 minutes.
+        - alert: AtlasBehindChainTip
+          expr: |
+            (
+              label_replace(
+                max by (gaia_namespace) (chain_tip_block_number),
+                "namespace", "$1", "gaia_namespace", "(.*)"
+              )
+              -
+              on(namespace) group_right
+              max by (namespace, service) (hermes_latest_processed_block{service="atlas"})
+            ) > 500
+          for: 30m
+          labels:
+            severity: warning
+            service: atlas
+          annotations:
+            summary: Atlas is falling behind chain tip
+            description: >-
+              Atlas is {{ $value }} blocks behind chain tip in {{ $labels.namespace }}
+              and has not caught up in 30 minutes. A restart replay clears well inside
+              this window, so this means it is genuinely not keeping pace.
+
+        # The stall detector converts a silent two-day freeze into an automatic
+        # restart — but a self-healing loop that flaps silently is its own outage.
+        # This surfaces a chronically unstable upstream instead of hiding it.
+        - alert: AtlasRestartingRepeatedly
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace="gaia", container="atlas"}[1h]) >= 3
+          for: 5m
+          labels:
+            severity: warning
+            service: atlas
+          annotations:
+            summary: Atlas is restarting repeatedly
+            description: >-
+              Atlas has restarted {{ $value }} times in the last hour, most likely its
+              stall detector firing on a substream that keeps dropping. Recovery is
+              working, but the upstream (Pinax) needs investigating.
+
+        # Belt and braces: if atlas stops publishing metrics entirely — crash-looping
+        # before it serves /metrics, or the Service/ServiceMonitor wiring breaks — the
+        # two rules above go stale rather than firing, because their series vanish.
+        - alert: AtlasMetricsMissing
+          expr: |
+            absent(hermes_latest_processed_block_timestamp{service="atlas"})
+          for: 15m
+          labels:
+            severity: warning
+            service: atlas
+          annotations:
+            summary: Atlas is not reporting metrics
+            description: >-
+              No atlas block metrics for 15 minutes. Either atlas is not running or the
+              Service / ServiceMonitor scrape is broken — which would also blind
+              AtlasStreamStalled, so treat this as the canonical graph being unmonitored.

--- a/monitoring/k8s/v2/hermes-metrics-servicemonitor.yaml
+++ b/monitoring/k8s/v2/hermes-metrics-servicemonitor.yaml
@@ -18,6 +18,9 @@ spec:
           - hermes-pipeline
           - hermes-ipfs-cache
           - chain-tip-exporter
+          # atlas publishes the same hermes_latest_processed_block gauge. Its lag
+          # thresholds differ (see atlas-lag-alerts.yaml), but the scrape is identical.
+          - atlas
   endpoints:
     - port: metrics
       path: /metrics


### PR DESCRIPTION
## The outage this prevents

On **2026-08-10** atlas's Pinax substream died in a way the client never treated as fatal:

```
Received tonic error status: Internal, message: "h2 protocol error: error reading a body from connection"
Blockstreams disconnected, connecting (...)
Blockstreams connected
```

…and then no `BlockScopedData` ever arrived again. The process stayed healthy — **0 restarts across 8 days** — so nothing restarted it.

| | |
|---|---|
| canonical graph frozen at | block **27694** |
| chain reached | **29448** |
| duration | **~2 days** |
| alerts fired | **none** — atlas published no metrics at all |

User-visible effect: personal spaces stopped becoming canonical, so canonical-only search silently stopped returning people who had just been verified. We only found it while chasing "why isn't Adam in search".

**A plain `rollout restart` was the entire remedy** — atlas resumed from its persisted cursor, recomputed, and emitted a correct graph in ~20 seconds. This PR makes that automatic, and separately makes the failure visible.

## Stall detector

`atlas/src/stall.rs` — a watchdog exits non-zero when no block has arrived for `ATLAS_STALL_TIMEOUT_SECS` (default **600**), letting Kubernetes restart the pod.

Exiting rather than rebuilding the stream in place is deliberate: a restart is the remedy already known to work, and it clears whatever else the dropped connection left behind. Re-processing is safe because atlas recomputes canonical state from **full graph state**, not replayed deltas.

**It keys on block *arrival*** — not on checkpoint writes or canonical changes. Those are legitimately sparse: real checkpoints landed hours apart (25278 → 25652 → 25791) because atlas only persists when the graph changes, so a state-change detector would fire constantly on a healthy quiet stream. Block arrival also stays quiet through a legitimate ~1,750-block catch-up, which is the trap that had a latency-based liveness probe killing busy-but-alive api pods (#880).

## Making it alertable

atlas publishes the shared `hermes_latest_processed_block{,_timestamp}` gauges via the existing `hermes-instrumentation` helper, plus a `Service` and a ServiceMonitor entry. This is the **outside-the-process** check — it still fires if the in-process detector fails to notice.

`monitoring/k8s/v2/atlas-lag-alerts.yaml`:

| alert | why |
|---|---|
| **AtlasStreamStalled** (primary) | matches the outage signature exactly. Keyed on the *block's own timestamp*, so it doesn't depend on `chain-tip-exporter` being healthy — both being down is precisely when an alert matters most |
| AtlasBehindChainTip | running but not keeping pace; loose threshold (500 / 30m) so a restart replay doesn't page |
| AtlasRestartingRepeatedly | the new self-healing must not be able to flap silently and hide a chronically unstable upstream |
| AtlasMetricsMissing | a broken scrape would otherwise just make the others go quiet instead of firing |

atlas is **excluded** from `HermesBehindChainTip`: same gauge, but its post-restart replay would trip that rule's 5-block/5-minute threshold on every legitimate catch-up.

## Verification

- **7 stall tests**, mutation-checked: disabling the trip fails 3 of them, dropping the startup baseline fails 2. So the coverage isn't decorative.
- 112 atlas lib tests pass; `cargo fmt` and `clippy` clean.
- All four manifests pass `kubectl apply --dry-run=server` against the live cluster.
- All five PromQL expressions parse against live Prometheus — and `AtlasMetricsMissing` **correctly matches today**, because atlas doesn't publish metrics yet. It should stop matching once this deploys, which is a good post-deploy check.

## Reviewer notes

- Needs a build + `deploy-v2` dispatch for atlas to take effect; the PrometheusRule/ServiceMonitor are applied separately from `monitoring/k8s/v2/`.
- Same failure mode plausibly applies to the other substream consumers (`hermes-pipeline`, `kg-indexer`). They already publish the block gauge and are covered by `HermesBehindChainTip`, but none has progress-based liveness — worth a follow-up rather than widening this PR.
- The 600s timeout is the one tunable worth a second opinion. Chain 55516 produces blocks every couple of seconds, so it's ~2 orders of magnitude above normal; `ATLAS_STALL_TIMEOUT_SECS=0` disables detection for local/mock runs.