### PR TITLE
fix(feed): never serve an entity with no name

### DIFF
--- a/api/drizzle/0075_feed_requires_name.sql
+++ b/api/drizzle/0075_feed_requires_name.sql
@@ -1,0 +1,75 @@
+-- Explore feed: never serve an entity with no name.
+--
+-- Measured on production 2026-08-13, and this is the single largest defect in the
+-- Phase A feed by a wide margin:
+--
+--   scored entities                     48,884,134
+--   of those with NO name at all        47,808,504   (97.8%)
+--   nameless entities in the top 2,000       1,455   (73%)
+--   first nameless result                 rank 497
+--
+-- So from roughly rank 500 onward the feed was mostly blank rows. A nameless
+-- entity has nothing to render — it surfaces as a raw uuid in the UI (the symptom
+-- reported on GEO-2548 for 660ef494c6d346a0a630b7cf449bfc9e) and, if picked from a
+-- collection dropdown, becomes a dangling reference in published content.
+--
+-- Root cause of the population: 99.4% of untyped entities are empty shells — bare
+-- `entities` rows with no values, no relations, and referenced by nothing. Sampling
+-- 20,000 of them found 101 with a name and 0 referenced by any relation. They are
+-- created as identifiers and never filled in.
+--
+-- Why this belongs at candidate generation rather than in the score: an entity with
+-- no name is not "low quality", it is unrenderable. Demoting it by weight would
+-- still surface it once nothing fresher existed. Type weights cannot fix this
+-- either — the population is untyped by definition, so no type config reaches it.
+--
+-- The name property is a126ca53-0c8e-48d5-b888-82c734c38935 (SystemIds.NAME_PROPERTY),
+-- the same id `entityComputedTextFilterPlugin` uses for EntityFilter.name.
+--
+-- NOTE: this filter is intentionally "has a name value", not "has any value". A
+-- description without a name still renders as a raw id, so name presence is the
+-- property that actually determines whether a row is displayable.
+
+CREATE OR REPLACE FUNCTION public.entities_ranked_for_feed(
+  min_ranking_score numeric DEFAULT NULL,
+  created_after text DEFAULT NULL,
+  created_before text DEFAULT NULL
+)
+RETURNS SETOF public.entities
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT e.*
+  FROM public.entities e
+  JOIN public.entity_ranking_scores rs ON rs.entity_id = e.id
+  WHERE (min_ranking_score IS NULL OR rs.ranking_score >= min_ranking_score)
+    AND (created_after   IS NULL OR e.created_at >  created_after)
+    AND (created_before  IS NULL OR e.created_at <= created_before)
+    -- Unrenderable entities are never candidates. See the header: this removes
+    -- 97.8% of the scored corpus, all of it content-free.
+    AND EXISTS (
+      SELECT 1 FROM public.values v
+      WHERE v.entity_id = e.id
+        AND v.property_id = 'a126ca53-0c8e-48d5-b888-82c734c38935'::uuid
+        AND v.text IS NOT NULL
+        AND length(trim(v.text)) > 0
+    )
+    -- Never serve blocked entities, whatever they score.
+    AND NOT EXISTS (SELECT 1 FROM public.entity_feed_blocklist b WHERE b.entity_id = e.id)
+    -- Excluded types are filtered at candidate generation rather than via a zero
+    -- weight, so they never consume candidate slots.
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.relations r
+      JOIN public.entity_type_exclusions x ON x.type_id = r.to_entity_id
+      WHERE r.from_entity_id = e.id
+        AND r.type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid  -- TYPES
+    )
+  ORDER BY rs.ranking_score DESC, rs.entity_id DESC;
+$$;
+--> statement-breakpoint
+
+-- Supports the name-presence check as an index-only probe rather than a heap fetch
+-- per candidate. Partial, because only non-empty name values are ever probed.
+CREATE INDEX IF NOT EXISTS "values_name_entity_idx"
+  ON "values" ("entity_id")
+  WHERE property_id = 'a126ca53-0c8e-48d5-b888-82c734c38935'::uuid
+    AND text IS NOT NULL;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1786560235869,
       "tag": "0074_entity_feed_query",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1786563835869,
