### PR TITLE
feat(feed): exclude system entities from the Explore feed

### DIFF
--- a/api/drizzle/0076_feed_excludes_system_entities.sql
+++ b/api/drizzle/0076_feed_excludes_system_entities.sql
@@ -1,0 +1,65 @@
+-- Explore feed: never serve system entities.
+--
+-- Preston's instruction was "all system entities can be excluded (space system
+-- entity, proposal system entity, etc.)". That is a category, not a type name, so it
+-- cannot be expressed in `entity_type_exclusions`, which is keyed on user-authored
+-- Type relations.
+--
+-- The right marker is the System Type relation, 88b3d6ad-288c-529c-a212-0e1c24819185
+-- (SYSTEM_TYPES_RELATION_TYPE_ID). Per 0065, it is system-minted and the indexer
+-- always drops user attempts to author it, so unlike a type name it cannot be
+-- forged — someone minting a type entity named "Space" does not become a system
+-- entity, and a real system entity cannot shed the marker.
+--
+-- Measured on production 2026-08-13: 28,744 entities carry it, by system type —
+--   System 28,744 · Proposal 27,508 · Space 1,236 · EOA Space 822 · DAO Space 414
+--
+-- Note this does NOT subsume the name-keyed exclusions already configured:
+--   * Payout has ZERO system-typed entities, so it still needs its own row.
+--   * The 1,146 user-typed "Space" entities are a DIFFERENT set from the 1,236
+--     system-typed ones — no overlap. Both exclusions are required.
+--
+-- No new index: `relations_type_from_to_idx` already serves a (type_id,
+-- from_entity_id) probe, which is the same shape the excluded-type check uses.
+
+CREATE OR REPLACE FUNCTION public.entities_ranked_for_feed(
+  min_ranking_score numeric DEFAULT NULL,
+  created_after text DEFAULT NULL,
+  created_before text DEFAULT NULL
+)
+RETURNS SETOF public.entities
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT e.*
+  FROM public.entities e
+  JOIN public.entity_ranking_scores rs ON rs.entity_id = e.id
+  WHERE (min_ranking_score IS NULL OR rs.ranking_score >= min_ranking_score)
+    AND (created_after   IS NULL OR e.created_at >  created_after)
+    AND (created_before  IS NULL OR e.created_at <= created_before)
+    -- Unrenderable entities are never candidates (0075).
+    AND EXISTS (
+      SELECT 1 FROM public.values v
+      WHERE v.entity_id = e.id
+        AND v.property_id = 'a126ca53-0c8e-48d5-b888-82c734c38935'::uuid
+        AND v.text IS NOT NULL
+        AND length(trim(v.text)) > 0
+    )
+    -- Never serve blocked entities, whatever they score.
+    AND NOT EXISTS (SELECT 1 FROM public.entity_feed_blocklist b WHERE b.entity_id = e.id)
+    -- System entities are infrastructure, not content. Keyed on the unforgeable
+    -- System Type relation rather than on type names.
+    AND NOT EXISTS (
+      SELECT 1 FROM public.relations r
+      WHERE r.from_entity_id = e.id
+        AND r.type_id = '88b3d6ad-288c-529c-a212-0e1c24819185'::uuid  -- System Type
+    )
+    -- Excluded types are filtered at candidate generation rather than via a zero
+    -- weight, so they never consume candidate slots.
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.relations r
+      JOIN public.entity_type_exclusions x ON x.type_id = r.to_entity_id
+      WHERE r.from_entity_id = e.id
+        AND r.type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid  -- TYPES
+    )
+  ORDER BY rs.ranking_score DESC, rs.entity_id DESC;
+$$;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1786563835869,
       "tag": "0075_feed_requires_name",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1786567435869,
