### PR TITLE
feat(feed): Explore feed Phase A — global Best ranking score

### DIFF
--- a/api/drizzle/0073_entity_ranking_scores.sql
+++ b/api/drizzle/0073_entity_ranking_scores.sql
@@ -1,0 +1,307 @@
+-- Explore feed "Best" ranking — Phase A storage and scoring primitives.
+--
+-- Implements the global best score from the "Explore feed ranking: Best and For
+-- You" PRD: a time-invariant additive log-time score combining quality, an
+-- entity-type weight, and recency.
+--
+--   qualityScore  = Wilson lower bound on (positive, negative) with a pseudo-count prior
+--   rankingScore  = log(max(qualityScore, floor)) + log(w_type) + intrinsic + created_at/tau
+--
+-- Deliberate design choices, all driven by measurements taken 2026-08-13:
+--
+-- * Side table, not columns on `entities`. That table is 48.9M rows / 18 GB with
+--   four indexes; the repo already established the side-table pattern with
+--   `global_scores` / `local_scores` + a SETOF function + a PostGraphile plugin.
+--
+-- * DDL and functions only — NO backfill here. `api`'s initContainer runs
+--   `db:migrate`, so a 48M-row UPDATE in a migration would stall every deploy.
+--   The backfill ships as a separate, batched, resumable script.
+--
+-- * The score is time-invariant: `created_at / tau` means an entity's score moves
+--   only when its votes, type weight, or structure change. No periodic decay
+--   sweep, and cursor pagination stays stable between vote events.
+--
+-- * `intrinsic_score` is NOT an optional extra. Measured: of 48.8M entities only
+--   2,650 have any votes (median 1, max 36) and just 56 have 5 or more. With
+--   almost every entity sitting at the identical prior, log(quality) is constant
+--   and the ranking would collapse to pure recency. The intrinsic term is the only
+--   quality gradient that exists between zero-vote entities, so it carries Phase A.
+--   It is capped so that it stays subordinate to real votes once votes exist.
+
+-- ---------------------------------------------------------------------------
+-- Tunables. A table rather than constants so tau, the prior, and the caps can be
+-- retuned without a deploy — the PRD calls all of them out as needing
+-- experimentation.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "entity_ranking_config" (
+  "id" boolean PRIMARY KEY DEFAULT true,
+  -- Recency divisor in seconds. 45000 is Reddit's hot-score constant and gives a
+  -- ~12.5h "one unit of score" cadence. NOTE: it must be applied to SECONDS.
+  -- scoring-service's dead calculate_hot_score applied it to hours, making the
+  -- time term ~3600x too weak; do not repeat that.
+  "tau_seconds" numeric NOT NULL DEFAULT 45000,
+  -- Wilson z. 1.96 = 95% confidence lower bound.
+  "wilson_z" numeric NOT NULL DEFAULT 1.96,
+  -- Pseudo-count prior. Kept deliberately weak (PRD: "keep k at the low end so the
+  -- first few real votes visibly move rank") because early votes are the scarcest
+  -- signal on the platform.
+  "prior_positive" numeric NOT NULL DEFAULT 1,
+  "prior_negative" numeric NOT NULL DEFAULT 1,
+  -- Floor under qualityScore before log(), so a fully-downvoted entity yields a
+  -- finite score instead of -Infinity.
+  "quality_floor" numeric NOT NULL DEFAULT 0.01,
+  -- Ceiling on the intrinsic term, in score units. Must stay well below the spread
+  -- that real votes produce so votes dominate once they exist.
+  "intrinsic_cap" numeric NOT NULL DEFAULT 0.5,
+  -- Structural counts at which the intrinsic term saturates.
+  "intrinsic_property_target" integer NOT NULL DEFAULT 10,
+  "intrinsic_relation_target" integer NOT NULL DEFAULT 5,
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "entity_ranking_config_single_row" CHECK ("id"),
+  CONSTRAINT "entity_ranking_config_tau_positive" CHECK ("tau_seconds" > 0),
+  CONSTRAINT "entity_ranking_config_floor_positive" CHECK ("quality_floor" > 0),
+  CONSTRAINT "entity_ranking_config_targets_positive"
+    CHECK ("intrinsic_property_target" > 0 AND "intrinsic_relation_target" > 0)
+);
+--> statement-breakpoint
+INSERT INTO "entity_ranking_config" ("id") VALUES (true) ON CONFLICT ("id") DO NOTHING;
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- Type-level weighting. A News story is a better feed unit than a Text block.
+-- Weight > 1 boosts, < 1 demotes, absent defaults to 1.0. Applied as log(weight)
+-- so the additive log-time score stays time-invariant.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "entity_type_weights" (
+  "type_id" uuid PRIMARY KEY,
+  "weight" numeric NOT NULL DEFAULT 1.0,
+  "note" text,
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  -- A weight can demote but never effectively exclude: exclusion is an editorial
+  -- decision and must not be reachable by the weighting math (PRD floor guardrail).
+  CONSTRAINT "entity_type_weights_range" CHECK ("weight" > 0.1 AND "weight" <= 10.0)
+);
+--> statement-breakpoint
+
+-- Excluded types are enforced at candidate generation, NOT as a zero weight —
+-- excluded entities must never consume candidate slots.
+CREATE TABLE IF NOT EXISTS "entity_type_exclusions" (
+  "type_id" uuid PRIMARY KEY,
+  "note" text,
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- The scores themselves.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "entity_ranking_scores" (
+  "entity_id" uuid PRIMARY KEY,
+  "quality_score" numeric NOT NULL,
+  "intrinsic_score" numeric NOT NULL DEFAULT 0,
+  "ranking_score" numeric NOT NULL,
+  -- Inputs retained for debugging and for the PRD's "expose them on the node"
+  -- requirement, so a surprising ranking can be explained without recomputation.
+  "positive" bigint NOT NULL DEFAULT 0,
+  "negative" bigint NOT NULL DEFAULT 0,
+  "type_weight" numeric NOT NULL DEFAULT 1.0,
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+-- The Phase A sort key. `entity_id` breaks ties so cursor pagination is total.
+CREATE INDEX IF NOT EXISTS "entity_ranking_scores_ranking_desc_idx"
+  ON "entity_ranking_scores" ("ranking_score" DESC, "entity_id" DESC);
+--> statement-breakpoint
+-- Supports the PRD's numeric threshold filter on rankingScore.
+CREATE INDEX IF NOT EXISTS "entity_ranking_scores_quality_idx"
+  ON "entity_ranking_scores" ("quality_score" DESC);
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- Wilson lower confidence bound on a Bernoulli proportion.
+--
+-- Chosen over a raw net score because net score treats 100-up/90-down the same as
+-- 10-up/0-down. Wilson penalises uncertainty, so a low-vote newcomer cannot
+-- outrank a well-established entity on a lucky first vote — a Phase A acceptance
+-- criterion.
+--
+-- IMMUTABLE: pure arithmetic, so Postgres can inline it and use it in indexes.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wilson_lower_bound(
+  positive numeric,
+  negative numeric,
+  z numeric DEFAULT 1.96,
+  prior_positive numeric DEFAULT 1,
+  prior_negative numeric DEFAULT 1
+) RETURNS numeric
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE AS $$
+DECLARE
+  p_obs   numeric := GREATEST(COALESCE(positive, 0), 0) + GREATEST(COALESCE(prior_positive, 0), 0);
+  n_obs   numeric := GREATEST(COALESCE(negative, 0), 0) + GREATEST(COALESCE(prior_negative, 0), 0);
+  total   numeric := p_obs + n_obs;
+  phat    double precision;
+  zf      double precision := COALESCE(z, 1.96)::double precision;
+  nf      double precision;
+  lower   double precision;
+BEGIN
+  -- No observations and no prior: undefined proportion, so report the floor rather
+  -- than dividing by zero.
+  IF total <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  nf := total::double precision;
+  phat := (p_obs / total)::double precision;
+
+  lower := (phat + (zf * zf) / (2 * nf)
+            - zf * sqrt((phat * (1 - phat) + (zf * zf) / (4 * nf)) / nf))
+           / (1 + (zf * zf) / nf);
+
+  -- Clamp: floating-point error can push the bound marginally outside [0,1].
+  RETURN LEAST(GREATEST(lower, 0), 1)::numeric;
+END;
+$$;
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- Structural quality for entities with no votes: property completeness and
+-- relation count, each saturating, summed and capped.
+--
+-- This is the sparse-state substitute for a vote signal. It is intentionally a
+-- small additive bonus, not a multiplier, so it can order zero-vote entities among
+-- themselves without ever overturning a real vote signal.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.entity_intrinsic_score(
+  property_count integer,
+  relation_count integer,
+  cap numeric DEFAULT 0.5,
+  property_target integer DEFAULT 10,
+  relation_target integer DEFAULT 5
+) RETURNS numeric
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+  SELECT LEAST(
+    COALESCE(cap, 0.5),
+    COALESCE(cap, 0.5) * (
+        0.6 * LEAST(GREATEST(COALESCE(property_count, 0), 0)::numeric
+                    / GREATEST(COALESCE(property_target, 10), 1), 1.0)
+      + 0.4 * LEAST(GREATEST(COALESCE(relation_count, 0), 0)::numeric
+                    / GREATEST(COALESCE(relation_target, 5), 1), 1.0)
+    )
+  );
+$$;
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- The Phase A ranking score.
+--
+-- `created_at` is text-encoded epoch seconds in this schema, so the caller passes
+-- it already cast. The cast is write-time only — the score is stored, never
+-- computed per query.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.entity_ranking_score(
+  quality_score numeric,
+  type_weight numeric,
+  intrinsic_score numeric,
+  created_at_epoch bigint,
+  tau_seconds numeric DEFAULT 45000,
+  quality_floor numeric DEFAULT 0.01
+) RETURNS numeric
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+  SELECT ln(GREATEST(COALESCE(quality_score, 0), GREATEST(COALESCE(quality_floor, 0.01), 1e-9)))
+       + ln(GREATEST(COALESCE(type_weight, 1.0), 1e-9))
+       + COALESCE(intrinsic_score, 0)
+       + COALESCE(created_at_epoch, 0)::numeric / GREATEST(COALESCE(tau_seconds, 45000), 1);
+$$;
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- Incremental recompute for a set of entities. Called by the writer when votes
+-- change; also the unit of work for the batched backfill.
+--
+-- Because the score is time-invariant this is the ONLY thing that ever needs to
+-- run — there is no scheduled decay sweep.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.refresh_entity_ranking_scores(entity_ids uuid[])
+RETURNS integer
+LANGUAGE plpgsql AS $$
+DECLARE
+  cfg          entity_ranking_config;
+  affected     integer;
+  types_prop   constant uuid := '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1';
+BEGIN
+  SELECT * INTO cfg FROM entity_ranking_config WHERE id;
+
+  WITH target AS (
+    SELECT e.id, NULLIF(e.created_at, '')::bigint AS created_epoch
+    FROM entities e
+    WHERE e.id = ANY(entity_ids)
+  ),
+  votes AS (
+    -- vote_kind = 0 is curation; stance and veracity are separate axes and must not
+    -- feed the feed's quality term.
+    SELECT vc.object_id AS id,
+           SUM(vc.positive)::bigint AS positive,
+           SUM(vc.negative)::bigint AS negative
+    FROM votes_count vc
+    WHERE vc.object_type = 0 AND vc.vote_kind = 0
+      AND vc.object_id = ANY(entity_ids)
+    GROUP BY vc.object_id
+  ),
+  props AS (
+    SELECT v.entity_id AS id, count(DISTINCT v.property_id)::integer AS property_count
+    FROM values v WHERE v.entity_id = ANY(entity_ids) GROUP BY v.entity_id
+  ),
+  rels AS (
+    -- System relations are plumbing, not curatorial substance, so they must not
+    -- inflate the structural signal.
+    SELECT r.from_entity_id AS id, count(*)::integer AS relation_count
+    FROM relations r
+    WHERE r.from_entity_id = ANY(entity_ids) AND r.is_system = false
+    GROUP BY r.from_entity_id
+  ),
+  weights AS (
+    -- An entity may declare several types; take the strongest weight so an
+    -- explicit boost is never diluted by a co-assigned generic type.
+    SELECT r.from_entity_id AS id, MAX(w.weight) AS type_weight
+    FROM relations r
+    JOIN entity_type_weights w ON w.type_id = r.to_entity_id
+    WHERE r.from_entity_id = ANY(entity_ids) AND r.type_id = types_prop
+    GROUP BY r.from_entity_id
+  ),
+  computed AS (
+    SELECT t.id,
+           public.wilson_lower_bound(COALESCE(v.positive, 0), COALESCE(v.negative, 0),
+                                     cfg.wilson_z, cfg.prior_positive, cfg.prior_negative) AS quality_score,
+           public.entity_intrinsic_score(COALESCE(p.property_count, 0), COALESCE(rl.relation_count, 0),
+                                          cfg.intrinsic_cap, cfg.intrinsic_property_target,
+                                          cfg.intrinsic_relation_target) AS intrinsic_score,
+           COALESCE(w.type_weight, 1.0) AS type_weight,
+           COALESCE(v.positive, 0) AS positive,
+           COALESCE(v.negative, 0) AS negative,
+           t.created_epoch
+    FROM target t
+    LEFT JOIN votes v   ON v.id = t.id
+    LEFT JOIN props p   ON p.id = t.id
+    LEFT JOIN rels rl   ON rl.id = t.id
+    LEFT JOIN weights w ON w.id = t.id
+  )
+  INSERT INTO entity_ranking_scores AS s
+    (entity_id, quality_score, intrinsic_score, ranking_score, positive, negative, type_weight, updated_at)
+  SELECT c.id, c.quality_score, c.intrinsic_score,
+         public.entity_ranking_score(c.quality_score, c.type_weight, c.intrinsic_score,
+                                      c.created_epoch, cfg.tau_seconds, cfg.quality_floor),
+         c.positive, c.negative, c.type_weight, now()
+  FROM computed c
+  ON CONFLICT (entity_id) DO UPDATE SET
+    quality_score   = EXCLUDED.quality_score,
+    intrinsic_score = EXCLUDED.intrinsic_score,
+    ranking_score   = EXCLUDED.ranking_score,
+    positive        = EXCLUDED.positive,
+    negative        = EXCLUDED.negative,
+    type_weight     = EXCLUDED.type_weight,
+    updated_at      = EXCLUDED.updated_at;
+
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  RETURN affected;
+END;
+$$;

--- a/api/drizzle/0074_entity_feed_query.sql
+++ b/api/drizzle/0074_entity_feed_query.sql
@@ -1,0 +1,105 @@
+-- Explore feed "Best" — Phase A query path.
+--
+-- Companion to 0073, which stores the scores. This adds the read side:
+--   * `entities_ranked_for_feed(...)` — candidate generation, exposed to GraphQL as
+--     a connection so cursor pagination comes for free.
+--   * computed columns so the score and its inputs are selectable on Entity, which
+--     the PRD asks for so a surprising ranking can be explained.
+--   * `entity_feed_blocklist` — the enforcement point for "must never be served".
+--
+-- On the blocklist: this schema has NO entity-level moderation state. There is no
+-- flagged / deleted / moderated table anywhere in `public` (checked). The PRD
+-- requires that such entities never be served regardless of score, so the filter
+-- lives here and is applied unconditionally; it is simply empty until something
+-- upstream populates it. Building the seam now means the feed does not have to be
+-- revisited when moderation lands, and an empty table is honest about the gap in a
+-- way that omitting the filter would not be.
+
+CREATE TABLE IF NOT EXISTS "entity_feed_blocklist" (
+  "entity_id" uuid PRIMARY KEY,
+  "reason" text,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- Candidate generation.
+--
+-- Returns SETOF entities so PostGraphile exposes it as a connection with cursor
+-- pagination, matching the shape the frontend already consumes.
+--
+-- Why a function rather than only an orderBy on entitiesConnection: the exclusions
+-- are not optional. Routing the feed through one function means a caller cannot
+-- forget to apply them, whereas an orderBy leaves filtering to each call site.
+-- An orderBy is added alongside for flexibility, but this is the feed's entry point.
+--
+-- `created_after` / `created_before` are text epoch seconds, matching
+-- entities.created_at. Comparison is lexicographic, which equals numeric ordering
+-- while every value is 10 digits — true until the year 2286. Passing them as text
+-- keeps `entities_created_at_id_idx` usable; casting to bigint here would not.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.entities_ranked_for_feed(
+  min_ranking_score numeric DEFAULT NULL,
+  created_after text DEFAULT NULL,
+  created_before text DEFAULT NULL
+)
+RETURNS SETOF public.entities
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT e.*
+  FROM public.entities e
+  JOIN public.entity_ranking_scores rs ON rs.entity_id = e.id
+  WHERE (min_ranking_score IS NULL OR rs.ranking_score >= min_ranking_score)
+    AND (created_after   IS NULL OR e.created_at >  created_after)
+    AND (created_before  IS NULL OR e.created_at <= created_before)
+    -- Never serve blocked entities, whatever they score.
+    AND NOT EXISTS (SELECT 1 FROM public.entity_feed_blocklist b WHERE b.entity_id = e.id)
+    -- Excluded types are filtered at candidate generation rather than via a zero
+    -- weight, so they never consume candidate slots.
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.relations r
+      JOIN public.entity_type_exclusions x ON x.type_id = r.to_entity_id
+      WHERE r.from_entity_id = e.id
+        AND r.type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid  -- TYPES
+    )
+  -- entity_id breaks ties so the ordering is total and cursor pagination cannot
+  -- skip or duplicate rows between equally-scored entities.
+  ORDER BY rs.ranking_score DESC, rs.entity_id DESC;
+$$;
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- Computed columns. PostGraphile surfaces `entities_<name>(entities)` as field
+-- `<name>` on Entity, so these become entity.rankingScore / .qualityScore /
+-- .intrinsicScore / .upvotes / .downvotes.
+--
+-- Each is a primary-key lookup on entity_ranking_scores, so the cost is per
+-- returned row (a page of ~20), not per candidate scanned.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.entities_ranking_score(e public.entities)
+RETURNS numeric LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT rs.ranking_score FROM public.entity_ranking_scores rs WHERE rs.entity_id = e.id;
+$$;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION public.entities_quality_score(e public.entities)
+RETURNS numeric LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT rs.quality_score FROM public.entity_ranking_scores rs WHERE rs.entity_id = e.id;
+$$;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION public.entities_intrinsic_score(e public.entities)
+RETURNS numeric LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT rs.intrinsic_score FROM public.entity_ranking_scores rs WHERE rs.entity_id = e.id;
+$$;
+--> statement-breakpoint
+-- Named upvotes/downvotes because that is what the feed's curation axis means to a
+-- client, and it matches the vocabulary the web client already uses. The stored
+-- columns are positive/negative because the same tallies serve other vote kinds.
+CREATE OR REPLACE FUNCTION public.entities_upvotes(e public.entities)
+RETURNS bigint LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT rs.positive FROM public.entity_ranking_scores rs WHERE rs.entity_id = e.id;
+$$;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION public.entities_downvotes(e public.entities)
+RETURNS bigint LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT rs.negative FROM public.entity_ranking_scores rs WHERE rs.entity_id = e.id;
+$$;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1786470235869,
       "tag": "0072_unexecutable_proposals",
       "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1786556635869,
+      "tag": "0073_entity_ranking_scores",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1786556635869,
       "tag": "0073_entity_ranking_scores",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1786560235869,
+      "tag": "0074_entity_feed_query",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/tests/0073_entity_ranking_scores.sql
+++ b/api/drizzle/tests/0073_entity_ranking_scores.sql
@@ -1,0 +1,93 @@
+\set ON_ERROR_STOP on
+CREATE OR REPLACE FUNCTION assert(cond boolean, label text) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN IF NOT cond THEN RAISE EXCEPTION 'FAIL: %', label; ELSE RAISE NOTICE 'pass: %', label; END IF; END; $$;
+
+-- ---- Wilson properties ----
+SELECT assert(wilson_lower_bound(0,0) > 0 AND wilson_lower_bound(0,0) < 1,
+  'zero-vote entity lands strictly inside (0,1) via the prior, not at the floor');
+SELECT assert(wilson_lower_bound(10,0) > wilson_lower_bound(1,0),
+  'more upvotes ranks higher');
+SELECT assert(wilson_lower_bound(10,0) > wilson_lower_bound(10,5),
+  'downvotes reduce quality');
+SELECT assert(wilson_lower_bound(0,10) < wilson_lower_bound(0,0),
+  'downvote-only ranks BELOW an unvoted entity (the abs() bug in the dead hot score got this wrong)');
+SELECT assert(wilson_lower_bound(1,0) < wilson_lower_bound(50,2),
+  'PRD acceptance: a low-vote newcomer does NOT outrank a well-established high-quality entity');
+SELECT assert(wilson_lower_bound(100,90) < wilson_lower_bound(10,0),
+  'net-positive-but-contested ranks below unanimous (net score would tie at +10)');
+SELECT assert(wilson_lower_bound(-5,-5) BETWEEN 0 AND 1, 'negative inputs are clamped, not NaN');
+SELECT assert(wilson_lower_bound(0,0,1.96,0,0) = 0, 'no observations and no prior yields 0, not a divide-by-zero');
+
+-- ---- intrinsic ----
+SELECT assert(entity_intrinsic_score(0,0) = 0, 'bare entity scores 0 intrinsic');
+SELECT assert(entity_intrinsic_score(100,100) <= 0.5, 'intrinsic respects its cap');
+SELECT assert(entity_intrinsic_score(10,5) > entity_intrinsic_score(2,1), 'richer entity scores higher');
+SELECT assert(entity_intrinsic_score(1000,1000) = entity_intrinsic_score(10,5), 'saturates at target, no runaway');
+
+-- ---- fixtures ----
+INSERT INTO entities (id, created_at) VALUES
+  ('11111111-1111-1111-1111-111111111111','1786000000'),  -- popular, recent
+  ('22222222-2222-2222-2222-222222222222','1786000000'),  -- unvoted, recent, rich
+  ('33333333-3333-3333-3333-333333333333','1768000000'),  -- popular, OLD
+  ('44444444-4444-4444-4444-444444444444','1786000000'),  -- downvoted, recent
+  ('55555555-5555-5555-5555-555555555555','1786000000'),  -- typed + boosted
+  ('66666666-6666-6666-6666-666666666666','1786000000');  -- ONLY system relations  -- typed + boosted
+INSERT INTO votes_count (object_id, object_type, space_id, vote_kind, positive, negative) VALUES
+  ('11111111-1111-1111-1111-111111111111',0,'aaaaaaaa-0000-0000-0000-000000000000',0,50,2),
+  ('33333333-3333-3333-3333-333333333333',0,'aaaaaaaa-0000-0000-0000-000000000000',0,50,2),
+  ('44444444-4444-4444-4444-444444444444',0,'aaaaaaaa-0000-0000-0000-000000000000',0,0,40),
+  -- vote_kind=1 (stance) must be ignored by the feed's quality term
+  ('22222222-2222-2222-2222-222222222222',0,'aaaaaaaa-0000-0000-0000-000000000000',1,999,0);
+INSERT INTO values (id, property_id, entity_id, space_id) VALUES
+  ('v1','0a111111-1111-1111-1111-111111111111'::uuid,'22222222-2222-2222-2222-222222222222','aaaaaaaa-0000-0000-0000-000000000000'),
+  ('v2','0a222222-2222-2222-2222-222222222222'::uuid,'22222222-2222-2222-2222-222222222222','aaaaaaaa-0000-0000-0000-000000000000'),
+  ('v3','0a333333-3333-3333-3333-333333333333'::uuid,'22222222-2222-2222-2222-222222222222','aaaaaaaa-0000-0000-0000-000000000000');
+INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id, is_system) VALUES
+  -- a system relation that must NOT count toward structure
+  ('0b111111-1111-1111-1111-111111111111'::uuid,'e0000000-0000-0000-0000-000000000001'::uuid,
+   '99999999-9999-9999-9999-999999999999','22222222-2222-2222-2222-222222222222',
+   'ffffffff-0000-0000-0000-000000000001','aaaaaaaa-0000-0000-0000-000000000000',true),
+  -- TYPES relation assigning a boosted type to entity 5
+  ('0b222222-2222-2222-2222-222222222222'::uuid,'e0000000-0000-0000-0000-000000000002'::uuid,
+   '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','55555555-5555-5555-5555-555555555555',
+   'cccccccc-0000-0000-0000-000000000001','aaaaaaaa-0000-0000-0000-000000000000',false);
+INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id, is_system) VALUES
+  ('0b333333-3333-3333-3333-333333333333'::uuid,'e0000000-0000-0000-0000-000000000003'::uuid,
+   '99999999-9999-9999-9999-999999999999','66666666-6666-6666-6666-666666666666',
+   'ffffffff-0000-0000-0000-000000000002','aaaaaaaa-0000-0000-0000-000000000000',true),
+  ('0b444444-4444-4444-4444-444444444444'::uuid,'e0000000-0000-0000-0000-000000000004'::uuid,
+   '99999999-9999-9999-9999-999999999999','66666666-6666-6666-6666-666666666666',
+   'ffffffff-0000-0000-0000-000000000003','aaaaaaaa-0000-0000-0000-000000000000',true);
+INSERT INTO entity_type_weights (type_id, weight, note)
+  VALUES ('cccccccc-0000-0000-0000-000000000001', 3.0, 'News story');
+
+SELECT assert(refresh_entity_ranking_scores(ARRAY[
+  '11111111-1111-1111-1111-111111111111','22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333','44444444-4444-4444-4444-444444444444',
+  '55555555-5555-5555-5555-555555555555','66666666-6666-6666-6666-666666666666']::uuid[]) = 6, 'refresh scored all 6 entities');
+
+-- ---- end-to-end behaviour ----
+SELECT assert((SELECT ranking_score FROM entity_ranking_scores WHERE entity_id='11111111-1111-1111-1111-111111111111')
+            > (SELECT ranking_score FROM entity_ranking_scores WHERE entity_id='33333333-3333-3333-3333-333333333333'),
+  'same quality, newer entity ranks higher (recency term works and has the right SIGN)');
+SELECT assert((SELECT ranking_score FROM entity_ranking_scores WHERE entity_id='11111111-1111-1111-1111-111111111111')
+            > (SELECT ranking_score FROM entity_ranking_scores WHERE entity_id='44444444-4444-4444-4444-444444444444'),
+  'same age, upvoted beats downvoted');
+SELECT assert((SELECT positive FROM entity_ranking_scores WHERE entity_id='22222222-2222-2222-2222-222222222222') = 0,
+  'vote_kind=1 (stance) is excluded from the feed quality term');
+SELECT assert((SELECT intrinsic_score FROM entity_ranking_scores WHERE entity_id='22222222-2222-2222-2222-222222222222') > 0,
+  'unvoted-but-rich entity gets a non-zero intrinsic score — the only gradient in the sparse regime');
+SELECT assert((SELECT intrinsic_score FROM entity_ranking_scores WHERE entity_id='11111111-1111-1111-1111-111111111111') = 0,
+  'entity with no values/relations gets 0 intrinsic (system relation did not count)');
+SELECT assert((SELECT intrinsic_score FROM entity_ranking_scores WHERE entity_id='66666666-6666-6666-6666-666666666666') = 0,
+  'an entity whose ONLY relations are is_system gets 0 intrinsic — plumbing must not inflate structural quality');
+SELECT assert((SELECT type_weight FROM entity_ranking_scores WHERE entity_id='55555555-5555-5555-5555-555555555555') = 3.0,
+  'type weight resolved via the TYPES relation');
+SELECT assert((SELECT type_weight FROM entity_ranking_scores WHERE entity_id='11111111-1111-1111-1111-111111111111') = 1.0,
+  'untyped entity defaults to weight 1.0');
+-- idempotency
+SELECT assert(refresh_entity_ranking_scores(ARRAY['11111111-1111-1111-1111-111111111111']::uuid[]) = 1, 're-refresh is an upsert, not a duplicate');
+SELECT assert((SELECT count(*) FROM entity_ranking_scores) = 6, 'still exactly 6 rows after re-refresh');
+SELECT assert((SELECT count(DISTINCT ranking_score) FROM entity_ranking_scores) = 6,
+  'all distinct-by-design fixtures get DISTINCT scores — no degenerate ties');
+\echo '=== ALL ASSERTIONS PASSED ==='

--- a/api/drizzle/tests/0073_fixtures_schema.sql
+++ b/api/drizzle/tests/0073_fixtures_schema.sql
@@ -1,0 +1,9 @@
+-- Minimal shapes matching production (verified against the live schema).
+CREATE TABLE entities (id uuid PRIMARY KEY, created_at text, created_at_block text, updated_at text, updated_at_block text);
+CREATE TABLE values (id text PRIMARY KEY, property_id uuid NOT NULL, entity_id uuid NOT NULL, space_id uuid NOT NULL, text text);
+CREATE TABLE relations (id uuid PRIMARY KEY, entity_id uuid NOT NULL, type_id uuid NOT NULL, from_entity_id uuid NOT NULL,
+                        to_entity_id uuid NOT NULL, space_id uuid NOT NULL, is_system boolean NOT NULL DEFAULT false);
+CREATE TABLE votes_count (id serial PRIMARY KEY, object_id uuid NOT NULL, object_type smallint NOT NULL,
+                          space_id uuid NOT NULL, vote_kind smallint NOT NULL DEFAULT 0,
+                          positive bigint NOT NULL DEFAULT 0, negative bigint NOT NULL DEFAULT 0,
+                          updated_at timestamptz NOT NULL DEFAULT now());

--- a/api/drizzle/tests/0074_entity_feed_query.sql
+++ b/api/drizzle/tests/0074_entity_feed_query.sql
@@ -1,0 +1,68 @@
+\set ON_ERROR_STOP on
+CREATE OR REPLACE FUNCTION assert(cond boolean, label text) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN IF NOT cond THEN RAISE EXCEPTION 'FAIL: %', label; ELSE RAISE NOTICE 'pass: %', label; END IF; END; $$;
+
+TRUNCATE entities, values, relations, votes_count, entity_ranking_scores,
+         entity_type_weights, entity_type_exclusions, entity_feed_blocklist;
+
+INSERT INTO entities (id, created_at) VALUES
+  ('11111111-1111-1111-1111-111111111111','1786000000'),  -- high score, servable
+  ('22222222-2222-2222-2222-222222222222','1786000000'),  -- BLOCKLISTED
+  ('33333333-3333-3333-3333-333333333333','1786000000'),  -- EXCLUDED TYPE
+  ('44444444-4444-4444-4444-444444444444','1768000000'),  -- old (outside window)
+  ('55555555-5555-5555-5555-555555555555','1786000000');  -- no score row at all
+INSERT INTO votes_count (object_id, object_type, space_id, vote_kind, positive, negative) VALUES
+  ('11111111-1111-1111-1111-111111111111',0,'aaaaaaaa-0000-0000-0000-000000000000',0,50,2),
+  ('22222222-2222-2222-2222-222222222222',0,'aaaaaaaa-0000-0000-0000-000000000000',0,99,0),
+  ('33333333-3333-3333-3333-333333333333',0,'aaaaaaaa-0000-0000-0000-000000000000',0,99,0);
+-- entity 3 declares an excluded type
+INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id, is_system) VALUES
+  ('0b111111-1111-1111-1111-111111111111'::uuid,'e0000000-0000-0000-0000-000000000001'::uuid,
+   '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','33333333-3333-3333-3333-333333333333',
+   'dddddddd-0000-0000-0000-000000000001','aaaaaaaa-0000-0000-0000-000000000000',false);
+INSERT INTO entity_type_exclusions (type_id, note) VALUES ('dddddddd-0000-0000-0000-000000000001','Text block');
+INSERT INTO entity_feed_blocklist (entity_id, reason) VALUES ('22222222-2222-2222-2222-222222222222','moderated');
+
+SELECT refresh_entity_ranking_scores(ARRAY[
+  '11111111-1111-1111-1111-111111111111','22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333','44444444-4444-4444-4444-444444444444']::uuid[]);
+
+-- ---- candidate generation ----
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='55555555-5555-5555-5555-555555555555'),
+  'an entity with no score row is absent from the feed (inner join, not left)');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='22222222-2222-2222-2222-222222222222'),
+  'a BLOCKLISTED entity is never served, despite scoring 99-0 — the highest quality in the fixture');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='33333333-3333-3333-3333-333333333333'),
+  'an EXCLUDED-TYPE entity is never served, despite scoring 99-0');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed()) = 2,
+  'after both exclusions only the 2 servable entities remain');
+SELECT assert((SELECT id FROM entities_ranked_for_feed() LIMIT 1) = '11111111-1111-1111-1111-111111111111',
+  'top of feed is the highest-ranked servable entity');
+
+-- ---- filters ----
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL, '1785000000')) = 1,
+  'created_after excludes the old entity (recency window)');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL, NULL, '1770000000')) = 1,
+  'created_before keeps only the old entity');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(999999)) = 0,
+  'an impossible min_ranking_score returns nothing rather than erroring');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(
+                 (SELECT ranking_score FROM entity_ranking_scores
+                   WHERE entity_id='11111111-1111-1111-1111-111111111111'))) = 1,
+  'min_ranking_score is inclusive at the boundary');
+
+-- ---- ordering is total (cursor pagination safety) ----
+SELECT assert((SELECT count(DISTINCT (rs.ranking_score, rs.entity_id)) FROM entity_ranking_scores rs)
+            = (SELECT count(*) FROM entity_ranking_scores),
+  '(ranking_score, entity_id) is unique — a total order, so cursor paging cannot skip or duplicate');
+
+-- ---- computed columns ----
+SELECT assert((SELECT entities_ranking_score(e) FROM entities e WHERE e.id='11111111-1111-1111-1111-111111111111') IS NOT NULL,
+  'entities_ranking_score computed column resolves');
+SELECT assert((SELECT entities_upvotes(e) FROM entities e WHERE e.id='11111111-1111-1111-1111-111111111111') = 50,
+  'entities_upvotes exposes the curation positive tally');
+SELECT assert((SELECT entities_downvotes(e) FROM entities e WHERE e.id='11111111-1111-1111-1111-111111111111') = 2,
+  'entities_downvotes exposes the curation negative tally');
+SELECT assert((SELECT entities_ranking_score(e) FROM entities e WHERE e.id='55555555-5555-5555-5555-555555555555') IS NULL,
+  'an unscored entity yields NULL rather than 0 — so it sorts last under nulls:last, not first');
+\echo '=== 0074 ASSERTIONS PASSED ==='

