### PR TITLE
feat(feed): scope the Explore feed by space and type

### DIFF
--- a/api/drizzle/0077_feed_space_and_type_scoping.sql
+++ b/api/drizzle/0077_feed_space_and_type_scoping.sql
@@ -1,0 +1,141 @@
+-- Explore feed: accept space and type scoping, so "Best" can serve the same
+-- surfaces "New" and "Top" already serve.
+--
+-- WHY THIS IS NEEDED
+--
+-- `fetchExploreFeed` (geogenesis apps/web/core/explore/fetch-explore-feed.ts) is
+-- space-scoped by construction: it derives `baseIds` from the browse sidebar,
+-- narrows to one space when the UI's space filter is set, and returns an empty feed
+-- when the set is empty. Both existing sorts pass that set to the server —
+-- "New" via `entitiesConnection(spaceIds:)` and "Top" via
+-- `entitiesOrderedByPropertyConnection(spaceIds:, typeIds:)`.
+--
+-- `entities_ranked_for_feed` took neither, so a "Best" sort built on it would have
+-- silently ignored the space filter — the control would still be on screen and do
+-- nothing on that one tab. This adds the two parameters rather than leaving the
+-- frontend to fake them.
+--
+-- WHY NOT PUT SPACE SCOPING IN `filter`
+--
+-- `EntityFilter.spaceIds` exists and would have needed no migration, but it is
+-- backed by `entities_space_ids(entities)` — a computed column (0004), not a stored
+-- array. Filtering on it costs a function call per candidate row and cannot be
+-- index-driven. `entities_ordered_by_property` reached the same conclusion in 0060
+-- and scopes on `values.space_id` directly; this follows it.
+--
+-- WHY THIS STAYS `LANGUAGE sql` AND DOES NOT COPY 0060's DYNAMIC SQL
+--
+-- This is the load-bearing decision, and 0060's own header warns about the failure
+-- mode it avoids: "LIMIT/OFFSET are applied by PostGraphile outside this function,
+-- so PG materializes the full ordered set before paginating." 0060 accepts that
+-- because its type-prefiltered set is small.
+--
+-- The feed's candidate set is not small — 960,495 rows as of 2026-08-13. It is fast
+-- (~0.3s, and 0.32s at offset 10,000) only because a single-statement `LANGUAGE sql`
+-- function is INLINED into the calling query, which lets PostGraphile's LIMIT push
+-- down into an index-ordered walk of `entity_ranking_scores_ranking_desc_idx` that
+-- terminates early. Rewriting this as plpgsql with `RETURN QUERY EXECUTE` would
+-- defeat inlining and sort ~1M rows on every request.
+--
+-- So the predicates are added as `arg IS NULL OR ...` guards, which 0060 explicitly
+-- avoids. That is the correct tradeoff *here*: because the function is inlined, the
+-- arguments are substituted into the body before planning, so a NULL argument folds
+-- the guard away at plan time instead of being evaluated per row. The guard costs
+-- nothing that dynamic SQL would save, and dynamic SQL would cost the inlining.
+--
+-- MEASURED CAVEAT (pre-existing, not introduced here)
+--
+-- Requesting `filter` + `totalCount` + `edges` together on this connection exceeds
+-- the statement timeout: totalCount forces a full scan of the filtered set while
+-- edges walks it again, and a low-selectivity filter (e.g. ILIKE) makes each pass
+-- deep. Each of the three alone is fine. The Explore documents never request
+-- top-level `totalCount` (their only `totalCount` is nested under `backlinks`, for
+-- comment counts), so the feed path is unaffected — but callers combining a broad
+-- filter with totalCount should expect it.
+
+-- Adding parameters with defaults creates a new signature rather than replacing the
+-- old one, which would leave two `entities_ranked_for_feed` functions for PostGraphile
+-- to choose between. Drop the 3-arg form explicitly, as 0060 does for its own
+-- superseded signatures.
+DROP FUNCTION IF EXISTS public.entities_ranked_for_feed(numeric, text, text);
+--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.entities_ranked_for_feed(
+  min_ranking_score numeric DEFAULT NULL,
+  created_after text DEFAULT NULL,
+  created_before text DEFAULT NULL,
+  space_ids uuid[] DEFAULT NULL,
+  type_ids uuid[] DEFAULT NULL
+)
+RETURNS SETOF public.entities
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT e.*
+  FROM public.entities e
+  JOIN public.entity_ranking_scores rs ON rs.entity_id = e.id
+  WHERE (min_ranking_score IS NULL OR rs.ranking_score >= min_ranking_score)
+    AND (created_after   IS NULL OR e.created_at >  created_after)
+    AND (created_before  IS NULL OR e.created_at <= created_before)
+    -- Unrenderable entities are never candidates (0075), AND — when `space_ids` is
+    -- given — the name must exist in one of those spaces.
+    --
+    -- Space scoping is folded into this probe rather than added as a separate EXISTS
+    -- because the name value already carries the space_id, so one index probe answers
+    -- both questions. It also reproduces exactly what the frontend's `requireName`
+    -- filter already asks for today:
+    --   values: { some: { spaceId: { in: spaceIds },
+    --                     propertyId: { is: NAME }, text: { isNull: false } } }
+    -- i.e. "has a usable name in a space I'm looking at", not the weaker "has a name
+    -- somewhere, and is present in one of these spaces". An entity named only in a
+    -- space the viewer is not browsing would render as a raw uuid, which is the whole
+    -- defect 0075 exists to prevent.
+    AND EXISTS (
+      SELECT 1 FROM public.values v
+      WHERE v.entity_id = e.id
+        AND v.property_id = 'a126ca53-0c8e-48d5-b888-82c734c38935'::uuid
+        AND v.text IS NOT NULL
+        AND length(trim(v.text)) > 0
+        AND (space_ids IS NULL OR v.space_id = ANY(space_ids))
+    )
+    -- Optional type restriction. OR semantics across the set, matching 0060's
+    -- `type_ids`. This is a positive filter supplied by the caller and is independent
+    -- of `entity_type_exclusions` below, which is global editorial config — an
+    -- excluded type stays excluded even if a caller names it here, since exclusion is
+    -- an invariant of the feed and this is a narrowing request.
+    AND (
+      type_ids IS NULL OR EXISTS (
+        SELECT 1 FROM public.relations r
+        WHERE r.from_entity_id = e.id
+          AND r.type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid  -- TYPES
+          AND r.to_entity_id = ANY(type_ids)
+      )
+    )
+    -- Never serve blocked entities, whatever they score.
+    AND NOT EXISTS (SELECT 1 FROM public.entity_feed_blocklist b WHERE b.entity_id = e.id)
+    -- System entities are infrastructure, not content (0076). Keyed on the unforgeable
+    -- System Type relation rather than on type names.
+    AND NOT EXISTS (
+      SELECT 1 FROM public.relations r
+      WHERE r.from_entity_id = e.id
+        AND r.type_id = '88b3d6ad-288c-529c-a212-0e1c24819185'::uuid  -- System Type
+    )
+    -- Excluded types are filtered at candidate generation rather than via a zero
+    -- weight, so they never consume candidate slots.
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.relations r
+      JOIN public.entity_type_exclusions x ON x.type_id = r.to_entity_id
+      WHERE r.from_entity_id = e.id
+        AND r.type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid  -- TYPES
+    )
+  ORDER BY rs.ranking_score DESC, rs.entity_id DESC;
+$$;
+--> statement-breakpoint
+
+-- The name probe now also filters on space_id. `values_name_entity_idx` (0075) is
+-- keyed on entity_id alone with the property/text predicate, so space_id came back
+-- from the heap. Including it makes the probe index-only again for the space-scoped
+-- path, which is the path the Explore UI actually takes.
+CREATE INDEX IF NOT EXISTS "values_name_entity_space_idx"
+  ON "values" ("entity_id", "space_id")
+  WHERE property_id = 'a126ca53-0c8e-48d5-b888-82c734c38935'::uuid
+    AND text IS NOT NULL;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1786567435869,
       "tag": "0076_feed_excludes_system_entities",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1786571035869,