+      "tag": "0076_feed_excludes_system_entities",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/tests/0076_feed_excludes_system_entities.sql
+++ b/api/drizzle/tests/0076_feed_excludes_system_entities.sql
@@ -1,0 +1,45 @@
+\set ON_ERROR_STOP on
+CREATE OR REPLACE FUNCTION assert(cond boolean, label text) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN IF NOT cond THEN RAISE EXCEPTION 'FAIL: %', label; ELSE RAISE NOTICE 'pass: %', label; END IF; END; $$;
+
+TRUNCATE entities, values, relations, votes_count, entity_ranking_scores,
+         entity_type_weights, entity_type_exclusions, entity_feed_blocklist;
+
+INSERT INTO entities (id, created_at) VALUES
+  ('11111111-1111-1111-1111-111111111111','1786000000'),  -- normal, named
+  ('22222222-2222-2222-2222-222222222222','1786000000'),  -- SYSTEM entity
+  ('33333333-3333-3333-3333-333333333333','1786000000');  -- user Type named "Space", NOT system
+INSERT INTO values (id, property_id, entity_id, space_id, text) VALUES
+  ('v1','a126ca53-0c8e-48d5-b888-82c734c38935','11111111-1111-1111-1111-111111111111','aaaaaaaa-0000-0000-0000-000000000000','Real Article'),
+  ('v2','a126ca53-0c8e-48d5-b888-82c734c38935','22222222-2222-2222-2222-222222222222','aaaaaaaa-0000-0000-0000-000000000000','Some Space System Entity'),
+  ('v3','a126ca53-0c8e-48d5-b888-82c734c38935','33333333-3333-3333-3333-333333333333','aaaaaaaa-0000-0000-0000-000000000000','A user-typed Space');
+-- entity 2 carries the unforgeable System Type relation
+INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id, is_system) VALUES
+  ('0b111111-1111-1111-1111-111111111111','e0000000-0000-0000-0000-000000000001',
+   '88b3d6ad-288c-529c-a212-0e1c24819185','22222222-2222-2222-2222-222222222222',
+   'cccccccc-0000-0000-0000-000000000001','aaaaaaaa-0000-0000-0000-000000000000',true),
+-- entity 3 declares a normal user Type pointing at an entity named "Space" — this
+-- must NOT be treated as a system entity. This is the forgery case the marker prevents.
+  ('0b222222-2222-2222-2222-222222222222','e0000000-0000-0000-0000-000000000002',
+   '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','33333333-3333-3333-3333-333333333333',
+   'dddddddd-0000-0000-0000-000000000001','aaaaaaaa-0000-0000-0000-000000000000',false);
+
+SELECT assert(refresh_entity_ranking_scores(ARRAY[
+  '11111111-1111-1111-1111-111111111111','22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333']::uuid[]) = 3,
+  'all 3 are SCORED — excluding system entities is a serving rule, not a scoring rule');
+
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='22222222-2222-2222-2222-222222222222'),
+  'a System Type entity is never served, even though it has a perfectly good name');
+SELECT assert(EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='33333333-3333-3333-3333-333333333333'),
+  'a user-typed entity is NOT treated as a system entity — the marker cannot be forged via a Type relation');
+SELECT assert(EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='11111111-1111-1111-1111-111111111111'),
+  'normal content is unaffected');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed()) = 2, 'exactly 2 servable');
+
+-- and the name-keyed exclusion still works independently (Payout has no system marker)
+INSERT INTO entity_type_exclusions (type_id, note, updated_at)
+  VALUES ('dddddddd-0000-0000-0000-000000000001','user-typed Space excluded by name', now());
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed() WHERE id='33333333-3333-3333-3333-333333333333'),
+  'name-keyed exclusion still applies on top — the two mechanisms are independent');
+\echo '=== 0076 ASSERTIONS PASSED ==='


### PR DESCRIPTION

Preston's instruction was "all system entities can be excluded (space system
entity, proposal system entity, etc.)". That is a category, not a type name, so it
cannot be expressed in `entity_type_exclusions`, which is keyed on user-authored
Type relations. It needed code.

Keyed on the System Type relation (88b3d6ad-288c-529c-a212-0e1c24819185). Per 0065
that relation is system-minted and the indexer always drops user attempts to author
it, so unlike a type name it cannot be forged: minting a type entity named "Space"
does not make you a system entity, and a real system entity cannot shed the marker.

Measured on production: 28,744 entities carry it — System 28,744, Proposal 27,508,
Space 1,236, EOA Space 822, DAO Space 414.

This deliberately does NOT replace the name-keyed exclusions already configured,
because the two sets are not the same:

  * Payout has ZERO system-typed entities, so it still needs its own row.
  * The 1,146 user-typed "Space" entities are a DIFFERENT set from the 1,236
    system-typed ones — no overlap at all. Both exclusions are required.

I checked that rather than assuming the marker subsumed the names; it does not.

No new index — relations_type_from_to_idx already serves a (type_id,
from_entity_id) probe, the same shape the excluded-type check uses.

Verified: 6 SQL assertions, mutation-tested twice. Removing the clause fails the
system-entity assertion; keying on the forgeable TYPES relation instead of the
System Type marker also fails it. An assertion pins that all fixtures remain
SCORED — this is a serving rule, not a scoring rule — and another pins that the
name-keyed mechanism still applies independently on top.

Not applied out-of-band. 0075 went straight to the database because the feed was
actively serving blank rows; system entities are not that urgent, so this one
should land through db:migrate on deploy and stay in step with the ledger.