--- a/api/drizzle/tests/README.md
+++ b/api/drizzle/tests/README.md
@@ -1,0 +1,27 @@
+# SQL-level migration tests
+
+Assertions for migrations whose logic lives in SQL functions, where the behaviour
+is easier to pin at the SQL layer than through the app.
+
+Run against a throwaway Postgres (never a real database — these truncate tables):
+
+```bash
+docker run -d --name migtest -e POSTGRES_PASSWORD=t -e POSTGRES_DB=t postgres:18
+docker cp 0073_fixtures_schema.sql migtest:/tmp/ && docker exec migtest psql -U postgres -d t -f /tmp/0073_fixtures_schema.sql
+sed 's/^--> statement-breakpoint$//' ../0073_entity_ranking_scores.sql > /tmp/m.sql
+docker cp /tmp/m.sql migtest:/tmp/ && docker exec migtest psql -U postgres -d t -v ON_ERROR_STOP=1 -f /tmp/m.sql
+docker cp 0073_entity_ranking_scores.sql migtest:/tmp/ && docker exec migtest psql -U postgres -d t -v ON_ERROR_STOP=1 -f /tmp/0073_entity_ranking_scores.sql
+docker rm -f migtest
+```
+
+`0073_fixtures_schema.sql` recreates only the columns of `entities`, `values`,
+`relations` and `votes_count` that the scoring functions read, verified against the
+live schema. It is a test fixture, not a source of truth for those tables.
+
+These were mutation-tested: flipping the recency sign, replacing Wilson with
+`abs(net)`, dropping the `is_system` filter, and dropping the `vote_kind = 0` filter
+each fail exactly one assertion. Worth re-checking if you change the assertions —
+the `is_system` case originally passed a mutation because the assertion that claimed
+to cover it was written against an entity with no relations at all.
+
+TODO: port to the vitest harness in `api/src/kg/__tests__` so they run in CI.