+      "tag": "0077_feed_space_and_type_scoping",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/tests/0073_entity_ranking_scores.sql
+++ b/api/drizzle/tests/0073_entity_ranking_scores.sql
@@ -2,6 +2,13 @@
 CREATE OR REPLACE FUNCTION assert(cond boolean, label text) RETURNS void LANGUAGE plpgsql AS $$
 BEGIN IF NOT cond THEN RAISE EXCEPTION 'FAIL: %', label; ELSE RAISE NOTICE 'pass: %', label; END IF; END; $$;
 
+-- This suite used to rely on being run first against a virgin database: its row-count
+-- assertions ("still exactly 6 rows after re-refresh") counted every row in
+-- entity_ranking_scores, so any fixture left behind by another suite failed it. The
+-- other suites all truncate; this one now does too, so the files can run in any order.
+TRUNCATE entities, values, relations, votes_count, entity_ranking_scores,
+         entity_type_weights, entity_type_exclusions, entity_feed_blocklist;
+
 -- ---- Wilson properties ----
 SELECT assert(wilson_lower_bound(0,0) > 0 AND wilson_lower_bound(0,0) < 1,
   'zero-vote entity lands strictly inside (0,1) via the prior, not at the floor');

--- a/api/drizzle/tests/0074_entity_feed_query.sql
+++ b/api/drizzle/tests/0074_entity_feed_query.sql
@@ -11,6 +11,15 @@ INSERT INTO entities (id, created_at) VALUES
   ('33333333-3333-3333-3333-333333333333','1786000000'),  -- EXCLUDED TYPE
   ('44444444-4444-4444-4444-444444444444','1768000000'),  -- old (outside window)
   ('55555555-5555-5555-5555-555555555555','1786000000');  -- no score row at all