+      "tag": "0075_feed_requires_name",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/tests/0075_feed_requires_name.sql
+++ b/api/drizzle/tests/0075_feed_requires_name.sql
@@ -1,0 +1,38 @@
+\set ON_ERROR_STOP on
+CREATE OR REPLACE FUNCTION assert(cond boolean, label text) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN IF NOT cond THEN RAISE EXCEPTION 'FAIL: %', label; ELSE RAISE NOTICE 'pass: %', label; END IF; END; $$;
+
+TRUNCATE entities, values, relations, votes_count, entity_ranking_scores,
+         entity_type_weights, entity_type_exclusions, entity_feed_blocklist;
+
+INSERT INTO entities (id, created_at) VALUES
+  ('11111111-1111-1111-1111-111111111111','1786000000'),  -- named
+  ('22222222-2222-2222-2222-222222222222','1786000000'),  -- NO values at all (empty shell)
+  ('33333333-3333-3333-3333-333333333333','1786000000'),  -- description but NO name
+  ('44444444-4444-4444-4444-444444444444','1786000000'),  -- name is empty string
+  ('55555555-5555-5555-5555-555555555555','1786000000');  -- name is whitespace only
+INSERT INTO values (id, property_id, entity_id, space_id, text) VALUES
+  ('v1','a126ca53-0c8e-48d5-b888-82c734c38935','11111111-1111-1111-1111-111111111111','aaaaaaaa-0000-0000-0000-000000000000','Real Entity'),
+  ('v3','9b1f76ff-9711-404c-861e-59dc3fa7d037','33333333-3333-3333-3333-333333333333','aaaaaaaa-0000-0000-0000-000000000000','a description but no name'),
+  ('v4','a126ca53-0c8e-48d5-b888-82c734c38935','44444444-4444-4444-4444-444444444444','aaaaaaaa-0000-0000-0000-000000000000',''),
+  ('v5','a126ca53-0c8e-48d5-b888-82c734c38935','55555555-5555-5555-5555-555555555555','aaaaaaaa-0000-0000-0000-000000000000','   ');
+
+SELECT assert(refresh_entity_ranking_scores(ARRAY[
+  '11111111-1111-1111-1111-111111111111','22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333','44444444-4444-4444-4444-444444444444',
+  '55555555-5555-5555-5555-555555555555']::uuid[]) = 5,
+  'all 5 are SCORED — the name rule is a serving rule, not a scoring rule');
+
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed()) = 1,
+  'only the named entity is servable');
+SELECT assert((SELECT id FROM entities_ranked_for_feed()) = '11111111-1111-1111-1111-111111111111',
+  'and it is the right one');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='22222222-2222-2222-2222-222222222222'),
+  'an empty shell with no values is never served — this was 97.8% of the corpus');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='33333333-3333-3333-3333-333333333333'),
+  'a description without a name is NOT enough — it still renders as a raw id');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='44444444-4444-4444-4444-444444444444'),
+  'an empty-string name does not count as a name');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='55555555-5555-5555-5555-555555555555'),
+  'a whitespace-only name does not count as a name');
+\echo '=== 0075 ASSERTIONS PASSED ==='


### PR DESCRIPTION
Follow-up to #889. The single largest defect in the Phase A feed, found while investigating what the untyped entity population actually is.

## The problem

Measured on production:

| | |
|---|---|
| Scored entities | 48,884,134 |
| **Of those with no name at all** | **47,808,504 (97.8%)** |
| Nameless entities in the top 2,000 | **1,455 (73%)** |
| First nameless result | **rank 497** |

From roughly rank 500, the feed was mostly blank rows. A nameless entity has nothing to render — it surfaces as a raw uuid, and picked from a collection dropdown it becomes a dangling reference in published content. Same defect as the raw-id symptom noted on GEO-2548, at scale rather than as an edge case.

## Why that population exists

**99.4% of untyped entities are empty shells.** A 20,000-row sample found **101 with a name** and **0 referenced by any relation** — bare `entities` rows created as identifiers and never filled in.

No type config could ever have reached them, because they are untyped by definition. Worth stating plainly: I had been tuning τ and type weights while 97.8% of the corpus was unrenderable.

## The fix

Filtered at candidate generation rather than demoted by weight. A nameless entity is not low quality, it is undisplayable — a demotion would still surface it whenever nothing fresher existed, which is precisely what was happening past rank 497.

Requires a **non-empty name** specifically, not "any value": a description without a name still renders as a raw id, and an empty or whitespace-only name is not a name.

## Verification

- Nameless entities in the top 2,000: **1,455 → 0**
- Plan stays index-driven — the new partial index is used as an `Index Scan` semi-join, so it is a probe rather than a heap fetch per candidate
- **7 SQL assertions**, mutation-tested: dropping the `trim`/`length` guard fails the empty-string assertion
- Scoring is deliberately unaffected — an assertion pins that all fixtures are still *scored*, since this is a serving rule, not a scoring rule

## ⚠️ Already applied to the v2 database

I applied this directly, because the feed was actively serving blank rows. The drizzle ledger does **not** record it, so the next `db:migrate` will apply it again — verified re-runnable (`CREATE OR REPLACE FUNCTION` + `CREATE INDEX IF NOT EXISTS`), so that pass is a no-op rather than a failure. Flagging explicitly since out-of-band schema application on this database has broken api pods before.