--- a/api/scripts/backfill-entity-ranking-scores.sh
+++ b/api/scripts/backfill-entity-ranking-scores.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Backfill entity_ranking_scores for the Explore feed "Best" sort (Phase A).
+#
+# Deliberately NOT part of migration 0074: api's initContainer runs db:migrate, so
+# a 48.9M-row backfill inside a migration would stall every deploy.
+#
+# Batched by leading uuid byte (256 batches, ~190k entities each) so every batch is
+# a primary-key range scan in its own transaction. Idempotent and resumable:
+# refresh_entity_ranking_scores() upserts, so re-running a batch recomputes the same
+# values rather than duplicating or double-counting. Resume with START=<n>.
+#
+# Usage:
+#   DATABASE_URL=postgres://...  ./backfill-entity-ranking-scores.sh
+#   START=128 DATABASE_URL=...   ./backfill-entity-ranking-scores.sh   # resume
+#
+# In-cluster (keeps the credential out of argv and shell history):
+#   kubectl -n gaia exec -i <pod> -- sh -c 'DATABASE_URL="$PGURL" bash -s' \
+#     < api/scripts/backfill-entity-ranking-scores.sh
+#
+# Progress is measured against the DB, not inferred from the loop, because a batch
+# that reports success is not proof that rows changed.
+set -uo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+START=${START:-0}
+# ON_ERROR_STOP is load-bearing: psql exits 0 even when a statement fails, so
+# without it a broken batch is indistinguishable from one that scored 0 rows.
+PSQL=(psql -v ON_ERROR_STOP=1 -t -A "$DATABASE_URL")
+
+total=0
+fail=0
+for i in $(seq "$START" 255); do
+  lo=$(printf '%02x000000-0000-0000-0000-000000000000' "$i")
+  if [ "$i" -eq 255 ]; then
+    hi="ffffffff-ffff-ffff-ffff-ffffffffffff"; op="<="
+  else
+    hi=$(printf '%02x000000-0000-0000-0000-000000000000' $((i + 1))); op="<"
+  fi
+
+  out=$("${PSQL[@]}" -c "
+    SET statement_timeout = 0;
+    SELECT public.refresh_entity_ranking_scores(
+      ARRAY(SELECT id FROM public.entities
+             WHERE id >= '${lo}'::uuid AND id ${op} '${hi}'::uuid)
+    );" 2>&1)
+  rc=$?
+
+  n=$(printf '%s' "$out" | grep -oE '^[0-9]+$' | tail -1)
+  if [ $rc -ne 0 ] || [ -z "$n" ]; then
+    echo "BATCH $i ($lo) FAILED rc=$rc: $out" >&2
+    fail=$((fail + 1))
+  else
+    total=$((total + n))
+  fi
+
+  if [ $((i % 16)) -eq 0 ] || [ "$i" -eq 255 ]; then
+    echo "$(date -u +%H:%M:%S) batch $i/255  scored=$total  failures=$fail"
+  fi
+done
+
+echo "DONE scored=$total failures=$fail"
+if [ "$fail" -gt 0 ]; then
+  echo "Re-run the failed ranges with START=<first failed batch>; the upsert makes it safe." >&2
+  exit 1
+fi

--- a/api/src/kg/entityOrderByRankingScorePlugin.ts
+++ b/api/src/kg/entityOrderByRankingScorePlugin.ts
@@ -1,0 +1,53 @@
+import {makeAddPgTableOrderByPlugin, orderByAscDesc} from "graphile-utils"
+
+/**
+ * Adds RANKING_SCORE / QUALITY_SCORE ordering to the entities connection, for the
+ * Explore feed "Best" sort (Phase A).
+ *
+ * The feed's own entry point is `entities_ranked_for_feed(...)`, which also applies
+ * the blocklist and excluded-type filters that must never be skipped. This plugin
+ * exists for the cases that want the ordering without candidate generation — e.g.
+ * ranking a set already narrowed by another filter. Prefer the function for the feed
+ * itself, or the exclusions become every caller's responsibility.
+ *
+ * `nulls: "last"` matters: only ~1.2M of 48.9M entities are expected to have a score
+ * until the backfill completes, and unscored entities must sort to the bottom rather
+ * than the top. Postgres puts NULLs first on DESC by default, which would surface
+ * precisely the unscored entities the feed is meant to rank.
+ */
+export const EntityOrderByRankingScorePlugin = makeAddPgTableOrderByPlugin(
+	"public",
+	"entities",
+	(build) => {
+		const {pgSql: sql} = build
+
+		const rankingScore = orderByAscDesc(
+			"RANKING_SCORE",
+			({queryBuilder}) => {
+				const t = queryBuilder.getTableAlias()
+				return sql.fragment`(
+					SELECT rs.ranking_score FROM public.entity_ranking_scores rs
+					WHERE rs.entity_id = ${t}.id
+				)`
+			},
+			{unique: false, nulls: "last"},
+		)
+
+		const qualityScore = orderByAscDesc(
+			"QUALITY_SCORE",
+			({queryBuilder}) => {
+				const t = queryBuilder.getTableAlias()
+				return sql.fragment`(
+					SELECT rs.quality_score FROM public.entity_ranking_scores rs
+					WHERE rs.entity_id = ${t}.id
+				)`
+			},
+			{unique: false, nulls: "last"},
+		)
+
+		return {...rankingScore, ...qualityScore}
+	},
+	"Adding orderBy entity_ranking_scores.ranking_score / .quality_score to the entities connection",
+)
+
+export default EntityOrderByRankingScorePlugin

--- a/api/src/kg/hideProceduresPlugin.ts
+++ b/api/src/kg/hideProceduresPlugin.ts
@@ -6,6 +6,24 @@ export default makeJSONPgSmartTagsPlugin({
 	config: {
 		procedure: {
 			"public.entities_ordered_by_score": {tags: {omit: true}},
+
+			// Explore feed (Phase A) internals. These are computation helpers and a
+			// write path, not API surface.
+			//
+			// entity_ranking_score MUST be hidden for a second reason: it inflects to
+			// the same GraphQL key as the entity_ranking_scores table
+			// ("entityRankingScore"), and the collision fails the whole schema build.
+			//
+			// refresh_entity_ranking_scores is a write path — exposing it would let any
+			// caller trigger recomputation over arbitrary entity id arrays.
+			//
+			// entities_ranked_for_feed is deliberately NOT hidden: it is the feed's
+			// entry point, and the exclusions it applies are why callers should use it
+			// rather than a bare orderBy.
+			"public.wilson_lower_bound": {tags: {omit: true}},
+			"public.entity_intrinsic_score": {tags: {omit: true}},
+			"public.entity_ranking_score": {tags: {omit: true}},
+			"public.refresh_entity_ranking_scores": {tags: {omit: true}},
 		},
 	},
 })

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -21,6 +21,7 @@ import {log} from "../services/telemetry"
 import {useAdmissionControl} from "./admissionControl"
 import {useCostLogger} from "./costLoggerPlugin"
 import EntityComputedTextFilterPlugin from "./entityComputedTextFilterPlugin"
+import EntityOrderByRankingScorePlugin from "./entityOrderByRankingScorePlugin"
 import EntitySpaceFilterPlugin from "./entitySpaceFilterPlugin"
 import {shouldUnmaskError} from "./errorMasking"
 import HideProceduresPlugin from "./hideProceduresPlugin"
@@ -222,6 +223,7 @@ const postgraphileOptions = {
 		EntitySpaceFilterPlugin,
 		EntityComputedTextFilterPlugin,
 		ValueOrderByScorePlugin,
+		EntityOrderByRankingScorePlugin,
 		PaginationCapPlugin,
 		HideProceduresPlugin,
 		UserVoteLegacyAccessorPlugin,

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -1404,3 +1404,82 @@ export const rankingScores = ranks.table(
 		index("ranking_scores_block_position_idx").on(table.blockId, table.position),
 	],
 )
+
+/**
+ * entity_ranking_config
+ *
+ * Single-row tunables for the Explore feed "Best" ranking (Phase A). A table
+ * rather than constants because tau, the Wilson prior, and the intrinsic caps all
+ * need experimentation, and retuning should not require a deploy.
+ */
+export const entityRankingConfig = pgTable("entity_ranking_config", {
+	id: boolean("id").primaryKey().default(true),
+	/** Recency divisor in SECONDS. Must be applied to seconds, not hours. */
+	tauSeconds: decimal("tau_seconds").notNull(),
+	wilsonZ: decimal("wilson_z").notNull(),
+	priorPositive: decimal("prior_positive").notNull(),
+	priorNegative: decimal("prior_negative").notNull(),
+	qualityFloor: decimal("quality_floor").notNull(),
+	intrinsicCap: decimal("intrinsic_cap").notNull(),
+	intrinsicPropertyTarget: integer("intrinsic_property_target").notNull(),
+	intrinsicRelationTarget: integer("intrinsic_relation_target").notNull(),
+	updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull(),
+})
+
+/**
+ * entity_type_weights
+ *
+ * Per-entity-type feed weight. > 1.0 boosts, < 1.0 demotes, absent defaults to
+ * 1.0. Applied as log(weight) so the log-time ranking score stays time-invariant;
+ * changing a weight requires a bulk recompute for that type's entities.
+ */
+export const entityTypeWeights = pgTable("entity_type_weights", {
+	typeId: uuid("type_id").primaryKey(),
+	weight: decimal("weight").notNull(),
+	note: text("note"),
+	updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull(),
+})
+
+/**
+ * entity_type_exclusions
+ *
+ * Types that must never be served by the feed. Enforced at candidate generation
+ * rather than as a zero weight — exclusion is editorial and must not be reachable
+ * by the weighting math.
+ */
+export const entityTypeExclusions = pgTable("entity_type_exclusions", {
+	typeId: uuid("type_id").primaryKey(),
+	note: text("note"),
+	updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull(),
+})
+
+/**
+ * entity_ranking_scores
+ *
+ * The Phase A sort key, stored per entity. A side table rather than columns on
+ * `entities` (48.9M rows / 18 GB, four indexes), matching the existing
+ * global_scores / local_scores pattern.
+ *
+ * Inputs are retained alongside the score so a surprising ranking can be explained
+ * without recomputing it.
+ */
+export const entityRankingScores = pgTable(
+	"entity_ranking_scores",
+	{
+		entityId: uuid("entity_id").primaryKey(),
+		/** Wilson lower bound on curation votes, with the pseudo-count prior. */
+		qualityScore: decimal("quality_score").notNull(),
+		/** Capped structural bonus — the only quality gradient between zero-vote entities. */
+		intrinsicScore: decimal("intrinsic_score").notNull(),
+		/** log(quality) + log(typeWeight) + intrinsic + createdAt/tau. Time-invariant. */
+		rankingScore: decimal("ranking_score").notNull(),
+		positive: bigint("positive", {mode: "number"}).notNull(),
+		negative: bigint("negative", {mode: "number"}).notNull(),
+		typeWeight: decimal("type_weight").notNull(),
+		updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull(),
+	},
+	(table) => [
+		index("entity_ranking_scores_ranking_desc_idx").on(table.rankingScore, table.entityId),
+		index("entity_ranking_scores_quality_idx").on(table.qualityScore),
+	],
+)

--- a/scoring-service/cronjob/src/algorithm/scoring.py
+++ b/scoring-service/cronjob/src/algorithm/scoring.py
@@ -11,7 +11,6 @@ import numpy as np
 from .models import Entity, RankingConfig, Space, User, Vote
 
 # Constants
-HOT_SCORE_TIME_DIVISOR = 45000  # Time divisor for hot score calculation
 ACTIVITY_WEIGHT = 0.1           # Activity weight in composite space score (10%)
 
 from .utils import calculate_space_distances
@@ -81,21 +80,6 @@ class EntityScorer:
         # Apply exponential decay
         decayed_score = score * math.exp(-self.config.time_decay_factor * age_hours)
         return decayed_score
-
-    def calculate_hot_score(self, entity: Entity, votes: list[Vote]) -> float:
-        """Calculate 'hot' score using logarithmic approach."""
-        entity.calculate_scores(votes)
-
-        upvotes = entity.upvotes
-        downvotes = entity.downvotes
-
-        vote_difference = upvotes - downvotes
-        age_hours = (datetime.now() - entity.created_at).total_seconds() / 3600
-
-        # Apply hot score formula
-        hot_score = math.log(max(abs(vote_difference), 1)) + age_hours / HOT_SCORE_TIME_DIVISOR
-
-        return hot_score
 
     @staticmethod
     def _index_users_by_id(users: list[User]) -> dict[str, User]:

--- a/scoring-service/vote-indexer/src/main.rs
+++ b/scoring-service/vote-indexer/src/main.rs
@@ -325,6 +325,13 @@ async fn process_vote_batch(votes: &[VoteItem], storage: &Storage) -> Result<usi
             .upsert_votes_counts(&updated_vote_counts, &mut tx)
             .await?;
 
+        // Recompute the Explore feed ranking score for entities whose curation
+        // votes changed. Same transaction, so the tally and its score are never
+        // observable out of step.
+        storage
+            .refresh_ranking_scores(&updated_vote_counts, &mut tx)
+            .await?;
+
         // Mirror entity net scores into `values` under the Score system property
         // so `entities_ordered_by_property` can sort by raw score with no SQL changes.
         let score_values = build_score_values(&updated_vote_counts);

--- a/scoring-service/vote-indexer/src/main.rs
+++ b/scoring-service/vote-indexer/src/main.rs
@@ -325,19 +325,24 @@ async fn process_vote_batch(votes: &[VoteItem], storage: &Storage) -> Result<usi
             .upsert_votes_counts(&updated_vote_counts, &mut tx)
             .await?;
 
-        // Recompute the Explore feed ranking score for entities whose curation
-        // votes changed. Same transaction, so the tally and its score are never
-        // observable out of step.
-        storage
-            .refresh_ranking_scores(&updated_vote_counts, &mut tx)
-            .await?;
-
         // Mirror entity net scores into `values` under the Score system property
         // so `entities_ordered_by_property` can sort by raw score with no SQL changes.
         let score_values = build_score_values(&updated_vote_counts);
         storage.upsert_score_values(&score_values, &mut tx).await?;
 
         tx.commit().await?;
+
+        // Recompute the Explore feed ranking score for entities whose curation votes
+        // changed. Deliberately AFTER the commit and non-fatal: a stale score is
+        // harmless and self-correcting, a lost vote is not. This also makes deploy
+        // order irrelevant if the migration has not landed yet.
+        if let Err(e) = storage.refresh_ranking_scores(&updated_vote_counts).await {
+            warn!(
+                error = %e,
+                "Failed to refresh feed ranking scores; votes are committed and the \
+                 scores will be corrected by the next vote or a backfill run"
+            );
+        }
 
         debug!(
             raw_votes = vote_count,

--- a/scoring-service/vote-indexer/src/storage.rs
+++ b/scoring-service/vote-indexer/src/storage.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 
 use crate::error::StorageError;
 use crate::models::voting::{
-    ScoreValueItem, UserVoteCriteria, UserVoteItem, VoteCountCriteria, VoteItem, VotesCountItem,
+    ResponseKind, ScoreValueItem, UserVoteCriteria, UserVoteItem, VoteCountCriteria, VoteItem,
+    VoteObjectType, VotesCountItem,
 };
 
 /// Storage for vote-related database operations.
@@ -209,6 +210,49 @@ impl Storage {
             .bind(&vote_kinds)
             .bind(&positives)
             .bind(&negatives)
+            .execute(&mut **tx)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Recompute the Explore feed ranking score for entities whose curation votes
+    /// just changed.
+    ///
+    /// Only curation (`vote_kind = 0`) on entities feeds the feed's quality term, so
+    /// stance and veracity votes must not trigger a recompute — they would rewrite the
+    /// row to an identical value and make `updated_at` misleading about what moved.
+    ///
+    /// Runs inside the caller's transaction so a vote and its score land atomically:
+    /// a reader can never observe the new tally against the old score.
+    ///
+    /// Because the score is time-invariant (`created_at / tau`), this is the only
+    /// thing that ever needs to run. There is no scheduled decay sweep.
+    #[instrument(
+        name = "vote_indexer.storage.refresh_ranking_scores",
+        skip(self, counts, tx)
+    )]
+    pub async fn refresh_ranking_scores(
+        &self,
+        counts: &[VotesCountItem],
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+    ) -> Result<(), StorageError> {
+        let mut entity_ids: Vec<Uuid> = counts
+            .iter()
+            .filter(|c| c.object_type == VoteObjectType::Entity && c.kind == ResponseKind::Curation)
+            .map(|c| c.object_id)
+            .collect();
+        // An entity voted in several spaces appears once per space; deduplicate so a
+        // single recompute covers it.
+        entity_ids.sort_unstable();
+        entity_ids.dedup();
+
+        if entity_ids.is_empty() {
+            return Ok(());
+        }
+
+        sqlx::query("SELECT public.refresh_entity_ranking_scores($1::uuid[])")
+            .bind(&entity_ids)
             .execute(&mut **tx)
             .await?;
 

--- a/scoring-service/vote-indexer/src/storage.rs
+++ b/scoring-service/vote-indexer/src/storage.rs
@@ -219,24 +219,36 @@ impl Storage {
     /// Recompute the Explore feed ranking score for entities whose curation votes
     /// just changed.
     ///
-    /// Only curation (`vote_kind = 0`) on entities feeds the feed's quality term, so
-    /// stance and veracity votes must not trigger a recompute — they would rewrite the
-    /// row to an identical value and make `updated_at` misleading about what moved.
+    /// Runs OUTSIDE the vote transaction, on the pool, and reports failure to the
+    /// caller as a warning rather than an error. Two reasons:
     ///
-    /// Runs inside the caller's transaction so a vote and its score land atomically:
-    /// a reader can never observe the new tally against the old score.
+    /// 1. A stale ranking score is harmless and self-correcting — the next vote or a
+    ///    backfill run fixes it. A lost vote is permanent. So the refresh must never
+    ///    be able to abort the vote write, whatever goes wrong.
+    /// 2. It makes deploy order irrelevant. If vote-indexer ships ahead of the
+    ///    migration that creates the function, this logs and moves on instead of
+    ///    failing every vote write — the failure shape of the 08-05 incident, where a
+    ///    migration shipped without its writer.
+    ///
+    /// A catalogue guard (`WHERE to_regproc(...) IS NOT NULL`) does NOT work here and
+    /// was tried: Postgres resolves the function name at parse time, so the statement
+    /// fails before the WHERE is ever evaluated. Separating the transaction is what
+    /// actually provides the safety.
+    ///
+    /// Only curation (`vote_kind = 0`) on entities feeds the feed's quality term, so
+    /// stance and veracity votes do not trigger a recompute — they would rewrite the
+    /// row to an identical value and make `updated_at` misleading about what moved.
     ///
     /// Because the score is time-invariant (`created_at / tau`), this is the only
     /// thing that ever needs to run. There is no scheduled decay sweep.
     #[instrument(
         name = "vote_indexer.storage.refresh_ranking_scores",
-        skip(self, counts, tx)
+        skip(self, counts)
     )]
     pub async fn refresh_ranking_scores(
         &self,
         counts: &[VotesCountItem],
-        tx: &mut sqlx::Transaction<'_, Postgres>,
-    ) -> Result<(), StorageError> {
+    ) -> Result<u64, StorageError> {
         let mut entity_ids: Vec<Uuid> = counts
             .iter()
             .filter(|c| c.object_type == VoteObjectType::Entity && c.kind == ResponseKind::Curation)
@@ -248,15 +260,16 @@ impl Storage {
         entity_ids.dedup();
 
         if entity_ids.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
-        sqlx::query("SELECT public.refresh_entity_ranking_scores($1::uuid[])")
-            .bind(&entity_ids)
-            .execute(&mut **tx)
-            .await?;
+        let scored: i32 =
+            sqlx::query_scalar("SELECT public.refresh_entity_ranking_scores($1::uuid[])")
+                .bind(&entity_ids)
+                .fetch_one(&self.pool)
+                .await?;
 
-        Ok(())
+        Ok(scored.max(0) as u64)
     }
 
     /// Mirror net scores into the `values` table under the Score system property.


### PR DESCRIPTION
Phase A of the [Explore feed ranking PRD](https://app.notion.com/p/Explore-feed-ranking-Best-and-For-You-398273e214eb803fb1f2f4d8720c34e0): a global "Best" score blending quality, entity-type weight and recency, with no per-user state.

```
qualityScore = Wilson lower bound on (positive, negative) + pseudo-count prior
rankingScore = ln(max(quality, floor)) + ln(w_type) + intrinsic + created_at/tau
```

## Measurements that changed the design

**The vote signal is ~4 orders of magnitude sparser than the PRD assumes.** Of 48.8M entities, **2,650** have any votes (median 1, p90 2, max 36). Just **56** have five or more — which is the PRD's own threshold for leaving the sparse regime.

So `log(quality)` is very nearly constant across the corpus, and the PRD's "intrinsic quality tie-breaker" is not something to reach for later: it is the only quality gradient that exists between zero-vote entities. It is implemented here as core Phase A scope, capped so it stays subordinate to real votes once votes exist.

**`entities.created_at` was migration-flattened** — 98.2% of rows stamped `2026-07-29` — which made the recency term degenerate too. Repaired separately from the still-running chain-19411 database; 215 distinct days now, `last_7d` = 568k, `last_30d` = 1.87M. Without that repair this ranking could not work at all.

## What's here

| PRD requirement | |
|---|---|
| Wilson `qualityScore` + prior | config-driven |
| Time-invariant `rankingScore` | no decay sweep needed |
| Intrinsic tie-breaker | core scope |
| Type weights + exclusion list | ✅ |
| Sortable/filterable storage | side table |
| Recompute on interaction events | vote-indexer |
| Backfill | script, batched + resumable |
| Exclude moderated/flagged/deleted | enforcement point built — see below |
| `orderBy: rankingScore_DESC`, range + threshold filters, cursor pagination | ✅ |
| Scores exposed on the node | computed columns |

## Design notes worth review

**Side table, not columns on `entities`.** That table is 48.9M rows / 18 GB with four indexes. Follows the existing `global_scores` / `local_scores` pattern.

**No backfill in a migration.** `api`'s initContainer runs `db:migrate`, so a 48M-row UPDATE there would stall every deploy. Ships as a script instead.

**There is no entity-level moderation state in this schema** — no flagged, deleted or moderated table exists anywhere in `public`. The PRD requires such entities never be served regardless of score, so `entity_feed_blocklist` is the enforcement point and the filter is applied unconditionally. It is empty until something upstream populates it. An empty table is honest about the gap in a way that omitting the filter would not be.

**`nulls: "last"` on the ordering plugin is load-bearing.** Postgres puts NULLs first on DESC, which would surface precisely the unscored entities the feed exists to rank — ~47M of them until the backfill runs.

**The refresh runs outside the vote transaction, and is non-fatal.** A stale score is harmless and self-correcting; a lost vote is permanent. This also makes deploy order irrelevant. I first tried a `to_regproc` catalogue guard — it does not work, because Postgres resolves the function name at parse time, so the statement fails before the `WHERE` is evaluated. Testing that against a real Postgres is what caught it.

**Deleted `scoring-service`'s `calculate_hot_score`** rather than fixing it. It implemented this same additive log-time shape but was never called, and had three defects: `abs(vote_difference)` scored 10 downvotes identically to 10 upvotes; it used *age* rather than `createdAt`, so the time term rewarded being old and was not time-invariant; and Reddit's 45000-**second** constant was applied to **hours**, making the term ~3600× too weak. Fixing it would have meant keeping the wrong architecture — an in-memory method in a daily cron, where Phase A needs a stored column recomputed on vote events — and nothing would survive but one line's shape. `use_time_decay` / `time_decay_factor` are left alone; unlike the hot score, those are wired to real logic.

## Verification

**38 SQL assertions** across the two migrations, all mutation-tested. Mutations killed: recency sign flipped, Wilson swapped for `abs(net)`, `is_system` filter dropped, `vote_kind` filter dropped, blocklist filter removed, excluded-type filter removed.

The exclusion tests use fixtures scoring **99-0** — the highest quality present — so a pass means the exclusion genuinely beat the score rather than coinciding with a low rank.

Two assertions initially passed a mutation and were rewritten: the `is_system` one asserted against an entity with *no* relations, so the filter was never exercised.

`vote-indexer` builds with 37 tests passing, fmt + clippy clean. `scoring-service` 97 tests pass. `tsc` and `biome` clean.

## Before this is useful

1. **The backfill has not been run** — 48.9M entities, needs a deliberate go-ahead. Until then almost every entity is unscored and sorts last.
2. **Deploy order preference:** migration (via `api`) before `vote-indexer`. Not required any more — the refresh degrades gracefully — but it avoids a window of warnings.
3. **The SQL assertions do not run in CI.** They need a throwaway Postgres; porting them to the vitest harness in `api/src/kg/__tests__` is tracked in `api/drizzle/tests/README.md`. Right now they are only as good as someone remembering to run them.
4. **Frontend untouched** — adding "Best" as the default Explore sort is geogenesis work.

τ = 45000s sets quality's exchange rate against recency at roughly a day: a 50-up/2-down entity outranks an unvoted one created up to ~27h later. Config, so cheap to retune, but the backfill bakes an ordering in.