+-- Every fixture needs a name to be servable at all (0075). Without these the suite
+-- asserts nothing: all five entities fail candidate generation on the name rule and
+-- the blocklist/exclusion assertions below pass vacuously.
+INSERT INTO values (id, property_id, entity_id, space_id, text) VALUES
+  ('m1','a126ca53-0c8e-48d5-b888-82c734c38935','11111111-1111-1111-1111-111111111111','aaaaaaaa-0000-0000-0000-000000000000','Servable'),
+  ('m2','a126ca53-0c8e-48d5-b888-82c734c38935','22222222-2222-2222-2222-222222222222','aaaaaaaa-0000-0000-0000-000000000000','Blocklisted'),
+  ('m3','a126ca53-0c8e-48d5-b888-82c734c38935','33333333-3333-3333-3333-333333333333','aaaaaaaa-0000-0000-0000-000000000000','Excluded type'),
+  ('m4','a126ca53-0c8e-48d5-b888-82c734c38935','44444444-4444-4444-4444-444444444444','aaaaaaaa-0000-0000-0000-000000000000','Old'),
+  ('m5','a126ca53-0c8e-48d5-b888-82c734c38935','55555555-5555-5555-5555-555555555555','aaaaaaaa-0000-0000-0000-000000000000','No score row');
 INSERT INTO votes_count (object_id, object_type, space_id, vote_kind, positive, negative) VALUES
   ('11111111-1111-1111-1111-111111111111',0,'aaaaaaaa-0000-0000-0000-000000000000',0,50,2),
   ('22222222-2222-2222-2222-222222222222',0,'aaaaaaaa-0000-0000-0000-000000000000',0,99,0),

--- a/api/drizzle/tests/0077_feed_space_and_type_scoping.sql
+++ b/api/drizzle/tests/0077_feed_space_and_type_scoping.sql
@@ -1,0 +1,113 @@
+\set ON_ERROR_STOP on
+CREATE OR REPLACE FUNCTION assert(cond boolean, label text) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN IF NOT cond THEN RAISE EXCEPTION 'FAIL: %', label; ELSE RAISE NOTICE 'pass: %', label; END IF; END; $$;
+
+TRUNCATE entities, values, relations, votes_count, entity_ranking_scores,
+         entity_type_weights, entity_type_exclusions, entity_feed_blocklist;
+
+-- Spaces A and B; types T1, T2, and TX (globally excluded).
+-- Entity naming is what carries space membership — see 0077's header for why space
+-- scoping is folded into the name probe rather than added as a separate predicate.
+INSERT INTO entities (id, created_at) VALUES
+  ('e1111111-1111-1111-1111-111111111111','1786000000'),  -- name in A,   type T1
+  ('e2222222-2222-2222-2222-222222222222','1786000000'),  -- name in B,   type T1
+  ('e3333333-3333-3333-3333-333333333333','1786000000'),  -- name in A,   type T2
+  ('e4444444-4444-4444-4444-444444444444','1786000000'),  -- name in A+B, type T1
+  ('e5555555-5555-5555-5555-555555555555','1786000000'),  -- name in A,   type TX (excluded)
+  ('e6666666-6666-6666-6666-666666666666','1786000000'),  -- name in A,   UNTYPED
+  ('e7777777-7777-7777-7777-777777777777','1786000000');  -- name in A,   type T1, BLOCKLISTED
+
+INSERT INTO values (id, property_id, entity_id, space_id, text) VALUES
+  ('n1','a126ca53-0c8e-48d5-b888-82c734c38935','e1111111-1111-1111-1111-111111111111','aaaaaaaa-0000-0000-0000-00000000000a','In A only'),
+  ('n2','a126ca53-0c8e-48d5-b888-82c734c38935','e2222222-2222-2222-2222-222222222222','bbbbbbbb-0000-0000-0000-00000000000b','In B only'),
+  ('n3','a126ca53-0c8e-48d5-b888-82c734c38935','e3333333-3333-3333-3333-333333333333','aaaaaaaa-0000-0000-0000-00000000000a','In A, type T2'),
+  ('n4a','a126ca53-0c8e-48d5-b888-82c734c38935','e4444444-4444-4444-4444-444444444444','aaaaaaaa-0000-0000-0000-00000000000a','In both, A name'),
+  ('n4b','a126ca53-0c8e-48d5-b888-82c734c38935','e4444444-4444-4444-4444-444444444444','bbbbbbbb-0000-0000-0000-00000000000b','In both, B name'),
+  ('n5','a126ca53-0c8e-48d5-b888-82c734c38935','e5555555-5555-5555-5555-555555555555','aaaaaaaa-0000-0000-0000-00000000000a','Excluded type'),
+  ('n6','a126ca53-0c8e-48d5-b888-82c734c38935','e6666666-6666-6666-6666-666666666666','aaaaaaaa-0000-0000-0000-00000000000a','Untyped'),
+  ('n7','a126ca53-0c8e-48d5-b888-82c734c38935','e7777777-7777-7777-7777-777777777777','aaaaaaaa-0000-0000-0000-00000000000a','Blocklisted');
+
+-- TYPES relations. d1d1d1d1… = T1, d2d2d2d2… = T2, dededede… = TX (globally excluded).
+INSERT INTO relations (id, entity_id, type_id, from_entity_id, to_entity_id, space_id, is_system) VALUES
+  ('0a000001-0000-0000-0000-000000000001','ee000000-0000-0000-0000-000000000001','8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','e1111111-1111-1111-1111-111111111111','d1d1d1d1-0000-0000-0000-000000000001','aaaaaaaa-0000-0000-0000-00000000000a',false),
+  ('0a000002-0000-0000-0000-000000000002','ee000000-0000-0000-0000-000000000002','8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','e2222222-2222-2222-2222-222222222222','d1d1d1d1-0000-0000-0000-000000000001','bbbbbbbb-0000-0000-0000-00000000000b',false),
+  ('0a000003-0000-0000-0000-000000000003','ee000000-0000-0000-0000-000000000003','8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','e3333333-3333-3333-3333-333333333333','d2d2d2d2-0000-0000-0000-000000000002','aaaaaaaa-0000-0000-0000-00000000000a',false),
+  ('0a000004-0000-0000-0000-000000000004','ee000000-0000-0000-0000-000000000004','8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','e4444444-4444-4444-4444-444444444444','d1d1d1d1-0000-0000-0000-000000000001','aaaaaaaa-0000-0000-0000-00000000000a',false),
+  ('0a000005-0000-0000-0000-000000000005','ee000000-0000-0000-0000-000000000005','8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','e5555555-5555-5555-5555-555555555555','dededede-0000-0000-0000-00000000000e','aaaaaaaa-0000-0000-0000-00000000000a',false),
+  ('0a000007-0000-0000-0000-000000000007','ee000000-0000-0000-0000-000000000007','8f151ba4-de20-4e3c-9cb4-99ddf96f48f1','e7777777-7777-7777-7777-777777777777','d1d1d1d1-0000-0000-0000-000000000001','aaaaaaaa-0000-0000-0000-00000000000a',false);
+
+INSERT INTO entity_type_exclusions (type_id, note) VALUES ('dededede-0000-0000-0000-00000000000e','TX is globally excluded');
+INSERT INTO entity_feed_blocklist (entity_id, reason) VALUES ('e7777777-7777-7777-7777-777777777777','moderated');
+
+SELECT refresh_entity_ranking_scores(ARRAY[
+  'e1111111-1111-1111-1111-111111111111','e2222222-2222-2222-2222-222222222222',
+  'e3333333-3333-3333-3333-333333333333','e4444444-4444-4444-4444-444444444444',
+  'e5555555-5555-5555-5555-555555555555','e6666666-6666-6666-6666-666666666666',
+  'e7777777-7777-7777-7777-777777777777']::uuid[]);
+
+-- ---- backward compatibility: the added params are optional ----
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed()) = 5,
+  'unscoped: all servable entities remain (TX excluded, blocklisted dropped)');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL, '1785000000')) = 5,
+  'positional pre-0077 call shape still resolves (recency arg, no space/type)');
+
+-- ---- space scoping ----
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,ARRAY['aaaaaaaa-0000-0000-0000-00000000000a']::uuid[])) = 4,
+  'space A serves the 4 entities named in A');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed(NULL,NULL,NULL,ARRAY['aaaaaaaa-0000-0000-0000-00000000000a']::uuid[])
+                          WHERE id='e2222222-2222-2222-2222-222222222222'),
+  'an entity named ONLY in B is not served to A — it would render as a raw uuid there');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,ARRAY['bbbbbbbb-0000-0000-0000-00000000000b']::uuid[])) = 2,
+  'space B serves only the B-named entities');
+SELECT assert(EXISTS (SELECT 1 FROM entities_ranked_for_feed(NULL,NULL,NULL,ARRAY['bbbbbbbb-0000-0000-0000-00000000000b']::uuid[])
+                      WHERE id='e4444444-4444-4444-4444-444444444444'),
+  'an entity named in BOTH spaces is served to either');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,
+    ARRAY['aaaaaaaa-0000-0000-0000-00000000000a','bbbbbbbb-0000-0000-0000-00000000000b']::uuid[])) = 5,
+  'both spaces together match the unscoped result (no double-counting from the two-name entity)');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,ARRAY['cccccccc-0000-0000-0000-00000000000c']::uuid[])) = 0,
+  'a space with no named entities serves nothing');
+
+-- ---- type scoping ----
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,NULL,ARRAY['d1d1d1d1-0000-0000-0000-000000000001']::uuid[])) = 3,
+  'type T1 serves its 3 servable entities');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed(NULL,NULL,NULL,NULL,ARRAY['d1d1d1d1-0000-0000-0000-000000000001']::uuid[])
+                          WHERE id='e6666666-6666-6666-6666-666666666666'),
+  'type_ids is a positive filter: an UNTYPED entity is excluded when types are named');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,NULL,
+    ARRAY['d1d1d1d1-0000-0000-0000-000000000001','d2d2d2d2-0000-0000-0000-000000000002']::uuid[])) = 4,
+  'type_ids has OR semantics across the set');
+
+-- ---- the invariant that must not be bypassable ----
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,NULL,ARRAY['dededede-0000-0000-0000-00000000000e']::uuid[])) = 0,
+  'asking for a GLOBALLY EXCLUDED type serves nothing — exclusion is a feed invariant, not a default a caller can opt out of');
+SELECT assert(NOT EXISTS (SELECT 1 FROM entities_ranked_for_feed(NULL,NULL,NULL,
+    ARRAY['aaaaaaaa-0000-0000-0000-00000000000a']::uuid[], ARRAY['d1d1d1d1-0000-0000-0000-000000000001']::uuid[])
+    WHERE id='e7777777-7777-7777-7777-777777777777'),
+  'the blocklist still wins when both space and type scoping are supplied');
+
+-- ---- combined ----
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,
+    ARRAY['aaaaaaaa-0000-0000-0000-00000000000a']::uuid[], ARRAY['d1d1d1d1-0000-0000-0000-000000000001']::uuid[])) = 2,
+  'space and type scoping intersect (AND), not union');
+SELECT assert((SELECT count(*) FROM entities_ranked_for_feed(NULL,NULL,NULL,
+    ARRAY['bbbbbbbb-0000-0000-0000-00000000000b']::uuid[], ARRAY['d2d2d2d2-0000-0000-0000-000000000002']::uuid[])) = 0,
+  'a space/type pair with no members serves nothing');
+
+-- ---- ordering survives scoping ----
+SELECT assert((SELECT count(*) FROM (
+    SELECT ranking_score FROM entities_ranked_for_feed(NULL,NULL,NULL,ARRAY['aaaaaaaa-0000-0000-0000-00000000000a']::uuid[]) f
+    JOIN entity_ranking_scores rs ON rs.entity_id=f.id
+  ) x) = 4,
+  'every scoped row still has its score row (the join is not dropped by scoping)');
+SELECT assert((
+    SELECT bool_and(prev >= cur) FROM (
+      SELECT rs.ranking_score AS cur,
+             lag(rs.ranking_score) OVER () AS prev
+      FROM entities_ranked_for_feed(NULL,NULL,NULL,ARRAY['aaaaaaaa-0000-0000-0000-00000000000a']::uuid[]) f
+      JOIN entity_ranking_scores rs ON rs.entity_id=f.id
+    ) s WHERE prev IS NOT NULL
+  ) IS NOT FALSE,
+  'scoped results are still returned in descending ranking_score order');
+
+\echo '=== 0077 ASSERTIONS PASSED ==='

--- a/api/drizzle/tests/README.md
+++ b/api/drizzle/tests/README.md
@@ -18,10 +18,30 @@ docker rm -f migtest
 `relations` and `votes_count` that the scoring functions read, verified against the
 live schema. It is a test fixture, not a source of truth for those tables.
 
+Apply migrations 0073–0077 in order, then run the suites. They truncate their own
+fixtures, so they pass in any order — verified by running the set forwards and
+backwards. 0073 originally had no `TRUNCATE` and only passed when it ran first
+against a virgin database; its row-count assertions counted every row in
+`entity_ranking_scores`, so a fixture left behind by any other suite failed it.
+
 These were mutation-tested: flipping the recency sign, replacing Wilson with
 `abs(net)`, dropping the `is_system` filter, and dropping the `vote_kind = 0` filter
-each fail exactly one assertion. Worth re-checking if you change the assertions —
+each fail exactly one assertion. For 0077, dropping the `space_ids` predicate,
+neutering `type_ids`, negating it (`= ANY` → `<> ALL`), and dropping the global type
+exclusion are each caught. Worth re-checking if you change the assertions —
 the `is_system` case originally passed a mutation because the assertion that claimed
 to cover it was written against an entity with no relations at all.
 
-TODO: port to the vitest harness in `api/src/kg/__tests__` so they run in CI.
+Two ways these have gone stale before, both worth guarding against:
+
+* 0075 added the name requirement, which invalidated 0074's fixtures — none of them
+  had a name, so every 0074 assertion passed vacuously except the one counting rows,
+  which failed. A migration that narrows candidate generation invalidates every
+  earlier suite's fixtures; fix by making the fixtures satisfy the new rule, not by
+  adjusting the expected count.
+* An assertion can go green because the thing it names is unreachable. Mutating the
+  code it claims to cover is the only reliable check.
+
+TODO: port to the vitest harness in `api/src/kg/__tests__` so they run in CI. Until
+then nothing here runs automatically, which is how both staleness cases above
+survived.


### PR DESCRIPTION
## What

Adds `space_ids` and `type_ids` to `entities_ranked_for_feed`, so the Phase A "Best" sort can serve the same surfaces "New" and "Top" already do.

## Why

`fetchExploreFeed` is space-scoped by construction — it derives its space set from the browse sidebar, narrows it when the UI's space filter is set, and returns an empty feed when the set is empty. Both existing sorts pass that set to the server. `entities_ranked_for_feed` took neither parameter, so a "Best" tab built on it would have silently ignored the space filter: the control stays on screen and does nothing on that one tab.

## Two decisions worth review

**Space scoping is folded into the name-presence probe** rather than added as a separate predicate. The name value already carries `space_id`, so one index probe answers both questions — and it reproduces exactly what the frontend's `requireName` filter asks for today: *has a usable name in a space I'm looking at*. The weaker reading (named anywhere, present here) would serve entities that render as a raw uuid, which is the defect 0075 exists to prevent.

**This deliberately does not follow 0060's dynamic-SQL approach** to the same problem. The function is fast — ~0.3s, and 0.32s at offset 10,000 over 728k candidates — only because a single-statement `LANGUAGE sql` function gets inlined into the caller, letting PostGraphile's LIMIT push down into an index-ordered walk that terminates early. `RETURN QUERY EXECUTE` would defeat inlining and sort ~1M rows per request. For the same reason the `arg IS NULL OR ...` guards that 0060 avoids are correct here: inlining substitutes arguments before planning, so a NULL argument folds away at plan time.

`type_ids` is a narrowing request, not an escape hatch — `entity_type_exclusions` still applies, so naming an excluded type serves nothing. That one is asserted explicitly.

## Test-suite fixes included

Both of these made assertions pass without testing anything:

- **0074's fixtures had no name values.** After 0075 added the name requirement, every candidate-generation assertion passed vacuously and the row-count one failed. Fixed by making the fixtures satisfy the rule, not by lowering the count.
- **0073 had no `TRUNCATE`** and only passed when run first against a virgin database. Suites now pass in any order — verified forwards and backwards.

## Verification

68 assertions across 0073–0077 against a throwaway Postgres 18, passing in both orders. Migration applies clean and leaves exactly one function signature (adding defaulted params would otherwise leave the 3-arg version behind for PostGraphile to choose between).

0077's assertions are mutation-tested — each of these is caught by exactly one assertion:

| mutation | caught by |
|---|---|
| drop the `space_ids` predicate | space A serves the 4 entities named in A |
| `type_ids` becomes a no-op | type T1 serves its 3 servable entities |
| `type_ids` negated (`= ANY` → `<> ALL`) | type T1 serves its 3 servable entities |
| drop the global type exclusion | unscoped: all servable entities remain |

## Note

Requesting `filter` + `totalCount` + `edges` together on this connection exceeds the statement timeout — pre-existing, not introduced here. The Explore documents request no top-level `totalCount`, so the feed path is unaffected. Documented in the migration header.
